### PR TITLE
Handles hooks load error

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -243,7 +243,6 @@ class ParseServer {
     Config.validate(AppCache.get(appId));
     this.config = AppCache.get(appId);
     Config.setupPasswordValidator(this.config.passwordPolicy);
-    hooksController.load();
 
     // Note: Tests will start to fail if any validation happens after this is called.
     if (process.env.TESTING) {


### PR DESCRIPTION
I changed the behavior when Parse Server fails to load `_Hooks` collection to prevent it from launching with incomplete state. If Parse Server fails to load `_Hooks` entries, currently it ignores error and launches without setting hooks. This behavior causes serious problems. (For example an important validation logic doesn't work in Before Save Hook.) So my change forces Parse Server to shutdown before it accepts requests.