### PR TITLE
Add support for resending verification email in case of expired token

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParsePlatform/parse-server"
+    "url": "https://github.com/LoungeBuddy/parse-server"
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "bcryptjs": "2.4.3",
-    "body-parser": "1.17.0",
+    "body-parser": "1.17.1",
     "commander": "2.9.0",
     "deepcopy": "0.6.3",
-    "express": "4.15.0",
+    "express": "4.15.2",
     "intersect": "1.0.1",
     "lodash": "4.17.4",
     "lru-cache": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LoungeBuddy/parse-server"
+    "url": "https://github.com/ParsePlatform/parse-server"
   },
   "files": [
     "bin/",

--- a/public_html/invalid_verification_link.html
+++ b/public_html/invalid_verification_link.html
@@ -36,10 +36,34 @@
     }
   </style>
   </head>
+  <script type="text/javascript">
+    function getUrlParameter(name) {
+      name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+      var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+      var results = regex.exec(location.search);
+      return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    };  
+
+    window.onload = addDataToForm;
+
+    function addDataToForm() {
+      var username = getUrlParameter("username");
+      document.getElementById("usernameField").value = username;
+
+      var appId = getUrlParameter("appId");
+      document.getElementById("resendForm").action = '/apps/' + appId + '/resend_verification_email'
+    }
+
+  </script>
 
   <body> 
     <div class="container">
-      <h1>Invalid Link</h1>
+      <h1>Invalid Verification Link</h1>
+        <form id="resendForm" method="POST" action="/resend_verification_email">
+          <input id="usernameField" class="form-control" name="username" type="hidden" value="">
+          <input id="tokenField" class="form-control" name="token" type="hidden" value="">
+          <button type="submit" class="btn btn-default">Resend Link</button>
+        </form>
     </div> 
   </body>
 </html>

--- a/public_html/invalid_verification_link.html
+++ b/public_html/invalid_verification_link.html
@@ -61,7 +61,6 @@
       <h1>Invalid Verification Link</h1>
         <form id="resendForm" method="POST" action="/resend_verification_email">
           <input id="usernameField" class="form-control" name="username" type="hidden" value="">
-          <input id="tokenField" class="form-control" name="token" type="hidden" value="">
           <button type="submit" class="btn btn-default">Resend Link</button>
         </form>
     </div> 

--- a/public_html/link_send_fail.html
+++ b/public_html/link_send_fail.html
@@ -39,7 +39,7 @@
 
   <body> 
     <div class="container">
-      <h1>Invalid Link</h1>
+      <h1>No link sent. User not found or email already verified</h1>
     </div> 
   </body>
 </html>

--- a/public_html/link_send_fail.html
+++ b/public_html/link_send_fail.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<!-- This page is displayed when someone navigates to a verify email or reset password link
-     but their security token is wrong. This can either mean the user has clicked on a
-     stale link (i.e. re-click on a password reset link after resetting their password) or
-     (rarely) this could be a sign of a malicious user trying to tamper with your app.
+<!-- This page is displayed when someone navigates to a verify email link with an invalid
+     security token and requests a link resend. This page is displayed when the username from
+     the original link is invalid or if the email of that user has already been verfieid when
+     the resend request is made
  -->
 <html>
   <head>

--- a/public_html/link_send_success.html
+++ b/public_html/link_send_success.html
@@ -39,7 +39,7 @@
 
   <body> 
     <div class="container">
-      <h1>Invalid Link</h1>
+      <h1>Link Sent! Check your email.</h1>
     </div> 
   </body>
 </html>

--- a/public_html/link_send_success.html
+++ b/public_html/link_send_success.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<!-- This page is displayed when someone navigates to a verify email or reset password link
-     but their security token is wrong. This can either mean the user has clicked on a
-     stale link (i.e. re-click on a password reset link after resetting their password) or
-     (rarely) this could be a sign of a malicious user trying to tamper with your app.
+<!-- This page is displayed when someone navigates to a verify email link with an invalid
+     security token and requests a link resend. This page is displayed when the username
+     from the original verification link has been found and a new verification link has
+     been successfully sent to the corresponding stored email
  -->
 <html>
   <head>

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -6,7 +6,7 @@ const Config = require('../src/Config');
 
 describe("Email Verification Token Expiration: ", () => {
 
-  it('show the invalid link page, if the user clicks on the verify email link after the email verify token expires', done => {
+  it('show the invalid verification link page, if the user clicks on the verify email link after the email verify token expires', done => {
     var user = new Parse.User();
     var sendEmailOptions;
     var emailAdapter = {
@@ -37,7 +37,7 @@ describe("Email Verification Token Expiration: ", () => {
           followRedirect: false,
         }, (error, response) => {
           expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html');
+          expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=testEmailVerifyTokenValidity&appId=test');
           done();
         });
       }, 1000);
@@ -313,7 +313,7 @@ describe("Email Verification Token Expiration: ", () => {
     });
   });
 
-  it('clicking on the email verify link by an email VERIFIED user that was setup before enabling the expire email verify token should show an invalid link', done => {
+  it('clicking on the email verify link by an email VERIFIED user that was setup before enabling the expire email verify token should show email verify email success', done => {
     var user = new Parse.User();
     var sendEmailOptions;
     var emailAdapter = {
@@ -359,7 +359,7 @@ describe("Email Verification Token Expiration: ", () => {
         followRedirect: false,
       }, (error, response) => {
         expect(response.statusCode).toEqual(302);
-        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html');
+        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=testEmailVerifyTokenValidity');
         done();
       });
     })
@@ -369,7 +369,7 @@ describe("Email Verification Token Expiration: ", () => {
     });
   });
 
-  it('clicking on the email verify link by an email UNVERIFIED user that was setup before enabling the expire email verify token should show an invalid link', done => {
+  it('clicking on the email verify link by an email UNVERIFIED user that was setup before enabling the expire email verify token should show invalid verficiation link page', done => {
     var user = new Parse.User();
     var sendEmailOptions;
     var emailAdapter = {
@@ -409,7 +409,7 @@ describe("Email Verification Token Expiration: ", () => {
         followRedirect: false,
       }, (error, response) => {
         expect(response.statusCode).toEqual(302);
-        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html');
+        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=testEmailVerifyTokenValidity&appId=test');
         done();
       });
     })

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -655,7 +655,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
     });
   });
 
-  it('redirects you to invalid link if you try to validate a nonexistant users email', done => {
+  it('redirects you to invalid verification link page if you try to validate a nonexistant users email', done => {
     reconfigureServer({
       appName: 'emailing app',
       verifyUserEmails: true,
@@ -671,7 +671,32 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
         followRedirect: false,
       }, (error, response) => {
         expect(response.statusCode).toEqual(302);
-        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html');
+        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=sadfasga&appId=test');
+        done();
+      });
+    });
+  });
+
+  it('redirects you to link send fail page if you try to resend a link for a nonexistant user', done => {
+    reconfigureServer({
+      appName: 'emailing app',
+      verifyUserEmails: true,
+      emailAdapter: {
+        sendVerificationEmail: () => Promise.resolve(),
+        sendPasswordResetEmail: () => Promise.resolve(),
+        sendMail: () => {}
+      },
+      publicServerURL: "http://localhost:8378/1"
+    })
+    .then(() => {
+      request.post('http://localhost:8378/1/apps/test/resend_verification_email', {
+        followRedirect: false,
+        form: {
+          username: "sadfasga"
+        }
+      }, (error, response) => {
+        expect(response.statusCode).toEqual(302);
+        expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/link_send_fail.html');
         done();
       });
     });
@@ -685,7 +710,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
           followRedirect: false,
         }, (error, response) => {
           expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html');
+          expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=zxcv&appId=test');
           user.fetch()
           .then(() => {
             expect(user.get('emailVerified')).toEqual(false);

--- a/src/Config.js
+++ b/src/Config.js
@@ -233,6 +233,18 @@ export class Config {
     return this.customPages.invalidLink || `${this.publicServerURL}/apps/invalid_link.html`;
   }
 
+  get invalidVerificationLinkURL() {
+    return this.customPages.invalidVerificationLink || `${this.publicServerURL}/apps/invalid_verification_link.html`;
+  }
+
+  get linkSendSuccessURL() {
+    return this.customPages.linkSendSuccess || `${this.publicServerURL}/apps/link_send_success.html`
+  }
+
+  get linkSendFailURL() {
+    return this.customPages.linkSendFail || `${this.publicServerURL}/apps/link_send_fail.html`
+  }
+
   get verifyEmailSuccessURL() {
     return this.customPages.verifyEmailSuccess || `${this.publicServerURL}/apps/verify_email_success.html`;
   }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -65,7 +65,7 @@ export class UserController extends AdaptableController {
     return checkIfAlreadyVerified.execute().then(function(result) {
       if (result.results.length) {
         return Promise.resolve(result.results.length[0]);
-      } 
+      }
       return self.config.database.update('_User', query, updateFields).then((document) => {
         if (!document) {
           throw undefined
@@ -148,7 +148,7 @@ export class UserController extends AdaptableController {
         throw undefined;
       }
       self.setEmailVerifyToken(aUser);
-      return self.config.database.update('_User', {username}, aUser).then(function(res) {
+      return self.config.database.update('_User', {username}, aUser).then(function() {
         self.sendVerificationEmail(aUser);
       });
     });

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -60,13 +60,12 @@ export class UserController extends AdaptableController {
       updateFields._email_verify_token_expires_at = {__op: 'Delete'};
     }
 
-    var self = this;
-    var checkIfAlreadyVerified = new RestQuery(self.config, Auth.master(self.config), '_User', {username: username, emailVerified: true});
-    return checkIfAlreadyVerified.execute().then(function(result) {
+    var checkIfAlreadyVerified = new RestQuery(this.config, Auth.master(this.config), '_User', {username: username, emailVerified: true});
+    return checkIfAlreadyVerified.execute().then(() => {
       if (result.results.length) {
         return Promise.resolve(result.results.length[0]);
       }
-      return self.config.database.update('_User', query, updateFields).then((document) => {
+      return this.config.database.update('_User', query, updateFields).then((document) => {
         if (!document) {
           throw undefined
         }
@@ -142,14 +141,13 @@ export class UserController extends AdaptableController {
   }
 
   resendVerificationEmail(username) {
-    var self = this;
-    return self.getUserIfNeeded({username: username}).then((aUser) => {
+    return this.getUserIfNeeded({username: username}).then((aUser) => {
       if (!aUser || aUser.emailVerified) {
         throw undefined;
       }
-      self.setEmailVerifyToken(aUser);
-      return self.config.database.update('_User', {username}, aUser).then(function() {
-        self.sendVerificationEmail(aUser);
+      this.setEmailVerifyToken(aUser);
+      return this.config.database.update('_User', {username}, aUser).then(() => {
+        this.sendVerificationEmail(aUser);
       });
     });
   }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -61,7 +61,7 @@ export class UserController extends AdaptableController {
     }
 
     var checkIfAlreadyVerified = new RestQuery(this.config, Auth.master(this.config), '_User', {username: username, emailVerified: true});
-    return checkIfAlreadyVerified.execute().then(() => {
+    return checkIfAlreadyVerified.execute().then(result => {
       if (result.results.length) {
         return Promise.resolve(result.results.length[0]);
       }

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -152,10 +152,12 @@ export class PublicAPIRouter extends PromiseRouter {
   }
 
   invalidVerificationLink(req) {
+    const config = req.config;
     if (req.query.username && req.params.appId) {
+      const params = qs.stringify({username: req.query.username, appId: req.params.appId});
       return Promise.resolve({
         status: 302,
-        location: req.config.invalidVerificationLinkURL + '?username=' + req.query.username + '&appId=' + req.params.appId
+        location: `${config.invalidVerificationLinkURL}?${params}`
       });
     } else {
       return this.invalidLink(req);
@@ -180,7 +182,7 @@ export class PublicAPIRouter extends PromiseRouter {
       req => { return this.verifyEmail(req); });
 
     this.route('POST', '/apps/:appId/resend_verification_email',
-      req => {this.setConfig(req) },
+      req => { this.setConfig(req); },
       req => { return this.resendVerificationEmail(req); });
 
     this.route('GET','/apps/choose_password',


### PR DESCRIPTION
- Defines new public API route /apps/:appId/resend_verification_email that will generate a new email verification link and email for a user identified by username in POST body

- Add default template and url support for invalid_verification_link, link_send_success, and link_send_fail pages. The invalid_verification_link page includes a button that allows the user to generate a new verification email if their current token has expired, using the new public API route

- All three pages have default html that will be functional "out of the box", but they can be customized in the customPages object. The custom page for invalidVerificationLink needs to handle the extraction of the username and appId from the url and the POST to generate the new link (this requires javascript)

- Clicking a link for an email that has already been verified now routes to the emailVerifySuccess page instead of the invalidLink page