### PR TITLE
Adds graceful shutdown handler for mongodb

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -97,6 +97,17 @@ export class MongoStorageAdapter {
 
     // MaxTimeMS is not a global MongoDB client option, it is applied per operation.
     this._maxTimeMS = mongoOptions.maxTimeMS;
+    process.on('SIGTERM', this.handleShutdown(this));
+    process.on('SIGINT', this.handleShutdown(this));
+  }
+
+  handleShutdown(storageAdapter) {
+    return () => {
+      if (!storageAdapter.database) {
+        return;
+      }
+      storageAdapter.database.close(false);
+    }
   }
 
   connect() {


### PR DESCRIPTION
When running some performance tests, I realized the server was not shutting down since the removal of `process.exit(0)` when using the CLI.

This will close gracefully the mongodb connections in order to let the process exit properly.