### PR TITLE
Allowing userSensitiveFields to be overriden in constructor

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -113,7 +113,7 @@ class ParseServer {
     restAPIKey,
     webhookKey,
     fileKey,
-    userSensitiveFields = [],
+    userSensitiveFields,
     enableAnonymousUsers = defaults.enableAnonymousUsers,
     allowClientClassCreation = defaults.allowClientClassCreation,
     oauth = {},
@@ -157,10 +157,10 @@ class ParseServer {
       throw 'When using an explicit database adapter, you must also use an explicit filesAdapter.';
     }
 
-    userSensitiveFields = Array.from(new Set(userSensitiveFields.concat(
-      defaults.userSensitiveFields,
-      userSensitiveFields
-    )));
+    // allow 'userSensitiveFields' from constructor to override default list
+    if (typeof userSensitiveFields === 'undefined'){
+      userSensitiveFields = defaults.userSensitiveFields
+    }
 
     const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
     const loggerController = new LoggerController(loggerControllerAdapter, appId);


### PR DESCRIPTION
I ran into the same issue outlined here (https://github.com/parse-community/parse-server/issues/3301) where I was unable to access user.get('email') in cloud code because it because a sensitive field in version 2.3.0.

@acinader, in the thread for the issue above, you mentioned you would be open to a change that allows unsetting 'email' as a sensitive field, so this is my attempt to do so.

Also tagging @Amex22 so you see this since you filed the initial issue