### PR TITLE
Skip authData validation if it hasn't changed.

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -106,7 +106,8 @@ var defaultConfiguration = {
     facebook: mockFacebook(),
     myoauth: {
       module: path.resolve(__dirname, "myoauth") // relative path as it's run from src
-    }
+    },
+    shortLivedAuth: mockShortLivedAuth()
   }
 };
 
@@ -367,6 +368,25 @@ function mockFacebookAuthenticator(id, token) {
 
 function mockFacebook() {
   return mockFacebookAuthenticator('8675309', 'jenny');
+}
+
+function mockShortLivedAuth() {
+  const auth = {};
+  let accessToken;
+  auth.setValidAccessToken = function(validAccessToken) {
+    accessToken = validAccessToken;
+  }
+  auth.validateAuthData = function(authData) {
+    if (authData.access_token == accessToken) {
+      return Promise.resolve();
+    } else {
+      return Promise.reject('Invalid access token');
+    }
+  };
+  auth.validateAppId = function() {
+    return Promise.resolve();
+  };
+  return auth;
 }
 
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -277,9 +277,7 @@ RestWrite.prototype.findUsersWithAuthData = function(authData) {
 
 RestWrite.prototype.handleAuthData = function(authData) {
   let results;
-  return this.handleAuthDataValidation(authData).then(() => {
-    return this.findUsersWithAuthData(authData);
-  }).then((r) => {
+  return this.findUsersWithAuthData(authData).then((r) => {
     results = r;
     if (results.length > 1) {
       // More than 1 user with the passed id's
@@ -307,16 +305,20 @@ RestWrite.prototype.handleAuthData = function(authData) {
             mutatedAuthData[provider] = providerData;
           }
         });
-
         this.response = {
           response: userResult,
           location: this.location()
         };
 
+        // If we didn't change the auth data, just keep going
+        if (Object.keys(mutatedAuthData).length === 0) {
+          return;
+        }
         // We have authData that is updated on login
         // that can happen when token are refreshed,
         // We should update the token and let the user in
-        if (Object.keys(mutatedAuthData).length > 0) {
+        // We should only check the mutated keys
+        return this.handleAuthDataValidation(mutatedAuthData).then(() => {
           // Assign the new authData in the response
           Object.keys(mutatedAuthData).forEach((provider) => {
             this.response.response.authData[provider] = mutatedAuthData[provider];
@@ -324,9 +326,7 @@ RestWrite.prototype.handleAuthData = function(authData) {
           // Run the DB update directly, as 'master'
           // Just update the authData part
           return this.config.database.update(this.className, {objectId: this.data.objectId}, {authData: mutatedAuthData}, {});
-        }
-        return;
-
+        });
       } else if (this.query && this.query.objectId) {
         // Trying to update auth data but users
         // are different
@@ -336,7 +336,7 @@ RestWrite.prototype.handleAuthData = function(authData) {
         }
       }
     }
-    return;
+    return this.handleAuthDataValidation(authData);
   });
 }
 


### PR DESCRIPTION
fixes #1455

This will allow expired token to let the user login as well as preventing unnecessary re-validation when editing objects from the dashboard or by other mean that would otherwise fail with a stale token.