### PR TITLE
requiresAuthentication is self-sufficient for ACL's

### DIFF
--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -1215,4 +1215,47 @@ describe('Class Level Permissions for requiredAuth', () => {
       done();
     });
   });
+
+  it('required auth test create/get/update/delete with roles (#3753)', (done) => {
+    config.database.loadSchema().then((schema) => {
+      // Just to create a valid class
+      return schema.validateObject('Stuff', {foo: 'bar'});
+    }).then((schema) => {
+      return schema.setPermissions('Stuff', {
+        'find': {
+          'requiresAuthentication': true,
+          'role:admin': true
+        },
+        'create': { 'role:admin': true },
+        'update': { 'role:admin': true },
+        'delete': { 'role:admin': true },
+        'get': {
+          'requiresAuthentication': true,
+          'role:admin': true
+        }
+      });
+    }).then(() => {
+      const user = new Parse.User({
+        username: 'user',
+        password: 'password'
+      })
+      return Parse.User.signUp('user', 'password').then(() => {
+        const stuff = new Parse.Object('Stuff');
+        stuff.set('foo', 'bar');
+        return stuff.save(null, {useMasterKey: true}).then(() => {
+          const query = new Parse.Query('Stuff');
+          return query.get(stuff.id, {sessionToken: user.getSessionToken()});
+        })
+      });
+    }).then((result) => {
+      expect(result.get('foo')).toEqual('bar');
+      const query = new Parse.Query('Stuff');
+      return query.find();
+    }).then((results) => {
+      expect(results.length).toBe(1);
+      done();
+    }, (e) => {
+      done.fail(e);
+    });
+  });
 })

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -813,11 +813,9 @@ export default class SchemaController {
         throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
         'Permission denied, user needs to be authenticated.');
       }
-      // no other CLP than requiresAuthentication
-      // let's resolve that!
-      if (Object.keys(perms).length == 1) {
-        return Promise.resolve();
-      }
+      // requiresAuthentication passed, just move forward
+      // probably would be wise at some point to rename to 'authenticatedUser'
+      return Promise.resolve();
     }
 
     // No matching CLP, let's check the Pointer permissions


### PR DESCRIPTION
Initially, requiresAuthentication CLP would not let through if other CLP's were conflicting (like in #3753)

This PR changes the behaviour of requiresAuthentication to match other CLP processing which is, if it pass, we move forward in the processing.