### PR TITLE
catch unhandled rejection with installation-handling

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -793,7 +793,15 @@ RestWrite.prototype.handleInstallation = function() {
         if (this.data.appIdentifier) {
           delQuery['appIdentifier'] = this.data.appIdentifier;
         }
-        this.config.database.destroy('_Installation', delQuery);
+        this.config.database.destroy('_Installation', delQuery)
+          .catch(err => {
+            if (err.code == Parse.Error.OBJECT_NOT_FOUND) {
+              // no deletions were made. Can be ignored.
+              return;
+            }
+            // rethrow the error
+            throw err;
+          });
         return;
       }
     } else {
@@ -806,6 +814,14 @@ RestWrite.prototype.handleInstallation = function() {
         return this.config.database.destroy('_Installation', delQuery)
           .then(() => {
             return deviceTokenMatches[0]['objectId'];
+          })
+          .catch(err => {
+            if (err.code == Parse.Error.OBJECT_NOT_FOUND) {
+              // no deletions were made. Can be ignored
+              return;
+            }
+            // rethrow the error
+            throw err;
           });
       } else {
         if (this.data.deviceToken &&
@@ -835,7 +851,15 @@ RestWrite.prototype.handleInstallation = function() {
           if (this.data.appIdentifier) {
             delQuery['appIdentifier'] = this.data.appIdentifier;
           }
-          this.config.database.destroy('_Installation', delQuery);
+          this.config.database.destroy('_Installation', delQuery)
+            .catch(err => {
+              if (err.code == Parse.Error.OBJECT_NOT_FOUND) {
+                // no deletions were made. Can be ignored.
+                return;
+              }
+              // rethrow the error
+              throw err;
+            });
         }
         // In non-merge scenarios, just return the installation match id
         return idMatch.objectId;


### PR DESCRIPTION
Hi,

as mentioned in https://github.com/parse-community/parse-server/issues/3758 I now found the time to fix the unhandled rejections when dealing with installations. I added catch-blocks to the delete-statements in RestWrite.js . The error is ignored when it is "ObjectNotFound". Otherwise it will be rethrown. 
We already use this in our production environment without problems. And log log now no longer has "unhandled rejection" warnings.

Best regards,
Benjamin