### PR TITLE
Fixes #3717

### DIFF
--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -14,9 +14,9 @@ export class PushController {
     }
     // Replace the expiration_time and push_time with a valid Unix epoch milliseconds time
     body.expiration_time = PushController.getExpirationTime(body);
-    let push_time = PushController.getPushTime(body);
-    if (typeof push_time !== 'undefined') { 
-      body['push_time'] = push_time; 
+    const push_time = PushController.getPushTime(body);
+    if (typeof push_time !== 'undefined') {
+      body['push_time'] = push_time;
     }
     // TODO: If the req can pass the checking, we return immediately instead of waiting
     // pushes to be sent. We probably change this behaviour in the future.

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -53,7 +53,7 @@ export class PushController {
       onPushStatusSaved(pushStatus.objectId);
       return badgeUpdate();
     }).then(() => {
-      if (body.push_time && config.hasPushScheduledSupport) {
+      if (body.hasOwnProperty('push_time') && config.hasPushScheduledSupport) {
         return Promise.resolve();
       }
       return config.pushControllerQueue.enqueue(body, where, config, auth, pushStatus);

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -14,7 +14,10 @@ export class PushController {
     }
     // Replace the expiration_time and push_time with a valid Unix epoch milliseconds time
     body.expiration_time = PushController.getExpirationTime(body);
-    body.push_time = PushController.getPushTime(body);
+    let push_time = PushController.getPushTime(body);
+    if (typeof push_time !== 'undefined') { 
+      body['push_time'] = push_time; 
+    }
     // TODO: If the req can pass the checking, we return immediately instead of waiting
     // pushes to be sent. We probably change this behaviour in the future.
     let badgeUpdate = () => {


### PR DESCRIPTION
This fixes PR #3717. Sending push with parse-server@2.4.0 returns error
504 GATEWAY_TIMEOUT. This happens when push_time is not set (default).