### PR TITLE
Use correct content-type with base64 type

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -101,6 +101,10 @@ export function handleParseHeaders(req, res, next) {
   }
 
   if (fileViaJSON) {
+    // Set the correct header
+    if (req.body._ContentType) {
+      req.headers['content-type'] = req.body._ContentType;
+    }
     // We need to repopulate req.body with a buffer
     var base64 = req.body.base64;
     req.body = new Buffer(base64, 'base64');


### PR DESCRIPTION
When you create a file with an Object like { base64: "..." } the content-type is not set properly. I am not sure if it's the right place to edit that but couldn't find a better one.