### PR TITLE
Job scheduling

### DIFF
--- a/spec/JobSchedule.spec.js
+++ b/spec/JobSchedule.spec.js
@@ -1,3 +1,21 @@
+const rp = require('request-promise');
+const defaultHeaders = {
+  'X-Parse-Application-Id': 'test',
+  'X-Parse-Rest-API-Key': 'rest'
+}
+const masterKeyHeaders = {
+  'X-Parse-Application-Id': 'test',
+  'X-Parse-Rest-API-Key': 'rest',
+  'X-Parse-Master-Key': 'test'
+}
+const defaultOptions = {
+  headers: defaultHeaders,
+  json: true
+}
+const masterKeyOptions = {
+  headers: masterKeyHeaders,
+  json: true
+}
 
 describe('JobSchedule', () => {
   it('should create _JobSchedule with masterKey', (done) => {
@@ -18,5 +36,97 @@ describe('JobSchedule', () => {
     });
     jobSchedule.save(null).then(done.fail)
     .catch(done);
+  });
+
+  it('should reject access when not using masterKey (/jobs)', (done) => {
+    rp.get(Parse.serverURL + '/cloud_code/jobs', defaultOptions).then(done.fail, done);
+  });
+
+  it('should reject access when not using masterKey (/jobs/data)', (done) => {
+    rp.get(Parse.serverURL + '/cloud_code/jobs/data', defaultOptions).then(done.fail, done);
+  });
+
+  it('should reject access when not using masterKey (PUT /jobs/id)', (done) => {
+    rp.put(Parse.serverURL + '/cloud_code/jobs/jobId', defaultOptions).then(done.fail, done);
+  });
+
+  it('should reject access when not using masterKey (PUT /jobs/id)', (done) => {
+    rp.del(Parse.serverURL + '/cloud_code/jobs/jobId', defaultOptions).then(done.fail, done);
+  });
+
+  it('should allow access when using masterKey (/jobs)', (done) => {
+    rp.get(Parse.serverURL + '/cloud_code/jobs', masterKeyOptions).then(done, done.fail);
+  });
+
+  it('should create a job schedule', (done) => {
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        job_schedule: {
+          jobName: 'job'
+        }
+      }
+    });
+    rp.post(Parse.serverURL + '/cloud_code/jobs', options).then((res) => {
+      expect(res.objectId).not.toBeUndefined();
+    })
+    .then(() => {
+      return rp.get(Parse.serverURL + '/cloud_code/jobs', masterKeyOptions);
+    })
+    .then((res) => {
+      expect(res.length).toBe(1);
+    })
+    .then(done)
+    .catch(done.fail);
+  });
+
+  it('should update a job', (done) => {
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        job_schedule: {
+          jobName: 'job'
+        }
+      }
+    });
+    rp.post(Parse.serverURL + '/cloud_code/jobs', options).then((res) => {
+      expect(res.objectId).not.toBeUndefined();
+      return rp.put(Parse.serverURL + '/cloud_code/jobs/' + res.objectId, Object.assign(options, {
+        body: {
+          job_schedule: {
+            jobName: 'OtherJobName'
+          }
+        }
+      }));
+    })
+    .then(() => {
+      return rp.get(Parse.serverURL + '/cloud_code/jobs', masterKeyOptions);
+    })
+    .then((res) => {
+      expect(res.length).toBe(1);
+      expect(res[0].jobName).toBe('OtherJobName');
+    })
+    .then(done)
+    .catch(done.fail);
+  });
+
+  it('should destroy a job', (done) => {
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        job_schedule: {
+          jobName: 'job'
+        }
+      }
+    });
+    rp.post(Parse.serverURL + '/cloud_code/jobs', options).then((res) => {
+      expect(res.objectId).not.toBeUndefined();
+      return rp.del(Parse.serverURL + '/cloud_code/jobs/' + res.objectId, masterKeyOptions);
+    })
+    .then(() => {
+      return rp.get(Parse.serverURL + '/cloud_code/jobs', masterKeyOptions);
+    })
+    .then((res) => {
+      expect(res.length).toBe(0);
+    })
+    .then(done)
+    .catch(done.fail);
   });
 });

--- a/spec/JobSchedule.spec.js
+++ b/spec/JobSchedule.spec.js
@@ -1,0 +1,22 @@
+
+describe('JobSchedule', () => {
+  it('should create _JobSchedule with masterKey', (done) => {
+    const jobSchedule = new Parse.Object('_JobSchedule');
+    jobSchedule.set({
+      'jobName': 'MY Cool Job'
+    });
+    jobSchedule.save(null,  {useMasterKey: true}).then(() => {
+      done();
+    })
+    .catch(done.fail);
+  });
+
+  it('should fail creating _JobSchedule without masterKey', (done) => {
+    const jobSchedule = new Parse.Object('_JobSchedule');
+    jobSchedule.set({
+      'jobName': 'SomeJob'
+    });
+    jobSchedule.save(null).then(done.fail)
+    .catch(done);
+  });
+});

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -667,7 +667,7 @@ export class PostgresStorageAdapter {
       const joins = results.reduce((list, schema) => {
         return list.concat(joinTablesForSchema(schema.schema));
       }, []);
-      const classes = ['_SCHEMA','_PushStatus','_JobStatus','_Hooks','_GlobalConfig', ...results.map(result => result.className), ...joins];
+      const classes = ['_SCHEMA','_PushStatus','_JobStatus','_JobSchedule','_Hooks','_GlobalConfig', ...results.map(result => result.className), ...joins];
       return this._client.tx(t=>t.batch(classes.map(className=>t.none('DROP TABLE IF EXISTS $<className:name>', { className }))));
     }, error => {
       if (error.code === PostgresRelationDoesNotExistError) {

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -95,6 +95,16 @@ const defaultColumns = Object.freeze({
     "params":     {type: 'Object'}, // params received when calling the job
     "finishedAt": {type: 'Date'}
   },
+  _JobSchedule: {
+    "jobName":      {type:'String'},
+    "description":  {type:'String'},
+    "params":       {type:'Object'},
+    "startAfter":   {type:'Date'},
+    "daysOfWeek":   {type:'Array'},
+    "timeOfDay":    {type:'String'},
+    "lastRun":      {type:'Number'},
+    "repeatMinutes":{type:'String'}
+  },
   _Hooks: {
     "functionName": {type:'String'},
     "className":    {type:'String'},
@@ -112,9 +122,9 @@ const requiredColumns = Object.freeze({
   _Role: ["name", "ACL"]
 });
 
-const systemClasses = Object.freeze(['_User', '_Installation', '_Role', '_Session', '_Product', '_PushStatus', '_JobStatus']);
+const systemClasses = Object.freeze(['_User', '_Installation', '_Role', '_Session', '_Product', '_PushStatus', '_JobStatus', '_JobSchedule']);
 
-const volatileClasses = Object.freeze(['_JobStatus', '_PushStatus', '_Hooks', '_GlobalConfig']);
+const volatileClasses = Object.freeze(['_JobStatus', '_PushStatus', '_Hooks', '_GlobalConfig', '_JobSchedule']);
 
 // 10 alpha numberic chars + uppercase
 const userIdRegex = /^[a-zA-Z0-9]{10}$/;
@@ -291,7 +301,12 @@ const _JobStatusSchema = convertSchemaToAdapterSchema(injectDefaultSchema({
   fields: {},
   classLevelPermissions: {}
 }));
-const VolatileClassesSchemas = [_HooksSchema, _JobStatusSchema, _PushStatusSchema, _GlobalConfigSchema];
+const _JobScheduleSchema = convertSchemaToAdapterSchema(injectDefaultSchema({
+  className: "_JobSchedule",
+  fields: {},
+  classLevelPermissions: {}
+}));
+const VolatileClassesSchemas = [_HooksSchema, _JobStatusSchema, _JobScheduleSchema, _PushStatusSchema, _GlobalConfigSchema];
 
 const dbTypeMatchesObjectType = (dbType, objectType) => {
   if (dbType.type !== objectType.type) return false;

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -98,12 +98,12 @@ const defaultColumns = Object.freeze({
   _JobSchedule: {
     "jobName":      {type:'String'},
     "description":  {type:'String'},
-    "params":       {type:'Object'},
-    "startAfter":   {type:'Date'},
+    "params":       {type:'String'},
+    "startAfter":   {type:'String'},
     "daysOfWeek":   {type:'Array'},
     "timeOfDay":    {type:'String'},
     "lastRun":      {type:'Number'},
-    "repeatMinutes":{type:'String'}
+    "repeatMinutes":{type:'Number'}
   },
   _Hooks: {
     "functionName": {type:'String'},

--- a/src/Routers/CloudCodeRouter.js
+++ b/src/Routers/CloudCodeRouter.js
@@ -1,20 +1,65 @@
-import PromiseRouter from '../PromiseRouter';
-const triggers = require('../triggers');
+import PromiseRouter  from '../PromiseRouter';
+import rest           from '../rest';
+const triggers        = require('../triggers');
+const middleware      = require('../middlewares');
 
 export class CloudCodeRouter extends PromiseRouter {
   mountRoutes() {
-    this.route('GET',`/cloud_code/jobs`, CloudCodeRouter.getJobs);
+    this.route('GET', '/cloud_code/jobs', middleware.promiseEnforceMasterKeyAccess, CloudCodeRouter.getJobs);
+    this.route('GET', '/cloud_code/jobs/data', middleware.promiseEnforceMasterKeyAccess, CloudCodeRouter.getJobsData);
+    this.route('POST', '/cloud_code/jobs', middleware.promiseEnforceMasterKeyAccess, CloudCodeRouter.createJob);
+    this.route('PUT', '/cloud_code/jobs/:objectId', middleware.promiseEnforceMasterKeyAccess, CloudCodeRouter.editJob);
+    this.route('DELETE', '/cloud_code/jobs/:objectId', middleware.promiseEnforceMasterKeyAccess, CloudCodeRouter.deleteJob);
   }
 
   static getJobs(req) {
+    return rest.find(req.config, req.auth, '_JobSchedule', {}, {}).then((scheduledJobs) => {
+      return {
+        response: scheduledJobs.results
+      }
+    });
+  }
+
+  static getJobsData(req) {
     const config = req.config;
     const jobs = triggers.getJobs(config.applicationId) || {};
-    return Promise.resolve({
-      response: Object.keys(jobs).map((jobName) => {
-        return {
-          jobName,
+    return rest.find(req.config, req.auth, '_JobSchedule', {}, {}).then((scheduledJobs) => {
+      return {
+        response: {
+          in_use: scheduledJobs.results.map((job) => job.jobName),
+          jobs: Object.keys(jobs),
         }
-      })
+      };
+    });
+  }
+
+  static createJob(req) {
+    const { job_schedule } = req.body;
+    if (typeof job_schedule.startAfter === 'undefined') {
+      job_schedule.startAfter = new Date().toISOString();
+    }
+    return rest.create(req.config, req.auth, '_JobSchedule', job_schedule, req.client);
+  }
+
+  static editJob(req) {
+    const { objectId } = req.params;
+    const { job_schedule } = req.body;
+    if (typeof job_schedule.startAfter === 'undefined') {
+      job_schedule.startAfter = new Date().toISOString();
+    }
+    return rest.update(req.config, req.auth, '_JobSchedule', { objectId }, job_schedule).then((response) => {
+      return {
+        response
+      }
+    });
+  }
+
+  static deleteJob(req) {
+    const { objectId } = req.params;
+    return rest.del(req.config, req.auth, '_JobSchedule', objectId).then((response) => {
+      return {
+        response
+      }
     });
   }
 }

--- a/src/rest.js
+++ b/src/rest.js
@@ -134,15 +134,9 @@ function update(config, auth, className, restWhere, restObject, clientSDK) {
   });
 }
 
-const classesWithMasterOnlyAccess = ['_PushStatus', '_Hooks', '_GlobalConfig', '_JobStatus', '_JobSchedule'];
-// Disallowing access to the _Role collection except by master key
+const classesWithMasterOnlyAccess = ['_JobStatus', '_PushStatus', '_Hooks', '_GlobalConfig', '_JobSchedule'];
+  // Disallowing access to the _Role collection except by master key
 function enforceRoleSecurity(method, className, auth) {
-  if (classesWithMasterOnlyAccess.indexOf(className) > -1 && !auth.isMaster) {
-    const error = new Error();
-    error.status = 403;
-    error.message = "unauthorized: master key is required";
-    throw error;
-  }
   if (className === '_Installation' && !auth.isMaster) {
     if (method === 'delete' || method === 'find') {
       const error = `Clients aren't allowed to perform the ${method} operation on the installation collection.`
@@ -151,8 +145,7 @@ function enforceRoleSecurity(method, className, auth) {
   }
 
   //all volatileClasses are masterKey only
-  const volatileClasses = ['_JobStatus', '_PushStatus', '_Hooks', '_GlobalConfig'];
-  if(volatileClasses.includes(className) && !auth.isMaster){
+  if(classesWithMasterOnlyAccess.includes(className) && !auth.isMaster){
     const error = `Clients aren't allowed to perform the ${method} operation on the ${className} collection.`
     throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, error);
   }

--- a/src/rest.js
+++ b/src/rest.js
@@ -134,8 +134,15 @@ function update(config, auth, className, restWhere, restObject, clientSDK) {
   });
 }
 
+const classesWithMasterOnlyAccess = ['_PushStatus', '_Hooks', '_GlobalConfig', '_JobStatus', '_JobSchedule'];
 // Disallowing access to the _Role collection except by master key
 function enforceRoleSecurity(method, className, auth) {
+  if (classesWithMasterOnlyAccess.indexOf(className) > -1 && !auth.isMaster) {
+    const error = new Error();
+    error.status = 403;
+    error.message = "unauthorized: master key is required";
+    throw error;
+  }
   if (className === '_Installation' && !auth.isMaster) {
     if (method === 'delete' || method === 'find') {
       const error = `Clients aren't allowed to perform the ${method} operation on the installation collection.`


### PR DESCRIPTION
I'm working on a JobScheduling worker (driven by a minute cron job on k8s) and I'd like to get back the original API's in. There is also a [PR](https://github.com/parse-community/parse-dashboard/pull/728) on the dashboard that restores the creation/update/delete of the _JobSchedule objects.

The _JobSchedule's Schema match the original parse.com api, so all original jobs should be editable.

TODO:

- [x] Add Tests