### PR TITLE
Add config for objectId size

### DIFF
--- a/spec/cryptoUtils.spec.js
+++ b/spec/cryptoUtils.spec.js
@@ -63,6 +63,10 @@ describe('newObjectId', () => {
     expect(cryptoUtils.newObjectId().length).toBeGreaterThan(9);
   });
 
+  it('returns result with required number of characters', () => {
+    expect(cryptoUtils.newObjectId(42).length).toBe(42);
+  });
+
   it('returns unique results', () => {
     expect(givesUniqueResults(() => cryptoUtils.newObjectId(), 100)).toBe(true);
   });

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -23,7 +23,21 @@ describe('rest create', () => {
         expect(results.length).toEqual(1);
         var obj = results[0];
         expect(typeof obj.objectId).toEqual('string');
+        expect(obj.objectId.length).toEqual(10);
         expect(obj._id).toBeUndefined();
+        done();
+      });
+  });
+
+  it('can use custom _id size', done => {
+    config.objectIdSize = 20;
+    rest.create(config, auth.nobody(config), 'Foo', {})
+      .then(() => database.adapter.find('Foo', { fields: {} }, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        var obj = results[0];
+        expect(typeof obj.objectId).toEqual('string');
+        expect(obj.objectId.length).toEqual(20);
         done();
       });
   });

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -33,11 +33,41 @@ describe('rest create', () => {
     config.objectIdSize = 20;
     rest.create(config, auth.nobody(config), 'Foo', {})
       .then(() => database.adapter.find('Foo', { fields: {} }, {}, {}))
-      .then(results => {
+      .then((results) => {
         expect(results.length).toEqual(1);
         var obj = results[0];
         expect(typeof obj.objectId).toEqual('string');
         expect(obj.objectId.length).toEqual(20);
+        done();
+      });
+  });
+
+  it('is backwards compatible when _id size changes', done => {
+    rest.create(config, auth.nobody(config), 'Foo', {size: 10})
+      .then(() => {
+        config.objectIdSize = 20;
+        return rest.find(config, auth.nobody(config), 'Foo', {size: 10});
+      })
+      .then((response) => {
+        expect(response.results.length).toEqual(1);
+        expect(response.results[0].objectId.length).toEqual(10);
+        return rest.update(config, auth.nobody(config), 'Foo', {objectId: response.results[0].objectId}, {update: 20});
+      })
+      .then(() => {
+        return rest.find(config, auth.nobody(config), 'Foo', {size: 10});
+      }).then((response) => {
+        expect(response.results.length).toEqual(1);
+        expect(response.results[0].objectId.length).toEqual(10);
+        expect(response.results[0].update).toEqual(20);
+        return rest.create(config, auth.nobody(config), 'Foo', {size: 20});
+      })
+      .then(() => {
+        config.objectIdSize = 10;
+        return rest.find(config, auth.nobody(config), 'Foo', {size: 20});
+      })
+      .then((response) => {
+        expect(response.results.length).toEqual(1);
+        expect(response.results[0].objectId.length).toEqual(20);
         done();
       });
   });

--- a/src/Config.js
+++ b/src/Config.js
@@ -73,6 +73,7 @@ export class Config {
     this.generateSessionExpiresAt = this.generateSessionExpiresAt.bind(this);
     this.generateEmailVerifyTokenExpiresAt = this.generateEmailVerifyTokenExpiresAt.bind(this);
     this.revokeSessionOnPasswordReset = cacheInfo.revokeSessionOnPasswordReset;
+    this.objectIdSize = cacheInfo.objectIdSize;
   }
 
   static validate({

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -141,6 +141,7 @@ class ParseServer {
     revokeSessionOnPasswordReset = defaults.revokeSessionOnPasswordReset,
     schemaCacheTTL = defaults.schemaCacheTTL, // cache for 5s
     enableSingleSchemaCache = false,
+    objectIdSize = defaults.objectIdSize,
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // Initialize the node client SDK automatically
@@ -262,7 +263,8 @@ class ParseServer {
       pushWorker,
       pushControllerQueue,
       hasPushSupport,
-      hasPushScheduledSupport
+      hasPushScheduledSupport,
+      objectIdSize
     });
 
     Config.validate(AppCache.get(appId));

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -187,7 +187,7 @@ RestWrite.prototype.setRequiredFieldsIfNeeded = function() {
 
       // Only assign new objectId if we are creating new object
       if (!this.data.objectId) {
-        this.data.objectId = cryptoUtils.newObjectId();
+        this.data.objectId = cryptoUtils.newObjectId(this.config.objectIdSize);
       }
     }
   }

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -52,7 +52,7 @@ function statusHandler(className, database) {
 
 export function jobStatusHandler(config) {
   let jobStatus;
-  const objectId = newObjectId();
+  const objectId = newObjectId(config.objectIdSize);
   const database = config.database;
   const handler = statusHandler(JOB_STATUS_COLLECTION, database);
   const setRunning = function(jobName, params) {
@@ -103,7 +103,7 @@ export function jobStatusHandler(config) {
   });
 }
 
-export function pushStatusHandler(config, objectId = newObjectId()) {
+export function pushStatusHandler(config, objectId = newObjectId(config.objectIdSize)) {
 
   let pushStatus;
   const database = config.database;

--- a/src/cli/definitions/parse-server.js
+++ b/src/cli/definitions/parse-server.js
@@ -256,5 +256,10 @@ export default {
   },
   "middleware": {
     help: "middleware for express server, can be string or function"
+  },
+  "objectIdSize": {
+    env: "PARSE_SERVER_OBJECT_ID_SIZE",
+    help: "Sets the number of characters in generated object id's, default 10",
+    action: numberParser("objectIdSize")
   }
 };

--- a/src/cryptoUtils.js
+++ b/src/cryptoUtils.js
@@ -35,9 +35,8 @@ export function randomString(size: number): string {
 }
 
 // Returns a new random alphanumeric string suitable for object ID.
-export function newObjectId(): string {
-  //TODO: increase length to better protect against collisions.
-  return randomString(10);
+export function newObjectId(size: number = 10): string {
+  return randomString(size);
 }
 
 // Returns a new random hex string suitable for secure tokens.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -32,5 +32,6 @@ export default {
   expireInactiveSessions: true,
   revokeSessionOnPasswordReset: true,
   schemaCacheTTL: 5000, // in ms
-  userSensitiveFields: ['email']
+  userSensitiveFields: ['email'],
+  objectIdSize: 10
 }


### PR DESCRIPTION
The current objectId length of 10 mixed case alphanumeric characters is only really suitable for classes that contain up to 1 million objects.

This review adds a new constructor option objectIdSize which defaults to the current value of 10, can also be set via the environment variable PARSE_OBJECT_ID_SIZE.