### PR TITLE
Remove warning for invalid MongoDB driver option

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -98,6 +98,7 @@ export class MongoStorageAdapter {
 
     // MaxTimeMS is not a global MongoDB client option, it is applied per operation.
     this._maxTimeMS = mongoOptions.maxTimeMS;
+    delete mongoOptions.maxTimeMS;
   }
 
   connect() {


### PR DESCRIPTION
MongoDB driver prints: "the options [maxTimeMS] is not supported" when parse server starts when you have the database option maxTimeMS set. This is because it's a query option that gets passed to each query in order to limit the execution time and is not a driver level option.

The way the Mongo adapter works is that we pass this option along with others directly into the driver but this one should not be passed in so we can avoid the warning.