### PR TITLE
Added minimum node version requirement

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -143,6 +143,11 @@ class ParseServer {
     enableSingleSchemaCache = false,
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
+    // verify parse-server is running on node >= 4.6
+    if (process.versions.node < '4.6') {
+      throw 'You must run parse-server on node >= 4.6. Your current node version is ' + process.versions.node + '.';
+    }
+
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
     Parse.serverURL = serverURL;


### PR DESCRIPTION
In regards to #3945 this adds a runtime check to parse-server, requiring that the current node version must be at least `4.6` or higher as stated in `engines` in parse-server's [package.json](https://github.com/parse-community/parse-server/blob/master/package.json#LC81) . Pretty simple overall but will throw on someone running below the current minimum requirement.

Upon looking into this it also came to my attention that perhaps a similar check should be added to the live query server as well. I'm not too familiar with the live query server itself but as far as I can tell adding a check to the constructor of `ParseLiveQueryServer` would probably suffice? Until I know for sure I'll just leave this focused on the primary server.

In terms of testing this _doesn't_ add any additional tests, but adds an additional 3 lines for the check utilizing `process.versions.node` to verify the min version against. If there is still a strong desire to test this it would involve factoring out process.versions.node in some way to test running against a 'bad' version, which can be done. I'll wait to hear based on the small # of additions in the first place.