### PR TITLE
Improved node min version checking

### DIFF
--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -1,0 +1,50 @@
+"use strict";
+
+// Tests for components within ParseServer
+// In this case specifically for testing semantic version comparison
+var ParseServer = require("../src/index");
+
+describe('Semantic Version Comparison Testing', () => {
+  it('Test Version Simple Equal', done => {
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1','1')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1.0.0','1.0.0')).toEqual(false);
+    done();
+  });
+
+  it('Test Complex Version Simple Equal', done => {
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.0.1','6.0.1')).toEqual(false);
+    done();
+  });
+
+  it('Test Version Less Than', done => {
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('0','1')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('0.1.0','1.0.0')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('0.0.1','1.0.0')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('0.9.0','0.10.0')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.0.0','6.0.1')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.9.3','6.10.1')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10.4.2','6.10.4.3')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10','6.10.4')).toEqual(true);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10','6.10.4.4')).toEqual(true);
+    done();
+  });
+
+  it('Test Complex Version Greater Than Equal To', done => {
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1','1')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1.0','1.0')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1.0.0','1.0.0')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1','0')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1.0.0','0.1.0')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('1.0.0','0.0.1')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('10.0.0','0.9.0')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.0.1','6.0.0')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10.1','6.9.3')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10.4.3','6.10.4.2')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10.4','6.10')).toEqual(false);
+    expect(ParseServer.default.isSemanticVersionLessThanVersion('6.10.4.4','6.10')).toEqual(false);
+    // just for fun test the current version, which should always be >= 4.6
+    expect(ParseServer.default.isSemanticVersionLessThanVersion(process.versions.node,'4.6')).toEqual(false);
+    done();
+  });
+
+});

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -145,7 +145,7 @@ class ParseServer {
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // verify parse-server is running on node >= 4.6
-    if (process.versions.node < '4.6') {
+    if (ParseServer.isSemanticVersionLessThanVersion(process.versions.node, '4.6')) {
       throw 'You must run parse-server on node >= 4.6. Your current node version is ' + process.versions.node + '.';
     }
 
@@ -314,6 +314,33 @@ class ParseServer {
         mongoOptions: databaseOptions,
       });
     }
+  }
+
+  static isSemanticVersionLessThanVersion(version1, version2) {
+    const versionParts1 = version1.split(".");
+    const versionParts2 = version2.split(".");
+
+    for(let x = 0; x < versionParts2.length; x++) {
+
+      if (x > versionParts1.length - 1) {
+        // version 1 is shorter than version 2, and thus less than
+        return true;
+      }
+
+      // get same parts from both versions to compare
+      const part1 = parseInt(versionParts1[x]);
+      const part2 = parseInt(versionParts2[x]);
+
+      if (part1 < part2) {
+        // version 1 less than version 2
+        return true;
+      } else if(part1 > part2) {
+        // version 1 greater than version 2
+        return false;
+      }
+    }
+    // greater than or equal to
+    return false;
   }
 
   get app() {


### PR DESCRIPTION
This is an improvement in regards to the potential issue matching mentioned in #3962, where something like `6.9.0` would be considered greater than `6.10.0` due to the direct string comparison. This check is improved via `isSemanticVersionLessThanVersion` added to **ParseServer.js**.  Here the version string is split up by `.` and the version numbers are tested one by one instead, starting from the major.

Additionally this adds tests to cover the expected behavior of the newly added function. I didn't see any ParseServer.spec file so I set one up. Let me know if that's acceptable or if this should put into an existing or different spec file altogether.

On another note, but still about node versions, I was testing the min versions for Parse and discovered that nothing < node `6.0` will work as expected. This is due to `Array.prototype.includes` not being present until node 6, throwing a series of types errors whenever `myArray.includes('key')` or the like is called. An example of this can be seen in [rest.js on line 158](https://github.com/parse-community/parse-server/blob/master/src/rest.js#LC158), where calling `classesWithMasterOnlyAccess.includes(className)` is one culprit. This can be seen immediately when running `npm test`.

I'm leaving the min version at `4.6` as currently noted, but if this isn't corrected anything below `6.0` will also misbehave.