### PR TITLE
Include username in password reset email

### DIFF
--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -213,7 +213,8 @@ export class UserController extends AdaptableController {
 
   defaultResetPasswordEmail({link, user, appName, }) {
     const text = "Hi,\n\n" +
-        "You requested to reset your password for " + appName + ".\n\n" +
+        "You requested to reset your password for " + appName +
+        (user.get('username') ? (" (your username is '" + user.get('username') + "')") : "") + ".\n\n" +
         "" +
         "Click here to reset it:\n" + link;
     const to = user.get("email") || user.get('username');


### PR DESCRIPTION
When user resets his password, he does it by filling his email. But often he could also not remember his username, which he needs for logging in. I think it's better to include the username in the password reset email, what do you think?