### PR TITLE
Fixes issue affecting linking users to a 3rd party auth

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1181,9 +1181,7 @@ describe('Parse.User testing', () => {
       // We should logout here as session token is passed
       // Probably need a fix in the JS SDK to handle those
       // linking errors
-      return Parse.User.logOut().then(() => {
-        return Parse.User._logInWith('facebook', {});
-      });
+      return Parse.User._logInWith('facebook', {});
     }).then(user => {
       const fileAgain = user.get('file');
       expect(fileAgain.name()).toMatch(/yolo.txt$/);

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1178,9 +1178,6 @@ describe('Parse.User testing', () => {
       return user._linkWith('facebook', {});
     }).then(user => {
       expect(user._isLinked("facebook")).toBeTruthy();
-      // We should logout here as session token is passed
-      // Probably need a fix in the JS SDK to handle those
-      // linking errors
       return Parse.User._logInWith('facebook', {});
     }).then(user => {
       const fileAgain = user.get('file');

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1178,17 +1178,19 @@ describe('Parse.User testing', () => {
       return user._linkWith('facebook', {});
     }).then(user => {
       expect(user._isLinked("facebook")).toBeTruthy();
-      return Parse.User._logInWith('facebook', {});
+      // We should logout here as session token is passed
+      // Probably need a fix in the JS SDK to handle those
+      // linking errors
+      return Parse.User.logOut().then(() => {
+        return Parse.User._logInWith('facebook', {});
+      });
     }).then(user => {
       const fileAgain = user.get('file');
       expect(fileAgain.name()).toMatch(/yolo.txt$/);
       expect(fileAgain.url()).toMatch(/yolo.txt$/);
     }).then(() => {
       done();
-    }, error => {
-      jfail(error);
-      done();
-    });
+    }).catch(done.fail);
   });
 
   it("log in with provider twice", (done) => {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -303,7 +303,8 @@ RestWrite.prototype.handleAuthData = function(authData) {
       } else if (this.auth && this.auth.user && this.auth.user.id) {
         userId = this.auth.user.id;
       }
-      if (!userId) { // no user making the call
+      if (!userId || userId === userResult.objectId) { // no user making the call
+        // OR the user making the call is the right one
         // Login with auth data
         delete results[0].password;
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -297,7 +297,13 @@ RestWrite.prototype.handleAuthData = function(authData) {
         }
       });
       const hasMutatedAuthData = Object.keys(mutatedAuthData).length !== 0;
-      if (!this.query) {
+      let userId;
+      if (this.query && this.query.objectId) {
+        userId = this.query.objectId;
+      } else if (this.auth && this.auth.user && this.auth.user.id) {
+        userId = this.auth.user.id;
+      }
+      if (!userId) { // no user making the call
         // Login with auth data
         delete results[0].password;
 
@@ -328,10 +334,10 @@ RestWrite.prototype.handleAuthData = function(authData) {
           // Just update the authData part
           return this.config.database.update(this.className, {objectId: this.data.objectId}, {authData: mutatedAuthData}, {});
         });
-      } else if (this.query && this.query.objectId) {
+      } else if (userId) {
         // Trying to update auth data but users
         // are different
-        if (userResult.objectId !== this.query.objectId) {
+        if (userResult.objectId !== userId) {
           throw new Parse.Error(Parse.Error.ACCOUNT_ALREADY_LINKED,
             'this auth is already used');
         }


### PR DESCRIPTION
When linking a user to an oauth provider in a client SDK (verified on iOS), the server would not check the session token for the authenticated user and the url doesn't hold the userId part of it (send as /users instead of /users/:id)

This PR addresses that issue, the userId provided by the session token will always take precedence over the query provided ID.

This should not break any installation as this server behaviour was not expected by the clients.