### PR TITLE
Add support for $centerSphere queries

### DIFF
--- a/spec/ParseGeoPoint.spec.js
+++ b/spec/ParseGeoPoint.spec.js
@@ -628,4 +628,46 @@ describe('Parse.GeoPoint testing', () => {
       done();
     });
   });
+
+  it('works with withinCenterSphereKilometers queries', (done) => {
+    makeSomeGeoPoints(function() {
+      var sfo = new Parse.GeoPoint(37.6189722, -122.3748889);
+      var query = new Parse.Query(TestObject);
+      query.withinCenterSphereKilometers('location', sfo, 2000);
+      query.find({
+        success: function(results) {
+          equal(results.length, 2);
+          done();
+        }
+      });
+    });
+  });
+
+  it('works with withinCenterSphereMiles queries', (done) => {
+    makeSomeGeoPoints(function() {
+      var sfo = new Parse.GeoPoint(37.6189722, -122.3748889);
+      var query = new Parse.Query(TestObject);
+      query.withinCenterSphereMiles('location', sfo, 1243);
+      query.find({
+        success: function(results) {
+          equal(results.length, 2);
+          done();
+        }
+      });
+    });
+  });
+
+  it('works with withinCenterSphereRadians queries', (done) => {
+    makeSomeGeoPoints(function() {
+      var sfo = new Parse.GeoPoint(37.6189722, -122.3748889);
+      var query = new Parse.Query(TestObject);
+      query.withinCenterSphereRadians('location', sfo, 0.313922461);
+      query.find({
+        success: function(results) {
+          equal(results.length, 2);
+          done();
+        }
+      });
+    });
+  });
 });

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -669,30 +669,59 @@ function transformConstraint(constraint, inArray) {
       break;
 
     case '$geoWithin': {
-      const polygon = constraint[key]['$polygon'];
-      if (!(polygon instanceof Array)) {
-        throw new Parse.Error(
-          Parse.Error.INVALID_JSON,
-          'bad $geoWithin value; $polygon should contain at least 3 GeoPoints'
-        );
-      }
-      if (polygon.length < 3) {
-        throw new Parse.Error(
-          Parse.Error.INVALID_JSON,
-          'bad $geoWithin value; $polygon should contain at least 3 GeoPoints'
-        );
-      }
-      const points = polygon.map((point) => {
-        if (!GeoPointCoder.isValidJSON(point)) {
-          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value');
-        } else {
-          Parse.GeoPoint._validate(point.latitude, point.longitude);
+      const query = Object.keys(constraint[key])[0];
+      const shape = constraint[key][query];
+      switch(query) {
+      case '$polygon': {
+        if (!(shape instanceof Array)) {
+          throw new Parse.Error(
+            Parse.Error.INVALID_JSON,
+            'bad $geoWithin value; $polygon should contain at least 3 GeoPoints'
+          );
         }
-        return [point.longitude, point.latitude];
-      });
-      answer[key] = {
-        '$polygon': points
-      };
+        if (shape.length < 3) {
+          throw new Parse.Error(
+            Parse.Error.INVALID_JSON,
+            'bad $geoWithin value; $polygon should contain at least 3 GeoPoints'
+          );
+        }
+        const points = shape.map((point) => {
+          if (!GeoPointCoder.isValidJSON(point)) {
+            throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value');
+          } else {
+            Parse.GeoPoint._validate(point.latitude, point.longitude);
+          }
+          return [point.longitude, point.latitude];
+        });
+        answer[key] = {
+          '$polygon': points
+        };
+        break;
+      }
+
+      case '$centerSphere': {
+        if (!(shape instanceof Array) || shape.length != 2) {
+          throw new Parse.Error(
+            Parse.Error.INVALID_JSON,
+            'bad $geoWithin value; $centerSphere malformatted'
+          );
+        }
+        const centerPoint = shape[0]
+        const radius = shape[1]
+        if (!GeoPointCoder.isValidJSON(centerPoint)) {
+          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; centerPoint malformatted');
+        } else {
+          Parse.GeoPoint._validate(centerPoint.latitude, centerPoint.longitude)
+        }
+        answer[key] = {
+          '$centerSphere': [
+            [centerPoint.longitude, centerPoint.latitude],
+            radius
+          ]
+        };
+        break;
+      }
+      }
       break;
     }
     case '$geoIntersects': {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -706,8 +706,11 @@ function transformConstraint(constraint, inArray) {
             'bad $geoWithin value; $centerSphere malformatted'
           );
         }
-        const centerPoint = shape[0]
+        let centerPoint = shape[0]
         const radius = shape[1]
+        if (centerPoint instanceof Array && centerPoint.length == 2) {
+          centerPoint = new Parse.GeoPoint(centerPoint[0], centerPoint[1]).toJSON();
+        }
         if (!GeoPointCoder.isValidJSON(centerPoint)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; centerPoint malformatted');
         } else {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1452,11 +1452,11 @@ function literalizeRegexPart(s) {
   // remove all instances of \Q and \E from the remaining text & escape single quotes
   return (
     s.replace(/([^\\])(\\E)/, '$1')
-    .replace(/([^\\])(\\Q)/, '$1')
-    .replace(/^\\E/, '')
-    .replace(/^\\Q/, '')
-    .replace(/([^'])'/, `$1''`)
-    .replace(/^'([^'])/, `''$1`)
+      .replace(/([^\\])(\\Q)/, '$1')
+      .replace(/^\\E/, '')
+      .replace(/^\\Q/, '')
+      .replace(/([^'])'/, `$1''`)
+      .replace(/^'([^'])/, `''$1`)
   );
 }
 

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1452,11 +1452,11 @@ function literalizeRegexPart(s) {
   // remove all instances of \Q and \E from the remaining text & escape single quotes
   return (
     s.replace(/([^\\])(\\E)/, '$1')
-      .replace(/([^\\])(\\Q)/, '$1')
-      .replace(/^\\E/, '')
-      .replace(/^\\Q/, '')
-      .replace(/([^'])'/, `$1''`)
-      .replace(/^'([^'])/, `''$1`)
+    .replace(/([^\\])(\\Q)/, '$1')
+    .replace(/^\\E/, '')
+    .replace(/^\\Q/, '')
+    .replace(/([^'])'/, `$1''`)
+    .replace(/^'([^'])/, `''$1`)
   );
 }
 

--- a/src/vendor/mongodbUrl.js
+++ b/src/vendor/mongodbUrl.js
@@ -255,8 +255,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
         hostEnd = i;
         break;
       case 64: // '@'
-          // At this point, either we have an explicit point where the
-          // auth portion cannot go past, or the last @ char is the decider.
+        // At this point, either we have an explicit point where the
+        // auth portion cannot go past, or the last @ char is the decider.
         atSign = i;
         nonHost = -1;
         break;


### PR DESCRIPTION
This commit adds support for `$centerSphere` queries, effectively deprecating `$nearSphere`/`$maxDistance` queries, which makes way for the use of 2dsphere indexes and GeoJSON objects for queries like $geoIntersects (#3942).

Parse JS SDK also has a pull request re. this change: https://github.com/parse-community/Parse-SDK-JS/pull/467