### PR TITLE
Allow coordinate pairs in $geoWithin/$polygon query

### DIFF
--- a/spec/ParseGeoPoint.spec.js
+++ b/spec/ParseGeoPoint.spec.js
@@ -479,6 +479,40 @@ describe('Parse.GeoPoint testing', () => {
     }, done.fail);
   });
 
+  it('supports withinPolygon coordinate array', (done) => {
+    const inbound = new Parse.GeoPoint(1.5, 1.5);
+    const onbound = new Parse.GeoPoint(10, 10);
+    const outbound = new Parse.GeoPoint(20, 20);
+    const obj1 = new Parse.Object('Polygon', {location: inbound});
+    const obj2 = new Parse.Object('Polygon', {location: onbound});
+    const obj3 = new Parse.Object('Polygon', {location: outbound});
+    Parse.Object.saveAll([obj1, obj2, obj3]).then(() => {
+      const where = {
+        location: {
+          $geoWithin: {
+            $polygon: [
+              [0, 0],
+              [0, 10],
+              [10, 10],
+              [10, 0]
+            ]
+          }
+        }
+      };
+      return rp.post({
+        url: Parse.serverURL + '/classes/Polygon',
+        json: { where, '_method': 'GET' },
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-Javascript-Key': Parse.javaScriptKey
+        }
+      });
+    }).then((resp) => {
+      expect(resp.results.length).toBe(2);
+      done();
+    }, done.fail);
+  });
+
   it('invalid input withinPolygon', (done) => {
     const point = new Parse.GeoPoint(1.5, 1.5);
     const obj = new Parse.Object('Polygon', {location: point});

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -684,7 +684,7 @@ function transformConstraint(constraint, inArray) {
       }
       const points = polygon.map((point) => {
         if (point instanceof Array && point.length === 2) {
-          return point;
+          return [point[1], point[0]];
         }
         if (!GeoPointCoder.isValidJSON(point)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value');

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -683,6 +683,9 @@ function transformConstraint(constraint, inArray) {
         );
       }
       const points = polygon.map((point) => {
+        if (point instanceof Array && point.length === 2) {
+          return point;
+        }
         if (!GeoPointCoder.isValidJSON(point)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value');
         } else {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -426,6 +426,9 @@ const buildWhereClause = ({ schema, query, index }) => {
         );
       }
       const points = polygon.map((point) => {
+        if (point instanceof Array && point.length === 2) {
+          return `(${point[1]}, ${point[0]})`;
+        }
         if (typeof point !== 'object' || point.__type !== 'GeoPoint') {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value');
         } else {

--- a/src/vendor/mongodbUrl.js
+++ b/src/vendor/mongodbUrl.js
@@ -255,8 +255,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
         hostEnd = i;
         break;
       case 64: // '@'
-          // At this point, either we have an explicit point where the
-          // auth portion cannot go past, or the last @ char is the decider.
+        // At this point, either we have an explicit point where the
+        // auth portion cannot go past, or the last @ char is the decider.
         atSign = i;
         nonHost = -1;
         break;


### PR DESCRIPTION
This pull requests allows for a polygon that consists of an array of basic coordinate pairs besides an array of `Parse.GeoPoint`s.