### PR TITLE
Update FilesAdapter comments and flow types

### DIFF
--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -4,32 +4,54 @@
 // Allows you to change the file storage mechanism.
 //
 // Adapter classes must implement the following functions:
-// * createFile(config, filename, data)
-// * getFileData(config, filename)
-// * getFileLocation(config, request, filename)
+// * createFile(filename, data, contentType)
+// * deleteFile(filename)
+// * getFileData(filename)
+// * getFileLocation(config, filename)
 //
 // Default is GridStoreAdapter, which requires mongo
 // and for the API server to be using the DatabaseController with Mongo
 // database adapter.
 
+import type { Config } from '../../Config'
+
 export class FilesAdapter {
-  /* This method is responsible to store the file in order to be retrieved later by its file name
+
+  /* Responsible for storing the file in order to be retrieved later by its filename
    *
-   * @param filename the filename to save
-   * @param data the buffer of data from the file
-   * @param contentType the supposed contentType
+   * @param {string} filename - the filename to save
+   * @param {*} data - the buffer of data from the file
+   * @param {string} contentType - the supposed contentType
    * @discussion the contentType can be undefined if the controller was not able to determine it
    *
-   * @return a promise that should fail if the storage didn't succeed
-   *
+   * @return {Promise} a promise that should fail if the storage didn't succeed
    */
-  createFile(filename: string, data, contentType: string) { }
+  createFile(filename: string, data, contentType: string): Promise { }
 
-  deleteFile(filename) { }
+  /* Responsible for deleting the specified file
+   *
+   * @param {string} filename - the filename to delete
+   *
+   * @return {Promise} a promise that should fail if the deletion didn't succeed
+   */
+  deleteFile(filename: string): Promise { }
 
-  getFileData(filename) { }
+  /* Responsible for retrieving the data of the specified file
+   *
+   * @param {string} filename - the name of file to retrieve
+   *
+   * @return {Promise} a promise that should pass with the file data or fail on error
+   */
+  getFileData(filename: string): Promise<any> { }
 
-  getFileLocation(config, filename) { }
+  /* Returns an absolute URL where the file can be accessed
+   *
+   * @param {Config} config - server configuration
+   * @param {string} filename
+   *
+   * @return {string} Absolute URL
+   */
+  getFileLocation(config: Config, filename: string): string { }
 }
 
 export default FilesAdapter;


### PR DESCRIPTION
I have been experimenting with file adapters and was initially confused by the lack of consistency between the comments/docs and the code - this PR updates the comments to match the code and adds some Flow types. 

[The docs](https://github.com/parse-community/parse-server/wiki/FilesAdapter.js) should also be updated, I didn't see a way to directly request a revision there.