### PR TITLE
Fixed a Postgres Adapter issue where putting 'false' value to 'where …

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -262,10 +262,16 @@ const buildWhereClause = ({ schema, query, index }) => {
       index += 2;
     }
 
-    if (fieldValue.$eq) {
-      patterns.push(`$${index}:name = $${index + 1}`);
-      values.push(fieldName, fieldValue.$eq);
-      index += 2;
+    if (fieldValue.$eq !== undefined) {
+      if (fieldValue.$eq === null){
+        patterns.push(`$${index}:name IS NULL`);
+        values.push(fieldName);
+        index += 1;
+      } else {
+        patterns.push(`$${index}:name = $${index + 1}`);
+        values.push(fieldName, fieldValue.$eq);
+        index += 2;
+      }
     }
     const isInOrNin = Array.isArray(fieldValue.$in) || Array.isArray(fieldValue.$nin);
     if (Array.isArray(fieldValue.$in) &&


### PR DESCRIPTION
…' clause in Query always raises an error

Fixed a bug where REST Query like below always fails when using Postgresql Adapter.
```
GET /parse/classes/sometbl/?where={"col1": {"$eq": false}}
```