### PR TITLE
Adds support for localized push notification in push payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Parse Server Changelog
 
+### master
+[Full Changelog](https://github.com/ParsePlatform/parse-server/compare/2.6.0...master)
+
+#### New Features
+* Adds ability to send localized pushes according to the _Installation localeIdentifier 
+
 ### 2.6.0
 [Full Changelog](https://github.com/ParsePlatform/parse-server/compare/2.5.3...2.6.0)
 

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -148,5 +148,12 @@ describe('PushWorker', () => {
         }
       });
     });
+
+    it('should properly handle defaut cases', () => {
+      expect(PushUtils.transformPushBodyForLocale({})).toEqual({});
+      expect(PushUtils.stripLocalesFromBody({})).toEqual({});
+      expect(PushUtils.bodiesPerLocales({where: {}})).toEqual({default: {where: {}}});
+      expect(PushUtils.groupByLocaleIdentifier([])).toEqual({default: []});
+    });
   });
 });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -1,4 +1,5 @@
 var PushWorker = require('../src').PushWorker;
+var PushUtils = require('../src/Push/utils');
 var Config = require('../src/Config');
 
 describe('PushWorker', () => {
@@ -53,5 +54,99 @@ describe('PushWorker', () => {
     }).catch(err => {
       jfail(err);
     })
+  });
+
+  describe('localized push', () => {
+    it('should return locales', () => {
+      const locales = PushUtils.getLocalesFromPush({
+        data: {
+          'alert-fr': 'french',
+          'alert': 'Yo!',
+          'alert-en-US': 'English',
+        }
+      });
+      expect(locales).toEqual(['fr', 'en-US']);
+    });
+
+    it('should return and empty array if no locale is set', () => {
+      const locales = PushUtils.getLocalesFromPush({
+        data: {
+          'alert': 'Yo!',
+        }
+      });
+      expect(locales).toEqual([]);
+    });
+
+    it('should deduplicate locales', () => {
+      const locales = PushUtils.getLocalesFromPush({
+        data: {
+          'alert': 'Yo!',
+          'alert-fr': 'french',
+          'title-fr': 'french'
+        }
+      });
+      expect(locales).toEqual(['fr']);
+    });
+
+    it('transforms body appropriately', () => {
+      const cleanBody = PushUtils.transformPushBodyForLocale({
+        data: {
+          alert: 'Yo!',
+          'alert-fr': 'frenchy!',
+          'alert-en': 'english',
+        }
+      }, 'fr');
+      expect(cleanBody).toEqual({
+        data: {
+          alert: 'frenchy!'
+        }
+      });
+    });
+
+    it('transforms body appropriately', () => {
+      const cleanBody = PushUtils.transformPushBodyForLocale({
+        data: {
+          alert: 'Yo!',
+          'alert-fr': 'frenchy!',
+          'alert-en': 'english',
+          'title-fr': 'french title'
+        }
+      }, 'fr');
+      expect(cleanBody).toEqual({
+        data: {
+          alert: 'frenchy!',
+          title: 'french title'
+        }
+      });
+    });
+
+    it('maps body on all provided locales', () => {
+      const bodies = PushUtils.bodiesPerLocales({
+        data: {
+          alert: 'Yo!',
+          'alert-fr': 'frenchy!',
+          'alert-en': 'english',
+          'title-fr': 'french title'
+        }
+      }, ['fr', 'en']);
+      expect(bodies).toEqual({
+        fr: {
+          data: {
+            alert: 'frenchy!',
+            title: 'french title'
+          }
+        },
+        en: {
+          data: {
+            alert: 'english',
+          }
+        },
+        default: {
+          data: {
+            alert: 'Yo!'
+          }
+        }
+      });
+    });
   });
 });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -149,7 +149,7 @@ describe('PushWorker', () => {
       });
     });
 
-    it('should properly handle defaut cases', () => {
+    it('should properly handle default cases', () => {
       expect(PushUtils.transformPushBodyForLocale({})).toEqual({});
       expect(PushUtils.stripLocalesFromBody({})).toEqual({});
       expect(PushUtils.bodiesPerLocales({where: {}})).toEqual({default: {where: {}}});

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -61,7 +61,7 @@ export class PushController {
     }).catch((err) => {
       return pushStatus.fail(err).then(() => {
         throw err;
-      })
+      });
     });
   }
 

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -61,7 +61,7 @@ export class PushController {
     }).catch((err) => {
       return pushStatus.fail(err).then(() => {
         throw err;
-      });
+      })
     });
   }
 

--- a/src/Push/PushWorker.js
+++ b/src/Push/PushWorker.js
@@ -12,17 +12,13 @@ import { PushQueue }          from './PushQueue';
 
 const UNSUPPORTED_BADGE_KEY = "unsupported";
 
-function groupBy(key, objects) {
-  return objects.reduce((map, object) => {
-    const value = object[key] + '';
-    map[value] = map[value] || [];
-    map[value].push(object);
+function groupByBadge(installations) {
+  return installations.reduce((map, installation) => {
+    const badge = installation.badge + '';
+    map[badge] = map[badge] || [];
+    map[badge].push(installation);
     return map;
   }, {});
-}
-
-function groupByBadge(installations) {
-  return groupBy('badge', installations);
 }
 
 export class PushWorker {

--- a/src/Push/utils.js
+++ b/src/Push/utils.js
@@ -8,6 +8,81 @@ export function isPushIncrementing(body) {
          body.data.badge.toLowerCase() == "increment"
 }
 
+const localizableKeys = ['alert', 'title'];
+
+export function getLocalesFromPush(body) {
+  const data = body.data;
+  if (!data) {
+    return [];
+  }
+  return [...new Set(Object.keys(data).reduce((memo, key) => {
+    localizableKeys.forEach((localizableKey) => {
+      if (key.indexOf(`${localizableKey}-`) == 0) {
+        memo.push(key.slice(localizableKey.length + 1));
+      }
+    });
+    return memo;
+  }, []))];
+}
+
+export function transformPushBodyForLocale(body, locale) {
+  const data = body.data;
+  if (!data) {
+    return body;
+  }
+  body = deepcopy(body);
+  localizableKeys.forEach((key) => {
+    const localeValue = body.data[`${key}-${locale}`];
+    if (localeValue) {
+      body.data[key] = localeValue;
+    }
+  });
+  return stripLocalesFromBody(body);
+}
+
+export function stripLocalesFromBody(body) {
+  if (!body.data) { return body; }
+  Object.keys(body.data).forEach((key) => {
+    localizableKeys.forEach((localizableKey) => {
+      if (key.indexOf(`${localizableKey}-`) == 0) {
+        delete body.data[key];
+      }
+    });
+  });
+  return body;
+}
+
+export function bodiesPerLocales(body, locales = []) {
+  // Get all tranformed bodies for each locale
+  const result = locales.reduce((memo, locale) => {
+    memo[locale] = transformPushBodyForLocale(body, locale);
+    return memo;
+  }, {});
+  // Set the default locale, with the stripped body
+  result.default = stripLocalesFromBody(body);
+  return result;
+}
+
+export function groupByLocaleIdentifier(installations, locales = []) {
+  return installations.reduce((map, installation) => {
+    let added = false;
+    locales.forEach((locale) => {
+      if (added) {
+        return;
+      }
+      if (installation.localeIdentifier && installation.localeIdentifier.indexOf(locale) == 0) {
+        added = true;
+        map[locale] = map[locale] || [];
+        map[locale].push(installation);
+      }
+    });
+    if (!added) {
+      map.default.push(installation);
+    }
+    return map;
+  }, {default: []});
+}
+
 /**
  * Check whether the deviceType parameter in qury condition is valid or not.
  * @param {Object} where A query condition

--- a/src/Push/utils.js
+++ b/src/Push/utils.js
@@ -70,7 +70,7 @@ export function groupByLocaleIdentifier(installations, locales = []) {
       if (added) {
         return;
       }
-      if (installation.localeIdentifier && installation.localeIdentifier.indexOf(locale) == 0) {
+      if (installation.localeIdentifier && installation.localeIdentifier.indexOf(locale) === 0) {
         added = true;
         map[locale] = map[locale] || [];
         map[locale].push(installation);

--- a/src/Routers/PushRouter.js
+++ b/src/Routers/PushRouter.js
@@ -28,6 +28,8 @@ export class PushRouter extends PromiseRouter {
           result: true
         }
       });
+    }).catch((err) => {
+      req.config.loggerController.error(err);
     });
     return promise;
   }

--- a/src/Routers/PushRouter.js
+++ b/src/Routers/PushRouter.js
@@ -28,9 +28,7 @@ export class PushRouter extends PromiseRouter {
           result: true
         }
       });
-    }).catch((err) => {
-      req.config.loggerController.error(err);
-    });
+    }).catch(req.config.loggerController.error);
     return promise;
   }
 


### PR DESCRIPTION
- passign alert-[lang|locale] or title-[lang|locale] will inject the
  proper locale on the push body based on the installation

ex:
```
{
   where: {...} // your query,
   data: {
     alert: 'Default alert',
     alert-fr: 'Alerte en Francais',
     ...
   }
}
```

I'll need to update the docs accordingly, with that feature, we'll be able to restore those in the dashboard as well, being able to add localized alerts etc...