### PR TITLE
Add master key override to live query ACL checks

### DIFF
--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -24,6 +24,7 @@ describe('ParseLiveQueryServer', function() {
       this.addSubscriptionInfo = jasmine.createSpy('addSubscriptionInfo');
       this.getSubscriptionInfo = jasmine.createSpy('getSubscriptionInfo');
       this.deleteSubscriptionInfo = jasmine.createSpy('deleteSubscriptionInfo');
+      this.hasMasterKey = jasmine.createSpy('hasMasterKey');
     }
     mockClient.pushError = jasmine.createSpy('pushError');
     jasmine.mockLibrary('../src/LiveQuery/Client', 'Client', mockClient);
@@ -1016,6 +1017,89 @@ describe('ParseLiveQueryServer', function() {
     }
 
     expect(parseLiveQueryServer._validateKeys(request, parseLiveQueryServer.keyPairs)).toBeTruthy();
+  });
+
+  it('can validate client has master key when valid', function() {
+    var parseLiveQueryServer = new ParseLiveQueryServer({}, {
+      keyPairs: {
+        masterKey: 'test'
+      }
+    });
+    var request = {
+      masterKey: 'test'
+    };
+
+    expect(parseLiveQueryServer._hasMasterKey(request, parseLiveQueryServer.keyPairs)).toBeTruthy();
+  });
+
+  it('can validate client doesn\'t have master key when invalid', function() {
+    var parseLiveQueryServer = new ParseLiveQueryServer({}, {
+      keyPairs: {
+        masterKey: 'test'
+      }
+    });
+    var request = {
+      masterKey: 'notValid'
+    };
+
+    expect(parseLiveQueryServer._hasMasterKey(request, parseLiveQueryServer.keyPairs)).not.toBeTruthy();
+  });
+
+  it('can validate client doesn\'t have master key when not provided', function() {
+    var parseLiveQueryServer = new ParseLiveQueryServer({}, {
+      keyPairs: {
+        masterKey: 'test'
+      }
+    });
+
+    expect(parseLiveQueryServer._hasMasterKey({}, parseLiveQueryServer.keyPairs)).not.toBeTruthy();
+  });
+
+  it('can validate client doesn\'t have master key when validKeyPairs is empty', function() {
+    var parseLiveQueryServer = new ParseLiveQueryServer({}, {});
+    var request = {
+      masterKey: 'test'
+    };
+
+    expect(parseLiveQueryServer._hasMasterKey(request, parseLiveQueryServer.keyPairs)).not.toBeTruthy();
+  });
+
+  it('will match non-public ACL when client has master key', function(done){
+
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    var acl = new Parse.ACL();
+    acl.setPublicReadAccess(false);
+    var client = {
+      getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
+      }),
+      hasMasterKey: true
+    };
+    var requestId = 0;
+
+    parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
+      expect(isMatched).toBe(true);
+      done();
+    });
+
+  });
+
+  it('won\'t match non-public ACL when client has no master key', function(done){
+
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    var acl = new Parse.ACL();
+    acl.setPublicReadAccess(false);
+    var client = {
+      getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
+      }),
+      hasMasterKey: false
+    };
+    var requestId = 0;
+
+    parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
+      expect(isMatched).toBe(false);
+      done();
+    });
+
   });
 
   afterEach(function(){

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -12,7 +12,7 @@ describe('ParseLiveQueryServer', function() {
     var mockParseWebSocketServer = jasmine.createSpy('ParseWebSocketServer');
     jasmine.mockLibrary('../src/LiveQuery/ParseWebSocketServer', 'ParseWebSocketServer', mockParseWebSocketServer);
     // Mock Client
-    var mockClient = function() {
+    var mockClient = function(id, socket, hasMasterKey) {
       this.pushConnect = jasmine.createSpy('pushConnect');
       this.pushSubscribe = jasmine.createSpy('pushSubscribe');
       this.pushUnsubscribe = jasmine.createSpy('pushUnsubscribe');
@@ -24,7 +24,7 @@ describe('ParseLiveQueryServer', function() {
       this.addSubscriptionInfo = jasmine.createSpy('addSubscriptionInfo');
       this.getSubscriptionInfo = jasmine.createSpy('getSubscriptionInfo');
       this.deleteSubscriptionInfo = jasmine.createSpy('deleteSubscriptionInfo');
-      this.hasMasterKey = jasmine.createSpy('hasMasterKey');
+      this.hasMasterKey = hasMasterKey;
     }
     mockClient.pushError = jasmine.createSpy('pushError');
     jasmine.mockLibrary('../src/LiveQuery/Client', 'Client', mockClient);

--- a/src/LiveQuery/Client.js
+++ b/src/LiveQuery/Client.js
@@ -8,6 +8,7 @@ const dafaultFields = ['className', 'objectId', 'updatedAt', 'createdAt', 'ACL']
 class Client {
   id: number;
   parseWebSocket: any;
+  hasMasterKey: boolean;
   userId: string;
   roles: Array<string>;
   subscriptionInfos: Object;
@@ -20,9 +21,10 @@ class Client {
   pushDelete: Function;
   pushLeave: Function;
 
-  constructor(id: number, parseWebSocket: any) {
+  constructor(id: number, parseWebSocket: any, hasMasterKey: boolean) {
     this.id = id;
     this.parseWebSocket = parseWebSocket;
+    this.hasMasterKey = hasMasterKey;
     this.roles = [];
     this.subscriptionInfos = new Map();
     this.pushConnect = this._pushEvent('connected');


### PR DESCRIPTION
This adds in the logic to check if a connecting client has supplied a matching master key in the live query server's key pairs. If it has, then a flag is set on the Client object when its created and is checked for whenever _matchesACL checks are performed.

Tests have been included to check the _hasMasterKey() logic that is performed on connect and the new _matchesACL logic.

Accompanying issue: #4127 