### PR TITLE
Fix/issue pointer permissions

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -941,7 +941,14 @@ DatabaseController.prototype.addPointerPermissions = function(schema, className,
       const q = {
         [key]: userPointer
       };
-      return {'$and': [q, query]};
+      // if we already have a constraint on the key, use the $and
+      if (query.hasOwnProperty(key)) {
+        return {'$and': [q, query]};
+      }
+      // otherwise just add the constaint
+      return Object.assign({}, query, {
+        [`${key}`]: userPointer,
+      })
     });
     if (ors.length > 1) {
       return {'$or': ors};

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -635,7 +635,13 @@ function includePath(config, auth, response, path, restOptions = {}) {
   }
 
   const queryPromises = Object.keys(pointersHash).map((className) => {
-    const where = {'objectId': {'$in': Array.from(pointersHash[className])}};
+    const objectIds = Array.from(pointersHash[className]);
+    let where;
+    if (objectIds.length === 1) {
+      where = {'objectId': objectIds[0]};
+    } else {
+      where = {'objectId': {'$in': objectIds}};
+    }
     var query = new RestQuery(config, auth, className, where, includeRestOptions);
     return query.execute({op: 'get'}).then((results) => {
       results.className = className;

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -102,8 +102,7 @@ RestWrite.prototype.getUserAndRoleACL = function() {
 
   if (this.auth.user) {
     return this.auth.getUserRoles().then((roles) => {
-      roles.push(this.auth.user.id);
-      this.runOptions.acl = this.runOptions.acl.concat(roles);
+      this.runOptions.acl = this.runOptions.acl.concat(roles, [this.auth.user.id]);
       return;
     });
   } else {


### PR DESCRIPTION
When refactoring the InMemoryCacheAdapter to not serialize, an issue was introduced and yielded a side effect on the userRoles of the Auth.js module.

The 1st commit fixes that issue, making sure the roles are never mutated.

Other improvements:

- When matching for pointer permissions, we use a flatter query on the key instead of $and operator for all cases.
- When running an include, if only 1 object is required, we do not use the $in operator