### PR TITLE
fix: Issue #4142

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -258,7 +258,10 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
         user.setUsername("zxcv");
         user.set("email", "testInvalidConfig@parse.com");
         user.signUp(null)
-          .then(() => Parse.User.logIn("zxcv", "asdf"))
+          .then((user) => {
+            expect(user.getSessionToken()).toBe(undefined);
+            return Parse.User.logIn("zxcv", "asdf");
+          })
           .then(() => {
             fail('login should have failed');
             done();

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -548,6 +548,11 @@ RestWrite.prototype.createSessionTokenIfNeeded = function() {
   if (this.query) {
     return;
   }
+  if (!this.storage['authProvider'] // signup call, with
+      && this.config.preventLoginWithUnverifiedEmail // no login without verification
+      && this.config.verifyUserEmails) { // verification is on
+    return; // do not create the session token in that case!
+  }
   return this.createSessionToken();
 }
 


### PR DESCRIPTION
Makes sure we don't create a session when the server is configured to only allow login with verified emails (as signup is logging in as well). 