### PR TITLE
Fixes issue affecting liveQuery on GeoPoint null/undefined values

### DIFF
--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -360,7 +360,16 @@ describe('matchesQuery', function() {
       id: new Id('Checkin', 'C1'),
       location: new Parse.GeoPoint(40, 40)
     };
+    var ptUndefined = {
+      id: new Id('Checkin', 'C1')
+    };
+    var ptNull = {
+      id: new Id('Checkin', 'C1'),
+      location: null
+    };
     expect(matchesQuery(pt, q)).toBe(true);
+    expect(matchesQuery(ptUndefined, q)).toBe(false);
+    expect(matchesQuery(ptNull, q)).toBe(false);
 
     q = new Parse.Query('Checkin');
     pt.location = new Parse.GeoPoint(40, 40);
@@ -384,6 +393,17 @@ describe('matchesQuery', function() {
       name: 'Santa Clara'
     };
 
+    var noLocation = {
+      id: new Id('Checkin', 'C2'),
+      name: 'Santa Clara'
+    };
+
+    var nullLocation = {
+      id: new Id('Checkin', 'C2'),
+      location: null,
+      name: 'Santa Clara'
+    };
+
     var q = new Parse.Query('Checkin').withinGeoBox(
       'location',
       new Parse.GeoPoint(37.708813, -122.526398),
@@ -392,7 +412,8 @@ describe('matchesQuery', function() {
 
     expect(matchesQuery(caltrainStation, q)).toBe(true);
     expect(matchesQuery(santaClara, q)).toBe(false);
-
+    expect(matchesQuery(noLocation, q)).toBe(false);
+    expect(matchesQuery(nullLocation, q)).toBe(false);
     // Invalid rectangles
     q = new Parse.Query('Checkin').withinGeoBox(
       'location',

--- a/src/LiveQuery/QueryTools.js
+++ b/src/LiveQuery/QueryTools.js
@@ -262,10 +262,16 @@ function matchesKeyConstraints(object, key, constraints) {
       }
       break;
     case '$nearSphere':
+      if (!compareTo || !object[key]) {
+        return false;
+      }
       var distance = compareTo.radiansTo(object[key]);
       var max = constraints.$maxDistance || Infinity;
       return distance <= max;
     case '$within':
+      if (!compareTo || !object[key]) {
+        return false;
+      }
       var southWest = compareTo.$box[0];
       var northEast = compareTo.$box[1];
       if (southWest.latitude > northEast.latitude ||


### PR DESCRIPTION
When matching queries with undefined or null locations, the server would crash when using the redis adapter (as not wrapping into promises). This properly compares the geopoints if and only if the comparator and the compared are set.