### PR TITLE
Refactor pushStatusHandler to use Parse instead of direct access

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1627,4 +1627,19 @@ describe('afterFind hooks', () => {
       })
       .then(() => done());
   });
+
+  it('should validate triggers correctly', () => {
+    expect(() => {
+      Parse.Cloud.beforeSave('_Session', () => {});
+    }).toThrow('Triggers are not supported for _Session class.');
+    expect(() => {
+      Parse.Cloud.afterSave('_Session', () => {});
+    }).toThrow('Triggers are not supported for _Session class.');
+    expect(() => {
+      Parse.Cloud.beforeSave('_PushStatus', () => {});
+    }).toThrow('Only afterSave is allowed on _PushStatus');
+    expect(() => {
+      Parse.Cloud.afterSave('_PushStatus', () => {});
+    }).not.toThrow();
+  });
 });

--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -155,6 +155,7 @@ describe('Parse.Push', () => {
           alert: 'Hello world!'
         }
       }, {useMasterKey: true}))
+      .then(() => new Promise((resolve) => setTimeout(resolve, 500))) // put a delay as we keep writing
       .then(() => {
         request.get({
           url: 'http://localhost:8378/1/classes/_PushStatus',

--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -127,6 +127,7 @@ describe('Parse.Push', () => {
           alert: 'Hello world!'
         }
       }, {useMasterKey: true}))
+      .then(() => delayPromise(500))
       .then(() => {
         request.get({
           url: 'http://localhost:8378/1/classes/_PushStatus',
@@ -155,7 +156,7 @@ describe('Parse.Push', () => {
           alert: 'Hello world!'
         }
       }, {useMasterKey: true}))
-      .then(() => new Promise((resolve) => setTimeout(resolve, 500))) // put a delay as we keep writing
+      .then(() => delayPromise(500)) // put a delay as we keep writing
       .then(() => {
         request.get({
           url: 'http://localhost:8378/1/classes/_PushStatus',

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -710,7 +710,7 @@ describe('PushController', () => {
     }).then(() => {
       return Parse.Object.saveAll(installations).then(() => {
         return pushController.sendPush(payload, {}, config, auth);
-      });
+      }).then(() => new Promise(resolve => setTimeout(resolve, 300)));
     }).then(() => {
       const query = new Parse.Query('_PushStatus');
       return query.find({useMasterKey: true}).then((results) => {
@@ -776,20 +776,15 @@ describe('PushController', () => {
       var config = new Config(Parse.applicationId);
       return Parse.Object.saveAll(installations).then(() => {
         return pushController.sendPush(payload, {}, config, auth);
-      }).then(() => new Promise(resolve => setTimeout(resolve, 100)));
+      }).then(() => new Promise(resolve => setTimeout(resolve, 300)));
     }).then(() => {
       const query = new Parse.Query('_PushStatus');
       return query.find({useMasterKey: true}).then((results) => {
         expect(results.length).toBe(1);
         const pushStatus = results[0];
         expect(pushStatus.get('status')).toBe('scheduled');
-        done();
       });
-    }).catch((err) => {
-      console.error(err);
-      fail('should not fail');
-      done();
-    });
+    }).then(done).catch(done.err);
   });
 
   it('should not enqueue push when device token is not set', (done) => {

--- a/src/Push/PushWorker.js
+++ b/src/Push/PushWorker.js
@@ -52,6 +52,7 @@ export class PushWorker {
     const auth = master(config);
     const where = utils.applyDeviceTokenExists(query.where);
     delete query.where;
+    pushStatus = pushStatusHandler(config, pushStatus.objectId);
     return rest.find(config, auth, '_Installation', where, query).then(({results}) => {
       if (results.length == 0) {
         return;
@@ -63,7 +64,6 @@ export class PushWorker {
   }
 
   sendToAdapter(body: any, installations: any[], pushStatus: any, config: Config, UTCOffset: ?any): Promise<*> {
-    pushStatus = pushStatusHandler(config, pushStatus.objectId);
     // Check if we have locales in the push body
     const locales = utils.getLocalesFromPush(body);
     if (locales.length > 0) {

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -100,6 +100,7 @@ export function jobStatusHandler(config) {
   const setRunning = function(jobName, params) {
     const now = new Date();
     jobStatus = {
+      objectId,
       jobName,
       params,
       status: 'running',

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -1,19 +1,11 @@
 import { Parse }     from 'parse/node';
 import * as triggers from '../triggers';
 
-function validateClassNameForTriggers(className) {
-  const restrictedClassNames = [ '_Session' ];
-  if (restrictedClassNames.indexOf(className) != -1) {
-    throw `Triggers are not supported for ${className} class.`;
-  }
-  return className;
-}
-
 function getClassName(parseClass) {
   if (parseClass && parseClass.className) {
-    return validateClassNameForTriggers(parseClass.className);
+    return parseClass.className;
   }
-  return validateClassNameForTriggers(parseClass);
+  return parseClass;
 }
 
 var ParseCloud = {};

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -30,6 +30,20 @@ const baseStore = function() {
   });
 };
 
+function validateClassNameForTriggers(className, type) {
+  const restrictedClassNames = [ '_Session' ];
+  if (restrictedClassNames.indexOf(className) != -1) {
+    throw `Triggers are not supported for ${className} class.`;
+  }
+  if (type == Types.beforeSave && className === '_PushStatus') {
+    // _PushStatus uses undocumented nested key increment ops
+    // allowing beforeSave would mess up the objects big time
+    // TODO: Allow proper documented way of using nested increment ops
+    throw 'Only afterSave is allowed on _PushStatus';
+  }
+  return className;
+}
+
 const _triggerStore = {};
 
 export function addFunction(functionName, handler, validationHandler, applicationId) {
@@ -46,6 +60,7 @@ export function addJob(jobName, handler, applicationId) {
 }
 
 export function addTrigger(type, className, handler, applicationId) {
+  validateClassNameForTriggers(className, type);
   applicationId = applicationId || Parse.applicationId;
   _triggerStore[applicationId] =  _triggerStore[applicationId] || baseStore();
   _triggerStore[applicationId].Triggers[type][className] = handler;


### PR DESCRIPTION
- PushStatus now uses the REST API, so we can leverage beforeSave/afterSave
- Block beforeSave(_PushStatus) as we use an internally non documented dot notation update, and the JS SDK don't like it much
- Adds support in database controller to properly resolve dot incremented properties
- Adds tests for ensuring we have a sane object in afterSave.

My intended use? Forward analytics with _PushStatus

Worth noting: when using the experimental direct access, this is pretty much 0 overhead.