### PR TITLE
Make the malformed response error message debuggable

### DIFF
--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -191,7 +191,11 @@ function wrapToHTTPRequest(hook, key) {
           try {
             body = JSON.parse(body);
           } catch (e) {
-            err = { error: "Malformed response", code: -1 };
+            err = {
+              error: "Malformed response",
+              code: -1,
+              partialResponse: body.substring(0, 100)
+            };
           }
         }
         if (!err) {


### PR DESCRIPTION
It would be nice if this error message contained some or all of the malformed response to aid in debugging the problem. What do you think?