### PR TITLE
Prefix default push channel with applicationId

### DIFF
--- a/spec/PushQueue.spec.js
+++ b/spec/PushQueue.spec.js
@@ -1,0 +1,58 @@
+import Config from "../src/Config";
+import {PushQueue} from "../src/Push/PushQueue";
+
+describe('PushQueue', () => {
+  describe('With a defined channel', () => {
+    it('should be propagated to the PushWorker and PushQueue', (done) => {
+      reconfigureServer({
+        push: {
+          queueOptions: {
+            disablePushWorker: false,
+            channel: 'my-specific-channel'
+          },
+          adapter: {
+            send() {
+              return Promise.resolve();
+            },
+            getValidPushTypes() {
+              return [];
+            }
+          }
+        }
+      })
+        .then(() => {
+          const config = new Config(Parse.applicationId);
+          expect(config.pushWorker.channel).toEqual('my-specific-channel', 'pushWorker.channel');
+          expect(config.pushControllerQueue.channel).toEqual('my-specific-channel', 'pushWorker.channel');
+        })
+        .then(done, done.fail);
+    });
+  });
+
+  describe('Default channel', () => {
+    it('should be prefixed with the applicationId', (done) => {
+      reconfigureServer({
+        push: {
+          queueOptions: {
+            disablePushWorker: false
+          },
+          adapter: {
+            send() {
+              return Promise.resolve();
+            },
+            getValidPushTypes() {
+              return [];
+            }
+          }
+        }
+      })
+        .then(() => {
+          const config = new Config(Parse.applicationId);
+          expect(PushQueue.defaultPushChannel()).toEqual('test-parse-server-push');
+          expect(config.pushWorker.channel).toEqual('test-parse-server-push');
+          expect(config.pushControllerQueue.channel).toEqual('test-parse-server-push');
+        })
+        .then(done, done.fail);
+    });
+  });
+});

--- a/src/Push/PushQueue.js
+++ b/src/Push/PushQueue.js
@@ -1,6 +1,7 @@
 import { ParseMessageQueue }      from '../ParseMessageQueue';
 import rest                       from '../rest';
 import { applyDeviceTokenExists } from './utils';
+import Parse from 'parse/node';
 
 const PUSH_CHANNEL = 'parse-server-push';
 const DEFAULT_BATCH_SIZE = 100;
@@ -13,13 +14,13 @@ export class PushQueue {
   // config object of the publisher, right now it only contains the redisURL,
   // but we may extend it later.
   constructor(config: any = {}) {
-    this.channel = config.channel || PUSH_CHANNEL;
+    this.channel = config.channel || PushQueue.defaultPushChannel();
     this.batchSize = config.batchSize || DEFAULT_BATCH_SIZE;
     this.parsePublisher = ParseMessageQueue.createPublisher(config);
   }
 
   static defaultPushChannel() {
-    return PUSH_CHANNEL;
+    return `${Parse.applicationId}-${PUSH_CHANNEL}`;
   }
 
   enqueue(body, where, config, auth, pushStatus) {


### PR DESCRIPTION
## Overview
- The default push channel is now unique to each application.

My hope is that this change will reduce the chances of accidentally sending pushes to wrong environment.