### PR TITLE
Postgres: Properly handle undefined field values

### DIFF
--- a/spec/ParseACL.spec.js
+++ b/spec/ParseACL.spec.js
@@ -1248,7 +1248,6 @@ describe('Parse.ACL', () => {
         var user = req.object;
         var acl = new Parse.ACL(user);
         user.setACL(acl);
-        console.log('IN AFTER SAVE!');
         user.save(null, {useMasterKey: true}).then(user => {
           new Parse.Query('_User').get(user.objectId).then(() => {
             fail('should not have fetched user without public read enabled');

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -235,7 +235,7 @@ const buildWhereClause = ({ schema, query, index }) => {
           patterns.push(`${name} = '${fieldValue}'`);
         }
       }
-    } else if (fieldValue === null) {
+    } else if (fieldValue === null || fieldValue === undefined) {
       patterns.push(`$${index}:name IS NULL`);
       values.push(fieldName);
       index += 1;


### PR DESCRIPTION
Prevents `UnhandledPromiseRejectionWarning: Unhandled promise rejection` when building queries.

This specifically happens when passing `installationId=undefined` on `_Session`