### PR TITLE
Allow queries with String array for pointers containedIn

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2802,6 +2802,27 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  it('containedIn with pointers should work with string array', done => {
+    const obj = new Parse.Object('MyClass');
+    const child = new Parse.Object('Child');
+    child.save().then(() => {
+      obj.set('child', child);
+      return obj.save();
+    }).then(() => {
+      const objs = [];
+      for(let i = 0; i < 10; i++) {
+        objs.push(new Parse.Object('MyClass'));
+      }
+      return Parse.Object.saveAll(objs);
+    }).then(() => {
+      const query = new Parse.Query('MyClass');
+      query.containedIn('child', [child.id]);
+      return query.find();
+    }).then((results) => {
+      expect(results.length).toBe(1);
+    }).then(done).catch(done.fail);
+  });
+
   it('include for specific object', function(done){
     var child = new Parse.Object('Child');
     var parent = new Parse.Object('Parent');

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2823,6 +2823,32 @@ describe('Parse.Query testing', () => {
     }).then(done).catch(done.fail);
   });
 
+  it('containedIn with pointers should work with string array, with many objects', done => {
+    const objs = [];
+    const children = [];
+    for(let i = 0; i < 10; i++) {
+      const obj = new Parse.Object('MyClass');
+      const child = new Parse.Object('Child');
+      objs.push(obj);
+      children.push(child);
+    }
+    Parse.Object.saveAll(children).then(() => {
+      return Parse.Object.saveAll(objs.map((obj, i) => {
+        obj.set('child', children[i]);
+        return obj;
+      }));
+    }).then(() => {
+      const query = new Parse.Query('MyClass');
+      const subset = children.slice(0, 5).map((child) => {
+        return child.id;
+      });
+      query.containedIn('child', subset);
+      return query.find();
+    }).then((results) => {
+      expect(results.length).toBe(5);
+    }).then(done).catch(done.fail);
+  });
+
   it('include for specific object', function(done){
     var child = new Parse.Object('Child');
     var parent = new Parse.Object('Parent');

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -488,7 +488,7 @@ function transformTopLevelAtom(atom, field) {
   case 'undefined':
     return atom;
   case 'string':
-    if (field.type === 'Pointer') {
+    if (field && field.type === 'Pointer') {
       return `${field.targetClass}$${atom}`;
     }
     return atom;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -539,7 +539,7 @@ function transformTopLevelAtom(atom, field) {
 // else, return CannotTransform.
 // inArray is whether this is an array field.
 function transformConstraint(constraint, field) {
-  const inArray = field.type && field.type === 'Array';
+  const inArray = field && field.type && field.type === 'Array';
   if (typeof constraint !== 'object' || !constraint) {
     return CannotTransform;
   }


### PR DESCRIPTION
This provides a lighter way to run a contained in with a pointer column, without serializing all the garbage for className/type etc.., lighter requests, better API!

~~Will most probably fail on PG~~ (was already supported)