### PR TITLE
Fix for #4194 - me no likey much

### DIFF
--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -60,8 +60,6 @@ function restStatusHandler(className, config) {
       return rest.create(config, auth, className, object)
         .then(({ response }) => {
           // merge the objects
-          /* eslint-disable */
-          console.log(response);
           return Promise.resolve(Object.assign({}, object, response));
         });
     });
@@ -71,11 +69,9 @@ function restStatusHandler(className, config) {
   function update(where, object) {
     // TODO: when we have updateWhere, use that for proper interfacing
     lastPromise = lastPromise.then(() => {
-      console.log('UPDATE!', where, object);
       return rest.update(config, auth, className, { objectId: where.objectId }, object)
         .then(({ response }) => {
           // merge the objects
-          console.log(response);
           return Promise.resolve(Object.assign({}, object, response));
         });
     });
@@ -184,13 +180,11 @@ export function pushStatusHandler(config, existingObjectId) {
       // lockdown!
       ACL: {}
     }
-    console.log('CREATE!');
     return handler.create(object).then((result) => {
       objectId = result.objectId;
       pushStatus = {
         objectId
       };
-      console.log(pushStatus);
       return Promise.resolve(pushStatus);
     });
   }


### PR DESCRIPTION
A bit of backstory

when revamping the _PushStatus update handler, I wanted to isolate it as much as possible, from parse-server, so the PushWorker can be run independently from parse-server (think a push micro-service).

When moving in that direction, I used the Parse._request call in order to call the server to update the _PushStatus objects. This is failing to some users which have misconfigured `serverUrl` (cc @TylerBrock @handymoby)

Yes, serverUrl is required, but never validated when set. If the user is not using cloud code (and making additional queries, it's likely he'll never realize the mistake).

This fix, reverts the usage or Parse._request and brings us back 1 step further from complete isolation of the PushWorker. 
This merge can always be reverted also, when we're ready to make the isolated push worker.