### PR TITLE
Add support for expiration interval in Push

### DIFF
--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -1319,6 +1319,9 @@ describe('PushController', () => {
             expect(pushStatus.get('expiry')).toBeDefined('expiry must be set');
             expect(pushStatus.get('expiry'))
               .toEqual(new Date('2017-09-25T13:50:10.452Z').valueOf());
+
+            expect(pushStatus.get('expiration_interval')).toBeDefined('expiration_interval must be defined');
+            expect(pushStatus.get('expiration_interval')).toBe(20 * 60);
           })
           .then(done, done.fail);
       });

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -7,7 +7,7 @@ import { applyDeviceTokenExists } from '../Push/utils';
 
 export class PushController {
 
-  sendPush(body = {}, where = {}, config, auth, onPushStatusSaved = () => {}) {
+  sendPush(body = {}, where = {}, config, auth, onPushStatusSaved = () => {}, now = new Date()) {
     if (!config.hasPushSupport) {
       throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
         'Missing push configuration');
@@ -16,11 +16,15 @@ export class PushController {
     // Replace the expiration_time and push_time with a valid Unix epoch milliseconds time
     body.expiration_time = PushController.getExpirationTime(body);
     body.expiration_interval = PushController.getExpirationInterval(body);
-
     if (body.expiration_time && body.expiration_interval) {
       throw new Parse.Error(
         Parse.Error.PUSH_MISCONFIGURED,
         'Both expiration_time and expiration_interval cannot be set');
+    }
+
+    // Immediate push
+    if (body.expiration_interval && !body.hasOwnProperty('push_time')) {
+      body.expiration_time = new Date(now.valueOf() + body.expiration_interval);
     }
 
     const pushTime = PushController.getPushTime(body);

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -12,8 +12,17 @@ export class PushController {
       throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
         'Missing push configuration');
     }
+
     // Replace the expiration_time and push_time with a valid Unix epoch milliseconds time
     body.expiration_time = PushController.getExpirationTime(body);
+    body.expiration_interval = PushController.getExpirationInterval(body);
+
+    if (body.expiration_time && body.expiration_interval) {
+      throw new Parse.Error(
+        Parse.Error.PUSH_MISCONFIGURED,
+        'Both expiration_time and expiration_interval cannot be set');
+    }
+
     const pushTime = PushController.getPushTime(body);
     if (pushTime && pushTime.date !== 'undefined') {
       body['push_time'] = PushController.formatPushTime(pushTime);
@@ -106,6 +115,19 @@ export class PushController {
         body['expiration_time'] + ' is not valid time.');
     }
     return expirationTime.valueOf();
+  }
+
+  static getExpirationInterval(body = {}) {
+    const hasExpirationInterval = body.hasOwnProperty('expiration_interval');
+    if (!hasExpirationInterval) {
+      return;
+    }
+
+    var expirationIntervalParam = body['expiration_interval'];
+    if (typeof expirationIntervalParam !== 'number' || expirationIntervalParam <= 0) {
+      throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
+        `expiration_interval must be a number greater than 0`);
+    }
   }
 
   /**

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -24,7 +24,8 @@ export class PushController {
 
     // Immediate push
     if (body.expiration_interval && !body.hasOwnProperty('push_time')) {
-      body.expiration_time = new Date(now.valueOf() + body.expiration_interval);
+      const ttlMs = body.expiration_interval * 1000;
+      body.expiration_time = (new Date(now.valueOf() + ttlMs)).valueOf();
     }
 
     const pushTime = PushController.getPushTime(body);
@@ -132,6 +133,7 @@ export class PushController {
       throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
         `expiration_interval must be a number greater than 0`);
     }
+    return expirationIntervalParam;
   }
 
   /**

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -72,22 +72,23 @@ const defaultColumns = Object.freeze({
     "subtitle":           {type:'String'},
   },
   _PushStatus: {
-    "pushTime":           {type:'String'},
-    "source":             {type:'String'}, // rest or webui
-    "query":              {type:'String'}, // the stringified JSON query
-    "payload":            {type:'String'}, // the stringified JSON payload,
-    "title":              {type:'String'},
-    "expiry":             {type:'Number'},
-    "status":             {type:'String'},
-    "numSent":            {type:'Number'},
-    "numFailed":          {type:'Number'},
-    "pushHash":           {type:'String'},
-    "errorMessage":       {type:'Object'},
-    "sentPerType":        {type:'Object'},
-    "failedPerType":      {type:'Object'},
-    "sentPerUTCOffset":   {type:'Object'},
-    "failedPerUTCOffset": {type:'Object'},
-    "count":              {type:'Number'}
+    "pushTime":            {type:'String'},
+    "source":              {type:'String'}, // rest or webui
+    "query":               {type:'String'}, // the stringified JSON query
+    "payload":             {type:'String'}, // the stringified JSON payload,
+    "title":               {type:'String'},
+    "expiry":              {type:'Number'},
+    "expiration_interval": {type:'Number'},
+    "status":              {type:'String'},
+    "numSent":             {type:'Number'},
+    "numFailed":           {type:'Number'},
+    "pushHash":            {type:'String'},
+    "errorMessage":        {type:'Object'},
+    "sentPerType":         {type:'Object'},
+    "failedPerType":       {type:'Object'},
+    "sentPerUTCOffset":    {type:'Object'},
+    "failedPerUTCOffset":  {type:'Object'},
+    "count":               {type:'Number'}
   },
   _JobStatus: {
     "jobName":    {type: 'String'},

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -174,6 +174,7 @@ export function pushStatusHandler(config, existingObjectId) {
       source: options.source,
       title: options.title,
       expiry: body.expiration_time,
+      expiration_interval: body.expiration_interval,
       status: status,
       numSent: 0,
       pushHash,


### PR DESCRIPTION
## Overview
- Support the `expiration_interval` parameter in the Push controller
- [Relevant doc](http://docs.parseplatform.org/rest/guide/#setting-an-expiration-date)
- [Related PR on parse-dashboard](https://github.com/parse-community/parse-dashboard/pull/773)
