### PR TITLE
Validate serverURL on Start

### DIFF
--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -1,32 +1,40 @@
-"use strict";
+'use strict';
 /* Tests for ParseServer.js */
 var express = require('express');
 
-import ParseServer          from '../src/ParseServer';
-
-var app = express();
-//app.use(bodyParser.json({ 'type': '*/*' }));
-app.get("/health", function(req, res){
-  res.send("OK");
-});
-app.listen(12345);
+import ParseServer from '../src/ParseServer';
 
 describe('Server Url Checks', () => {
-  it("validate good publicServerUrl", (done) => {
-    ParseServer.verifyServerUrl('http://localhost:12345', function(result) {
-      if(!result) {
-        jfail('Did not pass valid url');
-      }
-      done();
+
+  var app = express();
+  app.get('/health', function(req, res){
+    res.send('OK');
+  });
+  app.listen(12345);
+
+  it('validate good server url', (done) => {
+    reconfigureServer({
+      serverURL: 'http://localhost:12345'
+    }).then(function() {
+      ParseServer.verifyServerUrl(function(result) {
+        if(!result) {
+          done.fail('Did not pass valid url');
+        }
+        done();
+      });
     });
   });
 
-  it("mark bad publicServerUrl", (done) => {
-    ParseServer.verifyServerUrl('not a valid url', function(result) {
-      if(result) {
-        jfail('Did not mark invalid url');
-      }
-      done();
+  it('mark bad server url', (done) => {
+    reconfigureServer({
+      serverURL: 'notavalidurl'
+    }).then(function() {
+      ParseServer.verifyServerUrl(function(result) {
+        if(result) {
+          done.fail('Did not mark invalid url');
+        }
+        done();
+      });
     });
   });
 });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -10,11 +10,11 @@ describe('Server Url Checks', () => {
   app.get('/health', function(req, res){
     res.send('OK');
   });
-  app.listen(12345);
+  app.listen(13376);
 
   it('validate good server url', (done) => {
     reconfigureServer({
-      serverURL: 'http://localhost:12345'
+      serverURL: 'http://localhost:13376'
     }).then(function() {
       ParseServer.verifyServerUrl(function(result) {
         if(!result) {

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -1,12 +1,12 @@
 'use strict';
 /* Tests for ParseServer.js */
-var express = require('express');
+const express = require('express');
 
 import ParseServer from '../src/ParseServer';
 
 describe('Server Url Checks', () => {
 
-  var app = express();
+  const app = express();
   app.get('/health', function(req, res){
     res.send('OK');
   });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -13,28 +13,22 @@ describe('Server Url Checks', () => {
   app.listen(13376);
 
   it('validate good server url', (done) => {
-    reconfigureServer({
-      serverURL: 'http://localhost:13376'
-    }).then(function() {
-      ParseServer.verifyServerUrl(function(result) {
-        if(!result) {
-          done.fail('Did not pass valid url');
-        }
-        done();
-      });
+    Parse.serverURL = 'http://localhost:13376';
+    ParseServer.verifyServerUrl(function(result) {
+      if(!result) {
+        done.fail('Did not pass valid url');
+      }
+      done();
     });
   });
 
   it('mark bad server url', (done) => {
-    reconfigureServer({
-      serverURL: 'notavalidurl'
-    }).then(function() {
-      ParseServer.verifyServerUrl(function(result) {
-        if(result) {
-          done.fail('Did not mark invalid url');
-        }
-        done();
-      });
+    Parse.serverURL = 'notavalidurl';
+    ParseServer.verifyServerUrl(function(result) {
+      if(result) {
+        done.fail('Did not mark invalid url');
+      }
+      done();
     });
   });
 });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -1,0 +1,32 @@
+"use strict";
+/* Tests for ParseServer.js */
+var express = require('express');
+
+import ParseServer          from '../src/ParseServer';
+
+var app = express();
+//app.use(bodyParser.json({ 'type': '*/*' }));
+app.get("/health", function(req, res){
+  res.send("OK");
+});
+app.listen(12345);
+
+describe('Server Url Checks', () => {
+  it("validate good publicServerUrl", (done) => {
+    ParseServer.verifyServerUrl('http://localhost:12345', function(result) {
+      if(!result) {
+        jfail('Did not pass valid url');
+      }
+      done();
+    });
+  });
+
+  it("mark bad publicServerUrl", (done) => {
+    ParseServer.verifyServerUrl('not a valid url', function(result) {
+      if(result) {
+        jfail('Did not mark invalid url');
+      }
+      done();
+    });
+  });
+});

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -373,6 +373,7 @@ class ParseServer {
     if (process.env.PARSE_SERVER_ENABLE_EXPERIMENTAL_DIRECT_ACCESS === '1') {
       Parse.CoreManager.setRESTController(ParseServerRESTController(appId, appRouter));
     }
+    this.verifyServerUrl(_ref2.publicServerURL);
     return api;
   }
 
@@ -409,6 +410,18 @@ class ParseServer {
 
   static createLiveQueryServer(httpServer, config) {
     return new ParseLiveQueryServer(httpServer, config);
+  }
+
+  static verifyServerUrl(serverUrl) {
+    // perform a health check on the provided serverURL
+    if(serverUrl) {
+      const request = require('request');
+      request(serverUrl.replace(/\/$/, "") + "/health", function (error, response, body) {
+        if (error || response.statusCode !== 200 || body !== "OK") {
+          console.error("\nWARNING, Unable to connect to publicServerURL '" + serverUrl + "'. Cloud code and push notifications may be unavailable!\n");
+        }
+      });
+    }
   }
 }
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -373,11 +373,7 @@ class ParseServer {
     if (process.env.PARSE_SERVER_ENABLE_EXPERIMENTAL_DIRECT_ACCESS === '1') {
       Parse.CoreManager.setRESTController(ParseServerRESTController(appId, appRouter));
     }
-
-    const AppCache = require('./cache');
-    var serverUrl = AppCache.AppCache.cache[appId]['value']['publicServerURL'];
-    this.verifyServerUrl(serverUrl);
-
+    this.verifyServerUrl();
     return api;
   }
 
@@ -416,15 +412,16 @@ class ParseServer {
     return new ParseLiveQueryServer(httpServer, config);
   }
 
-  static verifyServerUrl(serverUrl, callback) {
+  static verifyServerUrl(callback) {
     // perform a health check on the publicServerURL value, with 2.5 second delay
     setTimeout(function() {
-      if(serverUrl) {
+      if(Parse.serverURL) {
         const request = require('request');
-        request(serverUrl.replace(/\/$/, "") + "/health", function (error, response, body) {
+        request(Parse.serverURL.replace(/\/$/, "") + "/health", function (error, response, body) {
           if (error || response.statusCode !== 200 || body !== "OK") {
-            // eslint-disable-next-line
-            console.warn("\nWARNING, Unable to connect to publicServerURL '" + serverUrl + "'. Cloud code and push notifications may be unavailable!\n");
+            /* eslint-disable no-console */
+            console.warn(`\nWARNING, Unable to connect to '${Parse.serverURL}'.` +
+              ` Cloud code and push notifications may be unavailable!\n`);
             if(callback) {
               callback(false);
             }


### PR DESCRIPTION
Specifically this adds validation for `publicServerUrl`, if the value is present. This will attempt to grab the `/health` endpoint, expecting a **200** code and **OK**  body, if it doesn't receive this it will spit out something like.
```
...
[1234] parse-server running on http://localhost:1337/parse

WARNING, Unable to connect to publicServerURL 'http://localhost:1337/oops'. Cloud code and push notifications may be unavailable!
```

This does not add tests _yet_ as I wanted to field the positioning (and wording) of this before I proceed. There may be other systems that would be affected besides cloud code and push. 

If this looks ok as is I'll rework it so we can get test coverage on this.