### PR TITLE
Remove device token when APNS error is BadDeviceToken

### DIFF
--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -226,7 +226,7 @@ export function pushStatusHandler(config, existingObjectId) {
               devicesToRemove.push(token);
             }
             // APNS errors
-            if (error === 'Unregistered') {
+            if (error === 'Unregistered' || error === 'BadDeviceToken') {
               devicesToRemove.push(token);
             }
           }


### PR DESCRIPTION
When push is sent, also check to remove the device token if the APNS error is BadDeviceToken
Issue reported on Parse Server Push Adapter: https://github.com/parse-server-modules/parse-server-push-adapter/issues/90