### PR TITLE
Corrects Outdated Links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ If you have a non-bug question, ask on Stack Overflow or Server Fault:
 - https://stackoverflow.com/questions/tagged/parse.com 
 - https://serverfault.com/tags/parse
 
-You may also search through existing issues before opening a new one: https://github.com/ParsePlatform/Parse-Server/issues?utf8=%E2%9C%93&q=is%3Aissue 
+You may also search through existing issues before opening a new one: https://github.com/parse-community/parse-server/issues?utf8=%E2%9C%93&q=is%3Aissue 
 
 --- Please use this template. If you don't use this template, your issue may be closed without comment. ---
 

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -35,7 +35,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     );
   });
 
-  // https://github.com/ParsePlatform/parse-server/pull/148#issuecomment-180407057
+  // https://github.com/parse-community/parse-server/pull/148#issuecomment-180407057
   it('preserves replica sets', () => {
     spyOn(MongoClient, 'connect').and.returnValue(Promise.resolve(null));
     new MongoStorageAdapter({

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -54,7 +54,7 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
   this.include = [];
 
   // If we have keys, we probably want to force some includes (n-1 level)
-  // See issue: https://github.com/ParsePlatform/parse-server/issues/3185
+  // See issue: https://github.com/parse-community/parse-server/issues/3185
   if (restOptions.hasOwnProperty('keys')) {
     const keysForInclude = restOptions.keys.split(',').filter((key) => {
       // At least 2 components

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -118,7 +118,7 @@ export class UsersRouter extends ClassesRouter {
         delete user.password;
 
         // Sometimes the authData still has null on that keys
-        // https://github.com/ParsePlatform/parse-server/issues/935
+        // https://github.com/parse-community/parse-server/issues/935
         if (user.authData) {
           Object.keys(user.authData).forEach((provider) => {
             if (user.authData[provider] === null) {

--- a/src/cli/definitions/parse-server.js
+++ b/src/cli/definitions/parse-server.js
@@ -82,7 +82,7 @@ export default {
   },
   "push": {
     env: "PARSE_SERVER_PUSH",
-    help: "Configuration for push, as stringified JSON. See https://github.com/ParsePlatform/parse-server/wiki/Push",
+    help: "Configuration for push, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#push-notifications",
     action: objectParser
   },
   "scheduledPush": {
@@ -92,12 +92,12 @@ export default {
   },
   "oauth": {
     env: "PARSE_SERVER_OAUTH_PROVIDERS",
-    help: "[DEPRECATED (use auth option)] Configuration for your oAuth providers, as stringified JSON. See https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide#oauth",
+    help: "[DEPRECATED (use auth option)] Configuration for your oAuth providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication",
     action: objectParser
   },
   "auth": {
     env: "PARSE_SERVER_AUTH_PROVIDERS",
-    help: "Configuration for your authentication providers, as stringified JSON. See https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide#oauth",
+    help: "Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication",
     action: objectParser
   },
   "fileKey": {

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -11,7 +11,7 @@ const help = function(){
   console.log('  Get Started guide:');
   console.log('');
   console.log('    Please have a look at the get started guide!');
-  console.log('    https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide');
+  console.log('    http://docs.parseplatform.org/parse-server/guide/');
   console.log('');
   console.log('');
   console.log('  Usage with npm start');

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -57,7 +57,7 @@ ParseCloud._removeAllHooks = () => {
 
 ParseCloud.useMasterKey = () => {
   // eslint-disable-next-line
-  console.warn("Parse.Cloud.useMasterKey is deprecated (and has no effect anymore) on parse-server, please refer to the cloud code migration notes: https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#cloud-code")
+  console.warn("Parse.Cloud.useMasterKey is deprecated (and has no effect anymore) on parse-server, please refer to the cloud code migration notes: http://docs.parseplatform.org/parse-server/guide/#master-key-must-be-passed-explicitly")
 }
 
 ParseCloud.httpRequest = require("./httpRequest");

--- a/src/vendor/README.md
+++ b/src/vendor/README.md
@@ -5,4 +5,4 @@ allowed in hostnames. While this results in a slightly incorrect parsed result,
 as the hostname field for a mongodb should be an array of replica sets, it's 
 good enough to let us pull out and escape the auth portion of the URL.
 
-See also: https://github.com/ParsePlatform/parse-server/pull/986
+https://github.com/parse-community/parse-server/pull/986


### PR DESCRIPTION
This corrects a variety of outdated wiki and doc links that either go nowhere or redirect to `parse-community` instead of the former `ParsePlatform` .