### PR TITLE
Fix for beforeSave with increment causing key to be Dropped

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1196,9 +1196,7 @@ RestWrite.prototype._updateResponseWithData = function(response, data) {
   this.storage.fieldsChangedByTrigger.forEach(fieldName => {
     const dataValue = data[fieldName];
 
-    if(response.hasOwnProperty(fieldName)) {
-      response[fieldName] = response[fieldName];
-    } else {
+    if(!response.hasOwnProperty(fieldName)) {
       response[fieldName] = dataValue;
     }
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1195,10 +1195,9 @@ RestWrite.prototype._updateResponseWithData = function(response, data) {
   const clientSupportsDelete = ClientSDK.supportsForwardDelete(this.clientSDK);
   this.storage.fieldsChangedByTrigger.forEach(fieldName => {
     const dataValue = data[fieldName];
-    const responseValue = response[fieldName];
 
-    if(responseValue || responseValue === 0) {
-      response[fieldName] = responseValue;
+    if(response.hasOwnProperty(fieldName)) {
+      response[fieldName] = response[fieldName];
     } else {
       response[fieldName] = dataValue;
     }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1197,7 +1197,11 @@ RestWrite.prototype._updateResponseWithData = function(response, data) {
     const dataValue = data[fieldName];
     const responseValue = response[fieldName];
 
-    response[fieldName] = responseValue || dataValue;
+    if(responseValue || responseValue === 0) {
+      response[fieldName] = responseValue;
+    } else {
+      response[fieldName] = dataValue;
+    }
 
     // Strips operations from responses
     if (response[fieldName] && response[fieldName].__op) {


### PR DESCRIPTION
This is a fix for #2717 , including a personally verified failing test to guard against this. In summary, an issue was observed where calling increment on a key in cloud code that resulted in a zero value caused that key to be dropped from the response. A subsequent query or fetch would reveal that the save was in fact handled properly, it would just return an initially bad response in cloud code. This would trip in a save op from a cloud code function on a class with a beforeSave hook, and specifically where the hook performed an increment op that resulted in a zero value. These specific conditions had to be met for this to happen.

When parse-server compares modified fields from a hook it attempts to take the original value _or_ the data value (hook value) if the former evaluated to false. Since the hook value was a json object with an **__op** property, it was immediately removed from the response by a subsequent check for that very property. This is summarized in more detail in the original issue.