### PR TITLE
Add request ip to request object

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1239,10 +1239,33 @@ describe('Cloud Code', () => {
   });
 });
 
+describe('cloud functions', () => {
+  it('Should have request ip', (done) => {
+    Parse.Cloud.define('myFunction', (req, res) => {
+      console.log('kör gör!');
+      expect(req.ip).toBeDefined();
+      res.success("success");
+    });
+
+    Parse.Cloud.run('myFunction', {}).then(() => done(), (a) => console.log('s', a));
+  });
+});
+
 describe('beforeSave hooks', () => {
   it('should have request headers', (done) => {
     Parse.Cloud.beforeSave('MyObject', (req, res) => {
       expect(req.headers).toBeDefined();
+      res.success();
+    });
+
+    const MyObject = Parse.Object.extend('MyObject');
+    const myObject = new MyObject();
+    myObject.save().then(() => done());
+  });
+
+  it('should have request ip', (done) => {
+    Parse.Cloud.beforeSave('MyObject', (req, res) => {
+      expect(req.ip).toBeDefined();
       res.success();
     });
 
@@ -1263,6 +1286,17 @@ describe('afterSave hooks', () => {
     myObject.save()
       .then(() => done());
   });
+
+  it('should have request ip', (done) => {
+    Parse.Cloud.afterSave('MyObject', (req, res) => {
+      expect(req.ip).toBeDefined();
+      res.success();
+    });
+
+    const MyObject = Parse.Object.extend('MyObject');
+    const myObject = new MyObject();
+    myObject.save().then(() => done());
+  });
 });
 
 describe('beforeDelete hooks', () => {
@@ -1278,12 +1312,37 @@ describe('beforeDelete hooks', () => {
       .then(myObj => myObj.destroy())
       .then(() => done());
   });
+
+  it('should have request ip', (done) => {
+    Parse.Cloud.beforeDelete('MyObject', (req, res) => {
+      expect(req.ip).toBeDefined();
+      res.success();
+    });
+
+    const MyObject = Parse.Object.extend('MyObject');
+    const myObject = new MyObject();
+    myObject.save()
+      .then(myObj => myObj.destroy())
+      .then(() => done());
+  });
 });
 
 describe('afterDelete hooks', () => {
   it('should have request headers', (done) => {
     Parse.Cloud.afterDelete('MyObject', (req) => {
       expect(req.headers).toBeDefined();
+    });
+
+    const MyObject = Parse.Object.extend('MyObject');
+    const myObject = new MyObject();
+    myObject.save()
+      .then(myObj => myObj.destroy())
+      .then(() => done());
+  });
+
+  it('should have request ip', (done) => {
+    Parse.Cloud.afterDelete('MyObject', (req) => {
+      expect(req.ip).toBeDefined();
     });
 
     const MyObject = Parse.Object.extend('MyObject');
@@ -1432,6 +1491,26 @@ describe('beforeFind hooks', () => {
   it('should have request headers', (done) => {
     Parse.Cloud.beforeFind('MyObject', (req) => {
       expect(req.headers).toBeDefined();
+    });
+
+    const MyObject = Parse.Object.extend('MyObject');
+    const myObject = new MyObject();
+    myObject.save()
+      .then((myObj) => {
+        const query = new Parse.Query('MyObject');
+        query.equalTo('objectId', myObj.id);
+        return Promise.all([
+          query.get(myObj.id),
+          query.first(),
+          query.find(),
+        ]);
+      })
+      .then(() => done());
+  });
+
+  it('should have request ip', (done) => {
+    Parse.Cloud.beforeFind('MyObject', (req) => {
+      expect(req.ip).toBeDefined();
     });
 
     const MyObject = Parse.Object.extend('MyObject');
@@ -1649,6 +1728,27 @@ describe('afterFind hooks', () => {
   it('should have request headers', (done) => {
     Parse.Cloud.afterFind('MyObject', (req, res) => {
       expect(req.headers).toBeDefined();
+      res.success();
+    });
+
+    const MyObject = Parse.Object.extend('MyObject');
+    const myObject = new MyObject();
+    myObject.save()
+      .then((myObj) => {
+        const query = new Parse.Query('MyObject');
+        query.equalTo('objectId', myObj.id);
+        return Promise.all([
+          query.get(myObj.id),
+          query.first(),
+          query.find(),
+        ]);
+      })
+      .then(() => done());
+  });
+
+  it('should have request ip', (done) => {
+    Parse.Cloud.afterFind('MyObject', (req, res) => {
+      expect(req.ip).toBeDefined();
       res.success();
     });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1242,7 +1242,6 @@ describe('Cloud Code', () => {
 describe('cloud functions', () => {
   it('Should have request ip', (done) => {
     Parse.Cloud.define('myFunction', (req, res) => {
-      console.log('kör gör!');
       expect(req.ip).toBeDefined();
       res.success("success");
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1246,7 +1246,7 @@ describe('cloud functions', () => {
       res.success("success");
     });
 
-    Parse.Cloud.run('myFunction', {}).then(() => done(), (a) => console.log('s', a));
+    Parse.Cloud.run('myFunction', {}).then(() => done());
   });
 });
 

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -54,7 +54,8 @@ export class FunctionsRouter extends PromiseRouter {
     const request = {
       params: params,
       log: req.config.loggerController,
-      headers: req.headers,
+      headers: req.config.headers,
+      ip: req.config.ip,
       jobName
     };
     const status = {
@@ -111,7 +112,8 @@ export class FunctionsRouter extends PromiseRouter {
         user: req.auth && req.auth.user,
         installationId: req.info.installationId,
         log: req.config.loggerController,
-        headers: req.headers,
+        headers: req.config.headers,
+        ip: req.config.ip,
         functionName
       };
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -106,12 +106,15 @@ export function handleParseHeaders(req, res, next) {
     req.body = new Buffer(base64, 'base64');
   }
 
+  const clientIp = getClientIp(req);
+
   info.app = AppCache.get(info.appId);
   req.config = new Config(info.appId, mount);
   req.config.headers = req.headers || {};
+  req.config.ip = clientIp;
   req.info = info;
 
-  if (info.masterKey && req.config.masterKeyIps && req.config.masterKeyIps.length !== 0 && req.config.masterKeyIps.indexOf(getClientIp(req)) === -1) {
+  if (info.masterKey && req.config.masterKeyIps && req.config.masterKeyIps.length !== 0 && req.config.masterKeyIps.indexOf(clientIp) === -1) {
     return invalidRequest(req, res);
   }
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -144,6 +144,7 @@ export function getRequestObject(triggerType, auth, parseObject, originalParseOb
     master: false,
     log: config.loggerController,
     headers: config.headers,
+    ip: config.ip,
   };
 
   if (originalParseObject) {
@@ -176,6 +177,7 @@ export function getRequestQueryObject(triggerType, auth, query, count, config, i
     log: config.loggerController,
     isGet,
     headers: config.headers,
+    ip: config.ip,
   };
 
   if (!auth) {


### PR DESCRIPTION
Adds the client ip on the request object for cloud functions and trigger functions

useful for https://github.com/parse-community/parse-server/issues/3515 example