### PR TITLE
Enables login over POST in addition to GET

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -136,7 +136,6 @@ describe('Parse.User testing', () => {
             'X-Parse-REST-API-Key': 'rest',
           },
           json: {
-            _method: 'POST',
             username: 'some_user',
             password: 'some_password',
           }

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -126,6 +126,31 @@ describe('Parse.User testing', () => {
     });
   });
 
+  it('user login using POST with REST API', (done) => {
+    Parse.User.signUp('some_user', 'some_password', null, {
+      success: () => {
+        return rp.post({
+          url: 'http://localhost:8378/1/login',
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          json: {
+            _method: 'POST',
+            username: 'some_user',
+            password: 'some_password',
+          }
+        }).then((res) => {
+          expect(res.username).toBe('some_user');
+          done();
+        }).catch((err) => {
+          fail(`no request should fail: ${JSON.stringify(err)}`);
+          done();
+        });
+      },
+    });
+  });
+
   it("user login", (done) => {
     Parse.User.signUp("asdf", "zxcv", null, {
       success: function() {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -256,6 +256,7 @@ export class UsersRouter extends ClassesRouter {
     this.route('PUT', '/users/:objectId', req => { return this.handleUpdate(req); });
     this.route('DELETE', '/users/:objectId', req => { return this.handleDelete(req); });
     this.route('GET', '/login', req => { return this.handleLogIn(req); });
+    this.route('POST', '/login', req => { return this.handleLogIn(req); });
     this.route('POST', '/logout', req => { return this.handleLogOut(req); });
     this.route('POST', '/requestPasswordReset', req => { return this.handleResetRequest(req); });
     this.route('POST', '/verificationEmailRequest', req => { return this.handleVerificationEmailRequest(req); });


### PR DESCRIPTION
So this is a little something for #4052 . The change is relatively minor and really doesn't do anything on it's own. A single test is added to verify login works over POST using REST.

Most importantly this will allow future development on the sdks to eventually switch to using POST for login requests, instead of GET. Perhaps at some distant point in time we could even consider deprecating and eventually removing the GET approach, but for now keeping it is essential for reverse compatibility.

Just to make a point there really isn't anything _too_ bad about the current approach using GET, so long as the connection is secure. The one thing that really stands out is that if logging is not done properly you risk including username/password combos in the log. Although this would really only happen if you were directly piping output from the process into a log or something like that. There is that chance that if you set up logging improperly _and_ someone else has access to that log that you might have a problem. Although this doesn't really fix that this gives us the option to do so down the road.