### PR TITLE
Relative time queries

### DIFF
--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -14,6 +14,7 @@
       "Container": true,
       "equal": true,
       "notEqual": true,
+      "it_only_db": true,
       "it_exclude_dbs": true,
       "describe_only_db": true,
       "describe_only": true,

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -24,7 +24,8 @@
       "expectError": true,
       "jequal": true,
       "create": true,
-      "arrayContains": true
+      "arrayContains": true,
+      "dropDatabase": true
     },
     "rules": {
       "no-console": [0]

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -25,8 +25,7 @@
       "expectError": true,
       "jequal": true,
       "create": true,
-      "arrayContains": true,
-      "dropDatabase": true
+      "arrayContains": true
     },
     "rules": {
       "no-console": [0]

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -353,9 +353,9 @@ describe('relativeTimeToDate', () => {
 
   describe('In the future', () => {
     it('should parse valid natural time', () => {
-      const text = 'in 12 days 10 hours 24 minutes';
+      const text = 'in 12 days 10 hours 24 minutes 30 seconds';
       const { result, status, info } = transform.relativeTimeToDate(text, now);
-      expect(result.toISOString()).toBe('2017-10-08T23:52:16.617Z');
+      expect(result.toISOString()).toBe('2017-10-08T23:52:46.617Z');
       expect(status).toBe('success');
       expect(info).toBe('future');
     });
@@ -363,15 +363,22 @@ describe('relativeTimeToDate', () => {
 
   describe('In the past', () => {
     it('should parse valid natural time', () => {
-      const text = '2 days 12 hours 1 minute ago';
+      const text = '2 days 12 hours 1 minute 12 seconds ago';
       const { result, status, info } = transform.relativeTimeToDate(text, now);
-      expect(result.toISOString()).toBe('2017-09-24T01:27:16.617Z');
+      expect(result.toISOString()).toBe('2017-09-24T01:27:04.617Z');
       expect(status).toBe('success');
       expect(info).toBe('past');
     });
   });
 
   describe('Error cases', () => {
+    it('should error if string is completely gibberish', () => {
+      expect(transform.relativeTimeToDate('gibberishasdnklasdnjklasndkl123j123')).toEqual({
+        status: 'error',
+        info: "Time should either start with 'in' or end with 'ago'",
+      });
+    });
+
     it('should error if string contains neither `ago` nor `in`', () => {
       expect(transform.relativeTimeToDate('12 hours 1 minute')).toEqual({
         status: 'error',

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -348,6 +348,42 @@ describe('transformUpdate', () => {
   });
 });
 
+describe('transformConstraint', () => {
+  describe('$relativeTime', () => {
+    it('should error on $eq, $ne, and $exists', () => {
+      expect(() => {
+        transform.transformConstraint({
+          $eq: {
+            ttl: {
+              $relativeTime: '12 days ago',
+            }
+          }
+        });
+      }).toThrow();
+
+      expect(() => {
+        transform.transformConstraint({
+          $ne: {
+            ttl: {
+              $relativeTime: '12 days ago',
+            }
+          }
+        });
+      }).toThrow();
+
+      expect(() => {
+        transform.transformConstraint({
+          $exists: {
+            ttl: {
+              $relativeTime: '12 days ago',
+            }
+          }
+        });
+      }).toThrow();
+    });
+  })
+});
+
 describe('relativeTimeToDate', () => {
   const now = new Date('2017-09-26T13:28:16.617Z');
 

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -374,9 +374,7 @@ describe('transformConstraint', () => {
       expect(() => {
         transform.transformConstraint({
           $exists: {
-            ttl: {
-              $relativeTime: '12 days ago',
-            }
+            $relativeTime: '12 days ago',
           }
         });
       }).toThrow();

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -347,3 +347,49 @@ describe('transformUpdate', () => {
     done();
   });
 });
+
+describe('naturalTimeToDate', () => {
+  const now = new Date('2017-09-26T13:28:16.617Z');
+
+  describe('In the future', () => {
+    it('should parse valid natural time', () => {
+      const text = 'in 12 days 10 hours 24 minutes';
+      const { result, status, info } = transform.naturalTimeToDate(text, now);
+      expect(result.toISOString()).toBe('2017-10-08T23:52:16.617Z');
+      expect(status).toBe('success');
+      expect(info).toBe('future');
+    });
+  });
+
+  describe('In the past', () => {
+    it('should parse valid natural time', () => {
+      const text = '2 days 12 hours 1 minute ago';
+      const { result, status, info } = transform.naturalTimeToDate(text, now);
+      expect(result.toISOString()).toBe('2017-09-24T01:27:16.617Z');
+      expect(status).toBe('success');
+      expect(info).toBe('past');
+    });
+  });
+
+  describe('Error cases', () => {
+    it('should error if string contains neither `ago` nor `in`', () => {
+      expect(transform.naturalTimeToDate('12 hours 1 minute')).toEqual({
+        status: 'error',
+        info: "Time should either start with 'in' or end with 'ago'",
+      });
+    });
+
+    it('should error if there are missing units or numbers', () => {
+      expect(transform.naturalTimeToDate('in 12 hours 1')).toEqual({
+        status: 'error',
+        info: 'Invalid time string. Dangling unit or number.',
+      });
+
+      expect(transform.naturalTimeToDate('12 hours minute ago')).toEqual({
+        status: 'error',
+        info: 'Invalid time string. Dangling unit or number.',
+      });
+    });
+  });
+});
+

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -390,6 +390,20 @@ describe('naturalTimeToDate', () => {
         info: 'Invalid time string. Dangling unit or number.',
       });
     });
+
+    it('should error if numbers are invalid', () => {
+      expect(transform.naturalTimeToDate('12 hours 123a minute ago')).toEqual({
+        status: 'error',
+        info: "'123a' is not an integer.",
+      });
+    });
+
+    it('should error on invalid interval units', () => {
+      expect(transform.naturalTimeToDate('4 score 7 years ago')).toEqual({
+        status: 'error',
+        info: "Invalid interval: 'score'",
+      });
+    });
   });
 });
 

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -398,6 +398,13 @@ describe('relativeTimeToDate', () => {
       });
     });
 
+    it('should error on floating point numbers', () => {
+      expect(transform.relativeTimeToDate('in 12.3 hours')).toEqual({
+        status: 'error',
+        info: "'12.3' is not an integer.",
+      });
+    });
+
     it('should error if numbers are invalid', () => {
       expect(transform.relativeTimeToDate('12 hours 123a minute ago')).toEqual({
         status: 'error',

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -404,6 +404,13 @@ describe('naturalTimeToDate', () => {
         info: "Invalid interval: 'score'",
       });
     });
+
+    it("should error when string contains 'ago' and 'in'", () => {
+      expect(transform.naturalTimeToDate('in 1 day 2 minutes ago')).toEqual({
+        status: 'error',
+        info: "Time cannot have both 'in' and 'ago'",
+      });
+    });
   });
 });
 

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -348,13 +348,13 @@ describe('transformUpdate', () => {
   });
 });
 
-describe('naturalTimeToDate', () => {
+describe('relativeTimeToDate', () => {
   const now = new Date('2017-09-26T13:28:16.617Z');
 
   describe('In the future', () => {
     it('should parse valid natural time', () => {
       const text = 'in 12 days 10 hours 24 minutes';
-      const { result, status, info } = transform.naturalTimeToDate(text, now);
+      const { result, status, info } = transform.relativeTimeToDate(text, now);
       expect(result.toISOString()).toBe('2017-10-08T23:52:16.617Z');
       expect(status).toBe('success');
       expect(info).toBe('future');
@@ -364,7 +364,7 @@ describe('naturalTimeToDate', () => {
   describe('In the past', () => {
     it('should parse valid natural time', () => {
       const text = '2 days 12 hours 1 minute ago';
-      const { result, status, info } = transform.naturalTimeToDate(text, now);
+      const { result, status, info } = transform.relativeTimeToDate(text, now);
       expect(result.toISOString()).toBe('2017-09-24T01:27:16.617Z');
       expect(status).toBe('success');
       expect(info).toBe('past');
@@ -373,40 +373,40 @@ describe('naturalTimeToDate', () => {
 
   describe('Error cases', () => {
     it('should error if string contains neither `ago` nor `in`', () => {
-      expect(transform.naturalTimeToDate('12 hours 1 minute')).toEqual({
+      expect(transform.relativeTimeToDate('12 hours 1 minute')).toEqual({
         status: 'error',
         info: "Time should either start with 'in' or end with 'ago'",
       });
     });
 
     it('should error if there are missing units or numbers', () => {
-      expect(transform.naturalTimeToDate('in 12 hours 1')).toEqual({
+      expect(transform.relativeTimeToDate('in 12 hours 1')).toEqual({
         status: 'error',
         info: 'Invalid time string. Dangling unit or number.',
       });
 
-      expect(transform.naturalTimeToDate('12 hours minute ago')).toEqual({
+      expect(transform.relativeTimeToDate('12 hours minute ago')).toEqual({
         status: 'error',
         info: 'Invalid time string. Dangling unit or number.',
       });
     });
 
     it('should error if numbers are invalid', () => {
-      expect(transform.naturalTimeToDate('12 hours 123a minute ago')).toEqual({
+      expect(transform.relativeTimeToDate('12 hours 123a minute ago')).toEqual({
         status: 'error',
         info: "'123a' is not an integer.",
       });
     });
 
     it('should error on invalid interval units', () => {
-      expect(transform.naturalTimeToDate('4 score 7 years ago')).toEqual({
+      expect(transform.relativeTimeToDate('4 score 7 years ago')).toEqual({
         status: 'error',
         info: "Invalid interval: 'score'",
       });
     });
 
     it("should error when string contains 'ago' and 'in'", () => {
-      expect(transform.naturalTimeToDate('in 1 day 2 minutes ago')).toEqual({
+      expect(transform.relativeTimeToDate('in 1 day 2 minutes ago')).toEqual({
         status: 'error',
         info: "Time cannot have both 'in' and 'ago'",
       });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3167,17 +3167,4 @@ describe('Parse.Query testing', () => {
       .then(() => q.find({ useMasterKey: true }))
       .then(done.fail, done);
   });
-
-  it_only_db('mongo')('should error when using $relativeTime with $eq, $ne, and $', function(done) {
-    const obj1 = new Parse.Object('MyCustomObject', {
-      name: 'obj1',
-      ttl: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
-    });
-
-    const q = new Parse.Query('MyCustomObject');
-    q.exists('ttl', { $relativeTime: 'in 1 day' });
-    obj1.save({ useMasterKey: true })
-      .then(() => q.find({ useMasterKey: true }))
-      .then(done.fail, done);
-  });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3147,4 +3147,17 @@ describe('Parse.Query testing', () => {
       })
       .then(done, done.fail);
   });
+
+  it('should error on invalid relative time', function(done) {
+    const obj1 = new Parse.Object('MyCustomObject', {
+      name: 'obj1',
+      ttl: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+    });
+
+    const q = new Parse.Query('MyCustomObject');
+    q.greaterThan('ttl', { $relativeTime: '-12 bananas ago' });
+    return obj1.save({ useMasterKey: true })
+      .then(() => q.find({ useMasterKey: true }))
+      .then(done.fail, done);
+  });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3108,7 +3108,7 @@ describe('Parse.Query testing', () => {
     }).catch(done.fail);
   });
 
-  it('should handle relative times correctly', function(done) {
+  it_only_db('mongo')('should handle relative times correctly', function(done) {
     const now = Date.now();
     const obj1 = new Parse.Object('MyCustomObject', {
       name: 'obj1',
@@ -3148,7 +3148,7 @@ describe('Parse.Query testing', () => {
       .then(done, done.fail);
   });
 
-  it('should error on invalid relative time', function(done) {
+  it_only_db('mongo')('should error on invalid relative time', function(done) {
     const obj1 = new Parse.Object('MyCustomObject', {
       name: 'obj1',
       ttl: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3145,6 +3145,14 @@ describe('Parse.Query testing', () => {
       .then((results) => {
         expect(results.length).toBe(0);
       })
+      .then(() => {
+        const q = new Parse.Query('MyCustomObject');
+        q.greaterThan('ttl', { $relativeTime: '3 days ago' });
+        return q.find({ useMasterKey: true });
+      })
+      .then((results) => {
+        expect(results.length).toBe(2);
+      })
       .then(done, done.fail);
   });
 

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3119,8 +3119,7 @@ describe('Parse.Query testing', () => {
       ttl: new Date(now - 2 * 24 * 60 * 60 * 1000), // 2 days ago
     });
 
-    dropDatabase()
-      .then(() => Parse.Object.saveAll([obj1, obj2]))
+    Parse.Object.saveAll([obj1, obj2])
       .then(() => {
         const q = new Parse.Query('MyCustomObject');
         q.greaterThan('ttl', { $relativeTime: 'in 1 day' });
@@ -3164,7 +3163,20 @@ describe('Parse.Query testing', () => {
 
     const q = new Parse.Query('MyCustomObject');
     q.greaterThan('ttl', { $relativeTime: '-12 bananas ago' });
-    return obj1.save({ useMasterKey: true })
+    obj1.save({ useMasterKey: true })
+      .then(() => q.find({ useMasterKey: true }))
+      .then(done.fail, done);
+  });
+
+  it_only_db('mongo')('should error when using $relativeTime with $eq, $ne, and $', function(done) {
+    const obj1 = new Parse.Object('MyCustomObject', {
+      name: 'obj1',
+      ttl: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+    });
+
+    const q = new Parse.Query('MyCustomObject');
+    q.exists('ttl', { $relativeTime: 'in 1 day' });
+    obj1.save({ useMasterKey: true })
       .then(() => q.find({ useMasterKey: true }))
       .then(done.fail, done);
   });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3167,4 +3167,18 @@ describe('Parse.Query testing', () => {
       .then(() => q.find({ useMasterKey: true }))
       .then(done.fail, done);
   });
+
+  it_only_db('mongo')('should error when using $relativeTime on non-Date field', function(done) {
+    const obj1 = new Parse.Object('MyCustomObject', {
+      name: 'obj1',
+      nonDateField: 'abcd',
+      ttl: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+    });
+
+    const q = new Parse.Query('MyCustomObject');
+    q.greaterThan('nonDateField', { $relativeTime: '1 day ago' });
+    obj1.save({ useMasterKey: true })
+      .then(() => q.find({ useMasterKey: true }))
+      .then(done.fail, done);
+  });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3123,7 +3123,7 @@ describe('Parse.Query testing', () => {
       .then(() => Parse.Object.saveAll([obj1, obj2]))
       .then(() => {
         const q = new Parse.Query('MyCustomObject');
-        q.greaterThan('ttl', 'in 1 day');
+        q.greaterThan('ttl', { $relativeTime: 'in 1 day' });
         return q.find({ useMasterKey: true });
       })
       .then((results) => {
@@ -3131,7 +3131,7 @@ describe('Parse.Query testing', () => {
       })
       .then(() => {
         const q = new Parse.Query('MyCustomObject');
-        q.greaterThan('ttl', '1 day ago');
+        q.greaterThan('ttl', { $relativeTime: '1 day ago' });
         return q.find({ useMasterKey: true });
       })
       .then((results) => {
@@ -3139,7 +3139,7 @@ describe('Parse.Query testing', () => {
       })
       .then(() => {
         const q = new Parse.Query('MyCustomObject');
-        q.lessThan('ttl', '5 days ago');
+        q.lessThan('ttl', { $relativeTime: '5 days ago' });
         return q.find({ useMasterKey: true });
       })
       .then((results) => {

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -459,26 +459,3 @@ jasmine.restoreLibrary = function(library, name) {
   }
   require(library)[name] = libraryCache[library][name];
 }
-
-const { MongoClient } = require('mongodb');
-global.dropDatabase = () => {
-  const connectionPromise = new Promise((resolve, reject) =>
-    MongoClient.connect(mongoURI, (err, db) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(db);
-      }
-    }));
-
-  return connectionPromise.then((connection) =>
-    new Promise((resolve, reject) => {
-      connection.dropDatabase((err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(res);
-        }
-      });
-    }));
-};

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -451,3 +451,26 @@ jasmine.restoreLibrary = function(library, name) {
   }
   require(library)[name] = libraryCache[library][name];
 }
+
+const { MongoClient } = require('mongodb');
+global.dropDatabase = () => {
+  const connectionPromise = new Promise((resolve, reject) =>
+    MongoClient.connect(mongoURI, (err, db) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(db);
+      }
+    }));
+
+  return connectionPromise.then((connection) =>
+    new Promise((resolve, reject) => {
+      connection.dropDatabase((err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
+        }
+      });
+    }));
+};

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -408,6 +408,14 @@ global.it_exclude_dbs = excluded => {
   }
 }
 
+global.it_only_db = db => {
+  if (process.env.PARSE_SERVER_TEST_DB === db) {
+    return it;
+  } else {
+    return xit;
+  }
+};
+
 global.fit_exclude_dbs = excluded => {
   if (excluded.indexOf(process.env.PARSE_SERVER_TEST_DB) >= 0) {
     return xit;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -561,7 +561,7 @@ function relativeTimeToDate(text, now = new Date()) {
   // strip the 'ago' or 'in'
   if (future) {
     parts = parts.slice(1);
-  } else if (past) {
+  } else { // past
     parts = parts.slice(0, parts.length - 1);
   }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -590,12 +590,12 @@ function relativeTimeToDate(text, now = new Date()) {
     switch(interval) {
     case 'day':
     case 'days':
-      seconds += val * 24 * 60 * 60;
+      seconds += val * 86400; // 24 * 60 * 60
       break;
 
     case 'hour':
     case 'hours':
-      seconds += val * 60 * 60;
+      seconds += val * 3600; // 60 * 60
       break;
 
     case 'minute':

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -537,9 +537,6 @@ function relativeTimeToDate(text, now = new Date()) {
   text = text.toLowerCase();
 
   let parts = text.split(' ');
-  if (!parts.length) {
-    return { status: 'error', info: 'Not a time string' };
-  }
 
   // Filter out whitespace
   parts = parts.filter((part) => part !== '');

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -568,33 +568,44 @@ function naturalTimeToDate(text, now = new Date()) {
     pairs.push([ parts.shift(), parts.shift() ]);
   }
 
-  const seconds = pairs.reduce((sum, [num, interval]) => {
-    const val = parseInt(num, 10);
+  let seconds = 0;
+  for (const [num, interval] of pairs) {
+    const val = Number(num);
+    if (!Number.isInteger(val)) {
+      return {
+        status: 'error',
+        info: `'${num}' is not an integer.`,
+      };
+    }
 
     switch(interval) {
     case 'day':
     case 'days':
-      sum += val * 24 * 60 * 60;
+      seconds += val * 24 * 60 * 60;
       break;
 
     case 'hour':
     case 'hours':
-      sum += val * 60 * 60;
+      seconds += val * 60 * 60;
       break;
 
     case 'minute':
     case 'minutes':
-      sum += val * 60;
+      seconds += val * 60;
       break;
 
     case 'second':
     case 'seconds':
-      sum += val;
+      seconds += val;
       break;
-    }
 
-    return sum;
-  }, 0);
+    default:
+      return {
+        status: 'error',
+        info: `Invalid interval: '${interval}'`,
+      };
+    }
+  }
 
   const milliseconds = seconds * 1000;
   if (future) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1320,4 +1320,5 @@ module.exports = {
   transformWhere,
   mongoObjectToParseObject,
   relativeTimeToDate,
+  transformConstraint,
 };

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -534,6 +534,8 @@ function transformTopLevelAtom(atom, field) {
 }
 
 function relativeTimeToDate(text, now = new Date()) {
+  text = text.toLowerCase();
+
   let parts = text.split(' ');
   if (!parts.length) {
     return { status: 'error', info: 'Not a time string' };

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -665,7 +665,7 @@ function transformConstraint(constraint, field) {
     case '$ne':
     case '$eq': {
       const val = constraint[key];
-      if (key !== '$exists' && typeof val === 'object' && val.$relativeTime) {
+      if (key !== '$exists' && val && typeof val === 'object' && val.$relativeTime) {
         const parserResult = relativeTimeToDate(val.$relativeTime);
         if (parserResult.status === 'success') {
           answer[key] = parserResult.result;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -593,16 +593,22 @@ function relativeTimeToDate(text, now = new Date()) {
       seconds += val * 86400; // 24 * 60 * 60
       break;
 
+    case 'hr':
+    case 'hrs':
     case 'hour':
     case 'hours':
       seconds += val * 3600; // 60 * 60
       break;
 
+    case 'min':
+    case 'mins':
     case 'minute':
     case 'minutes':
       seconds += val * 60;
       break;
 
+    case 'sec':
+    case 'secs':
     case 'second':
     case 'seconds':
       seconds += val;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -661,7 +661,7 @@ function transformConstraint(constraint, field) {
       if (typeof text === 'string') {
         const parserResult = naturalTimeToDate(text);
         if (parserResult.status === 'success') {
-          answer[key] = new Date(parserResult.result);
+          answer[key] = parserResult.result;
           break;
         }
       }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -549,6 +549,13 @@ function naturalTimeToDate(text, now = new Date()) {
     return { status: 'error', info: "Time should either start with 'in' or end with 'ago'" };
   }
 
+  if (future && past) {
+    return {
+      status: 'error',
+      info: "Time cannot have both 'in' and 'ago'",
+    };
+  }
+
   // strip the 'ago' or 'in'
   if (future) {
     parts = parts.slice(1);
@@ -663,6 +670,10 @@ function transformConstraint(constraint, field) {
         if (parserResult.status === 'success') {
           answer[key] = parserResult.result;
           break;
+        }
+
+        if (parserResult.status === 'error') {
+          log.info('Error while parsing relative date', parserResult);
         }
       }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -671,6 +671,10 @@ function transformConstraint(constraint, field) {
     case '$eq': {
       const val = constraint[key];
       if (val && typeof val === 'object' && val.$relativeTime) {
+        if (field && field.type !== 'Date') {
+          throw new Parse.Error(Parse.Error.INVALID_JSON, '$relativeTime can only be used with Date field');
+        }
+
         switch (key) {
         case '$exists':
         case '$ne':

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -651,7 +651,7 @@ function transformConstraint(constraint, field) {
         const parserResult = naturalTimeToDate(text);
 
         if (parserResult.status === 'success') {
-          answer[key] = parserResult.result;
+          answer[key] = Parse._encode(parserResult.result);
           break;
         }
       }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -533,7 +533,7 @@ function transformTopLevelAtom(atom, field) {
   }
 }
 
-function naturalTimeToDate(text, now = new Date()) {
+function relativeTimeToDate(text, now = new Date()) {
   let parts = text.split(' ');
   if (!parts.length) {
     return { status: 'invalid', info: 'Not a time string' };
@@ -666,7 +666,7 @@ function transformConstraint(constraint, field) {
     case '$eq': {
       const text = constraint[key];
       if (typeof text === 'string') {
-        const parserResult = naturalTimeToDate(text);
+        const parserResult = relativeTimeToDate(text);
         if (parserResult.status === 'success') {
           answer[key] = parserResult.result;
           break;
@@ -1308,5 +1308,5 @@ module.exports = {
   transformUpdate,
   transformWhere,
   mongoObjectToParseObject,
-  naturalTimeToDate,
+  relativeTimeToDate,
 };

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -665,7 +665,7 @@ function transformConstraint(constraint, field) {
     case '$ne':
     case '$eq': {
       const val = constraint[key];
-      if (typeof val === 'object' && val.$relativeTime) {
+      if (key !== '$exists' && typeof val === 'object' && val.$relativeTime) {
         const parserResult = relativeTimeToDate(val.$relativeTime);
         if (parserResult.status === 'success') {
           answer[key] = parserResult.result;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -673,7 +673,14 @@ function transformConstraint(constraint, field) {
     case '$ne':
     case '$eq': {
       const val = constraint[key];
-      if (key !== '$exists' && val && typeof val === 'object' && val.$relativeTime) {
+      if (val && typeof val === 'object' && val.$relativeTime) {
+        switch (key) {
+        case '$exists':
+        case '$ne':
+        case '$eq':
+          throw new Parse.Error(Parse.Error.INVALID_JSON, '$relativeTime can only be used with the $lt, $lte, $gt, and $gte operators');
+        }
+
         const parserResult = relativeTimeToDate(val.$relativeTime);
         if (parserResult.status === 'success') {
           answer[key] = parserResult.result;
@@ -684,7 +691,7 @@ function transformConstraint(constraint, field) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, `bad $relativeTime (${key}) value. ${parserResult.info}`);
       }
 
-      answer[key] = transformer(constraint[key]);
+      answer[key] = transformer(val);
       break;
     }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -664,9 +664,9 @@ function transformConstraint(constraint, field) {
     case '$exists':
     case '$ne':
     case '$eq': {
-      const text = constraint[key];
-      if (typeof text === 'string') {
-        const parserResult = relativeTimeToDate(text);
+      const val = constraint[key];
+      if (typeof val === 'object' && val.$relativeTime) {
+        const parserResult = relativeTimeToDate(val.$relativeTime);
         if (parserResult.status === 'success') {
           answer[key] = parserResult.result;
           break;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -536,7 +536,7 @@ function transformTopLevelAtom(atom, field) {
 function relativeTimeToDate(text, now = new Date()) {
   let parts = text.split(' ');
   if (!parts.length) {
-    return { status: 'invalid', info: 'Not a time string' };
+    return { status: 'error', info: 'Not a time string' };
   }
 
   // Filter out whitespace
@@ -672,9 +672,8 @@ function transformConstraint(constraint, field) {
           break;
         }
 
-        if (parserResult.status === 'error') {
-          log.info('Error while parsing relative date', parserResult);
-        }
+        log.info('Error while parsing relative date', parserResult);
+        throw new Parse.Error(Parse.Error.INVALID_JSON, `bad $relativeTime (${key}) value. ${parserResult.info}`);
       }
 
       answer[key] = transformer(constraint[key]);

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -649,9 +649,8 @@ function transformConstraint(constraint, field) {
       const text = constraint[key];
       if (typeof text === 'string') {
         const parserResult = naturalTimeToDate(text);
-
         if (parserResult.status === 'success') {
-          answer[key] = Parse._encode(parserResult.result);
+          answer[key] = new Date(parserResult.result);
           break;
         }
       }


### PR DESCRIPTION
# Context
I would like to be able to create queries where the current time is injected by Parse.

For example:
```javascript
const recentInactiveQ = new Parse.Query(Parse.Installation);
recentInactiveQ.greaterThan('createdAt', { $relativeTime: '2 weeks ago' });
recentInactiveQ.lessThan('updatedAt', { $relativeTime: '3 days ago' });

Parse.Push.send({
  where: recentInactiveQ,
  data: {
    alert: "Here's what you missed this week...",
    url: "https://example.org/this-weeks-content"
  },
});
```

## The future
This type of query can be serialized and re-executed at any time. I plan on adding support for recurring push notifications and relative time queries are essential for this feature.  
It would look something like this (#4105):
```javascript
Parse.Push.createCampaign({
  where: recentInactiveQ,
  data: {
    alert: "Here's what you missed this week...",
    url: "https://example.org/this-weeks-content"
  },
  interval: 'daily',
  sendTime: '17:30',
});
```