### PR TITLE
Handle possible afterSave exception

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1076,6 +1076,29 @@ describe('Cloud Code', () => {
       });
   });
 
+  /**
+   * Verifies that an afterSave hook throwing an exception
+   * will not prevent a successful save response from being returned
+   */
+  it('after save should succeed on exception', (done) => {
+    Parse.Cloud.afterSave("AfterSaveTestClass", function () {
+      throw "Exception";
+    });
+    const AfterSaveTestClass = Parse.Object.extend('AfterSaveTestClass');
+    const obj = new AfterSaveTestClass();
+    obj.save()
+      .then(function() {
+        // expected success
+        done();
+      })
+      .catch(function() {
+        // failed
+        fail("afterSave throwing an exception indicated that the save failed");
+        done();
+      })
+
+  });
+
   describe('cloud jobs', () => {
     it('should define a job', (done) => {
       expect(() => {

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1080,7 +1080,7 @@ describe('Cloud Code', () => {
    * Verifies that an afterSave hook throwing an exception
    * will not prevent a successful save response from being returned
    */
-  it('after save should succeed on exception', (done) => {
+  it('should succeed on afterSave exception', (done) => {
     Parse.Cloud.afterSave("AfterSaveTestClass", function () {
       throw "Exception";
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1086,17 +1086,7 @@ describe('Cloud Code', () => {
     });
     const AfterSaveTestClass = Parse.Object.extend('AfterSaveTestClass');
     const obj = new AfterSaveTestClass();
-    obj.save()
-      .then(function() {
-        // expected success
-        done();
-      })
-      .catch(function() {
-        // failed
-        fail("afterSave throwing an exception indicated that the save failed");
-        done();
-      })
-
+    obj.save().then(done, done.fail);
   });
 
   describe('cloud jobs', () => {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -13,6 +13,7 @@ var triggers = require('./triggers');
 var ClientSDK = require('./ClientSDK');
 import RestQuery from './RestQuery';
 import _         from 'lodash';
+import logger    from './logger';
 
 // query and data are both provided in REST API format. So data
 // types are encoded by plain old objects.
@@ -1123,9 +1124,7 @@ RestWrite.prototype.runAfterTrigger = function() {
   // Run afterSave trigger
   return triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config)
     .catch(function(err) {
-      /* eslint-disable no-console */
-      console.warn('afterSave caught an error: ' + err);
-      /* eslint-enable no-console */
+      logger.warn('afterSave caught an error', err);
     })
 };
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1120,8 +1120,15 @@ RestWrite.prototype.runAfterTrigger = function() {
   // Notifiy LiveQueryServer if possible
   this.config.liveQueryController.onAfterSave(updatedObject.className, updatedObject, originalObject);
 
+
   // Run afterSave trigger
-  return triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config);
+  return triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config)
+    .catch(function(err) {
+      // log this error
+      /* eslint-disable no-console */
+      console.warn("afterSave caught an error: " + err);
+      /* eslint-enable no-console */
+    })
 };
 
 // A helper to figure out what location this operation happens at.

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1120,13 +1120,11 @@ RestWrite.prototype.runAfterTrigger = function() {
   // Notifiy LiveQueryServer if possible
   this.config.liveQueryController.onAfterSave(updatedObject.className, updatedObject, originalObject);
 
-
   // Run afterSave trigger
   return triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config)
     .catch(function(err) {
-      // log this error
       /* eslint-disable no-console */
-      console.warn("afterSave caught an error: " + err);
+      console.warn('afterSave caught an error: ' + err);
       /* eslint-enable no-console */
     })
 };


### PR DESCRIPTION
Addresses the issue brought up in #3995 , where an exception thrown in an afterSave hook would then result in a response that suggests the save completely failed. Following what is noted in the docs...
```
The client will receive a successful response to the save request 
after the handler terminates, regardless of how it terminates.
```
this PR checks for that exception in the expected form of a rejected promise. If caught we make a note and log a warning of the exception.

This also adds 1 test case to verify that an afterSave hook that explicitly throws an exception never returns the exception directly to the user in the response.