### PR TITLE
Adds support for read-only masterKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The client keys used with Parse are no longer necessary with Parse Server. If yo
 * `customPages` - A hash with urls to override email verification links, password reset links and specify frame url for masking user-facing pages. Available keys: `parseFrameURL`, `invalidLink`, `choosePassword`, `passwordResetSuccess`, `verifyEmailSuccess`.
 * `middleware` - (CLI only), a module name, function that is an express middleware. When using the CLI, the express app will load it just **before** mounting parse-server on the mount path. This option is useful for injecting a monitoring middleware.
 * `masterKeyIps` - The array of ip addresses where masterKey usage will be restricted to only these ips. (Default to [] which means allow all ips). If you're using this feature and have `useMasterKey: true` in cloudcode, make sure that you put your own ip in this list.
-* `readOnlyMasterKey` -  A masterKey that has full read access to the data, but no write access. This keys should be treated the same way as your masterKey, keeping it private.
+* `readOnlyMasterKey` -  A masterKey that has full read access to the data, but no write access. This key should be treated the same way as your masterKey, keeping it private.
 
 ##### Logging
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The client keys used with Parse are no longer necessary with Parse Server. If yo
 * `customPages` - A hash with urls to override email verification links, password reset links and specify frame url for masking user-facing pages. Available keys: `parseFrameURL`, `invalidLink`, `choosePassword`, `passwordResetSuccess`, `verifyEmailSuccess`.
 * `middleware` - (CLI only), a module name, function that is an express middleware. When using the CLI, the express app will load it just **before** mounting parse-server on the mount path. This option is useful for injecting a monitoring middleware.
 * `masterKeyIps` - The array of ip addresses where masterKey usage will be restricted to only these ips. (Default to [] which means allow all ips). If you're using this feature and have `useMasterKey: true` in cloudcode, make sure that you put your own ip in this list.
+* `readOnlyMasterKey` -  A masterKey that has full read access to the data, but no write access. This keys should be treated the same way as your masterKey, keeping it private.
 
 ##### Logging
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -90,6 +90,7 @@ var defaultConfiguration = {
   restAPIKey: 'rest',
   webhookKey: 'hook',
   masterKey: 'test',
+  readOnlyMasterKey: 'read-only-test',
   fileKey: 'test',
   silent,
   logLevel,

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -690,7 +690,7 @@ describe('read-only masterKey', () => {
     });
   });
 
-  it('should throw when trying to create schema', (done) => {
+  it('should throw when trying to create schema with a name', (done) => {
     return rp.post(`${Parse.serverURL}/schemas/MyClass`, {
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -4,11 +4,12 @@ var RestQuery = require('./RestQuery');
 // An Auth object tells you who is requesting something and whether
 // the master key was used.
 // userObject is a Parse.User and can be null if there's no user.
-function Auth({ config, isMaster = false, user, installationId } = {}) {
+function Auth({ config, isMaster = false, isReadOnly = false, user, installationId } = {}) {
   this.config = config;
   this.installationId = installationId;
   this.isMaster = isMaster;
   this.user = user;
+  this.isReadOnly = isReadOnly;
 
   // Assuming a users roles won't change during a single request, we'll
   // only load them once.
@@ -32,6 +33,11 @@ Auth.prototype.couldUpdateUserId = function(userId) {
 // A helper to get a master-level Auth object
 function master(config) {
   return new Auth({ config, isMaster: true });
+}
+
+// A helper to get a master-level Auth object
+function readOnly(config) {
+  return new Auth({ config, isMaster: true, isReadOnly: true });
 }
 
 // A helper to get a nobody-level Auth object
@@ -207,9 +213,10 @@ Auth.prototype._getAllRolesNamesForRoleIds = function(roleIDs, names = [], queri
 }
 
 module.exports = {
-  Auth: Auth,
-  master: master,
-  nobody: nobody,
+  Auth,
+  master,
+  nobody,
+  readOnly,
   getAuthForSessionToken,
   getAuthForLegacySessionToken
 };

--- a/src/Config.js
+++ b/src/Config.js
@@ -60,8 +60,15 @@ export class Config {
     emailVerifyTokenValidityDuration,
     accountLockout,
     passwordPolicy,
-    masterKeyIps
+    masterKeyIps,
+    masterKey,
+    readOnlyMasterKey,
   }) {
+
+    if (masterKey === readOnlyMasterKey) {
+      throw new Error('masterKey and readOnlyMasterKey should be different');
+    }
+
     const emailAdapter = userController.adapter;
     if (verifyUserEmails) {
       this.validateEmailConfiguration({emailAdapter, appName, publicServerURL, emailVerifyTokenValidityDuration});

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -123,6 +123,10 @@ module.exports.ParseServerOptions = {
     "env": "PARSE_SERVER_REST_API_KEY",
     "help": "Key for REST calls"
   },
+  "readOnlyMasterKey": {
+    "env": "PARSE_SERVER_READ_ONLY_MASTER_KEY",
+    "help": "Read-only key, which has the same capabilities as MasterKey without writes"
+  },
   "webhookKey": {
     "env": "PARSE_SERVER_WEBHOOK_KEY",
     "help": "Key sent with outgoing webhook calls"

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -58,6 +58,8 @@ export interface ParseServerOptions {
   /* Key for REST calls
   :ENV: PARSE_SERVER_REST_API_KEY */
   restAPIKey: ?string;
+  /* Read-only key, which has the same capabilities as MasterKey without writes */
+  readOnlyMasterKey: ?string;
   /* Key sent with outgoing webhook calls */
   webhookKey: ?string;
   /* Key for your files */

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -24,6 +24,9 @@ import _         from 'lodash';
 // everything. It also knows to use triggers and special modifications
 // for the _User class.
 function RestWrite(config, auth, className, query, data, originalData, clientSDK) {
+  if (auth.isReadOnly) {
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'Cannot perform a write operation when using readOnlyMasterKey');
+  }
   this.config = config;
   this.auth = auth;
   this.className = className;

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -1,5 +1,5 @@
 // global_config.js
-
+import Parse           from 'parse/node';
 import PromiseRouter   from '../PromiseRouter';
 import * as middleware from "../middlewares";
 
@@ -16,6 +16,9 @@ export class GlobalConfigRouter extends PromiseRouter {
   }
 
   updateGlobalConfig(req) {
+    if (req.auth.isReadOnly) {
+      throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to update the config.');
+    }
     const params = req.body.params;
     // Transform in dot notation to make sure it works
     const update = Object.keys(params).reduce((acc, key) => {

--- a/src/Routers/PushRouter.js
+++ b/src/Routers/PushRouter.js
@@ -9,6 +9,9 @@ export class PushRouter extends PromiseRouter {
   }
 
   static handlePOST(req) {
+    if (req.auth.isReadOnly) {
+      throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to send push notifications.');
+    }
     const pushController = req.config.pushController;
     if (!pushController) {
       throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED, 'Push controller is not set');

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -34,6 +34,9 @@ function getOneSchema(req) {
 }
 
 function createSchema(req) {
+  if (req.auth.isReadOnly) {
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to create a schema.');
+  }
   if (req.params.className && req.body.className) {
     if (req.params.className != req.body.className) {
       return classNameMismatchResponse(req.body.className, req.params.className);
@@ -51,6 +54,9 @@ function createSchema(req) {
 }
 
 function modifySchema(req) {
+  if (req.auth.isReadOnly) {
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to modify a schema.');
+  }
   if (req.body.className && req.body.className != req.params.className) {
     return classNameMismatchResponse(req.body.className, req.params.className);
   }
@@ -64,6 +70,9 @@ function modifySchema(req) {
 }
 
 const deleteSchema = req => {
+  if (req.auth.isReadOnly) {
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to modify a schema.');
+  }
   if (!SchemaController.classNameIsValid(req.params.className)) {
     throw new Parse.Error(Parse.Error.INVALID_CLASS_NAME, SchemaController.invalidClassNameMessage(req.params.className));
   }

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -55,7 +55,7 @@ function createSchema(req) {
 
 function modifySchema(req) {
   if (req.auth.isReadOnly) {
-    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to modify a schema.');
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to update a schema.');
   }
   if (req.body.className && req.body.className != req.params.className) {
     return classNameMismatchResponse(req.body.className, req.params.className);
@@ -71,7 +71,7 @@ function modifySchema(req) {
 
 const deleteSchema = req => {
   if (req.auth.isReadOnly) {
-    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to modify a schema.');
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'read-only masterKey isn\'t allowed to delete a schema.');
   }
   if (!SchemaController.classNameIsValid(req.params.className)) {
     throw new Parse.Error(Parse.Error.INVALID_CLASS_NAME, SchemaController.invalidClassNameMessage(req.params.className));

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -126,6 +126,13 @@ export function handleParseHeaders(req, res, next) {
     return;
   }
 
+  var isReadOnlyMaster = (info.masterKey === req.config.readOnlyMasterKey);
+  if (typeof req.config.readOnlyMasterKey != 'undefined' && req.config.readOnlyMasterKey && isReadOnlyMaster) {
+    req.auth = new auth.Auth({ config: req.config, installationId: info.installationId, isMaster: true, isReadOnly: true });
+    next();
+    return;
+  }
+
   // Client keys are not required in parse-server, but if any have been configured in the server, validate them
   //  to preserve original behavior.
   const keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];

--- a/src/rest.js
+++ b/src/rest.js
@@ -159,6 +159,12 @@ function enforceRoleSecurity(method, className, auth) {
     const error = `Clients aren't allowed to perform the ${method} operation on the ${className} collection.`
     throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, error);
   }
+
+  // readOnly masterKey is not allowed
+  if (auth.isReadOnly && (method === 'delete' || method === 'create' || method === 'update')) {
+    const error = `read-only masterKey isn't allowed to perform the ${method} operation.`
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, error);
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #4296 

The motivation for this feature is to provide read only access to all the data, in the dashboard, the readOnlyMasterKey should be treated with as much respect as the masterKey