### PR TITLE
Relative Time now,weeks,months,years

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -387,9 +387,9 @@ describe('relativeTimeToDate', () => {
 
   describe('In the future', () => {
     it('should parse valid natural time', () => {
-      const text = 'in 1 year 1 month 2 weeks 12 days 10 hours 24 minutes 30 seconds';
+      const text = 'in 1 year 2 weeks 12 days 10 hours 24 minutes 30 seconds';
       const { result, status, info } = transform.relativeTimeToDate(text, now);
-      expect(result.toISOString()).toBe('2018-11-21T23:52:46.617Z');
+      expect(result.toISOString()).toBe('2018-10-22T23:52:46.617Z');
       expect(status).toBe('success');
       expect(info).toBe('future');
     });

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -387,9 +387,9 @@ describe('relativeTimeToDate', () => {
 
   describe('In the future', () => {
     it('should parse valid natural time', () => {
-      const text = 'in 12 days 10 hours 24 minutes 30 seconds';
+      const text = 'in 1 year 1 month 2 weeks 12 days 10 hours 24 minutes 30 seconds';
       const { result, status, info } = transform.relativeTimeToDate(text, now);
-      expect(result.toISOString()).toBe('2017-10-08T23:52:46.617Z');
+      expect(result.toISOString()).toBe('2018-11-21T23:52:46.617Z');
       expect(status).toBe('success');
       expect(info).toBe('future');
     });
@@ -402,6 +402,16 @@ describe('relativeTimeToDate', () => {
       expect(result.toISOString()).toBe('2017-09-24T01:27:04.617Z');
       expect(status).toBe('success');
       expect(info).toBe('past');
+    });
+  });
+
+  describe('From now', () => {
+    it('should equal current time', () => {
+      const text = 'now';
+      const { result, status, info } = transform.relativeTimeToDate(text, now);
+      expect(result.toISOString()).toBe('2017-09-26T13:28:16.617Z');
+      expect(status).toBe('success');
+      expect(info).toBe('present');
     });
   });
 

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3171,7 +3171,7 @@ describe('Parse.Query testing', () => {
       })
       .then(() => {
         const q = new Parse.Query('MyCustomObject');
-        q.greaterThan('ttl', { $relativeTime: '1 year 2 months 3 weeks ago' });
+        q.greaterThan('ttl', { $relativeTime: '1 year 3 weeks ago' });
         return q.find({ useMasterKey: true });
       })
       .then((results) => {

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3152,6 +3152,23 @@ describe('Parse.Query testing', () => {
       .then((results) => {
         expect(results.length).toBe(2);
       })
+      .then(() => {
+        const q = new Parse.Query('MyCustomObject');
+        q.greaterThan('ttl', { $relativeTime: 'now' });
+        return q.find({ useMasterKey: true });
+      })
+      .then((results) => {
+        expect(results.length).toBe(1);
+      })
+      .then(() => {
+        const q = new Parse.Query('MyCustomObject');
+        q.greaterThan('ttl', { $relativeTime: 'now' });
+        q.lessThan('ttl', { $relativeTime: 'in 1 day' });
+        return q.find({ useMasterKey: true });
+      })
+      .then((results) => {
+        expect(results.length).toBe(0);
+      })
       .then(done, done.fail);
   });
 

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3169,6 +3169,14 @@ describe('Parse.Query testing', () => {
       .then((results) => {
         expect(results.length).toBe(0);
       })
+      .then(() => {
+        const q = new Parse.Query('MyCustomObject');
+        q.greaterThan('ttl', { $relativeTime: '1 year 2 months 3 weeks ago' });
+        return q.find({ useMasterKey: true });
+      })
+      .then((results) => {
+        expect(results.length).toBe(2);
+      })
       .then(done, done.fail);
   });
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -544,7 +544,7 @@ function relativeTimeToDate(text, now = new Date()) {
   const future = parts[0] === 'in';
   const past = parts[parts.length - 1] === 'ago';
 
-  if (!future && !past) {
+  if (!future && !past && text !== 'now') {
     return { status: 'error', info: "Time should either start with 'in' or end with 'ago'" };
   }
 
@@ -562,7 +562,7 @@ function relativeTimeToDate(text, now = new Date()) {
     parts = parts.slice(0, parts.length - 1);
   }
 
-  if (parts.length % 2 !== 0) {
+  if (parts.length % 2 !== 0 && text !== 'now') {
     return {
       status: 'error',
       info: 'Invalid time string. Dangling unit or number.',
@@ -626,13 +626,18 @@ function relativeTimeToDate(text, now = new Date()) {
       info: 'future',
       result: new Date(now.valueOf() + milliseconds)
     };
-  }
-  if (past) {
+  } else if (past) {
     return {
       status: 'success',
       info: 'past',
       result: new Date(now.valueOf() - milliseconds)
     };
+  } else {
+    return {
+      status: 'success',
+      info: 'present',
+      result: new Date(now.valueOf())
+    }
   }
 }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -592,13 +592,6 @@ function relativeTimeToDate(text, now = new Date()) {
       seconds += val * 31536000; // 365 * 24 * 60 * 60
       break;
 
-    case 'mo':
-    case 'mos':
-    case 'month':
-    case 'months':
-      seconds += val * 2592000; // 30 * 24 * 60 * 60, approx. 30 days/month
-      break;
-
     case 'wk':
     case 'wks':
     case 'week':

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -585,6 +585,28 @@ function relativeTimeToDate(text, now = new Date()) {
     }
 
     switch(interval) {
+    case 'yr':
+    case 'yrs':
+    case 'year':
+    case 'years':
+      seconds += val * 31536000; // 365 * 24 * 60 * 60
+      break;
+
+    case 'mo':
+    case 'mos':
+    case 'month':
+    case 'months':
+      seconds += val * 2592000; // 30 * 24 * 60 * 60, approx. 30 days/month
+      break;
+
+    case 'wk':
+    case 'wks':
+    case 'week':
+    case 'weeks':
+      seconds += val * 604800; // 7 * 24 * 60 * 60
+      break;
+
+    case 'd':
     case 'day':
     case 'days':
       seconds += val * 86400; // 24 * 60 * 60

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -256,6 +256,7 @@ class ParseServer {
           /* eslint-disable no-console */
           console.warn(`\nWARNING, Unable to connect to '${Parse.serverURL}'.` +
             ` Cloud code and push notifications may be unavailable!\n`);
+          /* eslint-enable no-console */
           if(callback) {
             callback(false);
           }


### PR DESCRIPTION
Adds `now` as a recognized singular unit of time, indicating to use the current time as is. 

I figure this would be handy in cases where you would like to fetch objects from a certain # of days/weeks ago, but _not_ past the current time, or vice versa. On it's own it may be handy as well for getting anything that is still in the future.

Also adds an `eslint-enable no-console` mark where previously it was not closed.