### PR TITLE
Structured /health Response

### DIFF
--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -3,12 +3,16 @@
 const express = require('express');
 
 import ParseServer from '../src/ParseServer';
+import { version } from '../package.json';
 
 describe('Server Url Checks', () => {
 
   const app = express();
   app.get('/health', function(req, res){
-    res.send('OK');
+    res.json({
+      status: 'ok',
+      version: version
+    });
   });
   app.listen(13376);
 

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -3,15 +3,13 @@
 const express = require('express');
 
 import ParseServer from '../src/ParseServer';
-import { version } from '../package.json';
 
 describe('Server Url Checks', () => {
 
   const app = express();
   app.get('/health', function(req, res){
     res.json({
-      status: 'ok',
-      version: version
+      status: 'ok'
     });
   });
   app.listen(13376);

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -33,7 +33,8 @@ import { SchemasRouter }        from './Routers/SchemasRouter';
 import { SessionsRouter }       from './Routers/SessionsRouter';
 import { UsersRouter }          from './Routers/UsersRouter';
 import { PurgeRouter }          from './Routers/PurgeRouter';
-import { AudiencesRouter }          from './Routers/AudiencesRouter';
+import { AudiencesRouter }      from './Routers/AudiencesRouter';
+import { version }              from '../package.json';
 
 import { ParseServerRESTController } from './ParseServerRESTController';
 import * as controllers from './Controllers';
@@ -137,7 +138,12 @@ class ParseServer {
       maxUploadSize: maxUploadSize
     }));
 
-    api.use('/health', (req, res) => res.sendStatus(200));
+    api.use('/health', (function(req, res) {
+      res.json({
+        version: version,
+        status: 'ok'
+      });
+    }));
 
     api.use('/', bodyParser.urlencoded({extended: false}), new PublicAPIRouter().expressRouter());
 
@@ -252,7 +258,13 @@ class ParseServer {
     if(Parse.serverURL) {
       const request = require('request');
       request(Parse.serverURL.replace(/\/$/, "") + "/health", function (error, response, body) {
-        if (error || response.statusCode !== 200 || body !== "OK") {
+        let json;
+        try {
+          json = JSON.parse(body);
+        } catch(e) {
+          json = null;
+        }
+        if (error || response.statusCode !== 200 || !json || json && json.status !== 'ok') {
           /* eslint-disable no-console */
           console.warn(`\nWARNING, Unable to connect to '${Parse.serverURL}'.` +
             ` Cloud code and push notifications may be unavailable!\n`);

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -34,7 +34,6 @@ import { SessionsRouter }       from './Routers/SessionsRouter';
 import { UsersRouter }          from './Routers/UsersRouter';
 import { PurgeRouter }          from './Routers/PurgeRouter';
 import { AudiencesRouter }      from './Routers/AudiencesRouter';
-import { version }              from '../package.json';
 
 import { ParseServerRESTController } from './ParseServerRESTController';
 import * as controllers from './Controllers';
@@ -140,7 +139,6 @@ class ParseServer {
 
     api.use('/health', (function(req, res) {
       res.json({
-        version: version,
         status: 'ok'
       });
     }));


### PR DESCRIPTION
The current response from `/health` is a simple `OK`. This is pretty straight forward, and is handy for quickly checking if a server is up. However the response from `/parse` will also do the same, leading the health check to appear rather extraneous.

This PR proposes to return structured data instead of a simple string from `/health`, sending a response that can be parsed by any of the sdks with additional details.
```json
{
    "status": "ok",
    "version": "2.6.5"
}
```
The endpoint remains simple, but through this we can not only tell if the server appears to be running but _which_ version of a server is running. I've also observed that certain providers of parse-server (sashido in this case) have already made a similar modification to their `/health` response.
```json
{
    "version":"X.Y.Z",
    "status":"ok",
    "database":"ok",
    "region":"2-us",
    "state":"finished",
    "build":"1",
    "deployment":"2"
}
```
Although what they are doing is not expected, I feel we could move to make this standard. Being able to assess a server by `/health` and knowing that you can expect a **status** and **version** as JSON is both handy and usable by all the sdks (if needed). With the server moving along, and no guarantee that a provider will be keeping up, this can provide an easier way to check for compatibility without needing the masterKey to check `/serverInfo`.

As stated above, I should note we already have `/serverInfo` which provides the version in addition to some _mostly_ [static configs](https://github.com/parse-community/parse-server/blob/master/src/Routers/FeaturesRouter.js#L7). In depth details may be better suited there, but I believe adding in the version to health makes sense as well.