### PR TITLE
Allows dot-notation to match against a complex structure when using matchesKeyInQuery

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3181,4 +3181,46 @@ describe('Parse.Query testing', () => {
       .then(() => q.find({ useMasterKey: true }))
       .then(done.fail, done);
   });
+
+  it('should match complex structure with dot notation when using matchesKeyInQuery', function(done) {
+    const group1 = new Parse.Object('Group', {
+      name: 'Group #1'
+    });
+
+    const group2 = new Parse.Object('Group', {
+      name: 'Group #2'
+    });
+
+    Parse.Object.saveAll([group1, group2])
+      .then(() => {
+        const role1 = new Parse.Object('Role', {
+          name: 'Role #1',
+          type: 'x',
+          belongsTo: group1
+        });
+
+        const role2 = new Parse.Object('Role', {
+          name: 'Role #2',
+          type: 'y',
+          belongsTo: group1
+        });
+
+        return Parse.Object.saveAll([role1, role2]);
+      })
+      .then(() => {
+        const rolesOfTypeX = new Parse.Query('Role');
+        rolesOfTypeX.equalTo('type', 'x');
+
+        const groupsWithRoleX = new Parse.Query('Group');
+        groupsWithRoleX.matchesKeyInQuery('objectId', 'belongsTo.objectId', rolesOfTypeX);
+
+        groupsWithRoleX.find(expectSuccess({
+          success: function(results) {
+            equal(results.length, 1);
+            equal(results[0].get('name'), group1.get('name'));
+            done();
+          }
+        }))
+      })
+  });
 });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -335,7 +335,7 @@ RestQuery.prototype.replaceNotInQuery = function() {
 const transformSelect = (selectObject, key ,objects) => {
   var values = [];
   for (var result of objects) {
-    values.push(result[key]);
+    values.push(key.split('.').reduce((o,i)=>o[i], result));
   }
   delete selectObject['$select'];
   if (Array.isArray(selectObject['$in'])) {


### PR DESCRIPTION
As the title suggests, this will allow dot notation to be used for matchesKeyInQuery, our use case is that we have a pointer we want to match against, simply using `result[key]` does not cut it.

Unfortunately I have not enough experience or time at the moment to write proper tests for this, so anyone is welcome to help with this PR.