### PR TITLE
Fix for _PushStatus Stuck 'running' when Count is Off

### DIFF
--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -282,7 +282,6 @@ describe('Parse.Push', () => {
       expect(result.get('status')).toEqual('succeeded');
       expect(result.get('numSent')).toEqual(1);
       expect(result.get('count')).toEqual(undefined);
-      expect(result.get('batches')).toEqual(undefined);
       done();
     });
   });
@@ -345,7 +344,6 @@ describe('Parse.Push', () => {
       expect(result.get('status')).toEqual('succeeded');
       expect(result.get('numSent')).toEqual(3);
       expect(result.get('count')).toEqual(undefined);
-      expect(result.get('batches')).toEqual(undefined);
       done();
     });
   });
@@ -390,7 +388,6 @@ describe('Parse.Push', () => {
       // expect # less than # of batches used, assuming each batch is 100 pushes
       expect(result.get('numSent')).toEqual(devices - (devices / 100));
       expect(result.get('count')).toEqual(undefined);
-      expect(result.get('batches')).toEqual(undefined);
       done();
     });
   });
@@ -460,7 +457,6 @@ describe('Parse.Push', () => {
       // expect # less than # of batches used, assuming each batch is 100 pushes
       expect(result.get('numSent')).toEqual(devices + (devices / 100));
       expect(result.get('count')).toEqual(undefined);
-      expect(result.get('batches')).toEqual(undefined);
       done();
     });
   });

--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -203,4 +203,265 @@ describe('Parse.Push', () => {
         done();
       });
   });
+
+  const successfulAny = function(body, installations) {
+    const promises = installations.map((device) => {
+      return Promise.resolve({
+        transmitted: true,
+        device: device,
+      })
+    });
+
+    return Promise.all(promises);
+  };
+
+  const provideInstallations = function(num) {
+    if(!num) {
+      num = 2;
+    }
+
+    const installations = [];
+    while(installations.length !== num) {
+      // add Android installations
+      const installation = new Parse.Object("_Installation");
+      installation.set("installationId", "installation_" + installations.length);
+      installation.set("deviceToken","device_token_" + installations.length);
+      installation.set("deviceType", "android");
+      installations.push(installation);
+    }
+
+    return installations;
+  };
+
+  const losingAdapter = {
+    send: function(body, installations) {
+      // simulate having lost an installation before this was called
+      // thus invalidating our 'count' in _PushStatus
+      installations.pop();
+
+      return successfulAny(body, installations);
+    },
+    getValidPushTypes: function() {
+      return ["android"];
+    }
+  };
+
+  /**
+   * Verifies that _PushStatus cannot get stuck in a 'running' state
+   * Simulates a simple push where 1 installation is removed between _PushStatus
+   * count being set and the pushes being sent
+   */
+  it('does not get stuck with _PushStatus \'running\' on 1 installation lost', (done) => {
+    reconfigureServer({
+      push: {adapter: losingAdapter}
+    }).then(() => {
+      return Parse.Object.saveAll(provideInstallations());
+    }).then(() => {
+      return Parse.Push.send(
+        {
+          data: {alert: "We fixed our status!"},
+          where: {deviceType: 'android'}
+        },
+        { useMasterKey: true }
+      );
+    }).then(() => {
+      // it is enqueued so it can take time
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+    }).then(() => {
+      // query for push status
+      const query = new Parse.Query('_PushStatus');
+      return query.find({useMasterKey: true});
+    }).then((results) => {
+      // verify status is NOT broken
+      expect(results.length).toBe(1);
+      const result = results[0];
+      expect(result.get('status')).toEqual('succeeded');
+      expect(result.get('numSent')).toEqual(1);
+      expect(result.get('count')).toEqual(undefined);
+      expect(result.get('batches')).toEqual(undefined);
+      done();
+    });
+  });
+
+  /**
+   * Verifies that _PushStatus cannot get stuck in a 'running' state
+   * Simulates a simple push where 1 installation is added between _PushStatus
+   * count being set and the pushes being sent
+   */
+  it('does not get stuck with _PushStatus \'running\' on 1 installation added', (done) => {
+    const installations = provideInstallations();
+
+    // add 1 iOS installation which we will omit & add later on
+    const iOSInstallation = new Parse.Object("_Installation");
+    iOSInstallation.set("installationId", "installation_" + installations.length);
+    iOSInstallation.set("deviceToken","device_token_" + installations.length);
+    iOSInstallation.set("deviceType", "ios");
+    installations.push(iOSInstallation);
+
+    reconfigureServer({
+      push: {
+        adapter: {
+          send: function(body, installations) {
+            // simulate having added an installation before this was called
+            // thus invalidating our 'count' in _PushStatus
+            installations.push(iOSInstallation);
+
+            return successfulAny(body, installations);
+          },
+          getValidPushTypes: function() {
+            return ["android"];
+          }
+        }
+      }
+    }).then(() => {
+      return Parse.Object.saveAll(installations);
+    }).then(() => {
+      return Parse.Push.send(
+        {
+          data: {alert: "We fixed our status!"},
+          where: {deviceType: {'$ne' : 'random'}}
+        },
+        { useMasterKey: true }
+      );
+    }).then(() => {
+      // it is enqueued so it can take time
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+    }).then(() => {
+      // query for push status
+      const query = new Parse.Query('_PushStatus');
+      return query.find({useMasterKey: true});
+    }).then((results) => {
+      // verify status is NOT broken
+      expect(results.length).toBe(1);
+      const result = results[0];
+      expect(result.get('status')).toEqual('succeeded');
+      expect(result.get('numSent')).toEqual(3);
+      expect(result.get('count')).toEqual(undefined);
+      expect(result.get('batches')).toEqual(undefined);
+      done();
+    });
+  });
+
+  /**
+   * Verifies that _PushStatus cannot get stuck in a 'running' state
+   * Simulates an extended push, where some installations may be removed,
+   * resulting in a non-zero count
+   */
+  it('does not get stuck with _PushStatus \'running\' on many installations removed', (done) => {
+    const devices = 1000;
+    const installations = provideInstallations(devices);
+
+    reconfigureServer({
+      push: {adapter: losingAdapter}
+    }).then(() => {
+      return Parse.Object.saveAll(installations);
+    }).then(() => {
+      return Parse.Push.send(
+        {
+          data: {alert: "We fixed our status!"},
+          where: {deviceType: 'android'}
+        },
+        { useMasterKey: true }
+      );
+    }).then(() => {
+      // it is enqueued so it can take time
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+    }).then(() => {
+      // query for push status
+      const query = new Parse.Query('_PushStatus');
+      return query.find({useMasterKey: true});
+    }).then((results) => {
+      // verify status is NOT broken
+      expect(results.length).toBe(1);
+      const result = results[0];
+      expect(result.get('status')).toEqual('succeeded');
+      // expect # less than # of batches used, assuming each batch is 100 pushes
+      expect(result.get('numSent')).toEqual(devices - (devices / 100));
+      expect(result.get('count')).toEqual(undefined);
+      expect(result.get('batches')).toEqual(undefined);
+      done();
+    });
+  });
+
+  /**
+   * Verifies that _PushStatus cannot get stuck in a 'running' state
+   * Simulates an extended push, where some installations may be added,
+   * resulting in a non-zero count
+   */
+  it('does not get stuck with _PushStatus \'running\' on many installations added', (done) => {
+    const devices = 1000;
+    const installations = provideInstallations(devices);
+
+    // add 1 iOS installation which we will omit & add later on
+    const iOSInstallations = [];
+
+    while(iOSInstallations.length !== (devices / 100)) {
+      const iOSInstallation = new Parse.Object("_Installation");
+      iOSInstallation.set("installationId", "installation_" + installations.length);
+      iOSInstallation.set("deviceToken", "device_token_" + installations.length);
+      iOSInstallation.set("deviceType", "ios");
+      installations.push(iOSInstallation);
+      iOSInstallations.push(iOSInstallation);
+    }
+
+    reconfigureServer({
+      push: {
+        adapter: {
+          send: function(body, installations) {
+            // simulate having added an installation before this was called
+            // thus invalidating our 'count' in _PushStatus
+            installations.push(iOSInstallations.pop());
+
+            return successfulAny(body, installations);
+          },
+          getValidPushTypes: function() {
+            return ["android"];
+          }
+        }
+      }
+    }).then(() => {
+      return Parse.Object.saveAll(installations);
+    }).then(() => {
+      return Parse.Push.send(
+        {
+          data: {alert: "We fixed our status!"},
+          where: {deviceType: {'$ne' : 'random'}}
+        },
+        { useMasterKey: true }
+      );
+    }).then(() => {
+      // it is enqueued so it can take time
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      });
+    }).then(() => {
+      // query for push status
+      const query = new Parse.Query('_PushStatus');
+      return query.find({useMasterKey: true});
+    }).then((results) => {
+      // verify status is NOT broken
+      expect(results.length).toBe(1);
+      const result = results[0];
+      expect(result.get('status')).toEqual('succeeded');
+      // expect # less than # of batches used, assuming each batch is 100 pushes
+      expect(result.get('numSent')).toEqual(devices + (devices / 100));
+      expect(result.get('count')).toEqual(undefined);
+      expect(result.get('batches')).toEqual(undefined);
+      done();
+    });
+  });
 });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -276,7 +276,7 @@ describe('PushWorker', () => {
           'failedPerType.ios': { __op: 'Increment', amount: 1 },
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
-          count: { __op: 'Increment', amount: -2 }
+          count: { __op: 'Increment', amount: -1 }
         });
         const query = new Parse.Query('_PushStatus');
         return query.get(handler.objectId, { useMasterKey: true });
@@ -354,7 +354,7 @@ describe('PushWorker', () => {
           'failedPerType.ios': { __op: 'Increment', amount: 1 },
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
-          count: { __op: 'Increment', amount: -2 }
+          count: { __op: 'Increment', amount: -1 }
         });
         done();
       });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -277,6 +277,7 @@ describe('PushWorker', () => {
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           count: { __op: 'Increment', amount: -2 },
+          batches: { __op: 'Increment', amount: -1 },
         });
         const query = new Parse.Query('_PushStatus');
         return query.get(handler.objectId, { useMasterKey: true });
@@ -355,6 +356,7 @@ describe('PushWorker', () => {
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           count: { __op: 'Increment', amount: -2 },
+          batches: { __op: 'Increment', amount: -1 },
         });
         done();
       });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -276,8 +276,7 @@ describe('PushWorker', () => {
           'failedPerType.ios': { __op: 'Increment', amount: 1 },
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
-          count: { __op: 'Increment', amount: -2 },
-          batches: { __op: 'Increment', amount: -1 },
+          count: { __op: 'Increment', amount: -2 }
         });
         const query = new Parse.Query('_PushStatus');
         return query.get(handler.objectId, { useMasterKey: true });
@@ -355,8 +354,7 @@ describe('PushWorker', () => {
           'failedPerType.ios': { __op: 'Increment', amount: 1 },
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
-          count: { __op: 'Increment', amount: -2 },
-          batches: { __op: 'Increment', amount: -1 },
+          count: { __op: 'Increment', amount: -2 }
         });
         done();
       });

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -88,8 +88,7 @@ const defaultColumns = Object.freeze({
     "failedPerType":       {type:'Object'},
     "sentPerUTCOffset":    {type:'Object'},
     "failedPerUTCOffset":  {type:'Object'},
-    "count":               {type:'Number'}, // tracks estimated # of pushes pending
-    "batches":             {type:'Number'}  // tracks # of batches queued and pending
+    "count":               {type:'Number'} // tracks # of batches queued and pending
   },
   _JobStatus: {
     "jobName":    {type: 'String'},

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -88,7 +88,8 @@ const defaultColumns = Object.freeze({
     "failedPerType":       {type:'Object'},
     "sentPerUTCOffset":    {type:'Object'},
     "failedPerUTCOffset":  {type:'Object'},
-    "count":               {type:'Number'}
+    "count":               {type:'Number'}, // tracks estimated # of pushes pending
+    "batches":             {type:'Number'}  // tracks # of batches queued and pending
   },
   _JobStatus: {
     "jobName":    {type: 'String'},

--- a/src/Push/PushQueue.js
+++ b/src/Push/PushQueue.js
@@ -40,7 +40,7 @@ export class PushQueue {
       if (!results || count == 0) {
         return Promise.reject({error: 'PushController: no results in query'})
       }
-      pushStatus.setRunning(count);
+      pushStatus.setRunning(count, Math.ceil(count / limit));
       let skip = 0;
       while (skip < count) {
         const query = { where,

--- a/src/Push/PushQueue.js
+++ b/src/Push/PushQueue.js
@@ -40,7 +40,7 @@ export class PushQueue {
       if (!results || count == 0) {
         return Promise.reject({error: 'PushController: no results in query'})
       }
-      pushStatus.setRunning(count, Math.ceil(count / limit));
+      pushStatus.setRunning(Math.ceil(count / limit));
       let skip = 0;
       while (skip < count) {
         const query = { where,

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -190,8 +190,8 @@ export function pushStatusHandler(config, existingObjectId) {
     });
   }
 
-  const setRunning = function(count, batches) {
-    logger.verbose(`_PushStatus ${objectId}: sending push to %d installations with %d batches`, count, batches);
+  const setRunning = function(batches) {
+    logger.verbose(`_PushStatus ${objectId}: sending push to installations with %d batches`, batches);
     return handler.update(
       {
         status:"pending",
@@ -199,8 +199,7 @@ export function pushStatusHandler(config, existingObjectId) {
       },
       {
         status: "running",
-        count: count,
-        batches: batches
+        count: batches
       }
     );
   }
@@ -244,7 +243,6 @@ export function pushStatusHandler(config, existingObjectId) {
         }
         return memo;
       }, update);
-      incrementOp(update, 'count', -results.length);
     }
 
     logger.verbose(`_PushStatus ${objectId}: sent push! %d success, %d failures`, update.numSent, update.numFailed);
@@ -269,10 +267,10 @@ export function pushStatusHandler(config, existingObjectId) {
     }
 
     // indicate this batch is complete
-    incrementOp(update, 'batches', -1);
+    incrementOp(update, 'count', -1);
 
     return handler.update({ objectId }, update).then((res) => {
-      if (res && res.batches === 0) {
+      if (res && res.count === 0) {
         return this.complete();
       }
     })
@@ -281,8 +279,7 @@ export function pushStatusHandler(config, existingObjectId) {
   const complete = function() {
     return handler.update({ objectId }, {
       status: 'succeeded',
-      count: {__op: 'Delete'},
-      batches: {__op: 'Delete'}
+      count: {__op: 'Delete'}
     });
   }
 


### PR DESCRIPTION
This is a proposed fix for #4315, where `count` computed for tracking outstanding pushes can differ from the actual # of devices that will be sent to. 

During large operations this can occur where there is a significant time variation between the original computing of `count` and completion of the pushes. Also count can potentially provide an incorrect value on sharded dbs. With this in mind it makes more sense to track the _batches_ instead. The # of batches is computed from the `count` that is set on `_PushStatus`, and even if the number of matched `_Installation` objects changes this does not. Given that, you can reliably track the batches instead of the count and still have an accurate `running` time.

This does **not** modify the existing behavior with `count`, so any dependence that anything or anyone may have on that factor is unchanged. The tracking for batches is achieved via an additional `batches` field on `_PushStatus`.

This adds some tests with a modified push adapter that either 'drops' or 'adds' installations during send ops to simulate `count` being inaccurate.