### PR TITLE
Fix for unhandled undefined config

### DIFF
--- a/spec/PublicAPI.spec.js
+++ b/spec/PublicAPI.spec.js
@@ -63,3 +63,47 @@ describe("public API without publicServerURL", () => {
     });
   });
 });
+
+
+describe("public API supplied with invalid application id", () => {
+  beforeEach(done => {
+    reconfigureServer({appName: "unused"})
+      .then(done, fail);
+  });
+
+  it("should get 403 on verify_email", (done) => {
+    request('http://localhost:8378/1/apps/invalid/verify_email', (err, httpResponse) => {
+      expect(httpResponse.statusCode).toBe(403);
+      done();
+    });
+  });
+
+  it("should get 403 choose_password", (done) => {
+    request('http://localhost:8378/1/apps/choose_password?id=invalid', (err, httpResponse) => {
+      expect(httpResponse.statusCode).toBe(403);
+      done();
+    });
+  });
+
+  it("should get 403 on get of request_password_reset", (done) => {
+    request('http://localhost:8378/1/apps/invalid/request_password_reset', (err, httpResponse) => {
+      expect(httpResponse.statusCode).toBe(403);
+      done();
+    });
+  });
+
+
+  it("should get 403 on post of request_password_reset", (done) => {
+    request.post('http://localhost:8378/1/apps/invalid/request_password_reset', (err, httpResponse) => {
+      expect(httpResponse.statusCode).toBe(403);
+      done();
+    });
+  });
+
+  it("should get 403 on resendVerificationEmail", (done) => {
+    request('http://localhost:8378/1/apps/invalid/resend_verification_email', (err, httpResponse) => {
+      expect(httpResponse.statusCode).toBe(403);
+      done();
+    });
+  });
+});

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -14,7 +14,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const { token, username } = req.query;
     const appId = req.params.appId;
     const config = Config.get(appId);
-    
+
     if(!config){
       this.invalidRequest();
     }
@@ -74,7 +74,7 @@ export class PublicAPIRouter extends PromiseRouter {
   changePassword(req) {
     return new Promise((resolve, reject) => {
       const config = Config.get(req.query.id);
-      
+
       if(!config){
         this.invalidRequest();
       }
@@ -193,10 +193,10 @@ export class PublicAPIRouter extends PromiseRouter {
   }
 
   invalidRequest() {
-      const error = new Error();
-      error.status = 403;
-      error.message = "unauthorized";
-      throw error;
+    const error = new Error();
+    error.status = 403;
+    error.message = "unauthorized";
+    throw error;
   }
 
   setConfig(req) {

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -16,7 +16,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const config = Config.get(appId);
     
     if(!config){
-      this.invalidRequest():
+      this.invalidRequest();
     }
 
     if (!config.publicServerURL) {
@@ -45,7 +45,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const config = Config.get(appId);
 
     if(!config){
-      this.invalidRequest():
+      this.invalidRequest();
     }
 
     if (!config.publicServerURL) {
@@ -103,7 +103,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const config = req.config;
 
     if(!config){
-      this.invalidRequest():
+      this.invalidRequest();
     }
 
     if (!config.publicServerURL) {
@@ -132,7 +132,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const config = req.config;
 
     if(!config){
-      this.invalidRequest():
+      this.invalidRequest();
     }
 
     if (!config.publicServerURL) {

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -15,7 +15,11 @@ export class PublicAPIRouter extends PromiseRouter {
     const appId = req.params.appId;
     const config = Config.get(appId);
 
-    if (!config || !config.publicServerURL) {
+    if(!config) {
+        this.invalidRequest();
+    }
+
+    if (!config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -40,7 +44,11 @@ export class PublicAPIRouter extends PromiseRouter {
     const appId = req.params.appId;
     const config = Config.get(appId);
 
-    if (!config || !config.publicServerURL) {
+    if(!config) {
+        this.invalidRequest();
+    }
+
+    if (!config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -66,7 +74,12 @@ export class PublicAPIRouter extends PromiseRouter {
   changePassword(req) {
     return new Promise((resolve, reject) => {
       const config = Config.get(req.query.id);
-      if (!config || !config.publicServerURL) {
+
+      if(!config) {
+          this.invalidRequest();
+      }
+
+      if (!config.publicServerURL) {
         return resolve({
           status: 404,
           text: 'Not found.'
@@ -89,7 +102,11 @@ export class PublicAPIRouter extends PromiseRouter {
 
     const config = req.config;
 
-    if (!config || !config.publicServerURL) {
+    if(!config) {
+        this.invalidRequest();
+    }
+
+    if (!config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -114,7 +131,11 @@ export class PublicAPIRouter extends PromiseRouter {
 
     const config = req.config;
 
-    if (!config || !config.publicServerURL) {
+    if(!config) {
+        this.invalidRequest();
+    }
+
+    if (!config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -135,7 +156,7 @@ export class PublicAPIRouter extends PromiseRouter {
         location: `${config.passwordResetSuccessURL}?${params}`
       });
     }, (err) => {
-      const params = qs.stringify({username: username, token: token, id: config.applicationId, error:err, app:config.appName})
+      const params = qs.stringify({username: username, token: token, id: config.applicationId, error:err, app:config.appName});
       return Promise.resolve({
         status: 302,
         location: `${config.choosePasswordURL}?${params}`
@@ -169,6 +190,13 @@ export class PublicAPIRouter extends PromiseRouter {
       text:  'Not found.',
       status: 404
     });
+  }
+
+  invalidRequest() {
+      const error = new Error();
+      error.status = 403;
+      error.message = "unauthorized";
+      throw error;
   }
 
   setConfig(req) {

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -15,7 +15,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const appId = req.params.appId;
     const config = Config.get(appId);
 
-    if (!config.publicServerURL) {
+    if (!config || !config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -40,7 +40,7 @@ export class PublicAPIRouter extends PromiseRouter {
     const appId = req.params.appId;
     const config = Config.get(appId);
 
-    if (!config.publicServerURL) {
+    if (!config || !config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -66,7 +66,7 @@ export class PublicAPIRouter extends PromiseRouter {
   changePassword(req) {
     return new Promise((resolve, reject) => {
       const config = Config.get(req.query.id);
-      if (!config.publicServerURL) {
+      if (!config || !config.publicServerURL) {
         return resolve({
           status: 404,
           text: 'Not found.'
@@ -89,7 +89,7 @@ export class PublicAPIRouter extends PromiseRouter {
 
     const config = req.config;
 
-    if (!config.publicServerURL) {
+    if (!config || !config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 
@@ -114,7 +114,7 @@ export class PublicAPIRouter extends PromiseRouter {
 
     const config = req.config;
 
-    if (!config.publicServerURL) {
+    if (!config || !config.publicServerURL) {
       return this.missingPublicServerURL();
     }
 

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -14,9 +14,9 @@ export class PublicAPIRouter extends PromiseRouter {
     const { token, username } = req.query;
     const appId = req.params.appId;
     const config = Config.get(appId);
-
-    if(!config) {
-        this.invalidRequest();
+    
+    if(!config){
+      this.invalidRequest():
     }
 
     if (!config.publicServerURL) {
@@ -44,8 +44,8 @@ export class PublicAPIRouter extends PromiseRouter {
     const appId = req.params.appId;
     const config = Config.get(appId);
 
-    if(!config) {
-        this.invalidRequest();
+    if(!config){
+      this.invalidRequest():
     }
 
     if (!config.publicServerURL) {
@@ -74,9 +74,9 @@ export class PublicAPIRouter extends PromiseRouter {
   changePassword(req) {
     return new Promise((resolve, reject) => {
       const config = Config.get(req.query.id);
-
-      if(!config) {
-          this.invalidRequest();
+      
+      if(!config){
+        this.invalidRequest();
       }
 
       if (!config.publicServerURL) {
@@ -102,8 +102,8 @@ export class PublicAPIRouter extends PromiseRouter {
 
     const config = req.config;
 
-    if(!config) {
-        this.invalidRequest();
+    if(!config){
+      this.invalidRequest():
     }
 
     if (!config.publicServerURL) {
@@ -131,8 +131,8 @@ export class PublicAPIRouter extends PromiseRouter {
 
     const config = req.config;
 
-    if(!config) {
-        this.invalidRequest();
+    if(!config){
+      this.invalidRequest():
     }
 
     if (!config.publicServerURL) {


### PR DESCRIPTION
When an invalid application id is passed either for reset/change password or email verification, config.get returns undefined. This causes internal server.