### PR TITLE
Leverage aggregation pipelines for $relatedTo queries

### DIFF
--- a/spec/ParseRelation.spec.js
+++ b/spec/ParseRelation.spec.js
@@ -777,4 +777,31 @@ describe('Parse.Relation testing', () => {
         done();
       });
   });
+
+  it('can skip/limit correctly', done => {
+    var ChildObject = Parse.Object.extend("ChildObject");
+    var childObjects = [];
+    for (var i = 0; i < 10; i++) {
+      childObjects.push(new ChildObject({x:i}));
+    }
+    var ParentObject = Parse.Object.extend("ParentObject");
+    var parent = new ParentObject();
+    Parse.Object.saveAll(childObjects).then(() => {
+      parent.set("x", 4);
+      var relation = parent.relation("child");
+      relation.add(childObjects);
+      return parent.save()
+    }).then(() => {
+      const query = parent.relation('child').query();
+      query.ascending('x');
+      query.limit(2);
+      query.skip(3);
+      return query.find();
+    }).then((results) => {
+      expect(results.length).toBe(2);
+      expect(results[0].get('x')).toBe(3);
+      expect(results[1].get('x')).toBe(4);
+    })
+      .then(done, done.fail);
+  });
 });

--- a/spec/ParseRelation.spec.js
+++ b/spec/ParseRelation.spec.js
@@ -169,7 +169,7 @@ describe('Parse.Relation testing', () => {
     var ChildObject = Parse.Object.extend("ChildObject");
     var childObjects = [];
     for (var i = 0; i < 10; i++) {
-      childObjects.push(new ChildObject({x: i}));
+      childObjects.push(new ChildObject({x: i, y: 'yolo'}));
     }
 
     Parse.Object.saveAll(childObjects, {
@@ -185,6 +185,7 @@ describe('Parse.Relation testing', () => {
           success: function() {
             var query = relation.query();
             query.equalTo("x", 2);
+            query.select('x');
             query.find({
               success: function(list) {
                 equal(list.length, 1,
@@ -193,6 +194,8 @@ describe('Parse.Relation testing', () => {
                   "Should be of type ChildObject");
                 equal(list[0].id, childObjects[2].id,
                   "We should have gotten back the right result");
+                expect(list[0].get('x')).toBe(2);
+                expect(list[0].get('y')).toBeUndefined();
                 done();
               }
             });

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -83,6 +83,10 @@ export default class MongoCollection {
     return this._mongoCollection.deleteMany(query);
   }
 
+  aggregate(options) {
+    return this._mongoCollection.aggregate(options).toArray();
+  }
+
   _ensureSparseUniqueIndexInBackground(indexRequest) {
     return new Promise((resolve, reject) => {
       this._mongoCollection.ensureIndex(indexRequest, { unique: true, background: true, sparse: true }, (error) => {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -365,7 +365,7 @@ export class MongoStorageAdapter {
       .then(objects => objects.map(object => mongoObjectToParseObject(className, object, schema)))
   }
 
-  leftJoin(className, from, localField, foreignField, schema, leftQuery, query, sort, keys, count) {
+  leftJoin(className, localField, from, foreignField, schema, leftQuery, query, { skip, limit, sort, keys, count }) {
     const as = `from_${from}`;
     schema = convertParseSchemaToMongoSchema(schema);
     // TODO: optimize here for keys mapping
@@ -406,6 +406,12 @@ export class MongoStorageAdapter {
     }
     if (sort && Object.keys(sort).length > 0) {
       aggregate.push({ $sort: sort });
+    }
+    if (skip) {
+      aggregate.push({ $skip: skip });
+    }
+    if (limit) {
+      aggregate.push({ $limit: limit });
     }
     if (keys && Object.keys(keys).length > 0) {
       aggregate.push({ $project: keys });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -871,9 +871,9 @@ DatabaseController.prototype.find = function(className, query, {
                 let promise;
                 if (relatedTo) {
                   const joinTable = joinTableName(relatedTo.object.className, relatedTo.key);
-                  promise = this.adapter.leftJoin(joinTable, className, 'relatedId', '_id', schema, {
+                  promise = this.adapter.leftJoin(joinTable, 'relatedId', className, '_id', schema, {
                     'owningId': relatedTo.object.objectId,
-                  }, query, sort, keys, count);
+                  }, query, { skip, limit, sort, keys, readPreference, count });
                 } else {
                   promise = this.adapter.find(className, schema, query, { skip, limit, sort, keys, readPreference });
                 }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -830,7 +830,12 @@ DatabaseController.prototype.find = function(className, query, {
             }
           });
           return (isMaster ? Promise.resolve() : schemaController.validatePermission(className, aclGroup, op))
-            .then(() => this.reduceRelationKeys(className, query))
+            .then(() => {
+              if (typeof this.adapter.leftJoin === 'function' && query['$relatedTo']) { // do the thing
+                return;
+              }
+              return this.reduceRelationKeys(className, query)
+            })
             .then(() => this.reduceInRelation(className, query, schemaController))
             .then(() => {
               if (!isMaster) {
@@ -846,25 +851,39 @@ DatabaseController.prototype.find = function(className, query, {
               if (!isMaster) {
                 query = addReadACL(query, aclGroup);
               }
+              // Cleanup related to before query validation
+              // can posibly be better
+              let relatedTo;
+              if (typeof this.adapter.leftJoin === 'function' && query['$relatedTo']) {
+                relatedTo = query['$relatedTo'];
+                delete query['$relatedTo'];
+              }
               validateQuery(query);
-              if (count) {
-                if (!classExists) {
+              if (!classExists) {
+                if (count) {
                   return 0;
-                } else {
-                  return this.adapter.count(className, schema, query, readPreference);
                 }
+                return [];
+              }
+              if (count && !relatedTo) {
+                return this.adapter.count(className, schema, query, readPreference);
               } else {
-                if (!classExists) {
-                  return [];
+                let promise;
+                if (relatedTo) {
+                  const joinTable = joinTableName(relatedTo.object.className, relatedTo.key);
+                  promise = this.adapter.leftJoin(joinTable, className, 'relatedId', '_id', schema, {
+                    'owningId': relatedTo.object.objectId,
+                  }, query, sort, keys, count);
                 } else {
-                  return this.adapter.find(className, schema, query, { skip, limit, sort, keys, readPreference })
-                    .then(objects => objects.map(object => {
-                      object = untransformObjectACL(object);
-                      return filterSensitiveData(isMaster, aclGroup, className, object)
-                    })).catch((error) => {
-                      throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, error);
-                    });
+                  promise = this.adapter.find(className, schema, query, { skip, limit, sort, keys, readPreference });
                 }
+                return promise
+                  .then(objects => objects.map(object => {
+                    object = untransformObjectACL(object);
+                    return filterSensitiveData(isMaster, aclGroup, className, object)
+                  })).catch((error) => {
+                    throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, error);
+                  });
               }
             });
         });


### PR DESCRIPTION
- use aggregation $lookup operator to 'join' tables on mongoDB instead of in parse-server memory.
- only compatible with mongoDB 3.2+ (let's discuss if we wanna have backwards compatibility with older DB versions)
- see: https://www.mongodb.com/blog/post/joins-and-other-aggregation-enhancements-coming-in-mongodb-3-2-part-2-of-3-worked-examples

