### PR TITLE
Fortifies Duplicate User Email Validation

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -450,15 +450,13 @@ RestWrite.prototype._validateEmail = function() {
   }
 
   // Validate basic email address format.
-  // Will strip spaces surrounding the string. Any space within the string will not pass.
-  if (!this.data.email.trim().match( /^[^\s@]+@[^\s@]+\.[^\s@]+$/ )) {
+  // Will strip spaces surrounding the string. If any space within the string, will not pass.
+  if (!this.data.email.trim().match( /^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/ )) {
     return Promise.reject(new Parse.Error(Parse.Error.INVALID_EMAIL_ADDRESS, 'Email address format is invalid.'));
   }
 
   //Fixes issues where emails might be duplicated because of a space ' ' or case sensitivity.
-  if ( this.data.email ) {
-    this.data.email = this.data.email.split(' ').join('').toLowerCase();
-  }
+  this.data.email = this.data.email.split(' ').join('').toLowerCase();
   
   // Same problem for email as above for username
   return this.config.database.find(

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -448,10 +448,18 @@ RestWrite.prototype._validateEmail = function() {
   if (!this.data.email || this.data.email.__op === 'Delete') {
     return Promise.resolve();
   }
-  // Validate basic email address format
-  if (!this.data.email.match(/^.+@.+$/)) {
+
+  // Validate basic email address format.
+  // Will strip spaces surrounding the string. Any space within the string will not pass.
+  if (!this.data.email.trim().match( /^[^\s@]+@[^\s@]+\.[^\s@]+$/ )) {
     return Promise.reject(new Parse.Error(Parse.Error.INVALID_EMAIL_ADDRESS, 'Email address format is invalid.'));
   }
+
+  //Fixes issues where emails might be duplicated because of a space ' ' or case sensitivity.
+  if ( this.data.email ) {
+    this.data.email = this.data.email.split(' ').join('').toLowerCase();
+  }
+  
   // Same problem for email as above for username
   return this.config.database.find(
     this.className,


### PR DESCRIPTION
Duplicates emails could be created if emails does not match exactly.
Like AB@CD.com and ab@cD.com
Also, strings in the middle of emails were allowed..

This change will force emails not to contain spaces and to always be converted to lower case before saving user.