### PR TITLE
Adds optimization for related relations

### DIFF
--- a/spec/ParseRelation.spec.js
+++ b/spec/ParseRelation.spec.js
@@ -163,6 +163,33 @@ describe('Parse.Relation testing', () => {
     });
   });
 
+  it("related at ordering optimizations", (done) => {
+    var ChildObject = Parse.Object.extend("ChildObject");
+    var childObjects = [];
+    for (var i = 0; i < 10; i++) {
+      childObjects.push(new ChildObject({x: i}));
+    }
+
+    var parent;
+    var relation;
+
+    Parse.Object.saveAll(childObjects).then(function() {
+      var ParentObject = Parse.Object.extend('ParentObject');
+      parent = new ParentObject();
+      parent.set('x', 4);
+      relation = parent.relation('child');
+      relation.add(childObjects);
+      return parent.save();
+    }).then(function() {
+      const query = relation.query();
+      query.descending('createdAt');
+      query.skip(1);
+      query.limit(3);
+      return query.find();
+    }).then(function(list) {
+      expect(list.length).toBe(3);
+    }).then(done, done.fail);
+  });
 
   it_exclude_dbs(['postgres'])("queries with relations", (done) => {
 

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -86,7 +86,7 @@ export class MongoStorageAdapter {
   // Public
   connectionPromise;
   database;
-
+  canSortOnJoinTables;
   constructor({
     uri = defaults.DefaultMongoURI,
     collectionPrefix = '',
@@ -98,6 +98,7 @@ export class MongoStorageAdapter {
 
     // MaxTimeMS is not a global MongoDB client option, it is applied per operation.
     this._maxTimeMS = mongoOptions.maxTimeMS;
+    this.canSortOnJoinTables = true;
     delete mongoOptions.maxTimeMS;
   }
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -602,7 +602,7 @@ DatabaseController.prototype.deleteEverything = function() {
 DatabaseController.prototype.relatedIds = function(className, key, owningId, queryOptions) {
   const { skip, limit, sort } = queryOptions;
   const findOptions = {};
-  if (sort && sort.createdAt) {
+  if (sort && sort.createdAt && this.adapter.canSortOnJoinTables) {
     findOptions.sort = { '_id' : sort.createdAt };
     findOptions.limit = limit;
     findOptions.skip = skip;

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -599,8 +599,16 @@ DatabaseController.prototype.deleteEverything = function() {
 
 // Returns a promise for a list of related ids given an owning id.
 // className here is the owning className.
-DatabaseController.prototype.relatedIds = function(className, key, owningId) {
-  return this.adapter.find(joinTableName(className, key), relationSchema, { owningId }, {})
+DatabaseController.prototype.relatedIds = function(className, key, owningId, queryOptions) {
+  const { skip, limit, sort } = queryOptions;
+  const findOptions = {};
+  if (sort && sort.createdAt) {
+    findOptions.sort = { '_id' : sort.createdAt };
+    findOptions.limit = limit;
+    findOptions.skip = skip;
+    queryOptions.skip = 0;
+  }
+  return this.adapter.find(joinTableName(className, key), relationSchema, { owningId }, findOptions)
     .then(results => results.map(result => result.relatedId));
 };
 
@@ -693,11 +701,11 @@ DatabaseController.prototype.reduceInRelation = function(className, query, schem
 
 // Modifies query so that it no longer has $relatedTo
 // Returns a promise that resolves when query is mutated
-DatabaseController.prototype.reduceRelationKeys = function(className, query) {
+DatabaseController.prototype.reduceRelationKeys = function(className, query, queryOptions) {
 
   if (query['$or']) {
     return Promise.all(query['$or'].map((aQuery) => {
-      return this.reduceRelationKeys(className, aQuery);
+      return this.reduceRelationKeys(className, aQuery, queryOptions);
     }));
   }
 
@@ -706,11 +714,12 @@ DatabaseController.prototype.reduceRelationKeys = function(className, query) {
     return this.relatedIds(
       relatedTo.object.className,
       relatedTo.key,
-      relatedTo.object.objectId)
+      relatedTo.object.objectId,
+      queryOptions)
       .then((ids) => {
         delete query['$relatedTo'];
         this.addInObjectIdsIds(ids, query);
-        return this.reduceRelationKeys(className, query);
+        return this.reduceRelationKeys(className, query, queryOptions);
       });
   }
 };
@@ -831,8 +840,9 @@ DatabaseController.prototype.find = function(className, query, {
               throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
             }
           });
+          const queryOptions = { skip, limit, sort, keys, readPreference };
           return (isMaster ? Promise.resolve() : schemaController.validatePermission(className, aclGroup, op))
-            .then(() => this.reduceRelationKeys(className, query))
+            .then(() => this.reduceRelationKeys(className, query, queryOptions))
             .then(() => this.reduceInRelation(className, query, schemaController))
             .then(() => {
               if (!isMaster) {
@@ -871,7 +881,7 @@ DatabaseController.prototype.find = function(className, query, {
                 if (!classExists) {
                   return [];
                 } else {
-                  return this.adapter.find(className, schema, query, { skip, limit, sort, keys, readPreference })
+                  return this.adapter.find(className, schema, query, queryOptions)
                     .then(objects => objects.map(object => {
                       object = untransformObjectACL(object);
                       return filterSensitiveData(isMaster, aclGroup, className, object)


### PR DESCRIPTION
So we ran a bit the aggregation optimization in prod and this was not satisfactory, not yielding enough benefits in terms of performance.

Went back to the drawing board and came up with this idea of leveraging the _id managed by mongoDB (which is ascending at creation time) to reduce the amount of keys pulled from the join table.

If you're sorting by createdAt ascending or descending, you'll benefit this optimization, otherwise, that will pretty much be the same.