### PR TITLE
Adds Table of Contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ Parse Server is an [open source version of the Parse backend](http://blog.parsep
 
 Parse Server works with the Express web application framework. It can be added to existing web applications, or run by itself.
 
+- [Getting Started](#getting-started)
+    - [Running Parse Server](#running-parse-server)
+        - [Locally](#locally)
+        - [Docker](#inside-a-docker-container)
+        - [Saving an Object](#saving-your-first-object)
+        - [Connect an SDK](#connect-your-app-to-parse-server)
+    - [Running elsewhere](#running-parse-server-elsewhere)
+        - [Sample Application](#parse-server-sample-application)
+        - [Parse Server + Express](#parse-server--express)
+    - [Logging](#logging)
+- [Documentation](#documentation)
+    - [Configuration](#configuration)
+        - [Basic Options](#basic-options)
+        - [Client Key Options](#client-key-options)
+        - [Advanced Options](#advanced-options)
+            - [Logging](#logging-1)
+            - [Email Verification & Password Reset](#email-verification-and-password-reset)
+        - [Using Environment Variables](#using-environment-variables-to-configure-parse-server)
+        - [Available Adapters](#available-adapters)
+        - [Configuring File Adapters](#configuring-file-adapters)
+- [Support](#support)
+- [Ride the Bleeding Edge](#want-to-ride-the-bleeding-edge)
+- [Contributing](#contributing)
+- [Backers](#backers)
+- [Sponsors](#sponsors)
+
 # Getting Started
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/parse-community/parse-server.svg)](https://greenkeeper.io/)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Build Status](https://img.shields.io/travis/parse-community/parse-server/master.svg?style=flat)](https://travis-ci.org/parse-community/parse-server)
 [![Coverage Status](https://img.shields.io/codecov/c/github/parse-community/parse-server/master.svg)](https://codecov.io/github/parse-community/parse-server?branch=master)
 [![npm version](https://img.shields.io/npm/v/parse-server.svg?style=flat)](https://www.npmjs.com/package/parse-server)
-
 [![Join Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ParsePlatform/Chat)
+[![Greenkeeper badge](https://badges.greenkeeper.io/parse-community/parse-server.svg)](https://greenkeeper.io/)
 
 Parse Server is an [open source version of the Parse backend](http://blog.parseplatform.org/announcements/introducing-parse-server-and-the-database-migration-tool/) that can be deployed to any infrastructure that can run Node.js.
 
@@ -38,9 +38,6 @@ Parse Server works with the Express web application framework. It can be added t
 - [Sponsors](#sponsors)
 
 # Getting Started
-
-[![Greenkeeper badge](https://badges.greenkeeper.io/parse-community/parse-server.svg)](https://greenkeeper.io/)
-
 
 April 2016 - We created a series of video screencasts, please check them out here: [http://blog.parseplatform.org/learn/parse-server-video-series-april-2016/](http://blog.parseplatform.org/learn/parse-server-video-series-april-2016/)
 


### PR DESCRIPTION
There's a lot in the README and there's no navigation currently. This adds a table of contents to allow new users to quickly understand what's listed where and jump to relevant sections.

While I was doing this I noticed a few things in the structure of the README that were a bit odd. I've put together this table of contents in a way that I think best represents the logical layout of the README. I would like to hear some opinions on it though, see if we should perhaps consider shifting sections around.