### PR TITLE
Push overhaul

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server",
-  "version": "2.6.5",
+  "version": "3.0.0-alpha.1",
   "description": "An express module providing a Parse-compatible API server",
   "main": "lib/index.js",
   "repository": {

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -804,7 +804,7 @@ describe('PushController', () => {
       return query.find({useMasterKey: true}).then((results) => {
         expect(results.length).toBe(1);
         const pushStatus = results[0];
-        expect(pushStatus.get('status')).not.toBe('scheduled');
+        expect(pushStatus.get('status')).toBe('succeeded');
         done();
       });
     }).catch((err) => {
@@ -870,7 +870,7 @@ describe('PushController', () => {
       return query.find({useMasterKey: true}).then((results) => {
         expect(results.length).toBe(1);
         const pushStatus = results[0];
-        expect(pushStatus.get('status')).toBe('scheduled');
+        expect(pushStatus.get('status')).toBe('pending');
       });
     }).then(done).catch(done.err);
   });
@@ -1247,7 +1247,7 @@ describe('PushController', () => {
           return q.get(pushStatusId, {useMasterKey: true});
         })
         .then((pushStatus) => {
-          expect(pushStatus.get('status')).toBe('scheduled');
+          expect(pushStatus.get('status')).toBe('pending');
           expect(pushStatus.get('pushTime')).toBe('2017-09-06T17:14:01.048');
         })
         .then(done, done.fail);

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -870,7 +870,7 @@ describe('PushController', () => {
       return query.find({useMasterKey: true}).then((results) => {
         expect(results.length).toBe(1);
         const pushStatus = results[0];
-        expect(pushStatus.get('status')).toBe('pending');
+        expect(pushStatus.get('status')).toBe('succeeded');
       });
     }).then(done).catch(done.err);
   });

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -477,7 +477,7 @@ describe('PushController', () => {
           return spy.calls.all()[callIndex].args[0].object;
         }
         expect(spy).toHaveBeenCalled();
-        expect(spy.calls.count()).toBe(4);
+        expect(spy.calls.count()).toBe(3);
         const allCalls = spy.calls.all();
         allCalls.forEach((call) => {
           expect(call.args.length).toBe(2);
@@ -485,9 +485,9 @@ describe('PushController', () => {
           expect(object instanceof Parse.Object).toBe(true);
         });
         expect(getPushStatus(0).get('status')).toBe('pending');
-        expect(getPushStatus(1).get('status')).toBe('running');
+        expect(getPushStatus(1).get('status')).toBe('succeeded');
         expect(getPushStatus(1).get('numSent')).toBe(0);
-        expect(getPushStatus(2).get('status')).toBe('running');
+        expect(getPushStatus(2).get('status')).toBe('succeeded');
         expect(getPushStatus(2).get('numSent')).toBe(10);
         expect(getPushStatus(2).get('numFailed')).toBe(5);
         // Those are updated from a nested . operation, this would
@@ -498,7 +498,6 @@ describe('PushController', () => {
         expect(getPushStatus(2).get('sentPerType')).toEqual({
           ios: 10
         });
-        expect(getPushStatus(3).get('status')).toBe('succeeded');
       })
       .then(done).catch(done.fail);
   });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -157,6 +157,69 @@ describe('PushWorker', () => {
       expect(PushUtils.bodiesPerLocales({where: {}})).toEqual({default: {where: {}}});
       expect(PushUtils.groupByLocaleIdentifier([])).toEqual({default: []});
     });
+
+    it('should propely apply translations strings', () => {
+      const bodies = PushUtils.bodiesPerLocales({
+        data: {
+          alert: 'Yo!',
+        },
+        translation: {
+          'fr': 'frenchy!',
+          'en': 'english',
+        }
+      }, ['fr', 'en']);
+      expect(bodies).toEqual({
+        fr: {
+          data: {
+            alert: 'frenchy!',
+          }
+        },
+        en: {
+          data: {
+            alert: 'english',
+          }
+        },
+        default: {
+          data: {
+            alert: 'Yo!'
+          }
+        }
+      });
+    });
+
+    it('should propely apply translations objects', () => {
+      const bodies = PushUtils.bodiesPerLocales({
+        data: {
+          alert: 'Yo!',
+          badge: 'Increment',
+        },
+        translation: {
+          'fr': { alert: 'frenchy!', title: 'yolo' },
+          'en': { alert: 'english', badge: 2, other: 'value' },
+        }
+      }, ['fr', 'en']);
+      expect(bodies).toEqual({
+        fr: {
+          data: {
+            alert: 'frenchy!',
+            title: 'yolo',
+          }
+        },
+        en: {
+          data: {
+            alert: 'english',
+            badge: 2,
+            other: 'value'
+          }
+        },
+        default: {
+          data: {
+            alert: 'Yo!',
+            badge: 'Increment',
+          }
+        }
+      });
+    });
   });
 
   describe('pushStatus', () => {

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -220,6 +220,75 @@ describe('PushWorker', () => {
         }
       });
     });
+
+    it('should propely override alert-lang with translations', () => {
+      const bodies = PushUtils.bodiesPerLocales({
+        data: {
+          alert: 'Yo!',
+          badge: 'Increment',
+          'alert-fr': 'Yolo!',
+        },
+        translation: {
+          'fr': { alert: 'frenchy!', title: 'yolo' },
+          'en': { alert: 'english', badge: 2, other: 'value' },
+        }
+      }, ['fr', 'en']);
+      expect(bodies).toEqual({
+        fr: {
+          data: {
+            alert: 'frenchy!',
+            title: 'yolo',
+          }
+        },
+        en: {
+          data: {
+            alert: 'english',
+            badge: 2,
+            other: 'value'
+          }
+        },
+        default: {
+          data: {
+            alert: 'Yo!',
+            badge: 'Increment',
+          }
+        }
+      });
+    });
+
+    it('should propely override alert-lang with translations strings', () => {
+      const bodies = PushUtils.bodiesPerLocales({
+        data: {
+          alert: 'Yo!',
+          badge: 'Increment',
+          'alert-fr': 'Yolo!',
+          'alert-en': 'Yolo!'
+        },
+        translation: {
+          'fr': 'frenchy',
+        }
+      }, ['fr', 'en']);
+      expect(bodies).toEqual({
+        fr: {
+          data: {
+            alert: 'frenchy',
+            badge: 'Increment',
+          }
+        },
+        en: {
+          data: {
+            alert: 'Yolo!',
+            badge: 'Increment'
+          }
+        },
+        default: {
+          data: {
+            alert: 'Yo!',
+            badge: 'Increment',
+          }
+        }
+      });
+    });
   });
 
   describe('pushStatus', () => {

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -276,7 +276,6 @@ describe('PushWorker', () => {
           'failedPerType.ios': { __op: 'Increment', amount: 1 },
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
-          count: { __op: 'Increment', amount: -1 }
         });
         const query = new Parse.Query('_PushStatus');
         return query.get(handler.objectId, { useMasterKey: true });
@@ -354,7 +353,6 @@ describe('PushWorker', () => {
           'failedPerType.ios': { __op: 'Increment', amount: 1 },
           [`sentPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
           [`failedPerUTCOffset.${UTCOffset}`]: { __op: 'Increment', amount: 1 },
-          count: { __op: 'Increment', amount: -1 }
         });
         done();
       });

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -626,6 +626,31 @@ describe('rest update', () => {
   });
 });
 
+describe('rest each', () => {
+  it('should iterate through all results', () => {
+    const className = 'Yolo';
+    const config = Config.get('test');
+    const master = auth.master(config);
+    let promise = Promise.resolve();
+    let done = 0;
+    while (done != 10) {
+      done++;
+      promise = promise.then(() => {
+        return rest.create(config, auth, className, {});
+      });
+    }
+    return promise.then(() => {
+      let seen = 0;
+      // use limit 1 to get them 1 by one
+      return rest.each(config, master, className, {}, {limit: 1}, () => {
+        seen++;
+      }).then(() => {
+        expect(seen).toBe(10);
+      })
+    }).then(done, done.fail);
+  });
+})
+
 describe('read-only masterKey', () => {
   it('properly throws on rest.create, rest.update and rest.del', () => {
     const config = Config.get('test');

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -87,6 +87,8 @@ export class PushController {
         return Promise.resolve();
       }
       return config.pushControllerQueue.enqueue(body, where, config, auth, pushStatus);
+    }).then(() => {
+      return pushStatus.complete();
     }).catch((err) => {
       return pushStatus.fail(err).then(() => {
         throw err;

--- a/src/Push/PushQueue.js
+++ b/src/Push/PushQueue.js
@@ -63,7 +63,6 @@ export class PushQueue {
           pushStatus: { objectId: pushStatus.objectId },
           applicationId: config.applicationId
         };
-        console.log(body) // eslint-disable-line
         this.parsePublisher.publish(this.channel, JSON.stringify(pushWorkItem));
       });
     }).then(() => {

--- a/src/Push/PushQueue.js
+++ b/src/Push/PushQueue.js
@@ -63,6 +63,7 @@ export class PushQueue {
           pushStatus: { objectId: pushStatus.objectId },
           applicationId: config.applicationId
         };
+        console.log(body) // eslint-disable-line
         this.parsePublisher.publish(this.channel, JSON.stringify(pushWorkItem));
       });
     }).then(() => {

--- a/src/Push/PushQueue.js
+++ b/src/Push/PushQueue.js
@@ -65,8 +65,6 @@ export class PushQueue {
         };
         this.parsePublisher.publish(this.channel, JSON.stringify(pushWorkItem));
       });
-    }).then(() => {
-      pushStatus.complete(); // complete right away
     });
   }
 }

--- a/src/Push/utils.js
+++ b/src/Push/utils.js
@@ -52,14 +52,29 @@ export function stripLocalesFromBody(body) {
   return body;
 }
 
+export function translateBody(body, locale) {
+  body = deepcopy(body);
+  if (body.translation && body.translation[locale] && locale) {
+    const translation = body.translation[locale];
+    if (typeof translation === 'string') { // use translation
+      body.data = body.data || {};
+      body.data.alert = translation;
+    } else if (typeof translation === 'object') { // override tranlsation
+      body.data = translation;
+    }
+  }
+  delete body.translation;
+  return body;
+}
+
 export function bodiesPerLocales(body, locales = []) {
   // Get all tranformed bodies for each locale
   const result = locales.reduce((memo, locale) => {
-    memo[locale] = transformPushBodyForLocale(body, locale);
+    memo[locale] = translateBody(transformPushBodyForLocale(body, locale), locale);
     return memo;
   }, {});
   // Set the default locale, with the stripped body
-  result.default = stripLocalesFromBody(body);
+  result.default = translateBody(stripLocalesFromBody(body));
   return result;
 }
 

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -190,20 +190,6 @@ export function pushStatusHandler(config, existingObjectId) {
     });
   }
 
-  const setRunning = function(batches) {
-    logger.verbose(`_PushStatus ${objectId}: sending push to installations with %d batches`, batches);
-    return handler.update(
-      {
-        status:"pending",
-        objectId: objectId
-      },
-      {
-        status: "running",
-        count: batches
-      }
-    );
-  }
-
   const trackSent = function(results, UTCOffset, cleanupInstallations = process.env.PARSE_SERVER_CLEANUP_INVALID_INSTALLATIONS) {
     const update = {
       numSent: 0,
@@ -266,20 +252,12 @@ export function pushStatusHandler(config, existingObjectId) {
       });
     }
 
-    // indicate this batch is complete
-    incrementOp(update, 'count', -1);
-
-    return handler.update({ objectId }, update).then((res) => {
-      if (res && res.count === 0) {
-        return this.complete();
-      }
-    })
+    return handler.update({ objectId }, update);
   }
 
   const complete = function() {
     return handler.update({ objectId }, {
-      status: 'succeeded',
-      count: {__op: 'Delete'}
+      status: 'succeeded'
     });
   }
 
@@ -296,7 +274,6 @@ export function pushStatusHandler(config, existingObjectId) {
 
   const rval = {
     setInitial,
-    setRunning,
     trackSent,
     complete,
     fail

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -146,11 +146,10 @@ export function pushStatusHandler(config, existingObjectId) {
   const setInitial = function(body = {}, where, options = {source: 'rest'}) {
     const now = new Date();
     let pushTime = now.toISOString();
-    let status = 'pending';
+    const status = 'pending';
     if (body.hasOwnProperty('push_time')) {
       if (config.hasPushScheduledSupport) {
         pushTime = body.push_time;
-        status = 'scheduled';
       } else {
         logger.warn('Trying to schedule a push while server is not configured.');
         logger.warn('Push will be sent immediately');

--- a/src/rest.js
+++ b/src/rest.js
@@ -35,6 +35,32 @@ function find(config, auth, className, restWhere, restOptions, clientSDK) {
   });
 }
 
+function each(config, auth, className, where, options, callback) {
+  options = Object.assign({}, options);
+  where = Object.assign({}, where);
+  let finished;
+  return Parse.Promise._continueWhile(() => {
+    return !finished;
+  }, () => {
+    return find(config, auth, className, where, options).then(({ results }) => {
+      let callbacksDone = Parse.Promise.as();
+      results.forEach((result) => {
+        callbacksDone = callbacksDone.then(() => {
+          return callback(result);
+        });
+      });
+      return callbacksDone.then(() => {
+        if (results.length >= options.limit) {
+          where['objectId'] = where['objectId'] || {};
+          where['objectId']['$gt'] = results[results.length - 1].id;
+        } else {
+          finished = true;
+        }
+      });
+    })
+  });
+}
+
 // get is just like find but only queries an objectId.
 const get = (config, auth, className, objectId, restOptions, clientSDK) => {
   var restWhere = { objectId };
@@ -172,5 +198,6 @@ module.exports = {
   del,
   find,
   get,
-  update
+  update,
+  each
 };

--- a/src/rest.js
+++ b/src/rest.js
@@ -37,6 +37,7 @@ function find(config, auth, className, restWhere, restOptions, clientSDK) {
 
 function each(config, auth, className, where, options, callback) {
   options = Object.assign({}, options);
+  options.order = 'objectId'; // force ordering on objectId
   where = Object.assign({}, where);
   let finished;
   return Parse.Promise._continueWhile(() => {
@@ -52,7 +53,7 @@ function each(config, auth, className, where, options, callback) {
       return callbacksDone.then(() => {
         if (results.length >= options.limit) {
           where['objectId'] = where['objectId'] || {};
-          where['objectId']['$gt'] = results[results.length - 1].id;
+          where['objectId']['$gt'] = results[results.length - 1].objectId;
         } else {
           finished = true;
         }


### PR DESCRIPTION
Motivation:

- we send a decent volume of push notifications and we found that the current strategy for slicing / dicing push notification is not efficient
- I noticed in the early commits of the dashboard, that pushStatus only have 3 possible states, pending, succeeded, failed. (thus we can don't *need* running, which caused issues before)
- Marking push as succeeded, when the working items have been scheduled is reasonable, perhaps, we could introduce 2 modes into the PushQueue, direct sending (calling worker directly and queue), in the case of calling the worker directly we could 'wait' till all push are sent to mark complete.
- I also noticed, many _PushStatus types are not implemented in the dashboard, including the experiments, campaigns etc... which could be easier to implement if we start sticking to the dashboard definitions instead. 
- This will is a *breaking change* for anyone using a custom push worker, or scheduler, as push won't be marked as scheduled etc... anymore.
- A scheduled push is just a pending push with a push time. This will help us move into a more scalable / modular architecture.
- Restores the `translation` key support as it was originally intended on parse-dashboard

This will require to bump to 3.0.