### PR TITLE
[NEW] Allows dot-notation to match against a complex structure when using matchesKeyInQuery

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3206,4 +3206,46 @@ describe('Parse.Query testing', () => {
       .then(() => q.find({ useMasterKey: true }))
       .then(done.fail, done);
   });
+
+  it('should match complex structure with dot notation when using matchesKeyInQuery', function(done) {
+    const group1 = new Parse.Object('Group', {
+      name: 'Group #1'
+    });
+
+    const group2 = new Parse.Object('Group', {
+      name: 'Group #2'
+    });
+
+    Parse.Object.saveAll([group1, group2])
+      .then(() => {
+        const role1 = new Parse.Object('Role', {
+          name: 'Role #1',
+          type: 'x',
+          belongsTo: group1
+        });
+
+        const role2 = new Parse.Object('Role', {
+          name: 'Role #2',
+          type: 'y',
+          belongsTo: group1
+        });
+
+        return Parse.Object.saveAll([role1, role2]);
+      })
+      .then(() => {
+        const rolesOfTypeX = new Parse.Query('Role');
+        rolesOfTypeX.equalTo('type', 'x');
+
+        const groupsWithRoleX = new Parse.Query('Group');
+        groupsWithRoleX.matchesKeyInQuery('objectId', 'belongsTo.objectId', rolesOfTypeX);
+
+        groupsWithRoleX.find(expectSuccess({
+          success: function(results) {
+            equal(results.length, 1);
+            equal(results[0].get('name'), group1.get('name'));
+            done();
+          }
+        }))
+      })
+  });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3249,7 +3249,7 @@ describe('Parse.Query testing', () => {
       })
   });
 
-  it('should match complex structure with dot notation when using matchesKeyInQuery', function(done) {
+  it('should match complex structure with dot notation when using doesNotMatchKeyInQuery', function(done) {
     const group1 = new Parse.Object('Group', {
       name: 'Group #1'
     });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -392,7 +392,7 @@ RestQuery.prototype.replaceSelect = function() {
 const transformDontSelect = (dontSelectObject, key, objects) => {
   var values = [];
   for (var result of objects) {
-    values.push(result[key]);
+    values.push(key.split('.').reduce((o,i)=>o[i], result));
   }
   delete dontSelectObject['$dontSelect'];
   if (Array.isArray(dontSelectObject['$nin'])) {

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -337,7 +337,7 @@ RestQuery.prototype.replaceNotInQuery = function() {
 const transformSelect = (selectObject, key ,objects) => {
   var values = [];
   for (var result of objects) {
-    values.push(result[key]);
+    values.push(key.split('.').reduce((o,i)=>o[i], result));
   }
   delete selectObject['$select'];
   if (Array.isArray(selectObject['$in'])) {


### PR DESCRIPTION
Just finishes out #4308 which @bohemima did the heavy lifting on. Fixes #4346.

It's too useful to let fester ;)