### PR TITLE
Remove nsp check from Travis YML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       env: 
       before_script: skip
       after_script: skip
-      script: npm install -g nsp && nsp check
+      script: skip
       deploy:
         - provider: script
           skip_cleanup: true


### PR DESCRIPTION
nsp is done through a GitHub PR hook and managed separately from Travis CI

Fixes issue #4393 which prevents Travis CI build failing for each PR