### PR TITLE
Move beforeFind trigger to RestQuery class

### DIFF
--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -22,7 +22,6 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
   this.restWhere = restWhere;
   this.restOptions = restOptions;
   this.clientSDK = clientSDK;
-  this.isGet = (Object.keys(restWhere).length == 1 && restWhere.hasOwnProperty('objectId'));
   this.response = null;
   this.findOptions = {};
   if (!this.auth.isMaster) {
@@ -44,6 +43,13 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
     }
   }
 
+  this.handleOptions();
+}
+
+// Parses restOptions and handles the values
+RestQuery.prototype.handleOptions = function() {
+  this.isGet = (Object.keys(this.restWhere).length == 1 && this.restWhere.hasOwnProperty('objectId'));
+
   this.doCount = false;
 
   // The format for this.include is not the same as the format for the
@@ -56,8 +62,8 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
 
   // If we have keys, we probably want to force some includes (n-1 level)
   // See issue: https://github.com/parse-community/parse-server/issues/3185
-  if (restOptions.hasOwnProperty('keys')) {
-    const keysForInclude = restOptions.keys.split(',').filter((key) => {
+  if (this.restOptions.hasOwnProperty('keys')) {
+    const keysForInclude = this.restOptions.keys.split(',').filter((key) => {
       // At least 2 components
       return key.split(".").length > 1;
     }).map((key) => {
@@ -69,18 +75,18 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
     // Concat the possibly present include string with the one from the keys
     // Dedup / sorting is handle in 'include' case.
     if (keysForInclude.length > 0) {
-      if (!restOptions.include || restOptions.include.length == 0) {
-        restOptions.include = keysForInclude;
+      if (!this.restOptions.include || this.restOptions.include.length == 0) {
+        this.restOptions.include = keysForInclude;
       } else {
-        restOptions.include += "," + keysForInclude;
+        this.restOptions.include += "," + keysForInclude;
       }
     }
   }
 
-  for (var option in restOptions) {
+  for (var option in this.restOptions) {
     switch(option) {
     case 'keys': {
-      const keys = restOptions.keys.split(',').concat(AlwaysSelectedKeys);
+      const keys = this.restOptions.keys.split(',').concat(AlwaysSelectedKeys);
       this.keys = Array.from(new Set(keys));
       break;
     }
@@ -92,10 +98,10 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
     case 'skip':
     case 'limit':
     case 'readPreference':
-      this.findOptions[option] = restOptions[option];
+      this.findOptions[option] = this.restOptions[option];
       break;
     case 'order':
-      var fields = restOptions.order.split(',');
+      var fields = this.restOptions.order.split(',');
       this.findOptions.sort = fields.reduce((sortMap, field) => {
         field = field.trim();
         if (field === '$score') {
@@ -109,7 +115,7 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
       }, {});
       break;
     case 'include': {
-      const paths = restOptions.include.split(',');
+      const paths = this.restOptions.include.split(',');
       // Load the existing includes (from keys)
       const pathSet = paths.reduce((memo, path) => {
         // Split each paths on . (a.b.c -> [a,b,c])
@@ -129,7 +135,7 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
       break;
     }
     case 'redirectClassNameForKey':
-      this.redirectKey = restOptions.redirectClassNameForKey;
+      this.redirectKey = this.restOptions.redirectClassNameForKey;
       this.redirectClassName = null;
       break;
     case 'includeReadPreference':
@@ -149,9 +155,9 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
 // TODO: consolidate the replaceX functions
 RestQuery.prototype.execute = function(executeOptions) {
   return Promise.resolve().then(() => {
-    return this.buildRestWhere();
-  }).then(() => {
     return this.runBeforeTrigger();
+  }).then(() => {
+    return this.buildRestWhere();
   }).then(() => {
     return this.runFind(executeOptions);
   }).then(() => {
@@ -515,10 +521,15 @@ RestQuery.prototype.runBeforeTrigger = function() {
     return Promise.resolve();
   }
 
-  return triggers.maybeRunQueryTrigger(triggers.Types.beforeFind, this.className, this.restWhere, this.restOptions, 
+  return triggers.maybeRunQueryTrigger(triggers.Types.beforeFind, this.className, this.restWhere, this.restOptions,
     this.config, this.auth, this.isGet).then((result) => {
     this.restWhere = result.restWhere || this.restWhere;
     this.restOptions = result.restOptions || this.restOptions;
+
+    // // Parse the options if the trigger returned options
+    if (result.restOptions) {
+      this.handleOptions();
+    }
   });
 };
 

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -22,6 +22,7 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
   this.restWhere = restWhere;
   this.restOptions = restOptions;
   this.clientSDK = clientSDK;
+  this.isGet = (Object.keys(restWhere).length == 1 && restWhere.hasOwnProperty('objectId'));
   this.response = null;
   this.findOptions = {};
   if (!this.auth.isMaster) {
@@ -514,7 +515,8 @@ RestQuery.prototype.runBeforeTrigger = function() {
     return Promise.resolve();
   }
 
-  return triggers.maybeRunQueryTrigger(triggers.Types.beforeFind, this.className, this.restWhere, this.restOptions, this.config, this.auth).then((result) => {
+  return triggers.maybeRunQueryTrigger(triggers.Types.beforeFind, this.className, this.restWhere, this.restOptions, 
+    this.config, this.auth, this.isGet).then((result) => {
     this.restWhere = result.restWhere || this.restWhere;
     this.restOptions = result.restOptions || this.restOptions;
   });

--- a/src/rest.js
+++ b/src/rest.js
@@ -27,12 +27,9 @@ function checkLiveQuery(className, config) {
 // Returns a promise for an object with optional keys 'results' and 'count'.
 function find(config, auth, className, restWhere, restOptions, clientSDK) {
   enforceRoleSecurity('find', className, auth);
-  return triggers.maybeRunQueryTrigger(triggers.Types.beforeFind, className, restWhere, restOptions, config, auth).then((result) => {
-    restWhere = result.restWhere || restWhere;
-    restOptions = result.restOptions || restOptions;
-    const query = new RestQuery(config, auth, className, restWhere, restOptions, clientSDK);
-    return query.execute();
-  });
+
+  const query = new RestQuery(config, auth, className, restWhere, restOptions, clientSDK);
+  return query.execute();
 }
 
 // get is just like find but only queries an objectId.

--- a/src/rest.js
+++ b/src/rest.js
@@ -36,12 +36,9 @@ function find(config, auth, className, restWhere, restOptions, clientSDK) {
 const get = (config, auth, className, objectId, restOptions, clientSDK) => {
   var restWhere = { objectId };
   enforceRoleSecurity('get', className, auth);
-  return triggers.maybeRunQueryTrigger(triggers.Types.beforeFind, className, restWhere, restOptions, config, auth, true).then((result) => {
-    restWhere = result.restWhere || restWhere;
-    restOptions = result.restOptions || restOptions;
-    const query = new RestQuery(config, auth, className, restWhere, restOptions, clientSDK);
-    return query.execute();
-  });
+
+  const query = new RestQuery(config, auth, className, restWhere, restOptions, clientSDK);
+  return query.execute();
 }
 
 // Returns a promise that doesn't resolve to any useful value.


### PR DESCRIPTION
Move beforeFind trigger to RestQuery class.

This makes more sense because the beforeSave and afterSave triggers are ran from RestWrite which is similar to RestQuery.

Determine if RestQuery is getting an object based on the restWhere parameters and not whether they called find or get function.