### PR TITLE
pg-promise refactoring

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -668,10 +668,11 @@ export class PostgresStorageAdapter {
   }
 
   createClass(className, schema) {
+    const self = this;
     return this._client.tx('create-class', function * (t) {
-      yield this.createTable(className, schema, t);
+      yield self.createTable(className, schema, t);
       yield t.none('INSERT INTO "_SCHEMA" ("className", "schema", "isParseClass") VALUES ($<className>, $<schema>, true)', { className, schema });
-      yield this.setIndexesWithSchemaFormat(className, schema.indexes, {}, schema.fields, t);
+      yield self.setIndexesWithSchemaFormat(className, schema.indexes, {}, schema.fields, t);
     })
       .then(() => {
         return toParseSchema(schema)


### PR DESCRIPTION
this is the initial introduction of ES6 generators into the database logic, so it can be easily upgraded into `await/async` later on.

This also fixes some connection misuse where a task was supposed to be used to share the connection.

There is a lot more to follow, after this one is merged. I can't test it locally, so have to rely on Travis CI, that's why i'm doing it in chunks.