### PR TITLE
db connection context fix

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -729,7 +729,7 @@ export class PostgresStorageAdapter {
     const values = [className, ...valuesArray];
     return conn.task(t => {
       return this._ensureSchemaCollectionExists(t)
-        .then(() => conn.none(qs, values))
+        .then(() => t.none(qs, values))
         .catch(error => {
           if (error.code === PostgresDuplicateRelationError) {
             // Table already exists, must have been created by a different request. Ignore error.


### PR DESCRIPTION
Fixing use of the wrong connection context inside a task.

Since it is only a task, and not a transaction, the consequence is only in poor connection usage, i.e. the logic is unaffected.