### PR TITLE
consistent error throwing

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1305,7 +1305,7 @@ export class PostgresStorageAdapter {
         if (err.code === PostgresRelationDoesNotExistError) {
           return [];
         }
-        return Promise.reject(err);
+        throw err;
       })
       .then(results => results.map(object => this.postgresObjectToParseObject(className, object, schema)));
   }


### PR DESCRIPTION
Should use `throw` inside `.catch`, not `return Promise.reject`.