### PR TITLE
fix package.json warning

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -108,7 +108,7 @@ cd "${INSTALL_DIR}"
 
 if [ -f "package.json" ]; then
   echo "\n${RED}package.json exists${NC}"
-  confirm 'N' "Do you want to continue? \n${RED}this will erase your configuration${NC} (y/N): "
+  confirm 'N' "Do you want to continue? \n${RED}this will erase your existing package.json${NC} (y/N): "
 fi
 
 


### PR DESCRIPTION
Improved warning message in [bootstrap.sh](https://github.com/parse-community/parse-server/blob/fc6a2fddc46c073b61ca3788ea9add1d68f7e90f/bootstrap.sh#L111) when there's an existing package.json to make it obvious what's going to be overwritten. 