### PR TITLE
Login hook

### DIFF
--- a/spec/LoginHook.spec.js
+++ b/spec/LoginHook.spec.js
@@ -1,0 +1,400 @@
+"use strict"
+const Parse = require("parse/node");
+
+describe('LoginHook', () => {
+  it('should accept only one handler', (done) => {
+    expect(() => {
+      Parse.Cloud.loginHook((userLoginData) => {
+        console.log(userLoginData);
+      });
+    }).not.toThrow();
+    expect(() => {
+      Parse.Cloud.loginHook((userLoginData) => {
+        console.log(userLoginData);
+      });
+    }).toThrow();
+    done();
+  });
+
+  it('should not be called on signUp with username/password', (done) => {
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData).toBeDefined();
+      setTimeout(() => { done.fail('should not be called on signUp') }, 1000);
+    });
+    var user = new Parse.User();
+    user.set("username", "my_name");
+    user.set("password", "my_pass");
+    user.set("email", "email@example.com");
+    user.set("name", "User Name");
+    user.signUp().then(() => {
+      Parse.User.logOut();
+      setTimeout(done, 2000);
+    });
+  });
+
+  it('should be called with valid userLoginData on login with username/password', (done) => {
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData.objectId).toBeDefined();
+      expect(typeof userLoginData.objectId).toEqual('string');
+      expect(userLoginData.username).toBeDefined();
+      expect(typeof userLoginData.username).toEqual('string');
+      expect(userLoginData.email).toBeDefined();
+      expect(typeof userLoginData.email).toEqual('string');
+      expect(userLoginData.createdAt).toBeDefined();
+      expect(typeof userLoginData.createdAt).toEqual('string');
+      expect(userLoginData.updatedAt).toBeDefined();
+      expect(typeof userLoginData.updatedAt).toEqual('string');
+      expect(userLoginData.authProvider).toBeDefined();
+      expect(userLoginData.authProvider).toBe('password');
+      expect(userLoginData.authData).toBeDefined();
+      expect(typeof userLoginData.authData).toEqual('object');
+      setTimeout(done, 1000);
+    });
+    var user = new Parse.User();
+    user.set("username", "my_name");
+    user.set("password", "my_pass");
+    user.set("email", "email@example.com");
+    user.set("name", "User Name");
+    user.signUp().then(() => {
+      Parse.User.logOut();
+      ok(Parse.User.current() === null);
+      var user = new Parse.User();
+      user.set("username", "my_name");
+      user.set("password", "my_pass");
+      user.logIn().then(() => {
+        Parse.User.logOut();
+        ok(Parse.User.current() === null);
+      });
+    });
+  });
+
+  it("should not be called on login with wrong username", (done) => {
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData).toBeDefined();
+      setTimeout(() => { done.fail('should not be called on signUp') }, 1000);
+    });
+    Parse.User.signUp("asdf", "zxcv", null, {
+      success: function () {
+        Parse.User.logIn("non_existent_user", "asdf3",
+          expectError(Parse.Error.OBJECT_NOT_FOUND, done));
+      },
+      error: function (err) {
+        jfail(err);
+        fail("should not fail");
+        done();
+      }
+    });
+  });
+
+  it("should not be called on login with wrong password", (done) => {
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData).toBeDefined();
+      setTimeout(() => { done.fail('should not be called on signUp') }, 1000);
+    });
+    Parse.User.signUp("asdf", "zxcv", null, {
+      success: function () {
+        Parse.User.logIn("asdf", "asdfWrong",
+          expectError(Parse.Error.OBJECT_NOT_FOUND, done));
+      }
+    });
+  });
+
+  it("should not be called on 'become'", (done) => {
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData).toBeDefined();
+      setTimeout(() => { done.fail('should not be called on signUp') }, 1000);
+    });
+    var user = null;
+    var sessionToken = null;
+
+    Parse.Promise.as().then(function () {
+      return Parse.User.signUp("Jason", "Parse", { "code": "red" });
+
+    }).then(function (newUser) {
+      equal(Parse.User.current(), newUser);
+
+      user = newUser;
+      sessionToken = newUser.getSessionToken();
+      ok(sessionToken);
+
+      return Parse.User.logOut();
+    }).then(() => {
+      ok(!Parse.User.current());
+
+      return Parse.User.become(sessionToken);
+
+    }).then(function (newUser) {
+      equal(Parse.User.current(), newUser);
+
+      ok(newUser);
+      equal(newUser.id, user.id);
+      equal(newUser.get("username"), "Jason");
+      equal(newUser.get("code"), "red");
+
+      return Parse.User.logOut();
+    }).then(() => {
+      ok(!Parse.User.current());
+
+      return Parse.User.become("somegarbage");
+
+    }).then(function () {
+      // This should have failed actually.
+      ok(false, "Shouldn't have been able to log in with garbage session token.");
+    }, function (error) {
+      ok(error);
+      // Handle the error.
+      return Parse.Promise.as();
+
+    }).then(function () {
+      done();
+    }, function (error) {
+      ok(false, error);
+      done();
+    });
+  });
+
+
+  Parse.User.extend({
+    extended: function () {
+      return true;
+    }
+  });
+  var getMockMyOauthProvider = function () {
+    return {
+      authData: {
+        id: "12345",
+        access_token: "12345",
+        expiration_date: new Date(new Date().getTime() + 10 * 60 * 1000).toJSON(), // 10 minutes
+      },
+      shouldError: false,
+      loggedOut: false,
+      synchronizedUserId: null,
+      synchronizedAuthToken: null,
+      synchronizedExpiration: null,
+
+      authenticate: function (options) {
+        if (this.shouldError) {
+          options.error(this, "An error occurred");
+        } else if (this.shouldCancel) {
+          options.error(this, null);
+        } else {
+          options.success(this, this.authData);
+        }
+      },
+      restoreAuthentication: function (authData) {
+        if (!authData) {
+          this.synchronizedUserId = null;
+          this.synchronizedAuthToken = null;
+          this.synchronizedExpiration = null;
+          return true;
+        }
+        this.synchronizedUserId = authData.id;
+        this.synchronizedAuthToken = authData.access_token;
+        this.synchronizedExpiration = authData.expiration_date;
+        return true;
+      },
+      getAuthType: function () {
+        return "shortLivedAuth";
+      },
+      deauthenticate: function () {
+        this.loggedOut = true;
+        this.restoreAuthentication(null);
+      }
+    };
+  };
+  it('should not be called on signUp with authProvider', (done) => {
+    Parse.Object.enableSingleInstance();
+    Parse.User.logOut();
+    ok(Parse.User.current() === null);
+
+    defaultConfiguration.auth.shortLivedAuth.setValidAccessToken('12345');
+    var provider = getMockMyOauthProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData).toBeDefined();
+      console.log(JSON.stringify(userLoginData, null, 2));
+      setTimeout(() => { done.fail('should not be called on signUp with authProvider') }, 1000);
+    });
+
+    const authData = {
+      id: "12345",
+      access_token: "12345",
+      expiration_date: new Date(new Date().getTime() + 10 * 60 * 1000).toJSON(), // 10 minutes
+    };
+    const options = {
+      authData: authData
+    };
+    var user = new Parse.User();
+    user.set('username', 'test');
+    user.set('email', 'test@test.test.com');
+
+    user._linkWith('shortLivedAuth', options).then((model) => {
+      ok(model instanceof Parse.User, "Model should be a Parse.User");
+      strictEqual(Parse.User.current(), model);
+      ok(model.extended(), "Should have used the subclass.");
+      strictEqual(provider.authData.id, provider.synchronizedUserId);
+      strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+      strictEqual(Date(provider.authData.expiration_date).toLocaleString(), Date(provider.synchronizedExpiration).toLocaleString());
+      ok(model._isLinked("shortLivedAuth"), "User should be linked to shortLivedAuth");
+      // signUp complete
+      setTimeout(done, 2000);
+    }).catch((e) => {
+      jfail(e);
+    });
+  });
+
+  it("should be called with valid userLoginData on login with authProvider", (done) => {
+    Parse.Object.enableSingleInstance();
+    Parse.User.logOut();
+    ok(Parse.User.current() === null);
+
+    defaultConfiguration.auth.shortLivedAuth.setValidAccessToken('12345');
+    var provider = getMockMyOauthProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData.objectId).toBeDefined();
+      expect(typeof userLoginData.objectId).toEqual('string');
+      expect(userLoginData.username).toBeDefined();
+      expect(typeof userLoginData.username).toEqual('string');
+      expect(userLoginData.email).toBeDefined();
+      expect(typeof userLoginData.email).toEqual('string');
+      expect(userLoginData.createdAt).toBeDefined();
+      expect(typeof userLoginData.createdAt).toEqual('string');
+      expect(userLoginData.updatedAt).toBeDefined();
+      expect(typeof userLoginData.updatedAt).toEqual('string');
+      expect(userLoginData.authProvider).toBeDefined();
+      expect(typeof userLoginData.authProvider).toEqual('string');
+      expect(userLoginData.authData).toBeDefined();
+      expect(typeof userLoginData.authData).toEqual('object');
+      setTimeout(done, 1000);
+    });
+
+    const authData = {
+      id: "12345",
+      access_token: "12345",
+      expiration_date: new Date(new Date().getTime() + 10 * 60 * 1000).toJSON(), // 10 minutes
+    };
+    const options = {
+      authData: authData
+    };
+
+    const authData2 = {
+      id: "12345",
+      access_token: "1234567",
+      expiration_date: new Date(new Date().getTime() + 10 * 60 * 1000).toJSON(), // 10 minutes
+    };
+    const options2 = {
+      authData: authData2
+    };
+
+    var user = new Parse.User();
+    user.set('username', 'test');
+    user.set('email', 'test@test.test.com');
+
+    user._linkWith('shortLivedAuth', options).then((model) => {
+      ok(model instanceof Parse.User, "Model should be a Parse.User");
+      strictEqual(Parse.User.current(), model);
+      ok(model.extended(), "Should have used the subclass.");
+      strictEqual(provider.authData.id, provider.synchronizedUserId);
+      strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+      strictEqual(Date(provider.authData.expiration_date).toLocaleString(), Date(provider.synchronizedExpiration).toLocaleString());
+      ok(model._isLinked("shortLivedAuth"), "User should be linked to shortLivedAuth");
+
+      //console.log('signUp completed');
+      model._logOutWithAll();
+      Parse.User.logOut();
+      ok(Parse.User.current() === null);
+
+      var user2 = new Parse.User();
+      user2.set('username', 'test');
+      user2.set('email', 'test@test.test.com');
+      // it's a new login with a new and valid token
+      defaultConfiguration.auth.shortLivedAuth.setValidAccessToken('1234567');
+      //console.log("let's login (this should trigger loginHook call)");
+      user2._linkWith('shortLivedAuth', options2).then((model2) => {
+        const userQuery = new Parse.Query(Parse.User);
+        userQuery.get(model2.id).then((user3) => {
+          expect(user3.id).toBe(model2.id);
+          model._logOutWithAll();
+          Parse.User.logOut();
+          //setTimeout(done, 2000);
+          ok(Parse.User.current() === null);
+        }).catch((e) => {
+          jfail(e);
+        })
+      }).catch((e) => {
+        jfail(e);
+      });
+    }).catch((e) => {
+      jfail(e);
+    });
+  });
+
+  it("should not be called on failed login with authProvider", (done) => {
+    Parse.Object.enableSingleInstance();
+    Parse.User.logOut();
+    ok(Parse.User.current() === null);
+
+    defaultConfiguration.auth.shortLivedAuth.setValidAccessToken('12345');
+    var provider = getMockMyOauthProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+
+    Parse.Cloud.loginHook((userLoginData) => {
+      expect(userLoginData).toBeDefined();
+      console.log(JSON.stringify(userLoginData, null, 2));
+      setTimeout(() => { done.fail('should not be called on failed login with authProvider') }, 1000);
+    });
+    const authData = {
+      id: "12345",
+      access_token: "12345",
+      expiration_date: new Date(new Date().getTime() + 10 * 60 * 1000).toJSON(), // 10 minutes
+    };
+    const options = {
+      authData: authData
+    };
+
+    const authData2 = {
+      id: "12345",
+      access_token: "1234567",
+      expiration_date: new Date(new Date().getTime() + 10 * 60 * 1000).toJSON(), // 10 minutes
+    };
+    const options2 = {
+      authData: authData2
+    };
+
+    var user = new Parse.User();
+    user.set('username', 'test');
+    user.set('email', 'test@test.test.com');
+
+    user._linkWith('shortLivedAuth', options).then((model) => {
+      ok(model instanceof Parse.User, "Model should be a Parse.User");
+      strictEqual(Parse.User.current(), model);
+      ok(model.extended(), "Should have used the subclass.");
+      strictEqual(provider.authData.id, provider.synchronizedUserId);
+      strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+      strictEqual(Date(provider.authData.expiration_date).toLocaleString(), Date(provider.synchronizedExpiration).toLocaleString());
+      ok(model._isLinked("shortLivedAuth"), "User should be linked to shortLivedAuth");
+
+      console.log('signUp complete');
+      model._logOutWithAll();
+      Parse.User.logOut();
+      ok(Parse.User.current() === null);
+
+      var user2 = new Parse.User();
+      user2.set('username', 'test');
+      user2.set('email', 'test@test.test.com');
+      // new login with a bad token, provider should fail
+      defaultConfiguration.auth.shortLivedAuth.setValidAccessToken('wrong-token');
+      console.log("let's try to login with a bad token");
+      user2._linkWith('shortLivedAuth', options2).then(() => {
+      }).catch((e) => {
+        ok(Parse.User.current() === null);
+        done(e);
+      });
+    }).catch((e) => {
+      jfail(e);
+    });
+  });
+});

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -9,6 +9,7 @@ import Auth           from '../Auth';
 import passwordCrypto from '../password';
 import RestWrite      from '../RestWrite';
 const cryptoUtils = require('../cryptoUtils');
+import { runLoginHookHandler } from '../triggers';
 
 export class UsersRouter extends ClassesRouter {
 
@@ -141,6 +142,8 @@ export class UsersRouter extends ClassesRouter {
               throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Your password has expired. Please reset your password.');
           }
         }
+        // runLoginHookHandler before session creation passing just user.objectId to avoid current 'user' object mutation
+        runLoginHookHandler(user.objectId);
 
         const token = 'r:' + cryptoUtils.newToken();
         user.sessionToken = token;

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -142,8 +142,6 @@ export class UsersRouter extends ClassesRouter {
               throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Your password has expired. Please reset your password.');
           }
         }
-        // runLoginHookHandler before session creation passing just user.objectId to avoid current 'user' object mutation
-        runLoginHookHandler(user.objectId);
 
         const token = 'r:' + cryptoUtils.newToken();
         user.sessionToken = token;
@@ -163,6 +161,22 @@ export class UsersRouter extends ClassesRouter {
           if (Object.keys(user.authData).length == 0) {
             delete user.authData;
           }
+        }
+        //runLoginHookHandler before session creation passing copies of user main properties to avoid current 'user' object mutation
+        try {
+          runLoginHookHandler({
+            'objectId': user.objectId,
+            'username': user.username,
+            'email': user.email,
+            'name':user.name,
+            'createdAt':user.createdAt,
+            'updatedAt':user.updatedAt,
+            'authProvider': 'password',
+            'authData': {}
+          });
+        }
+        catch (e) {
+          throw e;
         }
 
         req.config.filesController.expandFilesInObject(req.config, user);

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -51,6 +51,10 @@ ParseCloud.onLiveQueryEvent = function(handler) {
   triggers.addLiveQueryEventHandler(handler, Parse.applicationId);
 };
 
+ParseCloud.loginHook = function(handler){
+  triggers.addLoginHookHandler(handler, Parse.applicationId);
+};
+
 ParseCloud._removeAllHooks = () => {
   triggers._unregisterAll();
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -16,6 +16,7 @@ const baseStore = function() {
   const Functions = {};
   const Jobs = {};
   const LiveQuery = [];
+  const LoginHook = {};
   const Triggers = Object.keys(Types).reduce(function(base, key){
     base[key] = {};
     return base;
@@ -27,6 +28,7 @@ const baseStore = function() {
     Validators,
     Triggers,
     LiveQuery,
+    LoginHook
   });
 };
 
@@ -70,6 +72,12 @@ export function addLiveQueryEventHandler(handler, applicationId) {
   applicationId = applicationId || Parse.applicationId;
   _triggerStore[applicationId] =  _triggerStore[applicationId] || baseStore();
   _triggerStore[applicationId].LiveQuery.push(handler);
+}
+
+export function addLoginHookHandler(handler, applicationId) {
+  applicationId = applicationId || Parse.applicationId;
+  _triggerStore[applicationId] =  _triggerStore[applicationId] || baseStore();
+  _triggerStore[applicationId].LoginHook.handler =  handler;
 }
 
 export function removeFunction(functionName, applicationId) {
@@ -440,4 +448,12 @@ export function inflate(data, restObject) {
 export function runLiveQueryEventHandlers(data, applicationId = Parse.applicationId) {
   if (!_triggerStore || !_triggerStore[applicationId] || !_triggerStore[applicationId].LiveQuery) { return; }
   _triggerStore[applicationId].LiveQuery.forEach((handler) => handler(data));
+}
+
+export function runLoginHookHandler(userObjId, applicationId = Parse.applicationId) {
+  if (!_triggerStore ||
+    !_triggerStore[applicationId] ||
+    !_triggerStore[applicationId].LoginHook ||
+    !_triggerStore[applicationId].LoginHook.handler) { return; }
+  _triggerStore[applicationId].LoginHook.handler(userObjId);
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -76,8 +76,12 @@ export function addLiveQueryEventHandler(handler, applicationId) {
 
 export function addLoginHookHandler(handler, applicationId) {
   applicationId = applicationId || Parse.applicationId;
-  _triggerStore[applicationId] =  _triggerStore[applicationId] || baseStore();
-  _triggerStore[applicationId].LoginHook.handler =  handler;
+  _triggerStore[applicationId] = _triggerStore[applicationId] || baseStore();
+  if (_triggerStore[applicationId].LoginHook.handler) {
+    throw new Parse.Error(Parse.Error.VALIDATION_ERROR, 'Only one loginHook can be configured');
+  } else {
+    _triggerStore[applicationId].LoginHook.handler = handler;
+  }
 }
 
 export function removeFunction(functionName, applicationId) {
@@ -450,10 +454,10 @@ export function runLiveQueryEventHandlers(data, applicationId = Parse.applicatio
   _triggerStore[applicationId].LiveQuery.forEach((handler) => handler(data));
 }
 
-export function runLoginHookHandler(userObjId, applicationId = Parse.applicationId) {
+export function runLoginHookHandler(userLoginData, applicationId = Parse.applicationId) {
   if (!_triggerStore ||
     !_triggerStore[applicationId] ||
     !_triggerStore[applicationId].LoginHook ||
     !_triggerStore[applicationId].LoginHook.handler) { return; }
-  _triggerStore[applicationId].LoginHook.handler(userObjId);
+  _triggerStore[applicationId].LoginHook.handler(userLoginData);
 }


### PR DESCRIPTION
Create a login hook that is called just after username/password validation but before creating a session token. 
It allows addition of custom logic before login completion, like a custom validation or user logging.
The way it can be used is by adding code to cloud-code file like:

```
Parse.Cloud.loginHook(function (userObjId) {
 // custom logic here
  return;
});
```

As I am new to parse-server, I am neither completely sure if this is the correct way of adding a hook nor if it adds any security threats.
Please, correct me if I did it wrong.
Thanks