### PR TITLE
Fix server crash on invalid LiveQuery socket event

### DIFF
--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -345,7 +345,8 @@ describe('ParseLiveQueryServer', function() {
 
     // Check connect request
     var connectRequest = {
-      op: 'connect'
+      op: 'connect',
+      applicationId: '1'
     };
     // Trigger message event
     parseWebSocket.emit('message', connectRequest);
@@ -365,7 +366,11 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._onConnect(parseWebSocket);
 
     // Check subscribe request
-    var subscribeRequest = '{"op":"subscribe"}';
+    var subscribeRequest = JSON.stringify({
+      op: 'subscribe',
+      requestId: 1,
+      query: {className: 'Test', where: {}}
+    });
     // Trigger message event
     parseWebSocket.emit('message', subscribeRequest);
     // Make sure _handleSubscribe is called
@@ -385,7 +390,7 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._onConnect(parseWebSocket);
 
     // Check unsubscribe request
-    var unsubscribeRequest = '{"op":"unsubscribe"}';
+    var unsubscribeRequest = JSON.stringify({op: 'unsubscribe', requestId: 1});
     // Trigger message event
     parseWebSocket.emit('message', unsubscribeRequest);
     // Make sure _handleUnsubscribe is called
@@ -409,7 +414,11 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._onConnect(parseWebSocket);
 
     // Check updateRequest request
-    var updateRequest = '{"op":"update"}';
+    var updateRequest = JSON.stringify({
+      op: 'update',
+      requestId: 1,
+      query: {className: 'Test', where: {}}
+    });
     // Trigger message event
     parseWebSocket.emit('message', updateRequest);
     // Make sure _handleUnsubscribe is called

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -440,7 +440,7 @@ describe('ParseLiveQueryServer', function() {
     // Register message handlers for the parseWebSocket
     parseLiveQueryServer._onConnect(parseWebSocket);
 
-    // Check unknown request
+    // Check invalid request
     var invalidRequest = '{}';
     // Trigger message event
     parseWebSocket.emit('message', invalidRequest);

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -428,6 +428,22 @@ describe('ParseLiveQueryServer', function() {
     expect(parseLiveQueryServer._handleSubscribe).toHaveBeenCalled();
   });
 
+  it('can set missing command message handler for a parseWebSocket', function() {
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    // Make mock parseWebsocket
+    var EventEmitter = require('events');
+    var parseWebSocket = new EventEmitter();
+    // Register message handlers for the parseWebSocket
+    parseLiveQueryServer._onConnect(parseWebSocket);
+
+    // Check unknown request
+    var invalidRequest = '{}';
+    // Trigger message event
+    parseWebSocket.emit('message', invalidRequest);
+    var Client = require('../src/LiveQuery/Client').Client;
+    expect(Client.pushError).toHaveBeenCalled();
+  });
+
   it('can set unknown command message handler for a parseWebSocket', function() {
     var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
     // Make mock parseWebsocket

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -41,11 +41,6 @@ describe('ParseLiveQueryServer', function() {
     // Mock matchesQuery
     var mockMatchesQuery = jasmine.createSpy('matchesQuery').and.returnValue(true);
     jasmine.mockLibrary('../src/LiveQuery/QueryTools', 'matchesQuery', mockMatchesQuery);
-    // Mock tv4
-    var mockValidate = function() {
-      return true;
-    }
-    jasmine.mockLibrary('tv4', 'validate', mockValidate);
     // Mock ParsePubSub
     var mockParsePubSub = {
       createPublisher: function() {
@@ -1209,7 +1204,6 @@ describe('ParseLiveQueryServer', function() {
     jasmine.restoreLibrary('../src/LiveQuery/Subscription', 'Subscription');
     jasmine.restoreLibrary('../src/LiveQuery/QueryTools', 'queryHash');
     jasmine.restoreLibrary('../src/LiveQuery/QueryTools', 'matchesQuery');
-    jasmine.restoreLibrary('tv4', 'validate');
     jasmine.restoreLibrary('../src/LiveQuery/ParsePubSub', 'ParsePubSub');
     jasmine.restoreLibrary('../src/LiveQuery/SessionTokenCache', 'SessionTokenCache');
   });

--- a/src/LiveQuery/RequestSchema.js
+++ b/src/LiveQuery/RequestSchema.js
@@ -7,6 +7,7 @@ const general = {
       'enum': ['connect', 'subscribe', 'unsubscribe', 'update']
     },
   },
+  'required': ['op']
 };
 
 const connect =  {


### PR DESCRIPTION
Sending an invalid event through the LiveQuery client socket crashes the server process.

Reproduce on the client:
```javascript
Parse.CoreManager
.getLiveQueryController()
.getDefaultLiveQueryClient()
.then(client => client.socket.send(JSON.stringify({hello: 123})))
```

Server logs:
```bash
verbose: Create client bd1183f1-7d9b-4da8-824c-fc0c0d893db4 new subscription: 1
verbose: Current client number: 1
verbose: Request: {"hello":123}
/Users/.../node_modules/parse-server/lib/ParseServer.js:218
          throw err;
          ^

TypeError: Cannot read property '$ref' of undefined
    at ValidatorContext.resolveRefs (/Users/.../node_modules/tv4/tv4.js:399:12)
    at ValidatorContext.validateAll (/Users/.../node_modules/tv4/tv4.js:536:16)
    at Object.validate (/Users/.../node_modules/tv4/tv4.js:1573:24)
    at WebSocket.parseWebsocket.on.request [as internalOnMessage] (/Users/.../node_modules/parse-server/lib/LiveQuery/ParseLiveQueryServer.js:260:96)
    at onServerMessage (/Users/.../node_modules/uws/uws.js:19:15)
```

This PR fixes it by making the `op` property required in the general LiveQuery RequestSchema.

I added a test case and removed the `tv4.validate` mock to make the error visible, and updated the existing tests to pass when using the original module.