### PR TITLE
Handle duplicate value on unique index error

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -421,7 +421,13 @@ export class MongoStorageAdapter implements StorageAdapter {
     const mongoWhere = transformWhere(className, query, schema);
     return this._adaptiveCollection(className)
       .then(collection => collection._mongoCollection.findAndModify(mongoWhere, [], mongoUpdate, { new: true }))
-      .then(result => mongoObjectToParseObject(className, result.value, schema));
+      .then(result => mongoObjectToParseObject(className, result.value, schema))
+      .catch(error => {
+        if (error.code === 11000) {
+          throw new Parse.Error(Parse.Error.DUPLICATE_VALUE, 'A duplicate value for a field with unique values was provided');
+        }
+        throw error;
+      });
   }
 
   // Hopefully we can get rid of this. It's only used for config and hooks.


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/4542

This error is already handled on object creation but not handled when object field is updated.

Will add unique indexes in future release :)