### PR TITLE
Live query defaults reference ParseServer instead of LiverQuery server.

### DIFF
--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -372,7 +372,7 @@ module.exports.LiveQueryServerOptions = {
   },
   "port": {
     "env": "PARSE_LIVE_QUERY_SERVER_PORT",
-    "help": "The port to run the ParseServer. defaults to 1337.",
+    "help": "The port to run the LiveQuery server. Defaults to 1337.",
     "action": parsers.numberParser("port"),
     "default": 1337
   },

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -171,7 +171,7 @@ export interface LiveQueryServerOptions {
   cacheTimeout: ?number,
   /* This string defines the log level of the LiveQuery server. We support VERBOSE, INFO, ERROR, NONE. Defaults to INFO.*/
   logLevel: ?string,
-  /* The port to run the ParseServer. defaults to 1337.*/
+  /* The port to run the LiveQuery server. Defaults to 1337.*/
   port: ?number, // = 1337
   /* parse-server's LiveQuery redisURL */
   redisURL: ?string,


### PR DESCRIPTION
nit wording fix for live query defaults