### PR TITLE
Remove FB Graph API version from URL to use the oldest non deprecated version

### DIFF
--- a/src/Adapters/Auth/facebook.js
+++ b/src/Adapters/Auth/facebook.js
@@ -37,7 +37,7 @@ function validateAppId(appIds, authData) {
 // A promisey wrapper for FB graph requests.
 function graphRequest(path) {
   return new Promise(function(resolve, reject) {
-    https.get('https://graph.facebook.com/v2.5/' + path, function(res) {
+    https.get('https://graph.facebook.com/' + path, function(res) {
       var data = '';
       res.on('data', function(chunk) {
         data += chunk;


### PR DESCRIPTION
Facebook auth adapter uses a hard-coded version of the FB Graph API.
As 2.5 is going to be soon removed from the working versions, removing the version number allows the auth adapter to be always up-to-date.

Closes: https://github.com/parse-community/parse-server/issues/4638