### PR TITLE
Check for node version in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 jasmine",
     "coverage": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 nyc jasmine",
     "start": "node ./bin/parse-server",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "node -p 'require(\"./postinstall.js\")()'"
   },
   "engines": {
     "node": ">=6.11.4"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,50 @@
+const pkg = require('./package.json');
+
+const version = parseFloat( process.version.substr(1) );
+const minimum = parseFloat( pkg.engines.node.match(/\d+/g).join('.') );
+
+module.exports = function () {
+  const openCollective = `
+                  1111111111
+               1111111111111111
+            1111111111111111111111
+          11111111111111111111111111
+        111111111111111       11111111
+       1111111111111             111111
+      1111111111111   111111111   111111
+      111111111111   11111111111   111111
+     1111111111111   11111111111   111111
+     1111111111111   1111111111    111111
+     1111111111111111111111111    1111111
+     11111111                    11111111
+      111111         1111111111111111111
+      11111   11111  111111111111111111
+       11111         11111111111111111
+        111111     111111111111111111
+          11111111111111111111111111
+            1111111111111111111111
+              111111111111111111
+                  11111111111
+
+
+        Thanks for installing parse 🙏
+  Please consider donating to our open collective
+      to help us maintain this package.
+
+  👉 https://opencollective.com/parse-server
+
+  `;
+  process.stdout.write(openCollective);
+  if (version >= minimum) {
+    process.exit(0);
+  }
+
+  const errorMessage = `
+    ⚠️  parse-server requires at least node@${minimum}!
+    You have node@${version}
+
+  `;
+
+  process.stdout.write(errorMessage);
+  process.exit(1);
+};


### PR DESCRIPTION
Added open collective as a bonus. https://github.com/parse-community/parse-server/issues/4498

I notice a lot of user still fork parse-server-example. They then update to the latest version of parse-server but their engines.node in package.json stays the same.

This will output directions to support latest version.