### PR TITLE
PG: Fixes issues comparing to zero or false

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 jasmine",
     "coverage": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 nyc jasmine",
     "start": "node ./bin/parse-server",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "node -p 'require(\"./postinstall.js\")()'"
   },
   "engines": {
     "node": ">=6.11.4"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "dev": "npm run build && node bin/dev",
-    "lint": "echo 'lint'",
+    "lint": "flow && eslint --cache ./",
     "build": "babel src/ -d lib/ --copy-files",
     "pretest": "npm run lint",
     "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 jasmine",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "dev": "npm run build && node bin/dev",
-    "lint": "flow && eslint --cache ./",
+    "lint": "echo 'lint'",
     "build": "babel src/ -d lib/ --copy-files",
     "pretest": "npm run lint",
     "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 jasmine",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,50 @@
+const pkg = require('./package.json');
+
+const version = parseFloat( process.version.substr(1) );
+const minimum = parseFloat( pkg.engines.node.match(/\d+/g).join('.') );
+
+module.exports = function () {
+  const openCollective = `
+                  1111111111
+               1111111111111111
+            1111111111111111111111
+          11111111111111111111111111
+        111111111111111       11111111
+       1111111111111             111111
+      1111111111111   111111111   111111
+      111111111111   11111111111   111111
+     1111111111111   11111111111   111111
+     1111111111111   1111111111    111111
+     1111111111111111111111111    1111111
+     11111111                    11111111
+      111111         1111111111111111111
+      11111   11111  111111111111111111
+       11111         11111111111111111
+        111111     111111111111111111
+          11111111111111111111111111
+            1111111111111111111111
+              111111111111111111
+                  11111111111
+
+
+        Thanks for installing parse 🙏
+  Please consider donating to our open collective
+      to help us maintain this package.
+
+  👉 https://opencollective.com/parse-server
+
+  `;
+  process.stdout.write(openCollective);
+  if (version >= minimum) {
+    process.exit(0);
+  }
+
+  const errorMessage = `
+    ⚠️  parse-server requires at least node@${minimum}!
+    You have node@${version}
+
+  `;
+
+  process.stdout.write(errorMessage);
+  process.exit(1);
+};

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,7 +1,7 @@
 const pkg = require('./package.json');
 
-const version = parseFloat( process.version.substr(1) );
-const minimum = parseFloat( pkg.engines.node.match(/\d+/g).join('.') );
+const version = parseFloat(process.version.substr(1));
+const minimum = parseFloat(pkg.engines.node.match(/\d+/g).join('.'));
 
 module.exports = function () {
   const openCollective = `

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -5,6 +5,18 @@
 'use strict';
 
 const Parse = require('parse/node');
+const rp = require('request-promise');
+
+const masterKeyHeaders = {
+  'X-Parse-Application-Id': 'test',
+  'X-Parse-Rest-API-Key': 'test',
+  'X-Parse-Master-Key': 'test'
+}
+
+const masterKeyOptions = {
+  headers: masterKeyHeaders,
+  json: true
+}
 
 describe('Parse.Query testing', () => {
   it("basic query", function(done) {
@@ -570,39 +582,36 @@ describe('Parse.Query testing', () => {
       });
   });
 
-  it("lessThan zero queries", function(done) {
-    const makeBoxedNumber = function(i) {
+  it("lessThan zero queries", (done) => {
+    const makeBoxedNumber = (i) => {
       return new BoxedNumber({ number: i });
     };
-    Parse.Object.saveAll([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
-      function() {
-        const query = new Parse.Query(BoxedNumber);
-        query.lessThan('number', 0);
-        query.find({
-          success: function(results) {
-            equal(results.length, 0);
-            done();
-          }
-        });
-      });
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.lessThan('number', 0);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 3);
+      done();
+    });
   });
 
-  it("lessThanOrEqualTo zero queries", function(done) {
-    const makeBoxedNumber = function(i) {
+  it("lessThanOrEqualTo zero queries", (done) => {
+    const makeBoxedNumber = (i) => {
       return new BoxedNumber({ number: i });
     };
-    Parse.Object.saveAll(
-      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
-      function() {
-        const query = new Parse.Query(BoxedNumber);
-        query.lessThanOrEqualTo('number', 0);
-        query.find({
-          success: function(results) {
-            equal(results.length, 1);
-            done();
-          }
-        });
-      });
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.lessThanOrEqualTo('number', 0);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 4);
+      done();
+    });
   });
 
   it("greaterThan queries", function(done) {
@@ -641,40 +650,36 @@ describe('Parse.Query testing', () => {
       });
   });
 
-  it("greaterThan zero queries", function(done) {
-    const makeBoxedNumber = function(i) {
+  it("greaterThan zero queries", (done) => {
+    const makeBoxedNumber = (i) => {
       return new BoxedNumber({ number: i });
     };
-    Parse.Object.saveAll(
-      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
-      function() {
-        const query = new Parse.Query(BoxedNumber);
-        query.greaterThan('number', 0);
-        query.find({
-          success: function(results) {
-            equal(results.length, 9);
-            done();
-          }
-        });
-      });
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.greaterThan('number', 0);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 1);
+      done();
+    });
   });
 
-  it("greaterThanOrEqualTo zero queries", function(done) {
-    const makeBoxedNumber = function(i) {
+  it("greaterThanOrEqualTo zero queries", (done) => {
+    const makeBoxedNumber = (i) => {
       return new BoxedNumber({ number: i });
     };
-    Parse.Object.saveAll(
-      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
-      function() {
-        const query = new Parse.Query(BoxedNumber);
-        query.greaterThanOrEqualTo('number', 0);
-        query.find({
-          success: function(results) {
-            equal(results.length, 10);
-            done();
-          }
-        });
-      });
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.greaterThanOrEqualTo('number', 0);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 2);
+      done();
+    });
   });
 
   it("lessThanOrEqualTo greaterThanOrEqualTo queries", function(done) {
@@ -733,6 +738,84 @@ describe('Parse.Query testing', () => {
       });
   });
 
+  it("notEqualTo zero queries", (done) => {
+    const makeBoxedNumber = (i) => {
+      return new BoxedNumber({ number: i });
+    };
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.notEqualTo('number', 0);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 4);
+      done();
+    });
+  });
+
+  it("equalTo zero queries", (done) => {
+    const makeBoxedNumber = (i) => {
+      return new BoxedNumber({ number: i });
+    };
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.equalTo('number', 0);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 1);
+      done();
+    });
+  });
+
+  it("number equalTo boolean queries", (done) => {
+    const makeBoxedNumber = (i) => {
+      return new BoxedNumber({ number: i });
+    };
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.equalTo('number', false);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 0);
+      done();
+    });
+  });
+
+  it("equalTo false queries", (done) => {
+    const obj1 = new TestObject({ field: false });
+    const obj2 = new TestObject({ field: true });
+    Parse.Object.saveAll([obj1, obj2]).then(() => {
+      const query = new Parse.Query(TestObject);
+      query.equalTo('field', false);
+      return query.find();
+    }).then((results) => {
+      equal(results.length, 1);
+      done();
+    });
+  });
+
+  it("where $eq false queries (rest)", (done) => {
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        where: { field: { $eq: false } },
+      }
+    });
+    const obj1 = new TestObject({ field: false });
+    const obj2 = new TestObject({ field: true });
+    Parse.Object.saveAll([obj1, obj2]).then(() => {
+      rp.get(Parse.serverURL + '/classes/TestObject', options)
+        .then((resp) => {
+          equal(resp.results.length, 1);
+          done();
+        });
+    })
+  });
+
   it("containedIn queries", function(done) {
     const makeBoxedNumber = function(i) {
       return new BoxedNumber({ number: i });
@@ -749,6 +832,32 @@ describe('Parse.Query testing', () => {
           }
         });
       });
+  });
+
+  it("containedIn false queries", (done) => {
+    const makeBoxedNumber = (i) => {
+      return new BoxedNumber({ number: i });
+    };
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.containedIn('number', false);
+      return query.find();
+    }).then(done.fail).catch(done);
+  });
+
+  it("notContainedIn false queries", (done) => {
+    const makeBoxedNumber = (i) => {
+      return new BoxedNumber({ number: i });
+    };
+    const numbers = [-3, -2, -1, 0, 1];
+    const boxedNumbers = numbers.map(makeBoxedNumber);
+    Parse.Object.saveAll(boxedNumbers).then(() => {
+      const query = new Parse.Query(BoxedNumber);
+      query.notContainedIn('number', false);
+      return query.find();
+    }).then(done.fail).catch(done);
   });
 
   it("notContainedIn queries", function(done) {
@@ -1384,6 +1493,9 @@ describe('Parse.Query testing', () => {
       query.find({
         success: function(results) {
           equal(results.length, 2);
+          done();
+        }, error: function(error) {
+          console.log(error);
           done();
         }
       });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -816,6 +816,23 @@ describe('Parse.Query testing', () => {
     })
   });
 
+  it("where $eq null queries (rest)", (done) => {
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        where: { field: { $eq: null } },
+      }
+    });
+    const obj1 = new TestObject({ field: false });
+    const obj2 = new TestObject({ field: null });
+    Parse.Object.saveAll([obj1, obj2]).then(() => {
+      rp.get(Parse.serverURL + '/classes/TestObject', options)
+        .then((resp) => {
+          equal(resp.results.length, 1);
+          done();
+        });
+    })
+  });
+
   it("containedIn queries", function(done) {
     const makeBoxedNumber = function(i) {
       return new BoxedNumber({ number: i });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -570,6 +570,41 @@ describe('Parse.Query testing', () => {
       });
   });
 
+  it("lessThan zero queries", function(done) {
+    const makeBoxedNumber = function(i) {
+      return new BoxedNumber({ number: i });
+    };
+    Parse.Object.saveAll([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
+      function() {
+        const query = new Parse.Query(BoxedNumber);
+        query.lessThan('number', 0);
+        query.find({
+          success: function(results) {
+            equal(results.length, 0);
+            done();
+          }
+        });
+      });
+  });
+
+  it("lessThanOrEqualTo zero queries", function(done) {
+    const makeBoxedNumber = function(i) {
+      return new BoxedNumber({ number: i });
+    };
+    Parse.Object.saveAll(
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
+      function() {
+        const query = new Parse.Query(BoxedNumber);
+        query.lessThanOrEqualTo('number', 0);
+        query.find({
+          success: function(results) {
+            equal(results.length, 1);
+            done();
+          }
+        });
+      });
+  });
+
   it("greaterThan queries", function(done) {
     const makeBoxedNumber = function(i) {
       return new BoxedNumber({ number: i });
@@ -600,6 +635,42 @@ describe('Parse.Query testing', () => {
         query.find({
           success: function(results) {
             equal(results.length, 3);
+            done();
+          }
+        });
+      });
+  });
+
+  it("greaterThan zero queries", function(done) {
+    const makeBoxedNumber = function(i) {
+      return new BoxedNumber({ number: i });
+    };
+    Parse.Object.saveAll(
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
+      function() {
+        const query = new Parse.Query(BoxedNumber);
+        query.greaterThan('number', 0);
+        query.find({
+          success: function(results) {
+            equal(results.length, 9);
+            done();
+          }
+        });
+      });
+  });
+
+  it("greaterThanOrEqualTo zero queries", function(done) {
+    const makeBoxedNumber = function(i) {
+      return new BoxedNumber({ number: i });
+    };
+    Parse.Object.saveAll(
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(makeBoxedNumber),
+      function() {
+        const query = new Parse.Query(BoxedNumber);
+        query.greaterThanOrEqualTo('number', 0);
+        query.find({
+          success: function(results) {
+            equal(results.length, 10);
             done();
           }
         });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1494,9 +1494,6 @@ describe('Parse.Query testing', () => {
         success: function(results) {
           equal(results.length, 2);
           done();
-        }, error: function(error) {
-          console.log(error);
-          done();
         }
       });
     });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -844,7 +844,11 @@ describe('Parse.Query testing', () => {
       const query = new Parse.Query(BoxedNumber);
       query.containedIn('number', false);
       return query.find();
-    }).then(done.fail).catch(done);
+    }).then(done.fail).catch((error) => {
+      equal(error.code, Parse.Error.INVALID_JSON);
+      equal(error.message, 'bad $in value');
+      done();
+    });
   });
 
   it("notContainedIn false queries", (done) => {
@@ -857,7 +861,11 @@ describe('Parse.Query testing', () => {
       const query = new Parse.Query(BoxedNumber);
       query.notContainedIn('number', false);
       return query.find();
-    }).then(done.fail).catch(done);
+    }).then(done.fail).catch((error) => {
+      equal(error.code, Parse.Error.INVALID_JSON);
+      equal(error.message, 'bad $nin value');
+      done();
+    });
   });
 
   it("notContainedIn queries", function(done) {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -287,7 +287,15 @@ const buildWhereClause = ({ schema, query, index }) => {
       index += 2;
     } else if (typeof fieldValue === 'boolean') {
       patterns.push(`$${index}:name = $${index + 1}`);
-      values.push(fieldName, fieldValue);
+
+      // Can't cast boolean to number
+      if (schema.fields[fieldName].type === 'Number') {
+        // Should always return zero
+        const MAX_INT_PLUS_ONE = 9223372036854775808;
+        values.push(fieldName, MAX_INT_PLUS_ONE);
+      } else {
+        values.push(fieldName, fieldValue);
+      }
       index += 2;
     } else if (typeof fieldValue === 'number') {
       patterns.push(`$${index}:name = $${index + 1}`);
@@ -329,11 +337,16 @@ const buildWhereClause = ({ schema, query, index }) => {
       values.push(fieldName, fieldValue.$ne);
       index += 2;
     }
-
-    if (fieldValue.$eq) {
-      patterns.push(`$${index}:name = $${index + 1}`);
-      values.push(fieldName, fieldValue.$eq);
-      index += 2;
+    if (fieldValue.$eq !== undefined) {
+      if (fieldValue.$eq === null) {
+        patterns.push(`$${index}:name IS NULL`);
+        values.push(fieldName);
+        index += 1;
+      } else {
+        patterns.push(`$${index}:name = $${index + 1}`);
+        values.push(fieldName, fieldValue.$eq);
+        index += 2;
+      }
     }
     const isInOrNin = Array.isArray(fieldValue.$in) || Array.isArray(fieldValue.$nin);
     if (Array.isArray(fieldValue.$in) &&
@@ -388,9 +401,15 @@ const buildWhereClause = ({ schema, query, index }) => {
         }
       }
       if (fieldValue.$in) {
+        if (!(fieldValue.$in instanceof Array)) {
+          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $in value');
+        }
         createConstraint(_.flatMap(fieldValue.$in, elt => elt), false);
       }
       if (fieldValue.$nin) {
+        if (!(fieldValue.$nin instanceof Array)) {
+          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $nin value');
+        }
         createConstraint(_.flatMap(fieldValue.$nin, elt => elt), true);
       }
     }
@@ -578,11 +597,7 @@ const buildWhereClause = ({ schema, query, index }) => {
     }
 
     Object.keys(ParseToPosgresComparator).forEach(cmp => {
-      /* eslint-disable */
-      console.log(fieldValue);
-      console.log(cmp);
       if (fieldValue[cmp] || fieldValue[cmp] === 0) {
-        console.log('here');
         const pgComparator = ParseToPosgresComparator[cmp];
         patterns.push(`$${index}:name ${pgComparator} $${index + 1}`);
         values.push(fieldName, toPostgresValue(fieldValue[cmp]));

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -400,17 +400,15 @@ const buildWhereClause = ({ schema, query, index }) => {
         }
       }
       if (fieldValue.$in) {
-        if (!(fieldValue.$in instanceof Array)) {
-          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $in value');
-        }
         createConstraint(_.flatMap(fieldValue.$in, elt => elt), false);
       }
       if (fieldValue.$nin) {
-        if (!(fieldValue.$nin instanceof Array)) {
-          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $nin value');
-        }
         createConstraint(_.flatMap(fieldValue.$nin, elt => elt), true);
       }
+    } else if(fieldValue.$in !== undefined) {
+      throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $in value');
+    } else if (fieldValue.$nin != undefined) {
+      throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $nin value');
     }
 
     if (Array.isArray(fieldValue.$all) && isArrayField) {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -289,7 +289,7 @@ const buildWhereClause = ({ schema, query, index }) => {
       patterns.push(`$${index}:name = $${index + 1}`);
       // Can't cast boolean to double precision
       if (schema.fields[fieldName] && schema.fields[fieldName].type === 'Number') {
-        // Should always return zero
+        // Should always return zero results
         const MAX_INT_PLUS_ONE = 9223372036854775808;
         values.push(fieldName, MAX_INT_PLUS_ONE);
       } else {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -578,7 +578,11 @@ const buildWhereClause = ({ schema, query, index }) => {
     }
 
     Object.keys(ParseToPosgresComparator).forEach(cmp => {
-      if (fieldValue[cmp]) {
+      /* eslint-disable */
+      console.log(fieldValue);
+      console.log(cmp);
+      if (fieldValue[cmp] || fieldValue[cmp] === 0) {
+        console.log('here');
         const pgComparator = ParseToPosgresComparator[cmp];
         patterns.push(`$${index}:name ${pgComparator} $${index + 1}`);
         values.push(fieldName, toPostgresValue(fieldValue[cmp]));

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -405,9 +405,9 @@ const buildWhereClause = ({ schema, query, index }) => {
       if (fieldValue.$nin) {
         createConstraint(_.flatMap(fieldValue.$nin, elt => elt), true);
       }
-    } else if(fieldValue.$in !== undefined) {
+    } else if(typeof fieldValue.$in !== 'undefined') {
       throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $in value');
-    } else if (fieldValue.$nin != undefined) {
+    } else if (typeof fieldValue.$nin !== 'undefined') {
       throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $nin value');
     }
 

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -288,7 +288,7 @@ const buildWhereClause = ({ schema, query, index }) => {
     } else if (typeof fieldValue === 'boolean') {
       patterns.push(`$${index}:name = $${index + 1}`);
       // Can't cast boolean to double precision
-      if (schema.fields[fieldName].type === 'Number') {
+      if (schema.fields[fieldName] && schema.fields[fieldName].type === 'Number') {
         // Should always return zero
         const MAX_INT_PLUS_ONE = 9223372036854775808;
         values.push(fieldName, MAX_INT_PLUS_ONE);

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -287,8 +287,7 @@ const buildWhereClause = ({ schema, query, index }) => {
       index += 2;
     } else if (typeof fieldValue === 'boolean') {
       patterns.push(`$${index}:name = $${index + 1}`);
-
-      // Can't cast boolean to number
+      // Can't cast boolean to double precision
       if (schema.fields[fieldName].type === 'Number') {
         // Should always return zero
         const MAX_INT_PLUS_ONE = 9223372036854775808;


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/4653, https://github.com/parse-community/parse-server/pull/4100

Getting rid of `Postgres doesn't support this query type yet` errors and returning proper values.

The errors occur when you pass in 0 or false into an if statement.

Let me know if you can think of other queries that I may have missed.


