### PR TITLE
Fix purging empty class

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1493,7 +1493,7 @@ describe('miscellaneous', function() {
     });
   });
 
-  fit('purge empty class', (done) => {
+  it('purge empty class', (done) => {
     const testSchema = new Parse.Schema('UnknownClass');
     testSchema.purge().then(done).catch(done.fail);
   });

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1493,6 +1493,11 @@ describe('miscellaneous', function() {
     });
   });
 
+  fit('purge empty class', (done) => {
+    const testSchema = new Parse.Schema('UnknownClass');
+    testSchema.purge().then(done).catch(done.fail);
+  });
+
   it('should not update schema beforeSave #2672', (done) => {
     Parse.Cloud.beforeSave('MyObject', (request, response) => {
       if (request.object.get('secret')) {

--- a/src/Routers/PurgeRouter.js
+++ b/src/Routers/PurgeRouter.js
@@ -17,6 +17,11 @@ export class PurgeRouter extends PromiseRouter {
           cacheAdapter.role.clear();
         }
         return {response: {}};
+      }).catch((error) => {
+        if (!error || (error && error.code === Parse.Error.OBJECT_NOT_FOUND)) {
+          return {response: {}};
+        }
+        throw error;
       });
   }
 


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/4664

Without the fix I got the following error in `middleware.js`.

```bash
  Failed: should not call next
      - Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
      - Failed: There were open connections to the server left after the test finished
```