### PR TITLE
Making `response.error` accept a Parse.Error object as parameter

### DIFF
--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -89,6 +89,9 @@ export class FunctionsRouter extends PromiseRouter {
       },
       error: function(code, message) {
         if (!message) {
+          if (code instanceof Parse.Error) {
+            return reject(code)
+          }
           message = code;
           code = Parse.Error.SCRIPT_FAILED;
         }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -224,6 +224,9 @@ export function getResponseObject(request, resolve, reject) {
     },
     error: function(code, message) {
       if (!message) {
+        if (code instanceof Parse.Error) {
+          return reject(code)
+        }
         message = code;
         code = Parse.Error.SCRIPT_FAILED;
       }


### PR DESCRIPTION
Passing the original `Parse.Error` has the obvious benefit of preventing the re-creation of it.
Additionally, it can take advantage of keeping extra fields in the object such as the stack.

For example:
https://github.com/saulogt/parse-error-plus
I use this module (I'm the author) that makes Parse.Error a subclass o Error. It's being useful to trace the error when it happens, but the stack is reset when request.error is called.