### PR TITLE
upgrading pg-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mongodb": "3.0.6",
     "multer": "1.3.0",
     "parse": "1.11.1",
-    "pg-promise": "8.2.1",
+    "pg-promise": "8.4.0",
     "redis": "2.8.0",
     "request": "2.83.0",
     "semver": "5.5.0",

--- a/spec/PostgresInitOptions.spec.js
+++ b/spec/PostgresInitOptions.spec.js
@@ -6,22 +6,14 @@ const express = require('express');
 //public schema
 const databaseOptions1 = {
   initOptions: {
-    connect: function (client, dc, isFresh) {
-      if (isFresh) {
-        client.query('SET search_path = public');
-      }
-    }
+    schema: 'public'
   }
 };
 
 //not exists schema
 const databaseOptions2 = {
   initOptions: {
-    connect: function (client, dc, isFresh) {
-      if (isFresh) {
-        client.query('SET search_path = not_exists_schema');
-      }
-    }
+    schema: 'not_exists_schema'
   }
 };
 


### PR DESCRIPTION
Upgrading to pg-promise 8.4.0

Start using the new `schema` option, and thus resolving compatibility issue if the now obsolete `isFresh` flag. See [v8.4.0](https://github.com/vitaly-t/pg-promise/releases/tag/v.8.4.0).
