### PR TITLE
Allow creation of indices on default fields

### DIFF
--- a/spec/InMemoryCache.spec.js
+++ b/spec/InMemoryCache.spec.js
@@ -28,7 +28,7 @@ describe('InMemoryCache', function() {
     let value = cache.get(KEY);
     expect(value).toEqual(VALUE);
 
-    wait(BASE_TTL.ttl * 2).then(() => {
+    wait(BASE_TTL.ttl * 10).then(() => {
       value = cache.get(KEY)
       expect(value).toEqual(null);
       done();

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1869,19 +1869,7 @@ describe('schemas', () => {
           }
         }
       }, (error, response, body) => {
-      expect(body).toEqual({
-        className: 'NewClass',
-        fields: {
-          ACL: {type: 'ACL'},
-          createdAt: {type: 'Date'},
-          updatedAt: {type: 'Date'},
-          objectId: {type: 'String'}
-        },
-        classLevelPermissions: defaultClassLevelPermissions,
-        indexes: {
-          name1: { createdAt: 1},
-        },
-      });
+        expect(body.indexes.name1).toEqual({ createdAt: 1});
         done();
       });
     })

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1852,6 +1852,41 @@ describe('schemas', () => {
     })
   });
 
+  it('can create index on default field', done => {
+    request.post({
+      url: 'http://localhost:8378/1/schemas/NewClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {},
+    }, () => {
+      request.put({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          indexes: {
+            name1: { createdAt: 1},
+          }
+        }
+      }, (error, response, body) => {
+      expect(body).toEqual({
+        className: 'NewClass',
+        fields: {
+          ACL: {type: 'ACL'},
+          createdAt: {type: 'Date'},
+          updatedAt: {type: 'Date'},
+          objectId: {type: 'String'}
+        },
+        classLevelPermissions: defaultClassLevelPermissions,
+        indexes: {
+          name1: { createdAt: 1},
+        },
+      });
+        done();
+      });
+    })
+  });
+
   it('cannot create compound index if field does not exist', done => {
     request.post({
       url: 'http://localhost:8378/1/schemas/NewClass',

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -530,6 +530,8 @@ export default class SchemaController {
         delete existingFields._rperm;
         delete existingFields._wperm;
         const newSchema = buildMergedSchemaObject(existingFields, submittedFields);
+        const defaultFields = defaultColumns[className] || defaultColumns._Default;
+        const fullNewSchema = Object.assign({}, newSchema, defaultFields);
         const validationError = this.validateSchemaData(className, newSchema, classLevelPermissions, Object.keys(existingFields));
         if (validationError) {
           throw new Parse.Error(validationError.code, validationError.error);
@@ -561,7 +563,7 @@ export default class SchemaController {
             return Promise.all(promises);
           })
           .then(() => this.setPermissions(className, classLevelPermissions, newSchema))
-          .then(() => this._dbAdapter.setIndexesWithSchemaFormat(className, indexes, schema.indexes, newSchema))
+          .then(() => this._dbAdapter.setIndexesWithSchemaFormat(className, indexes, schema.indexes, fullNewSchema))
           .then(() => this.reloadData({ clearCache: true }))
         //TODO: Move this logic into the database adapter
           .then(() => {


### PR DESCRIPTION
This PR resolves https://github.com/parse-community/parse-server/issues/4714. Note that due to https://github.com/parse-community/parse-server/issues/4719 the indices this allows you to create are incorrect as of right now. Once https://github.com/parse-community/parse-server/issues/4719 is resolved the indices created on these fields should be correct (and useful).

CC @TylerBrock 