### PR TITLE
feature: User Lockout

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -980,7 +980,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
   if (this.query) {
     // Force the user to not lockout
     // Matched with parse.com
-    if (this.className === '_User' && this.data.ACL) {
+    if (this.className === '_User' && this.data.ACL && this.auth.isMaster !== true) {
       this.data.ACL[this.query.objectId] = { read: true, write: true };
     }
     // update password timestamp if user password is being changed

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -282,7 +282,9 @@ RestWrite.prototype.findUsersWithAuthData = function(authData) {
 RestWrite.prototype.handleAuthData = function(authData) {
   let results;
   return this.findUsersWithAuthData(authData).then((r) => {
-    results = r;
+    results = r.filter((user) => {
+      return !this.auth.isMaster && user.ACL && Object.keys(user.ACL).length > 0;
+    });
     if (results.length > 1) {
       // More than 1 user with the passed id's
       throw new Parse.Error(Parse.Error.ACCOUNT_ALREADY_LINKED,

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -114,6 +114,12 @@ export class UsersRouter extends ClassesRouter {
         if (!isValidPassword) {
           throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
         }
+        // Ensure the user isn't locked out
+        // A locked out user won't be able to login
+        // To lock a user out, just set the ACL to `masterKey` only  ({}).
+        if (!req.auth.isMaster && (!user.ACL || Object.keys(user.ACL).length == 0)) {
+          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
+        }
         if (req.config.verifyUserEmails && req.config.preventLoginWithUnverifiedEmail && !user.emailVerified) {
           throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, 'User email is not verified.');
         }


### PR DESCRIPTION
Is is possible that a user request to have it's data removed from the database. In order to provide a good experience, an administrator should be able to lock the account out.

- If the user was logged in with username / password, the login calls should fail, but a new account with the same username can't be created again till the _User object is destroyed
- If the user was logged in with 3rd party auth, any subsequent login would re-create a new account.

In order to lock a user out, it now is allowed to have masterKey only User objects. In those cases, the account will be consider locked out.