### PR TITLE
Use http agents for hook requests

### DIFF
--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -149,9 +149,10 @@ export function getDatabaseController(options: ParseServerOptions, cacheControll
 export function getHooksController(options: ParseServerOptions, databaseController: DatabaseController): HooksController {
   const {
     appId,
-    webhookKey
+    webhookKey,
+    hookKeepAlive,
   } = options;
-  return new HooksController(appId, databaseController, webhookKey);
+  return new HooksController(appId, databaseController, webhookKey, hookKeepAlive);
 }
 
 interface PushControlling {
@@ -228,4 +229,3 @@ export function getDatabaseAdapter(databaseURI, collectionPrefix, databaseOption
     });
   }
 }
-

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -131,6 +131,8 @@ export interface ParseServerOptions {
   startLiveQueryServer: ?boolean;
   /* Live query server configuration options (will start the liveQuery server) */
   liveQueryServerOptions: ?LiveQueryServerOptions;
+  /* Keep hook HTTP connections alive */
+  hookKeepAlive: ?boolean;
 
   __indexBuildCompletionCallbackForTests: ?()=>void;
 }


### PR DESCRIPTION
We've found that hooks create an enormous amount of http traffic (including dns lookups, socket churning, and port exhaustion).

Using a NodeJS http(s) agent with keepAlive enabled in both the client sdk and parse-server has been valuable for us as we scale our production load so I'm proposing this change upstream as it might help others (and could potentially be the default when people feel comfortable).