### PR TITLE
Don't error when attempting to sort on an object field

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1538,7 +1538,7 @@ describe('Parse.Query testing', () => {
     });
   });
 
-  fit('can order an on an object field', function (done) {
+  it('can order an on an object field', function (done) {
     const testSet = [
       { sortField: { value: 10 } },
       { sortField: { value: 1 } },

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1559,6 +1559,27 @@ describe('Parse.Query testing', () => {
       .catch(done.fail);
   });
 
+  it('can order on an object string field (level 2)', function (done) {
+    const testSet = [
+      { sortField: { value: { field: "Z" } } },
+      { sortField: { value: { field: "A" } } },
+      { sortField: { value: { field: "M" } } },
+    ];
+
+    const objects = testSet.map(e => new Parse.Object('Test', e));
+    Parse.Object.saveAll(objects)
+      .then(() => new Parse.Query('Test').addDescending('sortField.value.field').first())
+      .then((result) => {
+        expect(result.get('sortField').value.field).toBe("Z");
+        return new Parse.Query('Test').addAscending('sortField.value.field').first()
+      })
+      .then((result) => {
+        expect(result.get('sortField').value.field).toBe("A");
+        done();
+      })
+      .catch(done.fail);
+  });
+
   it('can order on an object number field', function (done) {
     const testSet = [
       { sortField: { value: 10 } },
@@ -1575,6 +1596,27 @@ describe('Parse.Query testing', () => {
       })
       .then((result) => {
         expect(result.get('sortField').value).toBe(1);
+        done();
+      })
+      .catch(done.fail);
+  });
+
+  it('can order on an object number field (level 2)', function (done) {
+    const testSet = [
+      { sortField: { value: { field: 10 } } },
+      { sortField: { value: { field: 1 } } },
+      { sortField: { value: { field: 5 } } },
+    ];
+
+    const objects = testSet.map(e => new Parse.Object('Test', e));
+    Parse.Object.saveAll(objects)
+      .then(() => new Parse.Query('Test').addDescending('sortField.value.field').first())
+      .then((result) => {
+        expect(result.get('sortField').value.field).toBe(10);
+        return new Parse.Query('Test').addAscending('sortField.value.field').first()
+      })
+      .then((result) => {
+        expect(result.get('sortField').value.field).toBe(1);
         done();
       })
       .catch(done.fail);

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1538,6 +1538,27 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  fit('can order an on an object field', function (done) {
+    const testSet = [
+      { sortField: { value: 10 } },
+      { sortField: { value: 1 } },
+      { sortField: { value: 5 } },
+    ];
+
+    const objects = testSet.map(e => new Parse.Object('Test', e));
+    Parse.Object.saveAll(objects)
+      .then(() => new Parse.Query('Test').addDescending('sortField.value').first())
+      .then((result) => {
+        expect(result.get('sortField').value).toBe(10);
+        return new Parse.Query('Test').addAscending('sortField.value').first()
+      })
+      .then((result) => {
+        expect(result.get('sortField').value).toBe(1);
+        done();
+      })
+      .catch(done.fail);
+  });
+
   it("order by ascending number then descending string", function(done) {
     const strings = ["a", "b", "c", "d"];
     const makeBoxedNumber = function(num, i) {

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1538,7 +1538,7 @@ describe('Parse.Query testing', () => {
     });
   });
 
-  it('can order an on an object field', function (done) {
+  it('can order on an object field', function (done) {
     const testSet = [
       { sortField: { value: 10 } },
       { sortField: { value: 1 } },

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1538,7 +1538,7 @@ describe('Parse.Query testing', () => {
     });
   });
 
-  it('can order on an object field', function (done) {
+  it_only_db('mongo')('can order on an object field', function (done) {
     const testSet = [
       { sortField: { value: 10 } },
       { sortField: { value: 1 } },

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1538,7 +1538,28 @@ describe('Parse.Query testing', () => {
     });
   });
 
-  it_only_db('mongo')('can order on an object field', function (done) {
+  it('can order on an object string field', function (done) {
+    const testSet = [
+      { sortField: { value: "Z" } },
+      { sortField: { value: "A" } },
+      { sortField: { value: "M" } },
+    ];
+
+    const objects = testSet.map(e => new Parse.Object('Test', e));
+    Parse.Object.saveAll(objects)
+      .then(() => new Parse.Query('Test').addDescending('sortField.value').first())
+      .then((result) => {
+        expect(result.get('sortField').value).toBe("Z");
+        return new Parse.Query('Test').addAscending('sortField.value').first()
+      })
+      .then((result) => {
+        expect(result.get('sortField').value).toBe("A");
+        done();
+      })
+      .catch(done.fail);
+  });
+
+  it('can order on an object number field', function (done) {
     const testSet = [
       { sortField: { value: 10 } },
       { sortField: { value: 1 } },

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1397,11 +1397,12 @@ export class PostgresStorageAdapter implements StorageAdapter {
     if (sort) {
       const sortCopy: any = sort;
       const sorting = Object.keys(sort).map((key) => {
+        const transformKey = transformDotFieldToComponents(key).join('->');
         // Using $idx pattern gives:  non-integer constant in ORDER BY
         if (sortCopy[key] === 1) {
-          return `"${key}" ASC`;
+          return `${transformKey} ASC`;
         }
-        return `"${key}" DESC`;
+        return `${transformKey} DESC`;
       }).join();
       sortPattern = sort !== undefined && Object.keys(sort).length > 0 ? `ORDER BY ${sorting}` : '';
     }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -297,7 +297,7 @@ const untransformObjectACL = ({_rperm, _wperm, ...output}) => {
 /**
  * When querying, the fieldName may be compound, extract the base fieldName
  *     `temperature.celsius` becomes `temperature`
- * @param {string} fieldName to extract the base name from
+ * @param {string} fieldName that may be a compound field name
  * @returns {string} the basename of the field
  */
 const getBaseFieldName = (fieldName: string): string => {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -900,6 +900,7 @@ class DatabaseController {
               if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
                 throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Cannot sort by ${fieldName}`);
               }
+              fieldName = fieldName.split('.')[0];
               if (!SchemaController.fieldNameIsValid(fieldName)) {
                 throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
               }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -294,6 +294,16 @@ const untransformObjectACL = ({_rperm, _wperm, ...output}) => {
   return output;
 }
 
+/**
+ * When querying, the fieldName may be compound, extract the base fieldName
+ *     `temperature.celsius` becomes `temperature`
+ * @param {string} fieldName to extract the base name from
+ * @returns {string} the basename of the field
+ */
+const getBaseFieldName = (fieldName: string): string => {
+  return fieldName.split('.')[0]
+}
+
 const relationSchema = { fields: { relatedId: { type: 'String' }, owningId: { type: 'String' } } };
 
 class DatabaseController {
@@ -411,8 +421,8 @@ class DatabaseController {
                   if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
                     throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name for update: ${fieldName}`);
                   }
-                  fieldName = fieldName.split('.')[0];
-                  if (!SchemaController.fieldNameIsValid(fieldName) && !isSpecialUpdateKey(fieldName)) {
+                  const baseFieldName = getBaseFieldName(fieldName);
+                  if (!SchemaController.fieldNameIsValid(baseFieldName) && !isSpecialUpdateKey(baseFieldName)) {
                     throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name for update: ${fieldName}`);
                   }
                 });
@@ -900,8 +910,8 @@ class DatabaseController {
               if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
                 throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Cannot sort by ${fieldName}`);
               }
-              fieldName = fieldName.split('.')[0];
-              if (!SchemaController.fieldNameIsValid(fieldName)) {
+              const baseFieldName = getBaseFieldName(fieldName);
+              if (!SchemaController.fieldNameIsValid(baseFieldName)) {
                 throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
               }
             });


### PR DESCRIPTION
fixes: #4805 

see https://github.com/parse-community/parse-server/blob/3b40d2227d9b9b7a768de0c6faf6916982fe8e89/src/Controllers/DatabaseController.js#L414

There is a validation check for the name of a field to make sure that it is valid.  This check is performed in both the Schema Controller and the Database Controller.  In the database controller, the check is applied when an update or a find operation is requested on the database.

Since updates can occur to and find's can be performed on members of a document, it is important that the check only be performed on the name of the field, and not the member.

In the case of the update, there is an existing split that separates the field from the member.

The split is missing from the find when trying to sort on a field which is erroneously causing an error.

This pull request introduces a test to sort on a member of a document and a fix to allow the test to pass.

