### PR TITLE
Fixed untruncated log in Cloud code router

### DIFF
--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -137,7 +137,6 @@ export class FunctionsRouter extends PromiseRouter {
               `Ran cloud function ${functionName} for user ${userString} with:\n  Input: ${cleanInput }\n  Result: ${cleanResult }`,
               {
                 functionName,
-                params,
                 user: userString,
               }
             );


### PR DESCRIPTION
When calling a cloud function, the logger logs the sent parameters twice.

```js
return new Promise(function (resolve, reject) {
        const userString = (req.auth && req.auth.user) ? req.auth.user.id : undefined;
        // Input params logged here, truncated
        const cleanInput = logger.truncateLogMessage(JSON.stringify(params));
        var response = FunctionsRouter.createResponseObject((result) => {
          try {
            const cleanResult = logger.truncateLogMessage(JSON.stringify(result.response.result));
            logger.info(
              `Ran cloud function ${functionName} for user ${userString} with:\n  Input: ${cleanInput }\n  Result: ${cleanResult }`,
              {
                functionName,
                // Input params logged here, not truncated
                params,
                user: userString,
              }
            );
            resolve(result);
          } catch (e) {
            reject(e);
          }
        }
...
```

The second one is redundant and untruncated.
This may result in huge logs when a base64 string is passed as parameter.
The fix removes it from the log.