### PR TITLE
[Fix] Columns of type "Object" merging with old value on Postgres

### DIFF
--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -1980,4 +1980,31 @@ describe('Parse.Object testing', () => {
       done();
     })
   });
+
+  it ('Update object field should store exactly same sent object', async (done) => {
+    let object = new TestObject();
+
+    // Set initial data
+    object.set("jsonData", { a: "b" });
+    object = await object.save();
+    equal(object.get('jsonData'), { a: "b" });
+
+    // Set empty JSON
+    object.set("jsonData", {});
+    object = await object.save();
+    equal(object.get('jsonData'), {});
+
+    // Set new JSON data
+    object.unset('jsonData')
+    object.set("jsonData", { c: "d" });
+    object = await object.save();
+    equal(object.get('jsonData'), { c: "d" });
+
+    // Fetch object from server
+    object = await object.fetch()
+    console.log(object.id, object.get('jsonData'))
+    equal(object.get('jsonData'), { c: "d" });
+
+    done();
+  });
 });

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1324,7 +1324,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
           return p + ` - '$${index + 1 + i}:value'`;
         }, '');
 
-        updatePatterns.push(`$${index}:name = ( COALESCE($${index}:name, '{}'::jsonb) ${deletePatterns} ${incrementPatterns} || $${index + 1 + keysToDelete.length}::jsonb )`);
+        updatePatterns.push(`$${index}:name = ('{}'::jsonb ${deletePatterns} ${incrementPatterns} || $${index + 1 + keysToDelete.length}::jsonb )`);
 
         values.push(fieldName, ...keysToDelete, JSON.stringify(fieldValue));
         index += 2 + keysToDelete.length;


### PR DESCRIPTION
After this discussion #4808

The PR fixes an issue with Postgres due to this commit #2984.

When updating a field of type object (JSON object), the previous and new values are merged.
This is not the expected behaviour as it is not documented and not happening in MongoDB.
