### PR TITLE
Add ability to deactivate a role (Enable/Disable) 

### DIFF
--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -527,4 +527,40 @@ describe('Parse Role testing', () => {
           });
       });
   });
+
+  it('should be able to create an active role', (done) => {
+    const roleACL = new Parse.ACL();
+    roleACL.setPublicReadAccess(true);
+    const role = new Parse.Role('some_active_role', roleACL);
+    role.set('active', true);
+    role.save({}, {useMasterKey : true})
+      .then((savedRole)=>{
+        expect(savedRole.get('active')).toEqual(true);
+        const query = new Parse.Query('_Role');
+        return query.find({ useMasterKey: true });
+      }).then((roles) => {
+        expect(roles.length).toEqual(1);
+        const role = roles[0];
+        expect(role.get('active')).toEqual(true);
+        done();
+      });
+  });
+
+  it('should be able to create an inactive role', (done) => {
+    const roleACL = new Parse.ACL();
+    roleACL.setPublicReadAccess(true);
+    const role = new Parse.Role('some_active_role', roleACL);
+    role.set('active', false);
+    role.save({}, {useMasterKey : true})
+      .then((savedRole)=>{
+        expect(savedRole.get('active')).toEqual(false);
+        const query = new Parse.Query('_Role');
+        return query.find({ useMasterKey: true });
+      }).then((roles) => {
+        expect(roles.length).toEqual(1);
+        const role = roles[0];
+        expect(role.get('active')).toEqual(false);
+        done();
+      });
+  });
 });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,7 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "*.spec.js"
+    "*spec.js"
   ],
   "helpers": [
     "../node_modules/babel-core/register.js",

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,7 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "ParseRole.spec.js"
+    "*.spec.js"
   ],
   "helpers": [
     "../node_modules/babel-core/register.js",

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,7 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "*spec.js"
+    "ParseRole.spec.js"
   ],
   "helpers": [
     "../node_modules/babel-core/register.js",

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -131,6 +131,10 @@ Auth.prototype._loadRoles = function() {
         __type: 'Pointer',
         className: '_User',
         objectId: this.user.id
+      },
+      // By using $ne instead of $eq=true we support earlier parse versions where the active field might be undefined
+      'active': {
+        '$ne' : false
       }
     };
     // First get the role ids this user is directly a member of
@@ -191,6 +195,9 @@ Auth.prototype._getAllRolesNamesForRoleIds = function(roleIDs, names = [], queri
   } else {
     restWhere = { 'roles': { '$in': ins }}
   }
+  // Always make sure roles are active
+  restWhere.active = { '$ne' : false }
+
   const query = new RestQuery(this.config, master(this.config), '_Role', restWhere, {});
   return query.execute().then((response) => {
     var results = response.results;

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -132,8 +132,9 @@ Auth.prototype._loadRoles = function() {
         className: '_User',
         objectId: this.user.id
       },
-      // By using $ne instead of $eq=true we support earlier parse versions where the active field might be undefined
-      'active': {
+      // By using $ne instead of $eq=true we support earlier versions of parse where the 'enabled' field might be undefined
+      // $ne should not affect performance since Roles are often fetched from cache
+      'enabled': {
         '$ne' : false
       }
     };
@@ -195,8 +196,8 @@ Auth.prototype._getAllRolesNamesForRoleIds = function(roleIDs, names = [], queri
   } else {
     restWhere = { 'roles': { '$in': ins }}
   }
-  // Always make sure roles are active
-  restWhere.active = { '$ne' : false }
+  // Always make sure roles are enabled
+  restWhere.enabled = { '$ne' : false }
 
   const query = new RestQuery(this.config, master(this.config), '_Role', restWhere, {});
   return query.execute().then((response) => {

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -62,7 +62,8 @@ const defaultColumns: {[string]: SchemaFields} = Object.freeze({
   _Role: {
     "name":  {type:'String'},
     "users": {type:'Relation', targetClass:'_User'},
-    "roles": {type:'Relation', targetClass:'_Role'}
+    "roles": {type:'Relation', targetClass:'_Role'},
+    "active": {type:'Boolean'}
   },
   // The additional default columns for the _Session collection (in addition to DefaultCols)
   _Session: {

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -63,7 +63,7 @@ const defaultColumns: {[string]: SchemaFields} = Object.freeze({
     "name":  {type:'String'},
     "users": {type:'Relation', targetClass:'_User'},
     "roles": {type:'Relation', targetClass:'_Role'},
-    "active": {type:'Boolean'}
+    "enabled": {type:'Boolean'}
   },
   // The additional default columns for the _Session collection (in addition to DefaultCols)
   _Session: {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1093,6 +1093,12 @@ RestWrite.prototype.runDatabaseOperation = function() {
         response.objectId = this.data.objectId;
         response.createdAt = this.data.createdAt;
 
+        // (#4591) Role "enabled" key is generated with on create, and SDKs might not support this change yet.
+        // removing this line will brake RoleTest ("should create an enabled role by default")
+        if(this.className === "_Role" && !this.query){
+          response.enabled = this.data.enabled;
+        }
+
         if (this.responseShouldHaveUsername) {
           response.username = this.data.username;
         }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -190,9 +190,16 @@ RestWrite.prototype.setRequiredFieldsIfNeeded = function() {
     if (!this.query) {
       this.data.createdAt = this.updatedAt;
 
-      // Only assign new objectId if we are creating new object
-      if (!this.data.objectId) {
+      const creatingObject = !this.data.objectId;
+      if (creatingObject) {
+        // Only assign new objectId if we are creating new object
         this.data.objectId = cryptoUtils.newObjectId(this.config.objectIdSize);
+        // On Role, assume is active, and assign 'active' to true
+        if(this.className === '_Role'){
+          if(this.data.active === undefined){
+            this.data.active = true;
+          }
+        }
       }
     }
   }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -194,10 +194,10 @@ RestWrite.prototype.setRequiredFieldsIfNeeded = function() {
       if (creatingObject) {
         // Only assign new objectId if we are creating new object
         this.data.objectId = cryptoUtils.newObjectId(this.config.objectIdSize);
-        // On Role, assume is active, and assign 'active' to true
+        // On Role, assume is not disabled, and assign 'enabled' to true
         if(this.className === '_Role'){
-          if(this.data.active === undefined){
-            this.data.active = true;
+          if(this.data.enabled === undefined){
+            this.data.enabled = true;
           }
         }
       }


### PR DESCRIPTION
This PR addresses the open proposal #4591  to add a functionality to Enable/Disable a role.
Disabling a role will prevent the role from granting permissions to its users or any of its children roles.
I think this functionality can come in handy when it is needed to temporarily disable a role tree.

Another other solution could be as discussed in #4591 is to set the role ACL to masterKey, 
preventing access to the role, but:
1. masterKey will also prevent any other role who has Write Access to be prevented access
2. ACL needs to be saved and rolled back to restore access
3. Currently, ACL is not applied to roles when gathering authentication, roles are fetched regardless of their acl in authentication. (as discussed in #4591)

This is my first PR, hope I did well :)