### PR TITLE
add support for geoWithin.centerSphere queries via withJSON

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3992,9 +3992,9 @@ describe('Parse.Query testing', () => {
     const obj1 = new Parse.Object('TestObject', {location: inbound});
     const obj2 = new Parse.Object('TestObject', {location: onbound});
     const obj3 = new Parse.Object('TestObject', {location: outbound});
+    const center = new Parse.GeoPoint(0, 0);
+    const distanceInKilometers = 1569 + 1; // 1569km is the approximate distance between {0, 0} and {10, 10}.
     Parse.Object.saveAll([obj1, obj2, obj3]).then(() => {
-      const center = new Parse.GeoPoint(0, 0);
-      const distanceInKilometers = 1569 + 1; // 1569km is the approximate distance between {0, 0} and {10, 10}.
       const q = new Parse.Query(TestObject);
       const jsonQ = q.toJSON();
       jsonQ.where.location = {
@@ -4009,6 +4009,23 @@ describe('Parse.Query testing', () => {
       return q.find();
     }).then(results => {
       equal(results.length, 2);
+      const q = new Parse.Query(TestObject);
+      const jsonQ = q.toJSON();
+      jsonQ.where.location = {
+        '$geoWithin': {
+          '$centerSphere': [
+            [0, 0],
+            distanceInKilometers / 6371.0
+          ]
+        }
+      };
+      q.withJSON(jsonQ);
+      return q.find();
+    }).then(results => {
+      equal(results.length, 2);
+      done();
+    }).catch(error => {
+      fail(error);
       done();
     });
   });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -4063,12 +4063,12 @@ describe('Parse.Query testing', () => {
     jsonQ.where.location = {
       '$geoWithin': {
         '$centerSphere': [
-          [0],
+          [-190,-190],
           1
         ]
       }
     };
     q.withJSON(jsonQ);
-    q.find(expectError(Parse.Error.INVALID_JSON, done));
+    q.find(expectError(undefined, done));
   });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3985,7 +3985,7 @@ describe('Parse.Query testing', () => {
       })
   });
 
-  it('toJSON works with geoWithin.centerSphere', (done) => {
+  it('withJSON supports geoWithin.centerSphere', (done) => {
     const inbound = new Parse.GeoPoint(1.5, 1.5);
     const onbound = new Parse.GeoPoint(10, 10);
     const outbound = new Parse.GeoPoint(20, 20);
@@ -4028,5 +4028,47 @@ describe('Parse.Query testing', () => {
       fail(error);
       done();
     });
+  });
+
+  it('withJSON with geoWithin.centerSphere fails without parameters', (done) => {
+    const q = new Parse.Query(TestObject);
+    const jsonQ = q.toJSON();
+    jsonQ.where.location = {
+      '$geoWithin': {
+        '$centerSphere': [
+        ]
+      }
+    };
+    q.withJSON(jsonQ);
+    q.find(expectError(Parse.Error.INVALID_JSON, done));
+  });
+
+  it('withJSON with geoWithin.centerSphere fails without distance', (done) => {
+    const q = new Parse.Query(TestObject);
+    const jsonQ = q.toJSON();
+    jsonQ.where.location = {
+      '$geoWithin': {
+        '$centerSphere': [
+          [0, 0]
+        ]
+      }
+    };
+    q.withJSON(jsonQ);
+    q.find(expectError(Parse.Error.INVALID_JSON, done));
+  });
+
+  it('withJSON with geoWithin.centerSphere fails with invalid geo point', (done) => {
+    const q = new Parse.Query(TestObject);
+    const jsonQ = q.toJSON();
+    jsonQ.where.location = {
+      '$geoWithin': {
+        '$centerSphere': [
+          [0],
+          1
+        ]
+      }
+    };
+    q.withJSON(jsonQ);
+    q.find(expectError(Parse.Error.INVALID_JSON, done));
   });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -4043,18 +4043,34 @@ describe('Parse.Query testing', () => {
     q.find(expectError(Parse.Error.INVALID_JSON, done));
   });
 
-  it('withJSON with geoWithin.centerSphere fails without distance', (done) => {
+  it('withJSON with geoWithin.centerSphere fails with invalid distance', (done) => {
     const q = new Parse.Query(TestObject);
     const jsonQ = q.toJSON();
     jsonQ.where.location = {
       '$geoWithin': {
         '$centerSphere': [
-          [0, 0]
+          [0, 0],
+          'invalid_distance'
         ]
       }
     };
     q.withJSON(jsonQ);
     q.find(expectError(Parse.Error.INVALID_JSON, done));
+  });
+
+  it('withJSON with geoWithin.centerSphere fails with invalid coordinate', (done) => {
+    const q = new Parse.Query(TestObject);
+    const jsonQ = q.toJSON();
+    jsonQ.where.location = {
+      '$geoWithin': {
+        '$centerSphere': [
+          [-190,-190],
+          1
+        ]
+      }
+    };
+    q.withJSON(jsonQ);
+    q.find(expectError(undefined, done));
   });
 
   it('withJSON with geoWithin.centerSphere fails with invalid geo point', (done) => {
@@ -4063,7 +4079,7 @@ describe('Parse.Query testing', () => {
     jsonQ.where.location = {
       '$geoWithin': {
         '$centerSphere': [
-          [-190,-190],
+          {'longitude': 0, 'dummytude': 0},
           1
         ]
       }

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -294,11 +294,13 @@ function expectError(errorCode, callback) {
     error: function(obj, e) {
       // Some methods provide 2 parameters.
       e = e || obj;
-      if (!e) {
-        fail('expected a specific error but got a blank error');
-        return;
+      if (errorCode !== undefined) {
+        if (!e) {
+          fail('expected a specific error but got a blank error');
+          return;
+        }
+        expect(e.code).toEqual(errorCode, e.message);
       }
-      expect(e.code).toEqual(errorCode, e.message);
       if (callback) {
         callback(e);
       }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -952,13 +952,11 @@ function transformConstraint(constraint, field) {
         // Get point, convert to geo point if necessary and validate
         let point = centerSphere[0];
         if (point instanceof Array && point.length === 2) {
-          Parse.GeoPoint._validate(point[1], point[0]);
           point = new Parse.GeoPoint(point[1], point[0]);
         } else if (!GeoPointCoder.isValidJSON(point)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; $centerSphere geo point invalid');
-        } else {
-          Parse.GeoPoint._validate(point.latitude, point.longitude);
         }
+        Parse.GeoPoint._validate(point.latitude, point.longitude);
         // Get distance and validate
         const distance = centerSphere[1];
         if(isNaN(distance) || distance < 0) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -947,22 +947,22 @@ function transformConstraint(constraint, field) {
         };
       } else if (centerSphere !== undefined) {
         if (!(centerSphere instanceof Array) || centerSphere.length < 2) {
-          throw new Parse.Error(
-            Parse.Error.INVALID_JSON,
-            'bad $geoWithin value; $centerSphere should be an array of Parse.Geopoint and distance'
-          );
+          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; $centerSphere should be an array of Parse.GeoPoint and distance');
         }
-        const point = centerSphere[0];
+        // Get point, convert to geo point if necessary and validate
+        let point = centerSphere[0];
         if (point instanceof Array && point.length === 2) {
           Parse.GeoPoint._validate(point[1], point[0]);
+          point = new Parse.GeoPoint(point[1], point[0]);
         } else if (!GeoPointCoder.isValidJSON(point)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; $centerSphere geo point invalid');
         } else {
           Parse.GeoPoint._validate(point.latitude, point.longitude);
         }
-        const distance = centerSphere[1]
+        // Get distance and validate
+        const distance = centerSphere[1];
         if(isNaN(distance) || distance < 0) {
-          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; $centerSphere distance invalid')
+          throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad $geoWithin value; $centerSphere distance invalid');
         }
         answer[key] = {
           '$centerSphere': [


### PR DESCRIPTION
This allows an unsorted geo query via `withJSON` as a faster performing alternative to the sorted geo queries of `withinKilometers`, `withinMiles` and `withinRadius` if sorting by distance is not needed.