### PR TITLE
Ensure User ACL's are more flexible and secure #3588

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -975,6 +975,25 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('test beforeDelete with locked down ACL', async () => {
+    let called = false;
+    Parse.Cloud.beforeDelete('GameScore', (req, res) => {
+      called = true;
+      res.success();
+    });
+    const object = new Parse.Object('GameScore');
+    object.setACL(new Parse.ACL());
+    await object.save();
+    const objects = await new Parse.Query('GameScore').find();
+    expect(objects.length).toBe(0);
+    try {
+      await object.destroy();
+    } catch(e) {
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
+    }
+    expect(called).toBe(false);
+  });
+
   it('test cloud function query parameters', (done) => {
     Parse.Cloud.define('echoParams', (req, res) => {
       res.success(req.params);

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -2444,7 +2444,7 @@ describe('Parse.User testing', () => {
         }, (error, response, body) => {
           expect(error).toBe(null);
           const b = JSON.parse(body);
-          expect(b.error).toBe('invalid session token');
+          expect(b.error).toBe('Invalid session token');
           request.put({
             headers: {
               'X-Parse-Application-Id': 'test',
@@ -2536,7 +2536,7 @@ describe('Parse.User testing', () => {
             expect(error).toBe(null);
             const b = JSON.parse(body);
             expect(b.code).toEqual(209);
-            expect(b.error).toBe('invalid session token');
+            expect(b.error).toBe('Invalid session token');
             done();
           });
         });
@@ -2578,7 +2578,7 @@ describe('Parse.User testing', () => {
         }, (error,response,body) => {
           const b = JSON.parse(body);
           expect(b.code).toEqual(209);
-          expect(b.error).toBe('invalid session token');
+          expect(b.error).toBe('Invalid session token');
           done();
         });
       });
@@ -2615,7 +2615,7 @@ describe('Parse.User testing', () => {
       done();
     }, function(err) {
       expect(err.code).toBe(Parse.Error.INVALID_SESSION_TOKEN);
-      expect(err.message).toBe('invalid session token');
+      expect(err.message).toBe('Invalid session token');
       done();
     });
   });
@@ -2691,7 +2691,7 @@ describe('Parse.User testing', () => {
     });
   });
 
-  it("invalid session tokens are rejected", (done) => {
+  it("Invalid session tokens are rejected", (done) => {
     Parse.User.signUp("asdf", "zxcv", null, {
       success: function() {
         request.get({
@@ -2704,7 +2704,7 @@ describe('Parse.User testing', () => {
           },
         }, (error, response, body) => {
           expect(body.code).toBe(209);
-          expect(body.error).toBe('invalid session token');
+          expect(body.error).toBe('Invalid session token');
           done();
         })
       }

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -114,7 +114,6 @@ if (process.env.PARSE_SERVER_TEST_CACHE === 'redis') {
 }
 
 const openConnections = {};
-
 // Set up a default API server for testing with default configuration.
 let server;
 

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -21,14 +21,14 @@ function Auth({ config, isMaster = false, isReadOnly = false, user, installation
 
 // Whether this auth could possibly modify the given user id.
 // It still could be forbidden via ACLs even if this returns true.
-Auth.prototype.couldUpdateUserId = function() {
+Auth.prototype.isUnauthenticated = function() {
   if (this.isMaster) {
-    return true;
+    return false;
   }
   if (this.user) {
-    return true;
+    return false;
   }
-  return false;
+  return true;
 };
 
 // A helper to get a master-level Auth object
@@ -64,7 +64,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
     return query.execute().then((response) => {
       var results = response.results;
       if (results.length !== 1 || !results[0]['user']) {
-        throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
+        throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'Invalid session token');
       }
 
       var now = new Date(),

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -21,11 +21,11 @@ function Auth({ config, isMaster = false, isReadOnly = false, user, installation
 
 // Whether this auth could possibly modify the given user id.
 // It still could be forbidden via ACLs even if this returns true.
-Auth.prototype.couldUpdateUserId = function(userId) {
+Auth.prototype.couldUpdateUserId = function() {
   if (this.isMaster) {
     return true;
   }
-  if (this.user && this.user.id === userId) {
+  if (this.user) {
     return true;
   }
   return false;

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -869,7 +869,8 @@ class DatabaseController {
     op,
     distinct,
     pipeline,
-    readPreference
+    readPreference,
+    isWrite,
   }: any = {}): Promise<any> {
     const isMaster = acl === undefined;
     const aclGroup = acl || [];
@@ -930,7 +931,11 @@ class DatabaseController {
                   }
                 }
                 if (!isMaster) {
-                  query = addReadACL(query, aclGroup);
+                  if (isWrite) {
+                    query = addWriteACL(query, aclGroup);
+                  } else {
+                    query = addReadACL(query, aclGroup);
+                  }
                 }
                 validateQuery(query);
                 if (count) {

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -30,7 +30,7 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
     if (this.className == '_Session') {
       if (!this.auth.user) {
         throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN,
-          'invalid session token');
+          'Invalid session token');
       }
       this.restWhere = {
         '$and': [this.restWhere, {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -965,7 +965,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
 
   if (this.className === '_User' &&
       this.query &&
-      !this.auth.couldUpdateUserId(this.query.objectId)) {
+      !this.auth.couldUpdateUserId()) {
     throw new Parse.Error(Parse.Error.SESSION_MISSING, `Cannot modify user ${this.query.objectId}.`);
   }
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -965,7 +965,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
 
   if (this.className === '_User' &&
       this.query &&
-      !this.auth.couldUpdateUserId()) {
+      this.auth.isUnauthenticated()) {
     throw new Parse.Error(Parse.Error.SESSION_MISSING, `Cannot modify user ${this.query.objectId}.`);
   }
 

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -130,7 +130,7 @@ export class UsersRouter extends ClassesRouter {
 
   handleMe(req) {
     if (!req.info || !req.info.sessionToken) {
-      throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
+      throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'Invalid session token');
     }
     const sessionToken = req.info.sessionToken;
     return rest.find(req.config, Auth.master(req.config), '_Session',
@@ -140,7 +140,7 @@ export class UsersRouter extends ClassesRouter {
         if (!response.results ||
           response.results.length == 0 ||
           !response.results[0].user) {
-          throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
+          throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'Invalid session token');
         } else {
           const user = response.results[0].user;
           // Send token back on the login, because SDKs expect that.

--- a/src/rest.js
+++ b/src/rest.js
@@ -55,7 +55,7 @@ function del(config, auth, className, objectId) {
 
   if (className === '_User' && auth.isUnauthenticated()) {
     throw new Parse.Error(Parse.Error.SESSION_MISSING,
-      'insufficient auth to delete user');
+      'Insufficient auth to delete user');
   }
 
   enforceRoleSecurity('delete', className, auth);
@@ -155,7 +155,7 @@ function handleSessionMissingError(error, className) {
   // If we're trying to update a user without / with bad session token
   if (className === '_User'
       && error.code === Parse.Error.OBJECT_NOT_FOUND) {
-    throw new Parse.Error(Parse.Error.SESSION_MISSING, 'insufficient auth.');
+    throw new Parse.Error(Parse.Error.SESSION_MISSING, 'Insufficient auth.');
   }
   throw error;
 }

--- a/src/rest.js
+++ b/src/rest.js
@@ -67,7 +67,7 @@ function del(config, auth, className, objectId) {
     const hasTriggers = checkTriggers(className, config, ['beforeDelete', 'afterDelete']);
     const hasLiveQuery = checkLiveQuery(className, config);
     if (hasTriggers || hasLiveQuery || className == '_Session') {
-      return find(config, Auth.master(config), className, {objectId: objectId})
+      return find(config, auth, className, {objectId: objectId})
         .then((response) => {
           if (response && response.results && response.results.length) {
             const firstResult = response.results[0];

--- a/src/rest.js
+++ b/src/rest.js
@@ -8,7 +8,6 @@
 // things.
 
 var Parse = require('parse/node').Parse;
-import Auth from './Auth';
 
 var RestQuery = require('./RestQuery');
 var RestWrite = require('./RestWrite');
@@ -54,7 +53,7 @@ function del(config, auth, className, objectId) {
       'bad objectId');
   }
 
-  if (className === '_User' && !auth.couldUpdateUserId(objectId)) {
+  if (className === '_User' && !auth.couldUpdateUserId()) {
     throw new Parse.Error(Parse.Error.SESSION_MISSING,
       'insufficient auth to delete user');
   }
@@ -67,7 +66,9 @@ function del(config, auth, className, objectId) {
     const hasTriggers = checkTriggers(className, config, ['beforeDelete', 'afterDelete']);
     const hasLiveQuery = checkLiveQuery(className, config);
     if (hasTriggers || hasLiveQuery || className == '_Session') {
-      return find(config, auth, className, {objectId: objectId})
+      return new RestQuery(config, auth, className, { objectId })
+        .forWrite()
+        .execute()
         .then((response) => {
           if (response && response.results && response.results.length) {
             const firstResult = response.results[0];
@@ -110,6 +111,8 @@ function del(config, auth, className, objectId) {
     }, options);
   }).then(() => {
     return triggers.maybeRunTrigger(triggers.Types.afterDelete, auth, inflatedObject, null, config);
+  }).catch((error) => {
+    handleSessionMissingError(error, className, auth);
   });
 }
 
@@ -130,18 +133,31 @@ function update(config, auth, className, restWhere, restObject, clientSDK) {
     const hasTriggers = checkTriggers(className, config, ['beforeSave', 'afterSave']);
     const hasLiveQuery = checkLiveQuery(className, config);
     if (hasTriggers || hasLiveQuery) {
-      return find(config, Auth.master(config), className, restWhere);
+      // Do not use find, as it runs the before finds
+      return new RestQuery(config, auth, className, restWhere)
+        .forWrite()
+        .execute();
     }
     return Promise.resolve({});
-  }).then((response) => {
+  }).then(({ results }) => {
     var originalRestObject;
-    if (response && response.results && response.results.length) {
-      originalRestObject = response.results[0];
+    if (results && results.length) {
+      originalRestObject = results[0];
     }
-
-    var write = new RestWrite(config, auth, className, restWhere, restObject, originalRestObject, clientSDK);
-    return write.execute();
+    return new RestWrite(config, auth, className, restWhere, restObject, originalRestObject, clientSDK)
+      .execute();
+  }).catch((error) => {
+    handleSessionMissingError(error, className, auth);
   });
+}
+
+function handleSessionMissingError(error, className) {
+  // If we're trying to update a user without / with bad session token
+  if (className === '_User'
+      && error.code === Parse.Error.OBJECT_NOT_FOUND) {
+    throw new Parse.Error(Parse.Error.SESSION_MISSING, 'insuffisant auth.');
+  }
+  throw error;
 }
 
 const classesWithMasterOnlyAccess = ['_JobStatus', '_PushStatus', '_Hooks', '_GlobalConfig', '_JobSchedule'];

--- a/src/rest.js
+++ b/src/rest.js
@@ -53,7 +53,7 @@ function del(config, auth, className, objectId) {
       'bad objectId');
   }
 
-  if (className === '_User' && !auth.couldUpdateUserId()) {
+  if (className === '_User' && auth.isUnauthenticated()) {
     throw new Parse.Error(Parse.Error.SESSION_MISSING,
       'insufficient auth to delete user');
   }
@@ -75,7 +75,7 @@ function del(config, auth, className, objectId) {
             firstResult.className = className;
             if (className === '_Session' && !auth.isMaster) {
               if (!auth.user || firstResult.user.objectId !== auth.user.id) {
-                throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
+                throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'Invalid session token');
               }
             }
             var cacheAdapter = config.cacheController;
@@ -155,7 +155,7 @@ function handleSessionMissingError(error, className) {
   // If we're trying to update a user without / with bad session token
   if (className === '_User'
       && error.code === Parse.Error.OBJECT_NOT_FOUND) {
-    throw new Parse.Error(Parse.Error.SESSION_MISSING, 'insuffisant auth.');
+    throw new Parse.Error(Parse.Error.SESSION_MISSING, 'insufficient auth.');
   }
   throw error;
 }


### PR DESCRIPTION
Hi guys! This is a fix for a long standing issue #3588. This should ensure user ACL'S let admins roles / other users manage them, while ensuring there is no data issue lock out possibility from the user himself.

This also fixes an issue where the beforeDelete would be called when the object is not writable because we were using the masterKey. It introduces a new `isWrite` on the find operation inthe DB so we can force the ACL's to use the write column (a find for an intended write). 

If you got test suggestions, let me know.