### PR TITLE
Removes need to use babel-register

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,6 @@
                 "node": "8"
             }
         }]
-    ]
+    ],
+    "sourceMaps": "inline"
 }

--- a/.nycrc
+++ b/.nycrc
@@ -5,7 +5,7 @@
   ],
   "exclude": [
     "**/spec/**",
-    "lib/"
+    "src/"
   ]
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,49 @@
-### Contributing to Parse Server
+# Contributing to Parse Server
 
-#### Pull Requests Welcome!
+We really want Parse to be yours, to see it grow and thrive in the open source community.
 
-We really want Parse to be yours, to see it grow and thrive in the open source community.  
+If you are not familiar with Pull Requests and want to know more about them, you can visit the [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) article. It contains detailed informations about the process.
 
-##### Please Do's
+## Setting up the project for debugging and contributing:
+
+### Recommended setup:
+
+* [vscode](https://code.visualstudio.com), the popular IDE.
+* [Jasmine Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer), a very practical test exploration plugin which let you run, debug and see the test results inline.
+
+### Setting up you local machine:
+
+* [Fork](https://github.com/parse-community/parse-server) this project and clone the fork on your local machine:
+
+```sh
+$ git clone https://github.com/parse-community/parse-server
+$ cd parse-server # go into the clone directory
+$ npm install # install all the node dependencies
+$ code . # launch vscode
+$ npm run watch # run babel watching for local file changes
+```
+
+Once you have babel running in watch mode, you can start making changes to parse-server.
+
+### Good to know:
+
+* The lib/ folder is not commited, so never make changes in there.
+* Always make changes to files in the `src/` folder.
+* All the tests should point to sources in the `lib/` folder.
+
+### Troubleshooting:
+
+*Question*: I modify the code in the src folder but it doesn't seem to have any effect.<br/>
+*Answer*: Check that `npm run watch` is running
+
+*Question*: How do I use breakpoints and debug step by step?<br/>
+*Answer*: The easiest way is to install [Jasmine Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer), it will let you run selectively tests and debug them.
+
+*Question*: How do I deploy my forked version on my servers?<br/>
+*Answer*: In your `package.json`, update the `parse-server` dependency to `https://github.com/MY_USERNAME/parse-server#MY_FEATURE`. Run `npm install`, commit the changes and deploy to your servers.
+
+
+### Please Do's
 
 * Begin by reading the [Development Guide](http://docs.parseplatform.org/parse-server/guide/#development-guide) to learn how to get started running the parse-server.
 * Take testing seriously! Aim to increase the test coverage with every pull request. To obtain the test coverage of the project, run:
@@ -17,7 +56,7 @@ We really want Parse to be yours, to see it grow and thrive in the open source c
 * Lint your code by running `npm run lint` to make sure the code is not going to be rejected by the CI.
 * **Do not** publish the *lib* folder.
 
-##### Run your tests against Postgres (optional)
+### Run your tests against Postgres (optional)
 
 If your pull request introduces a change that may affect the storage or retrieval of objects, you may want to make sure it plays nice with Postgres.
 
@@ -28,6 +67,6 @@ If your pull request introduces a change that may affect the storage or retrieva
   - `it_only_db('mongo')` // will make a test that only runs on mongo
   - `it_exclude_dbs(['postgres'])` // will make a test that runs against all DB's but postgres
 
-##### Code of Conduct
+### Code of Conduct
 
 This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/parse-community/parse-server/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to honor this code.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "dev": "npm run build && node bin/dev",
     "lint": "flow && eslint --cache ./",
     "build": "babel src/ -d lib/ --copy-files",
+    "watch": "babel --watch src/ -d lib/ --copy-files",
     "pretest": "npm run lint",
     "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 jasmine",
     "coverage": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 TESTING=1 nyc jasmine",

--- a/spec/AccountLockoutPolicy.spec.js
+++ b/spec/AccountLockoutPolicy.spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const Config = require("../src/Config");
+const Config = require("../lib/Config");
 
 const loginWithWrongCredentialsShouldFail = function(username, password) {
   return new Promise((resolve, reject) => {

--- a/spec/AdaptableController.spec.js
+++ b/spec/AdaptableController.spec.js
@@ -1,7 +1,7 @@
 
-const AdaptableController = require("../src/Controllers/AdaptableController").AdaptableController;
-const FilesAdapter = require("../src/Adapters/Files/FilesAdapter").default;
-const FilesController = require("../src/Controllers/FilesController").FilesController;
+const AdaptableController = require("../lib/Controllers/AdaptableController").AdaptableController;
+const FilesAdapter = require("../lib/Adapters/Files/FilesAdapter").default;
+const FilesController = require("../lib/Controllers/FilesController").FilesController;
 
 const MockController = function(options) {
   AdaptableController.call(this, options);

--- a/spec/AdapterLoader.spec.js
+++ b/spec/AdapterLoader.spec.js
@@ -1,9 +1,9 @@
 
-const loadAdapter = require("../src/Adapters/AdapterLoader").loadAdapter;
+const loadAdapter = require("../lib/Adapters/AdapterLoader").loadAdapter;
 const FilesAdapter = require("@parse/fs-files-adapter").default;
 const S3Adapter = require("@parse/s3-files-adapter").default;
 const ParsePushAdapter = require("@parse/push-adapter").default;
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 
 describe("AdapterLoader", ()=>{
 
@@ -33,7 +33,7 @@ describe("AdapterLoader", ()=>{
   });
 
   it("should instantiate an adapter from string that is module", (done) => {
-    const adapterPath = require('path').resolve("./src/Adapters/Files/FilesAdapter");
+    const adapterPath = require('path').resolve("./lib/Adapters/Files/FilesAdapter");
     const adapter = loadAdapter({
       adapter: adapterPath
     });

--- a/spec/AudienceRouter.spec.js
+++ b/spec/AudienceRouter.spec.js
@@ -1,7 +1,7 @@
-const auth = require('../src/Auth');
-const Config = require('../src/Config');
-const rest = require('../src/rest');
-const AudiencesRouter = require('../src/Routers/AudiencesRouter').AudiencesRouter;
+const auth = require('../lib/Auth');
+const Config = require('../lib/Config');
+const rest = require('../lib/rest');
+const AudiencesRouter = require('../lib/Routers/AudiencesRouter').AudiencesRouter;
 
 describe('AudiencesRouter', () => {
   it('uses find condition from request.body', (done) => {

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -1,5 +1,5 @@
 describe('Auth', () => {
-  const Auth = require('../src/Auth.js').Auth;
+  const Auth = require('../lib/Auth.js').Auth;
 
   describe('getUserRoles', () => {
     let auth;

--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -1,13 +1,13 @@
 const request = require('request');
-const Config = require("../src/Config");
-const defaultColumns = require('../src/Controllers/SchemaController').defaultColumns;
-const authenticationLoader = require('../src/Adapters/Auth');
+const Config = require("../lib/Config");
+const defaultColumns = require('../lib/Controllers/SchemaController').defaultColumns;
+const authenticationLoader = require('../lib/Adapters/Auth');
 const path = require('path');
 
 describe('AuthenticationProviders', function() {
   ["facebook", "facebookaccountkit", "github", "instagram", "google", "linkedin", "meetup", "twitter", "janrainengage", "janraincapture", "vkontakte"].map(function(providerName){
     it("Should validate structure of " + providerName, (done) => {
-      const provider = require("../src/Adapters/Auth/" + providerName);
+      const provider = require("../lib/Adapters/Auth/" + providerName);
       jequal(typeof provider.validateAuthData, "function");
       jequal(typeof provider.validateAppId, "function");
       const authDataPromise = provider.validateAuthData({}, {});

--- a/spec/CLI.spec.js
+++ b/spec/CLI.spec.js
@@ -1,7 +1,7 @@
 'use strict';
-import commander from '../src/cli/utils/commander';
-import definitions from '../src/cli/definitions/parse-server';
-import liveQueryDefinitions from '../src/cli/definitions/parse-live-query-server';
+const commander = require('../lib/cli/utils/commander').default;
+const definitions = require('../lib/cli/definitions/parse-server').default;
+const liveQueryDefinitions = require('../lib/cli/definitions/parse-live-query-server').default;
 
 const testDefinitions = {
   'arg0': 'PROGRAM_ARG_0',
@@ -173,7 +173,7 @@ describe('LiveQuery definitions', () => {
       if (typeof definition.env !== 'undefined') {
         expect(typeof definition.env).toBe('string');
       }
-      expect(typeof definition.help).toBe('string');
+      expect(typeof definition.help).toBe('string', `help for ${key} should be a string`);
       if (typeof definition.required !== 'undefined') {
         expect(typeof definition.required).toBe('boolean');
       }

--- a/spec/CacheController.spec.js
+++ b/spec/CacheController.spec.js
@@ -1,4 +1,4 @@
-const CacheController = require('../src/Controllers/CacheController.js').default;
+const CacheController = require('../lib/Controllers/CacheController.js').default;
 
 describe('CacheController', function() {
   let FakeCacheAdapter;

--- a/spec/Client.spec.js
+++ b/spec/Client.spec.js
@@ -1,5 +1,5 @@
-const Client = require('../src/LiveQuery/Client').Client;
-const ParseWebSocket = require('../src/LiveQuery/ParseWebSocketServer').ParseWebSocket;
+const Client = require('../lib/LiveQuery/Client').Client;
+const ParseWebSocket = require('../lib/LiveQuery/ParseWebSocketServer').ParseWebSocket;
 
 describe('Client', function() {
   it('can be initialized', function() {

--- a/spec/ClientSDK.spec.js
+++ b/spec/ClientSDK.spec.js
@@ -1,4 +1,4 @@
-const ClientSDK = require('../src/ClientSDK');
+const ClientSDK = require('../lib/ClientSDK');
 
 describe('ClientSDK', () => {
   it('should properly parse the SDK versions', () => {

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1,7 +1,7 @@
 "use strict"
 const Parse = require("parse/node");
 const rp = require('request-promise');
-const InMemoryCacheAdapter = require('../src/Adapters/Cache/InMemoryCacheAdapter').InMemoryCacheAdapter;
+const InMemoryCacheAdapter = require('../lib/Adapters/Cache/InMemoryCacheAdapter').InMemoryCacheAdapter;
 
 describe('Cloud Code', () => {
   it('can load absolute cloud code file', done => {

--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -1,5 +1,5 @@
-const LoggerController = require('../src/Controllers/LoggerController').LoggerController;
-const WinstonLoggerAdapter = require('../src/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
+const LoggerController = require('../lib/Controllers/LoggerController').LoggerController;
+const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
 const fs = require('fs');
 
 const loremFile = __dirname + '/support/lorem.txt';

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -1,4 +1,4 @@
-const DatabaseController = require('../src/Controllers/DatabaseController.js');
+const DatabaseController = require('../lib/Controllers/DatabaseController.js');
 const validateQuery = DatabaseController._validateQuery;
 
 describe('DatabaseController', function() {

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -2,7 +2,7 @@
 
 const request = require('request');
 const requestp = require('request-promise');
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 
 describe("Email Verification Token Expiration: ", () => {
 

--- a/spec/EnableSingleSchemaCache.spec.js
+++ b/spec/EnableSingleSchemaCache.spec.js
@@ -1,6 +1,6 @@
-const auth = require('../src/Auth');
-const Config = require('../src/Config');
-const rest = require('../src/rest');
+const auth = require('../lib/Auth');
+const Config = require('../lib/Config');
+const rest = require('../lib/rest');
 
 describe('Enable single schema cache', () => {
   beforeEach((done) => {

--- a/spec/EventEmitterPubSub.spec.js
+++ b/spec/EventEmitterPubSub.spec.js
@@ -1,4 +1,4 @@
-const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
 
 describe('EventEmitterPubSub', function() {
   it('can publish and subscribe', function() {

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -1,8 +1,8 @@
-const LoggerController = require('../src/Controllers/LoggerController').LoggerController;
-const WinstonLoggerAdapter = require('../src/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
-const GridStoreAdapter = require("../src/Adapters/Files/GridStoreAdapter").GridStoreAdapter;
-const Config = require("../src/Config");
-const FilesController = require('../src/Controllers/FilesController').default;
+const LoggerController = require('../lib/Controllers/LoggerController').LoggerController;
+const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
+const GridStoreAdapter = require("../lib/Adapters/Files/GridStoreAdapter").GridStoreAdapter;
+const Config = require("../lib/Config");
+const FilesController = require('../lib/Controllers/FilesController').default;
 
 const mockAdapter = {
   createFile: () => {

--- a/spec/GridStoreAdapter.js
+++ b/spec/GridStoreAdapter.js
@@ -1,9 +1,9 @@
 const MongoClient = require("mongodb").MongoClient;
 const GridStore = require("mongodb").GridStore;
 
-const GridStoreAdapter = require("../src/Adapters/Files/GridStoreAdapter").GridStoreAdapter;
-const Config = require("../src/Config");
-const FilesController = require('../src/Controllers/FilesController').default;
+const GridStoreAdapter = require("../lib/Adapters/Files/GridStoreAdapter").GridStoreAdapter;
+const Config = require("../lib/Config");
+const FilesController = require('../lib/Controllers/FilesController').default;
 
 
 // Small additional tests to improve overall coverage

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const httpRequest = require("../src/cloud-code/httpRequest"),
-  HTTPResponse = require('../src/cloud-code/HTTPResponse').default,
+const httpRequest = require("../lib/cloud-code/httpRequest"),
+  HTTPResponse = require('../lib/cloud-code/HTTPResponse').default,
   bodyParser = require('body-parser'),
   express = require("express");
 

--- a/spec/InMemoryCache.spec.js
+++ b/spec/InMemoryCache.spec.js
@@ -1,4 +1,4 @@
-const InMemoryCache = require('../src/Adapters/Cache/InMemoryCache').default;
+const InMemoryCache = require('../lib/Adapters/Cache/InMemoryCache').default;
 
 
 describe('InMemoryCache', function() {

--- a/spec/InMemoryCacheAdapter.spec.js
+++ b/spec/InMemoryCacheAdapter.spec.js
@@ -1,4 +1,4 @@
-const InMemoryCacheAdapter = require('../src/Adapters/Cache/InMemoryCacheAdapter').default;
+const InMemoryCacheAdapter = require('../lib/Adapters/Cache/InMemoryCacheAdapter').default;
 
 describe('InMemoryCacheAdapter', function() {
   const KEY = 'hello';

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -1,7 +1,7 @@
-const auth = require('../src/Auth');
-const Config = require('../src/Config');
-const rest = require('../src/rest');
-const InstallationsRouter = require('../src/Routers/InstallationsRouter').InstallationsRouter;
+const auth = require('../lib/Auth');
+const Config = require('../lib/Config');
+const rest = require('../lib/rest');
+const InstallationsRouter = require('../lib/Routers/InstallationsRouter').InstallationsRouter;
 
 describe('InstallationsRouter', () => {
   it('uses find condition from request.body', (done) => {

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -1,4 +1,4 @@
-const logging = require('../src/Adapters/Logger/WinstonLogger');
+const logging = require('../lib/Adapters/Logger/WinstonLogger');
 const winston = require('winston');
 
 class TestTransport extends winston.Transport {

--- a/spec/LoggerController.spec.js
+++ b/spec/LoggerController.spec.js
@@ -1,5 +1,5 @@
-const LoggerController = require('../src/Controllers/LoggerController').LoggerController;
-const WinstonLoggerAdapter = require('../src/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
+const LoggerController = require('../lib/Controllers/LoggerController').LoggerController;
+const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
 
 describe('LoggerController', () => {
   it('can check process a query without throwing', (done) => {

--- a/spec/LogsRouter.spec.js
+++ b/spec/LogsRouter.spec.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const request = require('request');
-const LogsRouter = require('../src/Routers/LogsRouter').LogsRouter;
-const LoggerController = require('../src/Controllers/LoggerController').LoggerController;
-const WinstonLoggerAdapter = require('../src/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
+const LogsRouter = require('../lib/Routers/LogsRouter').LogsRouter;
+const LoggerController = require('../lib/Controllers/LoggerController').LoggerController;
+const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
 
 const loggerController = new LoggerController(new WinstonLoggerAdapter());
 

--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -1,5 +1,5 @@
-const middlewares = require('../src/middlewares');
-const AppCache = require('../src/cache').AppCache;
+const middlewares = require('../lib/middlewares');
+const AppCache = require('../lib/cache').AppCache;
 
 describe('middlewares', () => {
 

--- a/spec/MongoSchemaCollectionAdapter.spec.js
+++ b/spec/MongoSchemaCollectionAdapter.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const MongoSchemaCollection = require('../src/Adapters/Storage/Mongo/MongoSchemaCollection').default;
+const MongoSchemaCollection = require('../lib/Adapters/Storage/Mongo/MongoSchemaCollection').default;
 
 describe('MongoSchemaCollection', () => {
   it('can transform legacy _client_permissions keys to parse format', done => {

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
 const { MongoClient } = require('mongodb');
 const databaseURI = 'mongodb://localhost:27017/parseServerMongoAdapterTestDatabase';
 

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -1,7 +1,7 @@
 // These tests are unit tests designed to only test transform.js.
 "use strict";
 
-const transform = require('../src/Adapters/Storage/Mongo/MongoTransform');
+const transform = require('../lib/Adapters/Storage/Mongo/MongoTransform');
 const dd = require('deep-diff');
 const mongodb = require('mongodb');
 

--- a/spec/NullCacheAdapter.spec.js
+++ b/spec/NullCacheAdapter.spec.js
@@ -1,4 +1,4 @@
-const NullCacheAdapter = require('../src/Adapters/Cache/NullCacheAdapter').default;
+const NullCacheAdapter = require('../lib/Adapters/Cache/NullCacheAdapter').default;
 
 describe('NullCacheAdapter', function() {
   const KEY = 'hello';

--- a/spec/OAuth1.spec.js
+++ b/spec/OAuth1.spec.js
@@ -1,4 +1,4 @@
-const OAuth = require("../src/Adapters/Auth/OAuth1Client");
+const OAuth = require("../lib/Adapters/Auth/OAuth1Client");
 
 describe('OAuth', function() {
   it("Nonce should have right length", (done) => {

--- a/spec/ParseACL.spec.js
+++ b/spec/ParseACL.spec.js
@@ -1,8 +1,8 @@
 // This is a port of the test suite:
 // hungry/js/test/parse_acl_test.js
-const rest = require('../src/rest');
-const Config = require('../src/Config');
-const auth = require('../src/Auth');
+const rest = require('../lib/rest');
+const Config = require('../lib/Config');
+const auth = require('../lib/Auth');
 
 describe('Parse.ACL', () => {
   it("acl must be valid", (done) => {

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -5,9 +5,9 @@
 const request = require('request');
 const rp = require('request-promise');
 const Parse = require("parse/node");
-const Config = require('../src/Config');
-const SchemaController = require('../src/Controllers/SchemaController');
-const TestUtils = require('../src/TestUtils');
+const Config = require('../lib/Config');
+const SchemaController = require('../lib/Controllers/SchemaController');
+const TestUtils = require('../lib/TestUtils');
 
 const userSchema = SchemaController.convertSchemaToAdapterSchema({ className: '_User', fields: Object.assign({}, SchemaController.defaultColumns._Default, SchemaController.defaultColumns._User) });
 

--- a/spec/ParseCloudCodePublisher.spec.js
+++ b/spec/ParseCloudCodePublisher.spec.js
@@ -1,4 +1,4 @@
-const ParseCloudCodePublisher = require('../src/LiveQuery/ParseCloudCodePublisher').ParseCloudCodePublisher;
+const ParseCloudCodePublisher = require('../lib/LiveQuery/ParseCloudCodePublisher').ParseCloudCodePublisher;
 const Parse = require('parse/node');
 
 describe('ParseCloudCodePublisher', function() {
@@ -14,7 +14,7 @@ describe('ParseCloudCodePublisher', function() {
         on: jasmine.createSpy('on')
       })
     };
-    jasmine.mockLibrary('../src/LiveQuery/ParsePubSub', 'ParsePubSub', mockParsePubSub);
+    jasmine.mockLibrary('../lib/LiveQuery/ParsePubSub', 'ParsePubSub', mockParsePubSub);
     done();
   });
 
@@ -22,7 +22,7 @@ describe('ParseCloudCodePublisher', function() {
     const config = {}
     new ParseCloudCodePublisher(config);
 
-    const ParsePubSub = require('../src/LiveQuery/ParsePubSub').ParsePubSub;
+    const ParsePubSub = require('../lib/LiveQuery/ParsePubSub').ParsePubSub;
     expect(ParsePubSub.createPublisher).toHaveBeenCalledWith(config);
   });
 
@@ -64,6 +64,6 @@ describe('ParseCloudCodePublisher', function() {
   });
 
   afterEach(function(){
-    jasmine.restoreLibrary('../src/LiveQuery/ParsePubSub', 'ParsePubSub');
+    jasmine.restoreLibrary('../lib/LiveQuery/ParsePubSub', 'ParsePubSub');
   });
 });

--- a/spec/ParseGlobalConfig.spec.js
+++ b/spec/ParseGlobalConfig.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const request = require('request');
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 
 describe('a GlobalConfig', () => {
   beforeEach(done => {

--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -1,14 +1,14 @@
 "use strict";
 /* global describe, it, expect, fail, Parse */
 const request = require('request');
-const triggers = require('../src/triggers');
-const HooksController = require('../src/Controllers/HooksController').default;
+const triggers = require('../lib/triggers');
+const HooksController = require('../lib/Controllers/HooksController').default;
 const express = require("express");
 const bodyParser = require('body-parser');
 
 const port = 12345;
 const hookServerURL = "http://localhost:" + port;
-const AppCache = require('../src/cache').AppCache;
+const AppCache = require('../lib/cache').AppCache;
 
 describe('Hooks', () => {
   let server;

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -2,15 +2,15 @@
 // These tests check the Installations functionality of the REST API.
 // Ported from installation_collection_test.go
 
-const auth = require('../src/Auth');
-const Config = require('../src/Config');
+const auth = require('../lib/Auth');
+const Config = require('../lib/Config');
 const Parse = require('parse/node').Parse;
-const rest = require('../src/rest');
+const rest = require('../lib/rest');
 const request = require("request");
 
 let config;
 let database;
-const defaultColumns = require('../src/Controllers/SchemaController').defaultColumns;
+const defaultColumns = require('../lib/Controllers/SchemaController').defaultColumns;
 
 const delay = function delay(delay) {
   return new Promise(resolve => setTimeout(resolve, delay));

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -1,6 +1,6 @@
 const Parse = require('parse/node');
-const ParseLiveQueryServer = require('../src/LiveQuery/ParseLiveQueryServer').ParseLiveQueryServer;
-const ParseServer = require('../src/ParseServer').default;
+const ParseLiveQueryServer = require('../lib/LiveQuery/ParseLiveQueryServer').ParseLiveQueryServer;
+const ParseServer = require('../lib/ParseServer').default;
 
 // Global mock info
 const queryHashValue = 'hash';
@@ -11,7 +11,7 @@ describe('ParseLiveQueryServer', function() {
   beforeEach(function(done) {
     // Mock ParseWebSocketServer
     const mockParseWebSocketServer = jasmine.createSpy('ParseWebSocketServer');
-    jasmine.mockLibrary('../src/LiveQuery/ParseWebSocketServer', 'ParseWebSocketServer', mockParseWebSocketServer);
+    jasmine.mockLibrary('../lib/LiveQuery/ParseWebSocketServer', 'ParseWebSocketServer', mockParseWebSocketServer);
     // Mock Client
     const mockClient = function(id, socket, hasMasterKey) {
       this.pushConnect = jasmine.createSpy('pushConnect');
@@ -28,19 +28,19 @@ describe('ParseLiveQueryServer', function() {
       this.hasMasterKey = hasMasterKey;
     }
     mockClient.pushError = jasmine.createSpy('pushError');
-    jasmine.mockLibrary('../src/LiveQuery/Client', 'Client', mockClient);
+    jasmine.mockLibrary('../lib/LiveQuery/Client', 'Client', mockClient);
     // Mock Subscription
     const mockSubscriotion = function() {
       this.addClientSubscription = jasmine.createSpy('addClientSubscription');
       this.deleteClientSubscription = jasmine.createSpy('deleteClientSubscription');
     }
-    jasmine.mockLibrary('../src/LiveQuery/Subscription', 'Subscription', mockSubscriotion);
+    jasmine.mockLibrary('../lib/LiveQuery/Subscription', 'Subscription', mockSubscriotion);
     // Mock queryHash
     const mockQueryHash = jasmine.createSpy('matchesQuery').and.returnValue(queryHashValue);
-    jasmine.mockLibrary('../src/LiveQuery/QueryTools', 'queryHash', mockQueryHash);
+    jasmine.mockLibrary('../lib/LiveQuery/QueryTools', 'queryHash', mockQueryHash);
     // Mock matchesQuery
     const mockMatchesQuery = jasmine.createSpy('matchesQuery').and.returnValue(true);
-    jasmine.mockLibrary('../src/LiveQuery/QueryTools', 'matchesQuery', mockMatchesQuery);
+    jasmine.mockLibrary('../lib/LiveQuery/QueryTools', 'matchesQuery', mockMatchesQuery);
     // Mock ParsePubSub
     const mockParsePubSub = {
       createPublisher: function() {
@@ -56,7 +56,7 @@ describe('ParseLiveQueryServer', function() {
         }
       }
     };
-    jasmine.mockLibrary('../src/LiveQuery/ParsePubSub', 'ParsePubSub', mockParsePubSub);
+    jasmine.mockLibrary('../lib/LiveQuery/ParsePubSub', 'ParsePubSub', mockParsePubSub);
     // Make mock SessionTokenCache
     const mockSessionTokenCache = function(){
       this.getUserId = function(sessionToken){
@@ -69,7 +69,7 @@ describe('ParseLiveQueryServer', function() {
         return Parse.Promise.as(testUserId);
       };
     };
-    jasmine.mockLibrary('../src/LiveQuery/SessionTokenCache', 'SessionTokenCache', mockSessionTokenCache);
+    jasmine.mockLibrary('../lib/LiveQuery/SessionTokenCache', 'SessionTokenCache', mockSessionTokenCache);
     done();
   });
 
@@ -167,7 +167,7 @@ describe('ParseLiveQueryServer', function() {
     };
     parseLiveQueryServer._handleSubscribe(incompleteParseConn, {});
 
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     expect(Client.pushError).toHaveBeenCalled();
   });
 
@@ -273,7 +273,7 @@ describe('ParseLiveQueryServer', function() {
     };
     parseLiveQueryServer._handleUnsubscribe(incompleteParseConn, {});
 
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     expect(Client.pushError).toHaveBeenCalled();
   });
 
@@ -284,7 +284,7 @@ describe('ParseLiveQueryServer', function() {
     };
     parseLiveQueryServer._handleUnsubscribe(parseWebSocket, {});
 
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     expect(Client.pushError).toHaveBeenCalled();
   });
 
@@ -299,7 +299,7 @@ describe('ParseLiveQueryServer', function() {
     };
     parseLiveQueryServer._handleUnsubscribe(parseWebSocket, {});
 
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     expect(Client.pushError).toHaveBeenCalled();
   });
 
@@ -445,7 +445,7 @@ describe('ParseLiveQueryServer', function() {
     const invalidRequest = '{}';
     // Trigger message event
     parseWebSocket.emit('message', invalidRequest);
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     expect(Client.pushError).toHaveBeenCalled();
   });
 
@@ -461,7 +461,7 @@ describe('ParseLiveQueryServer', function() {
     const unknownRequest = '{"op":"unknown"}';
     // Trigger message event
     parseWebSocket.emit('message', unknownRequest);
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     expect(Client.pushError).toHaveBeenCalled();
   });
 
@@ -788,7 +788,7 @@ describe('ParseLiveQueryServer', function() {
     const parseObject = {};
     expect(parseLiveQueryServer._matchesSubscription(parseObject, subscription)).toBe(true);
     // Make sure matchesQuery is called
-    const matchesQuery = require('../src/LiveQuery/QueryTools').matchesQuery;
+    const matchesQuery = require('../lib/LiveQuery/QueryTools').matchesQuery;
     expect(matchesQuery).toHaveBeenCalledWith(parseObject, subscription.query);
   });
 
@@ -1209,18 +1209,18 @@ describe('ParseLiveQueryServer', function() {
   });
 
   afterEach(function(){
-    jasmine.restoreLibrary('../src/LiveQuery/ParseWebSocketServer', 'ParseWebSocketServer');
-    jasmine.restoreLibrary('../src/LiveQuery/Client', 'Client');
-    jasmine.restoreLibrary('../src/LiveQuery/Subscription', 'Subscription');
-    jasmine.restoreLibrary('../src/LiveQuery/QueryTools', 'queryHash');
-    jasmine.restoreLibrary('../src/LiveQuery/QueryTools', 'matchesQuery');
-    jasmine.restoreLibrary('../src/LiveQuery/ParsePubSub', 'ParsePubSub');
-    jasmine.restoreLibrary('../src/LiveQuery/SessionTokenCache', 'SessionTokenCache');
+    jasmine.restoreLibrary('../lib/LiveQuery/ParseWebSocketServer', 'ParseWebSocketServer');
+    jasmine.restoreLibrary('../lib/LiveQuery/Client', 'Client');
+    jasmine.restoreLibrary('../lib/LiveQuery/Subscription', 'Subscription');
+    jasmine.restoreLibrary('../lib/LiveQuery/QueryTools', 'queryHash');
+    jasmine.restoreLibrary('../lib/LiveQuery/QueryTools', 'matchesQuery');
+    jasmine.restoreLibrary('../lib/LiveQuery/ParsePubSub', 'ParsePubSub');
+    jasmine.restoreLibrary('../lib/LiveQuery/SessionTokenCache', 'SessionTokenCache');
   });
 
   // Helper functions to add mock client and subscription to a liveQueryServer
   function addMockClient(parseLiveQueryServer, clientId) {
-    const Client = require('../src/LiveQuery/Client').Client;
+    const Client = require('../lib/LiveQuery/Client').Client;
     const client = new Client(clientId, {});
     parseLiveQueryServer.clients.set(clientId, client);
     return client;

--- a/spec/ParsePolygon.spec.js
+++ b/spec/ParsePolygon.spec.js
@@ -1,5 +1,5 @@
 const TestObject = Parse.Object.extend('TestObject');
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
 const mongoURI = 'mongodb://localhost:27017/parseServerMongoAdapterTestDatabase';
 const rp = require('request-promise');
 const defaultHeaders = {
@@ -314,7 +314,7 @@ describe_only_db('mongo')('Parse.Polygon testing', () => {
   });
 
   it('polygon coordinates reverse input', (done) => {
-    const Config = require('../src/Config');
+    const Config = require('../lib/Config');
     const config = Config.get('test');
 
     // When stored the first point should be the last point

--- a/spec/ParsePubSub.spec.js
+++ b/spec/ParsePubSub.spec.js
@@ -1,4 +1,4 @@
-const ParsePubSub = require('../src/LiveQuery/ParsePubSub').ParsePubSub;
+const ParsePubSub = require('../lib/LiveQuery/ParsePubSub').ParsePubSub;
 
 describe('ParsePubSub', function() {
 
@@ -8,13 +8,13 @@ describe('ParsePubSub', function() {
       createPublisher: jasmine.createSpy('createPublisherRedis'),
       createSubscriber: jasmine.createSpy('createSubscriberRedis')
     };
-    jasmine.mockLibrary('../src/Adapters/PubSub/RedisPubSub', 'RedisPubSub', mockRedisPubSub);
+    jasmine.mockLibrary('../lib/Adapters/PubSub/RedisPubSub', 'RedisPubSub', mockRedisPubSub);
     // Mock EventEmitterPubSub
     const mockEventEmitterPubSub = {
       createPublisher: jasmine.createSpy('createPublisherEventEmitter'),
       createSubscriber: jasmine.createSpy('createSubscriberEventEmitter')
     };
-    jasmine.mockLibrary('../src/Adapters/PubSub/EventEmitterPubSub', 'EventEmitterPubSub', mockEventEmitterPubSub);
+    jasmine.mockLibrary('../lib/Adapters/PubSub/EventEmitterPubSub', 'EventEmitterPubSub', mockEventEmitterPubSub);
     done();
   });
 
@@ -23,8 +23,8 @@ describe('ParsePubSub', function() {
       redisURL: 'redisURL'
     });
 
-    const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
-    const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+    const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
+    const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
     expect(RedisPubSub.createPublisher).toHaveBeenCalledWith({redisURL: 'redisURL'});
     expect(EventEmitterPubSub.createPublisher).not.toHaveBeenCalled();
   });
@@ -32,8 +32,8 @@ describe('ParsePubSub', function() {
   it('can create event emitter publisher', function() {
     ParsePubSub.createPublisher({});
 
-    const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
-    const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+    const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
+    const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
     expect(RedisPubSub.createPublisher).not.toHaveBeenCalled();
     expect(EventEmitterPubSub.createPublisher).toHaveBeenCalled();
   });
@@ -43,8 +43,8 @@ describe('ParsePubSub', function() {
       redisURL: 'redisURL'
     });
 
-    const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
-    const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+    const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
+    const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
     expect(RedisPubSub.createSubscriber).toHaveBeenCalledWith({redisURL: 'redisURL'});
     expect(EventEmitterPubSub.createSubscriber).not.toHaveBeenCalled();
   });
@@ -52,8 +52,8 @@ describe('ParsePubSub', function() {
   it('can create event emitter subscriber', function() {
     ParsePubSub.createSubscriber({});
 
-    const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
-    const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+    const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
+    const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
     expect(RedisPubSub.createSubscriber).not.toHaveBeenCalled();
     expect(EventEmitterPubSub.createSubscriber).toHaveBeenCalled();
   });
@@ -73,8 +73,8 @@ describe('ParsePubSub', function() {
     });
     expect(adapter.createSubscriber).toHaveBeenCalled();
 
-    const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
-    const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+    const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
+    const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
     expect(RedisPubSub.createSubscriber).not.toHaveBeenCalled();
     expect(EventEmitterPubSub.createSubscriber).not.toHaveBeenCalled();
     expect(RedisPubSub.createPublisher).not.toHaveBeenCalled();
@@ -100,8 +100,8 @@ describe('ParsePubSub', function() {
     });
     expect(adapter.createSubscriber).toHaveBeenCalled();
 
-    const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
-    const EventEmitterPubSub = require('../src/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
+    const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
+    const EventEmitterPubSub = require('../lib/Adapters/PubSub/EventEmitterPubSub').EventEmitterPubSub;
     expect(RedisPubSub.createSubscriber).not.toHaveBeenCalled();
     expect(EventEmitterPubSub.createSubscriber).not.toHaveBeenCalled();
     expect(RedisPubSub.createPublisher).not.toHaveBeenCalled();
@@ -109,7 +109,7 @@ describe('ParsePubSub', function() {
   });
 
   afterEach(function(){
-    jasmine.restoreLibrary('../src/Adapters/PubSub/RedisPubSub', 'RedisPubSub');
-    jasmine.restoreLibrary('../src/Adapters/PubSub/EventEmitterPubSub', 'EventEmitterPubSub');
+    jasmine.restoreLibrary('../lib/Adapters/PubSub/RedisPubSub', 'RedisPubSub');
+    jasmine.restoreLibrary('../lib/Adapters/PubSub/EventEmitterPubSub', 'EventEmitterPubSub');
   });
 });

--- a/spec/ParseQuery.FullTextSearch.spec.js
+++ b/spec/ParseQuery.FullTextSearch.spec.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
 const mongoURI = 'mongodb://localhost:27017/parseServerMongoAdapterTestDatabase';
-import PostgresStorageAdapter from '../src/Adapters/Storage/Postgres/PostgresStorageAdapter';
+const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/PostgresStorageAdapter').default;
 const postgresURI = 'postgres://localhost:5432/parse_server_postgres_adapter_test_database';
 const Parse = require('parse/node');
 const rp = require('request-promise');

--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -2,9 +2,9 @@
 
 // Roles are not accessible without the master key, so they are not intended
 // for use by clients.  We can manually test them using the master key.
-const RestQuery = require("../src/RestQuery");
-const Auth = require("../src/Auth").Auth;
-const Config = require("../src/Config");
+const RestQuery = require("../lib/RestQuery");
+const Auth = require("../lib/Auth").Auth;
+const Config = require("../lib/Config");
 
 describe('Parse Role testing', () => {
   it('Do a bunch of basic role testing', done => {

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -1,9 +1,9 @@
 'use strict';
 /* Tests for ParseServer.js */
 const express = require('express');
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
-import PostgresStorageAdapter from '../src/Adapters/Storage/Postgres/PostgresStorageAdapter';
-import ParseServer from '../src/ParseServer';
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
+const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/PostgresStorageAdapter').default;
+const ParseServer = require('../lib/ParseServer').default;
 
 describe('Server Url Checks', () => {
 

--- a/spec/ParseServerRESTController.spec.js
+++ b/spec/ParseServerRESTController.spec.js
@@ -1,5 +1,5 @@
-const ParseServerRESTController = require('../src/ParseServerRESTController').ParseServerRESTController;
-const ParseServer = require('../src/ParseServer').default;
+const ParseServerRESTController = require('../lib/ParseServerRESTController').ParseServerRESTController;
+const ParseServer = require('../lib/ParseServer').default;
 const Parse = require('parse/node').Parse;
 
 let RESTController;

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -7,10 +7,10 @@
 
 "use strict";
 
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
 const request = require('request');
-const passwordCrypto = require('../src/password');
-const Config = require('../src/Config');
+const passwordCrypto = require('../lib/password');
+const Config = require('../lib/Config');
 const rp = require('request-promise');
 
 function verifyACL(user) {

--- a/spec/ParseWebSocket.spec.js
+++ b/spec/ParseWebSocket.spec.js
@@ -1,4 +1,4 @@
-const ParseWebSocket = require('../src/LiveQuery/ParseWebSocketServer').ParseWebSocket;
+const ParseWebSocket = require('../lib/LiveQuery/ParseWebSocketServer').ParseWebSocket;
 
 describe('ParseWebSocket', function() {
 

--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -1,4 +1,4 @@
-const ParseWebSocketServer = require('../src/LiveQuery/ParseWebSocketServer').ParseWebSocketServer;
+const ParseWebSocketServer = require('../lib/LiveQuery/ParseWebSocketServer').ParseWebSocketServer;
 
 describe('ParseWebSocketServer', function() {
 

--- a/spec/PointerPermissions.spec.js
+++ b/spec/PointerPermissions.spec.js
@@ -1,5 +1,5 @@
 'use strict';
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 
 describe('Pointer Permissions', () => {
 

--- a/spec/PostgresConfigParser.spec.js
+++ b/spec/PostgresConfigParser.spec.js
@@ -1,4 +1,4 @@
-const parser = require('../src/Adapters/Storage/Postgres/PostgresConfigParser');
+const parser = require('../lib/Adapters/Storage/Postgres/PostgresConfigParser');
 
 const queryParamTests = {
   'a=1&b=2': { a: '1', b: '2' },

--- a/spec/PostgresInitOptions.spec.js
+++ b/spec/PostgresInitOptions.spec.js
@@ -1,7 +1,7 @@
 const Parse = require('parse/node').Parse;
-import PostgresStorageAdapter from '../src/Adapters/Storage/Postgres/PostgresStorageAdapter';
+const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/PostgresStorageAdapter').default;
 const postgresURI = 'postgres://localhost:5432/parse_server_postgres_adapter_test_database';
-const ParseServer = require("../src/index");
+const ParseServer = require("../lib/index");
 const express = require('express');
 //public schema
 const databaseOptions1 = {

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -1,4 +1,4 @@
-import PostgresStorageAdapter from '../src/Adapters/Storage/Postgres/PostgresStorageAdapter';
+const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/PostgresStorageAdapter').default;
 const databaseURI = 'postgres://localhost:5432/parse_server_postgres_adapter_test_database';
 
 const getColumns = (client, className) => {

--- a/spec/PromiseRouter.spec.js
+++ b/spec/PromiseRouter.spec.js
@@ -1,4 +1,4 @@
-const PromiseRouter = require("../src/PromiseRouter").default;
+const PromiseRouter = require("../lib/PromiseRouter").default;
 
 describe("PromiseRouter", () => {
   it("should properly handle rejects", (done) => {

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -1,8 +1,8 @@
 "use strict";
-const PushController = require('../src/Controllers/PushController').PushController;
-const StatusHandler = require('../src/StatusHandler');
-const Config = require('../src/Config');
-const validatePushType = require('../src/Push/utils').validatePushType;
+const PushController = require('../lib/Controllers/PushController').PushController;
+const StatusHandler = require('../lib/StatusHandler');
+const Config = require('../lib/Config');
+const validatePushType = require('../lib/Push/utils').validatePushType;
 
 const successfulTransmissions = function(body, installations) {
 

--- a/spec/PushQueue.spec.js
+++ b/spec/PushQueue.spec.js
@@ -1,5 +1,5 @@
-import Config from "../src/Config";
-import {PushQueue} from "../src/Push/PushQueue";
+const Config = require("../lib/Config");
+const {PushQueue} = require("../lib/Push/PushQueue");
 
 describe('PushQueue', () => {
   describe('With a defined channel', () => {

--- a/spec/PushRouter.spec.js
+++ b/spec/PushRouter.spec.js
@@ -1,4 +1,4 @@
-const PushRouter = require('../src/Routers/PushRouter').PushRouter;
+const PushRouter = require('../lib/Routers/PushRouter').PushRouter;
 const request = require('request');
 
 describe('PushRouter', () => {

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -1,8 +1,8 @@
-const PushWorker = require('../src').PushWorker;
-const PushUtils = require('../src/Push/utils');
-const Config = require('../src/Config');
-const { pushStatusHandler } = require('../src/StatusHandler');
-const rest = require('../src/rest');
+const PushWorker = require('../lib').PushWorker;
+const PushUtils = require('../lib/Push/utils');
+const Config = require('../lib/Config');
+const { pushStatusHandler } = require('../lib/StatusHandler');
+const rest = require('../lib/rest');
 
 describe('PushWorker', () => {
   it('should run with small batch', (done) => {

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -90,6 +90,10 @@ describe('PushWorker', () => {
       expect(locales).toEqual(['fr']);
     });
 
+    it('should handle empty body data', () => {
+      expect(PushUtils.getLocalesFromPush({})).toEqual([]);
+    });
+
     it('transforms body appropriately', () => {
       const cleanBody = PushUtils.transformPushBodyForLocale({
         data: {

--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -1,7 +1,7 @@
 const Parse = require('parse/node');
 
-const Id = require('../src/LiveQuery/Id');
-const QueryTools = require('../src/LiveQuery/QueryTools');
+const Id = require('../lib/LiveQuery/Id');
+const QueryTools = require('../lib/LiveQuery/QueryTools');
 const queryHash = QueryTools.queryHash;
 const matchesQuery = QueryTools.matchesQuery;
 

--- a/spec/ReadPreferenceOption.spec.js
+++ b/spec/ReadPreferenceOption.spec.js
@@ -3,7 +3,7 @@
 const Parse = require('parse/node');
 const ReadPreference = require('mongodb').ReadPreference;
 const rp = require('request-promise');
-const Config = require("../src/Config");
+const Config = require("../lib/Config");
 
 describe_only_db('mongo')('Read preference option', () => {
   it('should find in primary by default', (done) => {
@@ -40,7 +40,7 @@ describe_only_db('mongo')('Read preference option', () => {
   });
 
   it('should preserve the read preference set (#4831)', async () => {
-    const { MongoStorageAdapter } = require('../src/Adapters/Storage/Mongo/MongoStorageAdapter');
+    const { MongoStorageAdapter } = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter');
     const adapterOptions = {
       uri: 'mongodb://localhost:27017/parseServerMongoAdapterTestDatabase',
       mongoOptions: {

--- a/spec/ReadPreferenceOption.spec.js
+++ b/spec/ReadPreferenceOption.spec.js
@@ -75,7 +75,6 @@ describe_only_db('mongo')('Read preference option', () => {
     });
 
     expect(myObjectReadPreference).toBe(true);
-    console.log('OK!');
   });
 
   it('should change read preference in the beforeFind trigger', (done) => {

--- a/spec/RedisCacheAdapter.spec.js
+++ b/spec/RedisCacheAdapter.spec.js
@@ -1,4 +1,4 @@
-const RedisCacheAdapter = require('../src/Adapters/Cache/RedisCacheAdapter').default;
+const RedisCacheAdapter = require('../lib/Adapters/Cache/RedisCacheAdapter').default;
 /*
 To run this test part of the complete suite
 set PARSE_SERVER_TEST_CACHE='redis'

--- a/spec/RedisPubSub.spec.js
+++ b/spec/RedisPubSub.spec.js
@@ -1,4 +1,4 @@
-const RedisPubSub = require('../src/Adapters/PubSub/RedisPubSub').RedisPubSub;
+const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
 
 describe('RedisPubSub', function() {
 

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -1,8 +1,8 @@
 'use strict'
 // These tests check the "find" functionality of the REST API.
-const auth = require('../src/Auth');
-const Config = require('../src/Config');
-const rest = require('../src/rest');
+const auth = require('../lib/Auth');
+const Config = require('../lib/Config');
+const rest = require('../lib/rest');
 
 const querystring = require('querystring');
 const rp = require('request-promise');

--- a/spec/RevocableSessionsUpgrade.spec.js
+++ b/spec/RevocableSessionsUpgrade.spec.js
@@ -1,4 +1,4 @@
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 const sessionToken = 'legacySessionToken';
 const rp = require('request-promise');
 const Parse = require('parse/node');

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Config = require('../src/Config');
-const SchemaController = require('../src/Controllers/SchemaController');
+const Config = require('../lib/Config');
+const SchemaController = require('../lib/Controllers/SchemaController');
 const dd = require('deep-diff');
 
 let config;

--- a/spec/SchemaCache.spec.js
+++ b/spec/SchemaCache.spec.js
@@ -1,6 +1,6 @@
-const CacheController = require('../src/Controllers/CacheController.js').default;
-const InMemoryCacheAdapter = require('../src/Adapters/Cache/InMemoryCacheAdapter').default;
-const SchemaCache = require('../src/Controllers/SchemaCache').default;
+const CacheController = require('../lib/Controllers/CacheController.js').default;
+const InMemoryCacheAdapter = require('../lib/Adapters/Cache/InMemoryCacheAdapter').default;
+const SchemaCache = require('../lib/Controllers/SchemaCache').default;
 
 describe('SchemaCache', () => {
   let cacheController;

--- a/spec/SessionTokenCache.spec.js
+++ b/spec/SessionTokenCache.spec.js
@@ -1,4 +1,4 @@
-const SessionTokenCache = require('../src/LiveQuery/SessionTokenCache').SessionTokenCache;
+const SessionTokenCache = require('../lib/LiveQuery/SessionTokenCache').SessionTokenCache;
 
 describe('SessionTokenCache', function() {
 

--- a/spec/Subscription.spec.js
+++ b/spec/Subscription.spec.js
@@ -1,9 +1,9 @@
-const Subscription = require('../src/LiveQuery/Subscription').Subscription;
+const Subscription = require('../lib/LiveQuery/Subscription').Subscription;
 let logger;
 describe('Subscription', function() {
 
   beforeEach(function() {
-    logger = require('../src/logger').logger;
+    logger = require('../lib/logger').logger;
     spyOn(logger, 'error').and.callThrough();
   });
 

--- a/spec/TwitterAuth.spec.js
+++ b/spec/TwitterAuth.spec.js
@@ -1,4 +1,4 @@
-const twitter = require('../src/Adapters/Auth/twitter');
+const twitter = require('../lib/Adapters/Auth/twitter');
 
 describe('Twitter Auth', () => {
   it('should use the proper configuration', () => {

--- a/spec/Uniqueness.spec.js
+++ b/spec/Uniqueness.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Parse = require("parse/node");
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 
 describe('Uniqueness', function() {
   it('fail when create duplicate value in unique field', done => {

--- a/spec/UserController.spec.js
+++ b/spec/UserController.spec.js
@@ -1,6 +1,6 @@
-const UserController = require('../src/Controllers/UserController').UserController;
+const UserController = require('../lib/Controllers/UserController').UserController;
 const emailAdapter = require('./MockEmailAdapter')
-const AppCache = require('../src/cache').AppCache;
+const AppCache = require('../lib/cache').AppCache;
 
 describe('UserController', () => {
   const user = {

--- a/spec/UserPII.spec.js
+++ b/spec/UserPII.spec.js
@@ -3,7 +3,7 @@
 const Parse = require('parse/node');
 const request = require('request-promise');
 
-// const Config = require('../src/Config');
+// const Config = require('../lib/Config');
 
 const EMAIL = 'foo@bar.com';
 const ZIP = '10001';

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -2,7 +2,7 @@
 
 const MockEmailAdapterWithOptions = require('./MockEmailAdapterWithOptions');
 const request = require('request');
-const Config = require("../src/Config");
+const Config = require("../lib/Config");
 
 describe("Custom Pages, Email Verification, Password Reset", () => {
   it("should set the custom pages", (done) => {

--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const WinstonLoggerAdapter = require('../src/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
+const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapter').WinstonLoggerAdapter;
 const request = require('request');
 
 describe('info logs', () => {

--- a/spec/batch.spec.js
+++ b/spec/batch.spec.js
@@ -1,4 +1,4 @@
-const batch = require('../src/batch');
+const batch = require('../lib/batch');
 
 const originalURL = '/parse/batch';
 const serverURL = 'http://localhost:1234/parse';

--- a/spec/cryptoUtils.spec.js
+++ b/spec/cryptoUtils.spec.js
@@ -1,4 +1,4 @@
-const cryptoUtils = require('../src/cryptoUtils');
+const cryptoUtils = require('../lib/cryptoUtils');
 
 function givesUniqueResults(fn, iterations) {
   const results = {};

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -23,15 +23,15 @@ if (global._babelPolyfill) {
   process.exit(1);
 }
 
-const cache = require('../src/cache').default;
-const ParseServer = require('../src/index').ParseServer;
+const cache = require('../lib/cache').default;
+const ParseServer = require('../lib/index').ParseServer;
 const path = require('path');
-const TestUtils = require('../src/TestUtils');
-const GridStoreAdapter = require('../src/Adapters/Files/GridStoreAdapter').GridStoreAdapter;
+const TestUtils = require('../lib/TestUtils');
+const GridStoreAdapter = require('../lib/Adapters/Files/GridStoreAdapter').GridStoreAdapter;
 const FSAdapter = require('@parse/fs-files-adapter');
-import PostgresStorageAdapter from '../src/Adapters/Storage/Postgres/PostgresStorageAdapter';
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
-const RedisCacheAdapter = require('../src/Adapters/Cache/RedisCacheAdapter').default;
+const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/PostgresStorageAdapter').default;
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
+const RedisCacheAdapter = require('../lib/Adapters/Cache/RedisCacheAdapter').default;
 
 const mongoURI = 'mongodb://localhost:27017/parseServerMongoAdapterTestDatabase';
 const postgresURI = 'postgres://localhost:5432/parse_server_postgres_adapter_test_database';

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -5,7 +5,7 @@ const supportsColor = require('supports-color');
 jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.PARSE_SERVER_TEST_TIMEOUT || 5000;
 
 jasmine.getEnv().clearReporters();
-jasmine.getEnv().addReporter(new SpecReporter({ colors: { enabled: supportsColor.stdout }}));
+jasmine.getEnv().addReporter(new SpecReporter({ colors: { enabled: supportsColor.stdout }, spec: { displayDuration: true }}));
 
 global.on_db = (db, callback, elseCallback) => {
   if (process.env.PARSE_SERVER_TEST_DB == db) {
@@ -422,7 +422,7 @@ global.it_exclude_dbs = excluded => {
 }
 
 global.it_only_db = db => {
-  if (process.env.PARSE_SERVER_TEST_DB === db) {
+  if (process.env.PARSE_SERVER_TEST_DB === db || !process.env.PARSE_SERVER_TEST_DB && db == 'mongo') {
     return (name, suite) => {
       return it(`[${db}] ${name}`, suite);
     };

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -2,11 +2,11 @@
 const request = require('request');
 const parseServerPackage = require('../package.json');
 const MockEmailAdapterWithOptions = require('./MockEmailAdapterWithOptions');
-const ParseServer = require("../src/index");
-const Config = require('../src/Config');
+const ParseServer = require("../lib/index");
+const Config = require('../lib/Config');
 const express = require('express');
 
-import MongoStorageAdapter from '../src/Adapters/Storage/Mongo/MongoStorageAdapter';
+const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter').default;
 
 describe('server', () => {
   it('requires a master key and app id', done => {

--- a/spec/parsers.spec.js
+++ b/spec/parsers.spec.js
@@ -1,4 +1,4 @@
-import {
+const {
   numberParser,
   numberOrBoolParser,
   booleanParser,
@@ -6,7 +6,7 @@ import {
   arrayParser,
   moduleOrObjectParser,
   nullParser,
-} from '../src/Options/parsers';
+} = require('../lib/Options/parsers');
 
 describe('parsers', () => {
   it('parses correctly with numberParser', () => {

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -1,10 +1,10 @@
 "use strict";
 // These tests check the "create" / "update" functionality of the REST API.
-const auth = require('../src/Auth');
-const Config = require('../src/Config');
+const auth = require('../lib/Auth');
+const Config = require('../lib/Config');
 const Parse = require('parse/node').Parse;
-const rest = require('../src/rest');
-const RestWrite = require('../src/RestWrite');
+const rest = require('../lib/rest');
+const RestWrite = require('../lib/RestWrite');
 const request = require('request');
 const rp = require('request-promise');
 

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -4,7 +4,7 @@ const Parse = require('parse/node').Parse;
 const request = require('request');
 const rp = require('request-promise');
 const dd = require('deep-diff');
-const Config = require('../src/Config');
+const Config = require('../lib/Config');
 
 let config;
 

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -4,7 +4,6 @@
     "*spec.js"
   ],
   "helpers": [
-    "../node_modules/babel-core/register.js",
     "helper.js"
   ],
   "random": false

--- a/spec/testing-routes.js
+++ b/spec/testing-routes.js
@@ -1,11 +1,11 @@
 // testing-routes.js
-import AppCache         from '../src/cache';
-import * as middlewares from '../src/middlewares';
-import { ParseServer }  from '../src/index';
-import { Parse }        from 'parse/node';
+const AppCache = require('../lib/cache').default;
+const middlewares = require('../lib/middlewares');
+const { ParseServer } = require('../lib/index');
+const { Parse } = require('parse/node');
 
 const express = require('express'),
-  cryptoUtils = require('../src/cryptoUtils');
+  cryptoUtils = require('../lib/cryptoUtils');
 
 const router = express.Router();
 

--- a/src/Push/PushWorker.js
+++ b/src/Push/PushWorker.js
@@ -42,12 +42,6 @@ export class PushWorker {
     }
   }
 
-  unsubscribe(): void {
-    if (this.subscriber) {
-      this.subscriber.unsubscribe(this.channel);
-    }
-  }
-
   run({ body, query, pushStatus, applicationId, UTCOffset }: any): Promise<*> {
     const config = Config.get(applicationId);
     const auth = master(config);
@@ -59,8 +53,6 @@ export class PushWorker {
         return;
       }
       return this.sendToAdapter(body, results, pushStatus, config, UTCOffset);
-    }, err => {
-      throw err;
     });
   }
 


### PR DESCRIPTION
- Adds watch to watch changes when running the test to regenerate
- Tests are now pure node 8

@acinader what do you think? It shaves off 2 seconds of loading time, and you just need to run `npm run watch` alongside to regen the source in the lib folder.