### PR TITLE
Ensure legacy users with authData are not locked out

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3708,7 +3708,7 @@ describe('Parse.User testing', () => {
   });
 
   describe('issue #4897', () => {
-    it("should be able to login with a legacy user (no ACL)", async () => {
+    it_only_db('mongo')("should be able to login with a legacy user (no ACL)", async () => {
       // This issue is a side effect of the locked users and legacy users which don't have ACL's
       // In this scenario, a legacy user wasn't be able to login as there's no ACL on it
       const database = Config.get(Parse.applicationId).database;

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -427,7 +427,7 @@ class DatabaseController {
                   }
                 });
                 for (const updateOperation in update) {
-                  if (Object.keys(updateOperation).some(innerKey => innerKey.includes('$') || innerKey.includes('.'))) {
+                  if (update[updateOperation] && typeof update[updateOperation] === 'object' && Object.keys(update[updateOperation]).some(innerKey => innerKey.includes('$') || innerKey.includes('.'))) {
                     throw new Parse.Error(Parse.Error.INVALID_NESTED_KEY, "Nested keys should not contain the '$' or '.' characters");
                   }
                 }
@@ -660,7 +660,7 @@ class DatabaseController {
    * @param {boolean} fast set to true if it's ok to just delete rows and not indexes
    * @returns {Promise<void>} when the deletions completes
    */
-  deleteEverything(fast: boolean = false): Promise<void> {
+  deleteEverything(fast: boolean = false): Promise<any> {
     this.schemaPromise = null;
     return Promise.all([
       this.adapter.deleteAllClasses(fast),


### PR DESCRIPTION
Fixes #4897

When adding the feature with user lockout, this added an issue as legacy users, ones without ACL's would be locked out of their account, unable to login.

The fix is to ignore those accounts where the ACL is undefined and not treat it as a locked out ACL.