### PR TITLE
Adds exposed headers to avoid issue in JS SDK

### DIFF
--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -290,4 +290,16 @@ describe('middlewares', () => {
     middlewares.handleParseHeaders(fakeReq, fakeRes);
     expect(fakeRes.status).toHaveBeenCalledWith(403);
   });
+
+  it('should properly expose the headers', () => {
+    const headers = {};
+    const res = {
+      header: (key, value) => {
+        headers[key] = value
+      }
+    };
+    middlewares.allowCrossDomain({}, res, () => {});
+    expect(Object.keys(headers).length).toBe(4);
+    expect(headers['Access-Control-Expose-Headers']).toBe('X-Parse-Job-Status-Id, X-Parse-Push-Status-Id');
+  });
 });

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -247,7 +247,7 @@ export function allowCrossDomain(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
   res.header('Access-Control-Allow-Headers', 'X-Parse-Master-Key, X-Parse-REST-API-Key, X-Parse-Javascript-Key, X-Parse-Application-Id, X-Parse-Client-Version, X-Parse-Session-Token, X-Requested-With, X-Parse-Revocable-Session, Content-Type');
-
+  res.header('Access-Control-Expose-Headers', 'X-Parse-Job-Status-Id, X-Parse-Push-Status-Id');
   // intercept OPTIONS method
   if ('OPTIONS' == req.method) {
     res.sendStatus(200);


### PR DESCRIPTION
Fixes this issue server side: https://github.com/parse-community/Parse-SDK-JS/issues/622