### PR TITLE
Auth module refactoring in order to be reusable

### DIFF
--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -1,6 +1,6 @@
 describe('Auth', () => {
-  const Auth = require('../lib/Auth.js').Auth;
-
+  const { Auth, getAuthForSessionToken } = require('../lib/Auth.js');
+  const Config = require('../lib/Config');
   describe('getUserRoles', () => {
     let auth;
     let config;
@@ -89,5 +89,34 @@ describe('Auth', () => {
       });
     });
 
+  });
+
+  it('should load auth without a config', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password'
+    });
+    expect(user.getSessionToken()).not.toBeUndefined();
+    const userAuth = await getAuthForSessionToken({
+      sessionToken: user.getSessionToken()
+    });
+    expect(userAuth.user instanceof Parse.User).toBe(true);
+    expect(userAuth.user.id).toBe(user.id);
+  });
+
+  it('should load auth with a config', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password'
+    });
+    expect(user.getSessionToken()).not.toBeUndefined();
+    const userAuth = await getAuthForSessionToken({
+      sessionToken: user.getSessionToken(),
+      config: Config.get('test'),
+    });
+    expect(userAuth.user instanceof Parse.User).toBe(true);
+    expect(userAuth.user.id).toBe(user.id);
   });
 });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -832,10 +832,7 @@ describe('Cloud Code', () => {
         expect(body.result).toEqual('second data');
         done();
       })
-      .catch(error => {
-        fail(JSON.stringify(error));
-        done();
-      });
+      .catch(done.fail);
   });
 
   it('trivial beforeSave should not affect fetched pointers (regression test for #1238)', done => {

--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -142,7 +142,7 @@ describe('Parse Role testing', () => {
 
   });
 
-  it("should recursively load roles", (done) => {
+  function testLoadRoles(config, done) {
     const rolesNames = ["FooRole", "BarRole", "BazRole"];
     const roleIds = {};
     createTestUser().then((user) => {
@@ -159,7 +159,7 @@ describe('Parse Role testing', () => {
         return createRole(rolesNames[2], anotherRole, null);
       }).then((lastRole) => {
         roleIds[lastRole.get("name")] = lastRole.id;
-        const auth = new Auth({ config: Config.get("test"), isMaster: true, user: user });
+        const auth = new Auth({ config, isMaster: true, user: user });
         return auth._loadRoles();
       })
     }).then((roles) => {
@@ -172,6 +172,14 @@ describe('Parse Role testing', () => {
       fail("should succeed")
       done();
     });
+  }
+
+  it("should recursively load roles", (done) => {
+    testLoadRoles(Config.get('test'), done);
+  });
+
+  it("should recursively load roles without config", (done) => {
+    testLoadRoles(undefined, done);
   });
 
   it("_Role object should not save without name.", (done) => {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -49,13 +49,13 @@ function nobody(config) {
 
 
 // Returns a promise that resolves to an Auth object
-var getAuthForSessionToken = async function({ config, cacheController, sessionToken, installationId }) {
+const getAuthForSessionToken = async function({ config, cacheController, sessionToken, installationId }) {
   cacheController = cacheController || (config && config.cacheController);
   if (cacheController) {
     const userJSON = await cacheController.user.get(sessionToken);
     if (userJSON) {
       const cachedUser = Parse.Object.fromJSON(userJSON);
-      return Promise.resolve(new Auth({config, isMaster: false, installationId, user: cachedUser}));
+      return Promise.resolve(new Auth({config, cacheController, isMaster: false, installationId, user: cachedUser}));
     }
   }
 
@@ -93,7 +93,7 @@ var getAuthForSessionToken = async function({ config, cacheController, sessionTo
     cacheController.user.put(sessionToken, obj);
   }
   const userObject = Parse.Object.fromJSON(obj);
-  return new Auth({config, isMaster: false, installationId, user: userObject });
+  return new Auth({config, cacheController, isMaster: false, installationId, user: userObject });
 };
 
 var getAuthForLegacySessionToken = function({config, sessionToken, installationId }) {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -61,12 +61,12 @@ const getAuthForSessionToken = async function({ config, cacheController, session
 
   let results;
   if (config) {
-    var restOptions = {
+    const restOptions = {
       limit: 1,
       include: 'user'
     };
 
-    var query = new RestQuery(config, master(config), '_Session', {sessionToken}, restOptions);
+    const query = new RestQuery(config, master(config), '_Session', { sessionToken }, restOptions);
     results = (await query.execute()).results;
   } else {
     results = (await new Parse.Query(Parse.Session)
@@ -79,13 +79,13 @@ const getAuthForSessionToken = async function({ config, cacheController, session
   if (results.length !== 1 || !results[0]['user']) {
     throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'Invalid session token');
   }
-  var now = new Date(),
+  const now = new Date(),
     expiresAt = results[0].expiresAt ? new Date(results[0].expiresAt.iso) : undefined;
   if (expiresAt < now) {
     throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN,
       'Session token is expired.');
   }
-  var obj = results[0]['user'];
+  const obj = results[0]['user'];
   delete obj.password;
   obj['className'] = '_User';
   obj['sessionToken'] = sessionToken;
@@ -93,14 +93,14 @@ const getAuthForSessionToken = async function({ config, cacheController, session
     cacheController.user.put(sessionToken, obj);
   }
   const userObject = Parse.Object.fromJSON(obj);
-  return new Auth({config, cacheController, isMaster: false, installationId, user: userObject });
+  return new Auth({ config, cacheController, isMaster: false, installationId, user: userObject });
 };
 
-var getAuthForLegacySessionToken = function({config, sessionToken, installationId }) {
+var getAuthForLegacySessionToken = function({ config, sessionToken, installationId }) {
   var restOptions = {
     limit: 1
   };
-  var query = new RestQuery(config, master(config), '_User', { sessionToken: sessionToken}, restOptions);
+  var query = new RestQuery(config, master(config), '_User', { sessionToken }, restOptions);
   return query.execute().then((response) => {
     var results = response.results;
     if (results.length !== 1) {
@@ -109,7 +109,7 @@ var getAuthForLegacySessionToken = function({config, sessionToken, installationI
     const obj = results[0];
     obj.className = '_User';
     const userObject = Parse.Object.fromJSON(obj);
-    return new Auth({config, isMaster: false, installationId, user: userObject});
+    return new Auth({ config, isMaster: false, installationId, user: userObject });
   });
 }
 
@@ -138,9 +138,7 @@ Auth.prototype.getRolesForUser = function() {
       }
     };
     const query = new RestQuery(this.config, master(this.config), '_Role', restWhere, {});
-    return query.execute().then(({ results }) => {
-      return results;
-    });
+    return query.execute().then(({ results }) => results);
   }
 
   return new Parse.Query(Parse.Role)
@@ -149,7 +147,7 @@ Auth.prototype.getRolesForUser = function() {
     .then((results) => results.map((obj) => obj.toJSON()));
 }
 
-// Iterates through the role tree and compiles a users roles
+// Iterates through the role tree and compiles a user's roles
 Auth.prototype._loadRoles = async function() {
   if (this.cacheController) {
     const cachedRoles = await this.cacheController.role.get(this.user.id);


### PR DESCRIPTION
The Auth module can be reused in other parts in order to get a user and its roles based upon it's sessionToken (ie liveQuery and #4926 which needs a new users / roles cache).

Now it supports initialization without a ParseServer Config / cache so it can be reused in standalone, just simply with an initialized Parse SDK.