### PR TITLE
Support include('*') Query

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3474,6 +3474,50 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  it('include with *', async () => {
+    const child1 = new TestObject({ foo: 'bar', name: 'ac' });
+    const child2 = new TestObject({ foo: 'baz', name: 'flo' });
+    const child3 = new TestObject({ foo: 'bad', name: 'mo' });
+    const parent = new Container({ child1, child2, child3 });
+    await Parse.Object.saveAll([parent, child1, child2, child3]);
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        where: { objectId: parent.id },
+        include: '*',
+      }
+    });
+    const resp = await rp.get(Parse.serverURL + "/classes/Container", options);
+    const result = resp.results[0];
+    equal(result.child1.foo, 'bar');
+    equal(result.child2.foo, 'baz');
+    equal(result.child3.foo, 'bad');
+    equal(result.child1.name, 'ac');
+    equal(result.child2.name, 'flo');
+    equal(result.child3.name, 'mo');
+  });
+
+  it('include with * overrides', async () => {
+    const child1 = new TestObject({ foo: 'bar', name: 'ac' });
+    const child2 = new TestObject({ foo: 'baz', name: 'flo' });
+    const child3 = new TestObject({ foo: 'bad', name: 'mo' });
+    const parent = new Container({ child1, child2, child3 });
+    await Parse.Object.saveAll([parent, child1, child2, child3]);
+    const options = Object.assign({}, masterKeyOptions, {
+      body: {
+        where: { objectId: parent.id },
+        include: 'child2,*',
+      }
+    });
+    const resp = await rp.get(Parse.serverURL + "/classes/Container", options);
+    const result = resp.results[0];
+    equal(result.child1.foo, 'bar');
+    equal(result.child2.foo, 'baz');
+    equal(result.child3.foo, 'bad');
+    equal(result.child1.name, 'ac');
+    equal(result.child2.name, 'flo');
+    equal(result.child3.name, 'mo');
+  });
+
   it('includeAll', (done) => {
     const child1 = new TestObject({ foo: 'bar', name: 'ac' });
     const child2 = new TestObject({ foo: 'baz', name: 'flo' });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -114,6 +114,10 @@ function RestQuery(config, auth, className, restWhere = {}, restOptions = {}, cl
       break;
     case 'include': {
       const paths = restOptions.include.split(',');
+      if (paths.includes('*')) {
+        this.includeAll = true;
+        break;
+      }
       // Load the existing includes (from keys)
       const pathSet = paths.reduce((memo, path) => {
         // Split each paths on . (a.b.c -> [a,b,c])


### PR DESCRIPTION
Includes all pointers without having to use multiple include().

No updates to client sdk required.