### PR TITLE
Refactor all auth adapters to reduce duplications

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -424,3 +424,60 @@ describe('AuthenticationProviders', function() {
       })
   });
 });
+
+describe('google auth adapter', () => {
+  const google = require('../lib/Adapters/Auth/google');
+  const httpsRequest = require('../lib/Adapters/Auth/httpsRequest');
+
+  it('should use id_token for validation is passed', async () => {
+    spyOn(httpsRequest, 'request').and.callFake(() => {
+      return Promise.resolve({ sub: 'userId' });
+    });
+    await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
+  });
+
+  it('should use id_token for validation is passed and responds with user_id', async () => {
+    spyOn(httpsRequest, 'request').and.callFake(() => {
+      return Promise.resolve({ user_id: 'userId' });
+    });
+    await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
+  });
+
+  it('should use access_token for validation is passed and responds with user_id', async () => {
+    spyOn(httpsRequest, 'request').and.callFake(() => {
+      return Promise.resolve({ user_id: 'userId' });
+    });
+    await google.validateAuthData({ id: 'userId', access_token: 'the_token' }, {});
+  });
+
+  it('should use access_token for validation is passed with sub', async () => {
+    spyOn(httpsRequest, 'request').and.callFake(() => {
+      return Promise.resolve({ sub: 'userId' });
+    });
+    await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
+  });
+
+  it('should fail when the id_token is invalid', async () => {
+    spyOn(httpsRequest, 'request').and.callFake(() => {
+      return Promise.resolve({ sub: 'badId' });
+    });
+    try {
+      await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
+      fail()
+    } catch(e) {
+      expect(e.message).toBe('Google auth is invalid for this user.');
+    }
+  });
+
+  it('should fail when the access_token is invalid', async () => {
+    spyOn(httpsRequest, 'request').and.callFake(() => {
+      return Promise.resolve({ sub: 'badId' });
+    });
+    try {
+      await google.validateAuthData({ id: 'userId', access_token: 'the_token' }, {});
+      fail()
+    } catch(e) {
+      expect(e.message).toBe('Google auth is invalid for this user.');
+    }
+  });
+});

--- a/src/Adapters/Auth/facebook.js
+++ b/src/Adapters/Auth/facebook.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the Facebook Graph API.
-var { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
@@ -36,7 +36,7 @@ function validateAppId(appIds, authData) {
 
 // A promisey wrapper for FB graph requests.
 function graphRequest(path) {
-  return get('https://graph.facebook.com/' + path);
+  return httpsRequest.get('https://graph.facebook.com/' + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/facebook.js
+++ b/src/Adapters/Auth/facebook.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the Facebook Graph API.
-var https = require('https');
+var { get } = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
@@ -36,24 +36,7 @@ function validateAppId(appIds, authData) {
 
 // A promisey wrapper for FB graph requests.
 function graphRequest(path) {
-  return new Promise(function(resolve, reject) {
-    https.get('https://graph.facebook.com/' + path, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Facebook.');
-    });
-  });
+  return get('https://graph.facebook.com/' + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/facebookaccountkit.js
+++ b/src/Adapters/Auth/facebookaccountkit.js
@@ -1,9 +1,9 @@
 const crypto = require('crypto');
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 const Parse  = require('parse/node').Parse;
 
 const graphRequest = (path) => {
-  return get(`https://graph.accountkit.com/v1.1/${path}`);
+  return httpsRequest.get(`https://graph.accountkit.com/v1.1/${path}`);
 };
 
 function getRequestPath(authData, options) {

--- a/src/Adapters/Auth/github.js
+++ b/src/Adapters/Auth/github.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the github API.
 var Parse = require('parse/node').Parse;
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -22,7 +22,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(path, access_token) {
-  return get({
+  return httpsRequest.get({
     host: 'api.github.com',
     path: '/' + path,
     headers: {

--- a/src/Adapters/Auth/github.js
+++ b/src/Adapters/Auth/github.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the github API.
-var https = require('https');
 var Parse = require('parse/node').Parse;
+const { get } = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -22,30 +22,13 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(path, access_token) {
-  return new Promise(function(resolve, reject) {
-    https.get({
-      host: 'api.github.com',
-      path: '/' + path,
-      headers: {
-        'Authorization': 'bearer ' + access_token,
-        'User-Agent': 'parse-server'
-      }
-    }, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Github.');
-    });
+  return get({
+    host: 'api.github.com',
+    path: '/' + path,
+    headers: {
+      'Authorization': 'bearer ' + access_token,
+      'User-Agent': 'parse-server'
+    }
   });
 }
 

--- a/src/Adapters/Auth/google.js
+++ b/src/Adapters/Auth/google.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the google API.
 var Parse = require('parse/node').Parse;
-const { request } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 
 function validateIdToken(id, token) {
   return googleRequest("tokeninfo?id_token=" + token)
@@ -48,7 +48,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function googleRequest(path) {
-  return request("https://www.googleapis.com/oauth2/v3/" + path);
+  return httpsRequest.request("https://www.googleapis.com/oauth2/v3/" + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/google.js
+++ b/src/Adapters/Auth/google.js
@@ -1,9 +1,9 @@
 // Helper functions for accessing the google API.
-var https = require('https');
 var Parse = require('parse/node').Parse;
+const { request } = require('./httpsRequest');
 
 function validateIdToken(id, token) {
-  return request("tokeninfo?id_token=" + token)
+  return googleRequest("tokeninfo?id_token=" + token)
     .then((response) => {
       if (response && (response.sub == id || response.user_id == id)) {
         return;
@@ -15,7 +15,7 @@ function validateIdToken(id, token) {
 }
 
 function validateAuthToken(id, token) {
-  return request("tokeninfo?access_token=" + token)
+  return googleRequest("tokeninfo?access_token=" + token)
     .then((response) => {
       if (response &&  (response.sub == id || response.user_id == id)) {
         return;
@@ -47,25 +47,8 @@ function validateAppId() {
 }
 
 // A promisey wrapper for api requests
-function request(path) {
-  return new Promise(function(resolve, reject) {
-    https.get("https://www.googleapis.com/oauth2/v3/" + path, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Google.');
-    });
-  });
+function googleRequest(path) {
+  return request("https://www.googleapis.com/oauth2/v3/" + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/httpsRequest.js
+++ b/src/Adapters/Auth/httpsRequest.js
@@ -21,7 +21,6 @@ function makeCallback(resolve, reject, noJSON) {
   };
 }
 
-// A promisey wrapper for FB graph requests.
 function get(options, noJSON = false) {
   return new Promise((resolve, reject) => {
     https

--- a/src/Adapters/Auth/httpsRequest.js
+++ b/src/Adapters/Auth/httpsRequest.js
@@ -1,12 +1,15 @@
 const https = require('https');
 
-function makeCallback(resolve, reject) {
+function makeCallback(resolve, reject, noJSON) {
   return function(res) {
     let data = '';
     res.on('data', (chunk) => {
       data += chunk;
     });
     res.on('end', () => {
+      if (noJSON) {
+        return resolve(data);
+      }
       try {
         data = JSON.parse(data);
       } catch(e) {
@@ -19,10 +22,10 @@ function makeCallback(resolve, reject) {
 }
 
 // A promisey wrapper for FB graph requests.
-function get(path) {
+function get(options, noJSON = false) {
   return new Promise((resolve, reject) => {
     https
-      .get(path, makeCallback(resolve, reject))
+      .get(options, makeCallback(resolve, reject, noJSON))
       .on('error', reject);
   });
 }

--- a/src/Adapters/Auth/httpsRequest.js
+++ b/src/Adapters/Auth/httpsRequest.js
@@ -1,0 +1,39 @@
+const https = require('https');
+
+function makeCallback(resolve, reject) {
+  return function(res) {
+    let data = '';
+    res.on('data', (chunk) => {
+      data += chunk;
+    });
+    res.on('end', () => {
+      try {
+        data = JSON.parse(data);
+      } catch(e) {
+        return reject(e);
+      }
+      resolve(data);
+    });
+    res.on('error', reject);
+  };
+}
+
+// A promisey wrapper for FB graph requests.
+function get(path) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(path, makeCallback(resolve, reject))
+      .on('error', reject);
+  });
+}
+
+function request(options, postData) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, makeCallback(resolve, reject));
+    req.on('error', reject);
+    req.write(postData);
+    req.end();
+  });
+}
+
+module.exports = { get, request };

--- a/src/Adapters/Auth/instagram.js
+++ b/src/Adapters/Auth/instagram.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the instagram API.
-var https = require('https');
 var Parse = require('parse/node').Parse;
+const { get } = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -22,20 +22,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(path) {
-  return new Promise(function(resolve, reject) {
-    https.get("https://api.instagram.com/v1/" + path, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        data = JSON.parse(data);
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Instagram.');
-    });
-  });
+  return get("https://api.instagram.com/v1/" + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/instagram.js
+++ b/src/Adapters/Auth/instagram.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the instagram API.
 var Parse = require('parse/node').Parse;
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -22,7 +22,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(path) {
-  return get("https://api.instagram.com/v1/" + path);
+  return httpsRequest.get("https://api.instagram.com/v1/" + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/janraincapture.js
+++ b/src/Adapters/Auth/janraincapture.js
@@ -1,7 +1,7 @@
 // Helper functions for accessing the Janrain Capture API.
-var https = require('https');
 var Parse = require('parse/node').Parse;
 var querystring = require('querystring');
+const { get } = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, options) {
@@ -30,22 +30,7 @@ function request(host, access_token) {
     'attribute_name': 'uuid' // we only need to pull the uuid for this access token to make sure it matches
   });
 
-  return new Promise(function(resolve, reject) {
-    https.get({
-      host: host,
-      path: '/entity?' + query_string_data
-    }, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function () {
-        resolve(JSON.parse(data));
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Janrain capture.');
-    });
-  });
+  return get({ host: host, path: '/entity?' + query_string_data });
 }
 
 module.exports = {

--- a/src/Adapters/Auth/janraincapture.js
+++ b/src/Adapters/Auth/janraincapture.js
@@ -1,7 +1,7 @@
 // Helper functions for accessing the Janrain Capture API.
 var Parse = require('parse/node').Parse;
 var querystring = require('querystring');
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, options) {
@@ -30,7 +30,7 @@ function request(host, access_token) {
     'attribute_name': 'uuid' // we only need to pull the uuid for this access token to make sure it matches
   });
 
-  return get({ host: host, path: '/entity?' + query_string_data });
+  return httpsRequest.get({ host: host, path: '/entity?' + query_string_data });
 }
 
 module.exports = {

--- a/src/Adapters/Auth/janrainengage.js
+++ b/src/Adapters/Auth/janrainengage.js
@@ -1,11 +1,11 @@
 // Helper functions for accessing the Janrain Engage API.
-var https = require('https');
+var { request } = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 var querystring = require('querystring');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, options) {
-  return request(options.api_key, authData.auth_token)
+  return apiRequest(options.api_key, authData.auth_token)
     .then((data) => {
       //successful response will have a "stat" (status) of 'ok' and a profile node with an identifier
       //see: http://developers.janrain.com/overview/social-login/identity-providers/user-profile-data/#normalized-user-profile-data
@@ -23,7 +23,7 @@ function validateAppId() {
 }
 
 // A promisey wrapper for api requests
-function request(api_key, auth_token) {
+function apiRequest(api_key, auth_token) {
 
   var post_data = querystring.stringify({
     'token': auth_token,
@@ -41,29 +41,7 @@ function request(api_key, auth_token) {
     }
   };
 
-  return new Promise(function (resolve, reject) {
-    // Create the post request.
-    var post_req = https.request(post_options, function (res) {
-      var data = '';
-      res.setEncoding('utf8');
-      // Append data as we receive it from the Janrain engage server.
-      res.on('data', function (d) {
-        data += d;
-      });
-      // Once we have all the data, we can parse it and return the data we want.
-      res.on('end', function () {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    });
-
-    post_req.write(post_data);
-    post_req.end();
-  });
+  return request(post_options, post_data);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/janrainengage.js
+++ b/src/Adapters/Auth/janrainengage.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the Janrain Engage API.
-var { request } = require('./httpsRequest');
+var httpsRequest = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 var querystring = require('querystring');
 
@@ -41,7 +41,7 @@ function apiRequest(api_key, auth_token) {
     }
   };
 
-  return request(post_options, post_data);
+  return httpsRequest.request(post_options, post_data);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/linkedin.js
+++ b/src/Adapters/Auth/linkedin.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the linkedin API.
 var Parse = require('parse/node').Parse;
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -30,7 +30,7 @@ function request(path, access_token, is_mobile_sdk) {
   if(is_mobile_sdk) {
     headers['x-li-src'] = 'msdk';
   }
-  return get({
+  return httpsRequest.get({
     host: 'api.linkedin.com',
     path: '/v1/' + path,
     headers: headers

--- a/src/Adapters/Auth/linkedin.js
+++ b/src/Adapters/Auth/linkedin.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the linkedin API.
-var https = require('https');
 var Parse = require('parse/node').Parse;
+const { get } = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -30,28 +30,10 @@ function request(path, access_token, is_mobile_sdk) {
   if(is_mobile_sdk) {
     headers['x-li-src'] = 'msdk';
   }
-
-  return new Promise(function(resolve, reject) {
-    https.get({
-      host: 'api.linkedin.com',
-      path: '/v1/' + path,
-      headers: headers
-    }, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Linkedin.');
-    });
+  return get({
+    host: 'api.linkedin.com',
+    path: '/v1/' + path,
+    headers: headers
   });
 }
 

--- a/src/Adapters/Auth/meetup.js
+++ b/src/Adapters/Auth/meetup.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the meetup API.
 var Parse = require('parse/node').Parse;
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -22,7 +22,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(path, access_token) {
-  return get({
+  return httpsRequest.get({
     host: 'api.meetup.com',
     path: '/2/' + path,
     headers: {

--- a/src/Adapters/Auth/meetup.js
+++ b/src/Adapters/Auth/meetup.js
@@ -1,6 +1,6 @@
 // Helper functions for accessing the meetup API.
-var https = require('https');
 var Parse = require('parse/node').Parse;
+const { get } = require('./httpsRequest');
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
@@ -22,29 +22,12 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(path, access_token) {
-  return new Promise(function(resolve, reject) {
-    https.get({
-      host: 'api.meetup.com',
-      path: '/2/' + path,
-      headers: {
-        'Authorization': 'bearer ' + access_token
-      }
-    }, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Meetup.');
-    });
+  return get({
+    host: 'api.meetup.com',
+    path: '/2/' + path,
+    headers: {
+      'Authorization': 'bearer ' + access_token
+    }
   });
 }
 

--- a/src/Adapters/Auth/qq.js
+++ b/src/Adapters/Auth/qq.js
@@ -31,12 +31,7 @@ function parseResponseData(data) {
     throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'qq auth is invalid for this user.');
   }
   data = data.substring(starPos + 1,endPos - 1);
-  try {
-    data = JSON.parse(data);
-  } catch(e) {
-    throw e;
-  }
-  return data;
+  return JSON.parse(data);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/spotify.js
+++ b/src/Adapters/Auth/spotify.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the Spotify API.
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
@@ -36,7 +36,7 @@ function validateAppId(appIds, authData) {
 
 // A promisey wrapper for Spotify API requests.
 function request(path, access_token) {
-  return get({
+  return httpsRequest.get({
     host: 'api.spotify.com',
     path: '/v1/' + path,
     headers: {

--- a/src/Adapters/Auth/spotify.js
+++ b/src/Adapters/Auth/spotify.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the Spotify API.
-var https = require('https');
+const { get } = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
@@ -36,29 +36,12 @@ function validateAppId(appIds, authData) {
 
 // A promisey wrapper for Spotify API requests.
 function request(path, access_token) {
-  return new Promise(function(resolve, reject) {
-    https.get({
-      host: 'api.spotify.com',
-      path: '/v1/' + path,
-      headers: {
-        'Authorization': 'Bearer ' + access_token
-      }
-    }, function(res) {
-      var data = '';
-      res.on('data', function(chunk) {
-        data += chunk;
-      });
-      res.on('end', function() {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function() {
-      reject('Failed to validate this access token with Spotify.');
-    });
+  return get({
+    host: 'api.spotify.com',
+    path: '/v1/' + path,
+    headers: {
+      'Authorization': 'Bearer ' + access_token
+    }
   });
 }
 

--- a/src/Adapters/Auth/vkontakte.js
+++ b/src/Adapters/Auth/vkontakte.js
@@ -2,7 +2,7 @@
 
 // Helper functions for accessing the vkontakte API.
 
-const { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 var logger = require('../../logger').default;
 
@@ -41,7 +41,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(host, path) {
-  return get("https://" + host + "/" + path);
+  return httpsRequest.get("https://" + host + "/" + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/vkontakte.js
+++ b/src/Adapters/Auth/vkontakte.js
@@ -2,7 +2,7 @@
 
 // Helper functions for accessing the vkontakte API.
 
-var https = require('https');
+const { get } = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 var logger = require('../../logger').default;
 
@@ -41,24 +41,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function request(host, path) {
-  return new Promise(function (resolve, reject) {
-    https.get("https://" + host + "/" + path, function (res) {
-      var data = '';
-      res.on('data', function (chunk) {
-        data += chunk;
-      });
-      res.on('end', function () {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function () {
-      reject('Failed to validate this access token with Vk.');
-    });
-  });
+  return get("https://" + host + "/" + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/wechat.js
+++ b/src/Adapters/Auth/wechat.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the WeChat Graph API.
-var { get } = require('./httpsRequest');
+const httpsRequest = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
@@ -19,7 +19,7 @@ function validateAppId() {
 
 // A promisey wrapper for WeChat graph requests.
 function graphRequest(path) {
-  return get('https://api.weixin.qq.com/sns/' + path);
+  return httpsRequest.get('https://api.weixin.qq.com/sns/' + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/wechat.js
+++ b/src/Adapters/Auth/wechat.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the WeChat Graph API.
-var https = require('https');
+var { get } = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
@@ -19,24 +19,7 @@ function validateAppId() {
 
 // A promisey wrapper for WeChat graph requests.
 function graphRequest(path) {
-  return new Promise(function (resolve, reject) {
-    https.get('https://api.weixin.qq.com/sns/' + path, function (res) {
-      var data = '';
-      res.on('data', function (chunk) {
-        data += chunk;
-      });
-      res.on('end', function () {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-    }).on('error', function () {
-      reject('Failed to validate this access token with wechat.');
-    });
-  });
+  return get('https://api.weixin.qq.com/sns/' + path);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/weibo.js
+++ b/src/Adapters/Auth/weibo.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the weibo Graph API.
-var { request } = require('./httpsRequest');
+var httpsRequest = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 var querystring = require('querystring');
 
@@ -32,7 +32,7 @@ function graphRequest(access_token) {
       'Content-Length': Buffer.byteLength(postData)
     }
   };
-  return request(options, postData);
+  return httpsRequest.request(options, postData);
 }
 
 module.exports = {

--- a/src/Adapters/Auth/weibo.js
+++ b/src/Adapters/Auth/weibo.js
@@ -21,7 +21,7 @@ function validateAppId() {
 // A promisey wrapper for weibo graph requests.
 function graphRequest(access_token) {
   var postData = querystring.stringify({
-    "access_token":access_token
+    "access_token": access_token
   });
   var options = {
     hostname: 'api.weibo.com',

--- a/src/Adapters/Auth/weibo.js
+++ b/src/Adapters/Auth/weibo.js
@@ -1,5 +1,5 @@
 // Helper functions for accessing the weibo Graph API.
-var https = require('https');
+var { request } = require('./httpsRequest');
 var Parse = require('parse/node').Parse;
 var querystring = require('querystring');
 
@@ -20,42 +20,19 @@ function validateAppId() {
 
 // A promisey wrapper for weibo graph requests.
 function graphRequest(access_token) {
-  return new Promise(function (resolve, reject) {
-    var postData = querystring.stringify({
-      "access_token":access_token
-    });
-    var options = {
-      hostname: 'api.weibo.com',
-      path: '/oauth2/get_token_info',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': Buffer.byteLength(postData)
-      }
-    };
-    var req = https.request(options, function(res){
-      var data = '';
-      res.on('data', function (chunk) {
-        data += chunk;
-      });
-      res.on('end', function () {
-        try {
-          data = JSON.parse(data);
-        } catch(e) {
-          return reject(e);
-        }
-        resolve(data);
-      });
-      res.on('error', function () {
-        reject('Failed to validate this access token with weibo.');
-      });
-    });
-    req.on('error', function () {
-      reject('Failed to validate this access token with weibo.');
-    });
-    req.write(postData);
-    req.end();
+  var postData = querystring.stringify({
+    "access_token":access_token
   });
+  var options = {
+    hostname: 'api.weibo.com',
+    path: '/oauth2/get_token_info',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(postData)
+    }
+  };
+  return request(options, postData);
 }
 
 module.exports = {


### PR DESCRIPTION
I was tired of having so much duplicated code across all those modules. Now the HTTP request code is isolated into httpsRequest. Also now, I've added proper mocks and tests to ensure we let pass the proper responses from the providers.