### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---parse-server-3-0-0.md
+++ b/.github/ISSUE_TEMPLATE/---parse-server-3-0-0.md
@@ -1,0 +1,54 @@
+---
+name: "\U0001F525 parse-server 3.0.0"
+about: Report an issue while migrating to parse-server 3.0.0
+
+---
+
+<!--- 
+** Use this template only if you have an issue migrating to parse-server 3.0.0 **
+
+If you have a vulnerability disclosure, please follow our policy available here https://github.com/parse-community/parse-server/blob/master/SECURITY.md
+
+You may also search through existing issues before opening a new one: https://github.com/parse-community/parse-server/issues?utf8=%E2%9C%93&q=is%3Aissue 
+
+--- Please use this template. If you don't use this template, your issue may be closed without comment. ---
+--->
+
+# Before opening the issue please ensure that you have:
+
+- [ ] [Read the migration guide](https://github.com/parse-community/parse-server/blob/master/3.0.0.md) to parse-server 3.0.0
+- [ ] [Read the migration guide](https://github.com/parse-community/Parse-SDK-JS/blob/master/2.0.0.md) to Parse SDK JS 2.0.0
+
+### Issue Description
+
+<!--- Describe your issue in as much detail as possible. -->
+
+### Steps to reproduce
+
+<!--- Please include a detailed list of steps that reproduce the issue. Include curl commands when applicable.  --->
+ 
+### Expected Results
+
+<!--- What you expected to happen. --->
+
+### Actual Outcome
+
+<!--- What is happening instead. --->
+
+### Environment Setup
+
+- **Server**
+  - parse-server version (Be specific! Don't say 'latest'.) : [FILL THIS OUT]
+  - Operating System:     [FILL THIS OUT]
+  - Hardware:             [FILL THIS OUT]
+  - Localhost or remote server? (AWS, Heroku, Azure, Digital Ocean, etc): [FILL THIS OUT]
+
+- **Database**
+  - MongoDB version: [FILL THIS OUT]
+  - Storage engine:  [FILL THIS OUT]
+  - Hardware:        [FILL THIS OUT]
+  - Localhost or remote server? (AWS, mLab, ObjectRocket, Digital Ocean, etc): [FILL THIS OUT]
+
+### Logs/Trace
+
+<!--- Include all relevant logs. You can turn on additional logging by configuring VERBOSE=1 in your environment. --->

--- a/.github/ISSUE_TEMPLATE/---report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/---report-an-issue.md
@@ -6,7 +6,11 @@ about: Report an issue on parse-server
 
 <!--- 
 
-We use GitHub Issues for bugs.
+**We use GitHub Issues for reporting bugs with parse-server.**
+
+If you have a *question*, you should join the gitter chat where a community of more than 200 parse users gather.
+
+- https://gitter.im/ParsePlatform/Chat
 
 If you have a non-bug question, ask on Stack Overflow or Server Fault: 
 - https://stackoverflow.com/questions/tagged/parse.com 


### PR DESCRIPTION
Add an issue template for parse-server 3.0.0 in order to direct the users to the documentation before opening an issue.