### PR TITLE
Update Gomix to Glitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We have provided a basic [Node.js application](https://github.com/parse-communit
 * [Digital Ocean](https://www.digitalocean.com/community/tutorials/how-to-run-parse-server-on-ubuntu-14-04)
 * [Pivotal Web Services](https://github.com/cf-platform-eng/pws-parse-server)
 * [Back4app](http://blog.back4app.com/2016/03/01/quick-wizard-migration/)
-* [Gomix](https://gomix.com/#!/project/parse-server)
+* [Glitch](https://glitch.com/edit/#!/parse-server)
 * [Flynn](https://flynn.io/blog/parse-apps-on-flynn)
 
 ### Parse Server + Express


### PR DESCRIPTION
The name of the site has changed, along with its domain. This updates it in the README.