### PR TITLE
Use the correct function when validating google auth tokens

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -430,35 +430,35 @@ describe('google auth adapter', () => {
   const httpsRequest = require('../lib/Adapters/Auth/httpsRequest');
 
   it('should use id_token for validation is passed', async () => {
-    spyOn(httpsRequest, 'request').and.callFake(() => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ sub: 'userId' });
     });
     await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
   });
 
   it('should use id_token for validation is passed and responds with user_id', async () => {
-    spyOn(httpsRequest, 'request').and.callFake(() => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ user_id: 'userId' });
     });
     await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
   });
 
   it('should use access_token for validation is passed and responds with user_id', async () => {
-    spyOn(httpsRequest, 'request').and.callFake(() => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ user_id: 'userId' });
     });
     await google.validateAuthData({ id: 'userId', access_token: 'the_token' }, {});
   });
 
   it('should use access_token for validation is passed with sub', async () => {
-    spyOn(httpsRequest, 'request').and.callFake(() => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ sub: 'userId' });
     });
     await google.validateAuthData({ id: 'userId', id_token: 'the_token' }, {});
   });
 
   it('should fail when the id_token is invalid', async () => {
-    spyOn(httpsRequest, 'request').and.callFake(() => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ sub: 'badId' });
     });
     try {
@@ -470,7 +470,7 @@ describe('google auth adapter', () => {
   });
 
   it('should fail when the access_token is invalid', async () => {
-    spyOn(httpsRequest, 'request').and.callFake(() => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ sub: 'badId' });
     });
     try {

--- a/src/Adapters/Auth/google.js
+++ b/src/Adapters/Auth/google.js
@@ -48,7 +48,7 @@ function validateAppId() {
 
 // A promisey wrapper for api requests
 function googleRequest(path) {
-  return httpsRequest.request("https://www.googleapis.com/oauth2/v3/" + path);
+  return httpsRequest.get("https://www.googleapis.com/oauth2/v3/" + path);
 }
 
 module.exports = {


### PR DESCRIPTION
httpsRequest.request expects the param postData and has no default value
or validation to check if it is missing before using it. As a result, an
error `TypeError: First argument must be a string or Buffer` is
thrown when an attempt is made to authenticate with Google.

A quick check on the LinkedIn, FB, and twitter authentication adapters shows they are
using httpsRequest.get for their validation calls.