### PR TITLE
Remove request and request-promise from dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "2.18.0",
         "convert-source-map": "1.6.0",
         "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "output-file-sync": "2.0.1",
@@ -53,7 +53,7 @@
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0",
         "convert-source-map": "1.6.0",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "json5": "0.5.1",
         "lodash": "4.17.11",
         "resolve": "1.8.1",
@@ -61,51 +61,6 @@
         "source-map": "0.5.7"
       },
       "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -122,23 +77,11 @@
       "requires": {
         "@babel/types": "7.0.0",
         "jsesc": "2.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
       "dependencies": {
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -175,53 +118,6 @@
         "@babel/helper-hoist-variables": "7.0.0",
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "@babel/helper-define-map": {
@@ -233,36 +129,6 @@
         "@babel/helper-function-name": "7.1.0",
         "@babel/types": "7.0.0",
         "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        }
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -273,63 +139,16 @@
       "requires": {
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
-      "integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/template": "7.0.0",
+        "@babel/template": "7.1.0",
         "@babel/types": "7.0.0"
       }
     },
@@ -381,25 +200,6 @@
         "@babel/template": "7.1.0",
         "@babel/types": "7.0.0",
         "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -437,53 +237,6 @@
         "@babel/template": "7.1.0",
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "@babel/helper-replace-supers": {
@@ -496,53 +249,6 @@
         "@babel/helper-optimise-call-expression": "7.0.0",
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "@babel/helper-simple-access": {
@@ -553,25 +259,6 @@
       "requires": {
         "@babel/template": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -593,53 +280,6 @@
         "@babel/template": "7.1.0",
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "@babel/helpers": {
@@ -651,53 +291,6 @@
         "@babel/template": "7.1.0",
         "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
-          "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/generator": "7.0.0",
-            "@babel/helper-function-name": "7.1.0",
-            "@babel/helper-split-export-declaration": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0",
-            "debug": "3.1.0",
-            "globals": "11.7.0",
-            "lodash": "4.17.11"
-          }
-        }
       }
     },
     "@babel/highlight": {
@@ -709,40 +302,12 @@
         "chalk": "2.4.1",
         "esutils": "2.0.2",
         "js-tokens": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
-        }
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
+      "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -895,36 +460,6 @@
         "@babel/helper-replace-supers": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
         "globals": "11.7.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        }
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -1002,36 +537,6 @@
       "requires": {
         "@babel/helper-function-name": "7.1.0",
         "@babel/helper-plugin-utils": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "7.0.0",
-            "@babel/template": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.0.tgz",
-          "integrity": "sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
-          "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.1.0",
-            "@babel/types": "7.0.0"
-          }
-        }
       }
     },
     "@babel/plugin-transform-literals": {
@@ -1246,59 +751,31 @@
       }
     },
     "@babel/template": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
-      "integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.0.tgz",
+      "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.0.0",
+        "@babel/parser": "7.1.0",
         "@babel/types": "7.0.0"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
-          "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
-          "dev": true
-        }
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
-      "integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
+      "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
         "@babel/generator": "7.0.0",
-        "@babel/helper-function-name": "7.0.0",
+        "@babel/helper-function-name": "7.1.0",
         "@babel/helper-split-export-declaration": "7.0.0",
-        "@babel/parser": "7.0.0",
+        "@babel/parser": "7.1.0",
         "@babel/types": "7.0.0",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "globals": "11.7.0",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
-          "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
-          "dev": true
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
+        "lodash": "4.17.11"
       }
     },
     "@babel/types": {
@@ -1308,22 +785,8 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "to-fast-properties": "2.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
       }
     },
     "@parse/fs-files-adapter": {
@@ -1342,40 +805,9 @@
       "resolved": "https://registry.npmjs.org/@parse/node-gcm/-/node-gcm-0.14.12.tgz",
       "integrity": "sha512-fIXlY5LNR0VcPpFvwMvvczpByPNKxbCgMt/B3LwQqBjBCUJj/yEhBSePGUz2Kk+zOoj05v3KnG7ca+wZcAbh5A==",
       "requires": {
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "lodash": "4.17.11",
         "request": "2.85.0"
-      },
-      "dependencies": {
-        "request": {
-          "version": "2.85.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        }
       }
     },
     "@parse/push-adapter": {
@@ -1391,7 +823,7 @@
       "dependencies": {
         "parse": {
           "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-1.11.1.tgz",
+          "resolved": "http://registry.npmjs.org/parse/-/parse-1.11.1.tgz",
           "integrity": "sha1-VY5TnULZ+4khDggiCdbzsD1frtU=",
           "requires": {
             "babel-runtime": "6.26.0",
@@ -1416,7 +848,7 @@
       "resolved": "https://registry.npmjs.org/@parse/s3-files-adapter/-/s3-files-adapter-1.2.1.tgz",
       "integrity": "sha1-2dN8zoXj1CsogqX/J4m+wbF+xnU=",
       "requires": {
-        "aws-sdk": "2.235.1"
+        "aws-sdk": "2.320.0"
       }
     },
     "@parse/simple-mailgun-adapter": {
@@ -1450,7 +882,7 @@
       "requires": {
         "@semantic-release/error": "2.2.0",
         "aggregate-error": "1.0.0",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "dir-glob": "2.0.0",
         "execa": "0.10.0",
         "fs-extra": "6.0.1",
@@ -1459,205 +891,19 @@
         "p-reduce": "1.0.0"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "fs-extra": {
@@ -1669,88 +915,6 @@
             "graceful-fs": "4.1.11",
             "jsonfile": "4.0.0",
             "universalify": "0.1.2"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
           }
         }
       }
@@ -1766,14 +930,14 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "2.1.20",
         "negotiator": "0.6.1"
       }
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1782,7 +946,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "5.7.3"
       }
     },
     "agent-base": {
@@ -1913,10 +1077,13 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.3"
+      }
     },
     "any-observable": {
       "version": "0.3.0",
@@ -1929,7 +1096,6 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "micromatch": "3.1.10",
         "normalize-path": "2.1.1"
@@ -1940,9 +1106,9 @@
       "resolved": "https://registry.npmjs.org/apn/-/apn-3.0.0-alpha1.tgz",
       "integrity": "sha512-o/wVNAxaQ7eegLZ69rtNEgiIQFngPClOAFFsVowsBDjVIaFsRccI+kfTda6rmVuiMSiGBMurlX01jyMNlO+AXQ==",
       "requires": {
-        "debug": "3.1.0",
-        "jsonwebtoken": "8.2.1",
-        "node-forge": "0.7.5",
+        "debug": "3.2.5",
+        "jsonwebtoken": "8.3.0",
+        "node-forge": "0.7.6",
         "verror": "1.10.0"
       }
     },
@@ -1952,9 +1118,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.6"
@@ -2050,9 +1216,9 @@
       "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
         "lodash": "4.17.11"
       }
@@ -2074,15 +1240,15 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.235.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.235.1.tgz",
-      "integrity": "sha1-uJXalIK7XZCy9UxFIDt6PBwrfOo=",
+      "version": "2.320.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.320.0.tgz",
+      "integrity": "sha512-qJBjZ0sIIy6AzBe0RkK5HDl3Kl1uAz01R4Nqy+RyflB//XWz+dPN8CFYtzrQNyfpLtPe/4uPrmxC4NwGW1MXBQ==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -2092,14 +1258,13 @@
         "sax": "1.2.1",
         "url": "0.10.3",
         "uuid": "3.1.0",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
@@ -2113,17 +1278,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
     "babel-eslint": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
@@ -2131,19 +1285,11 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.0.0",
-        "@babel/traverse": "7.0.0",
+        "@babel/parser": "7.1.0",
+        "@babel/traverse": "7.1.0",
         "@babel/types": "7.0.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0"
-      },
-      "dependencies": {
-        "@babel/parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
-          "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -2151,9 +1297,15 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.6",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
+    },
+    "babylon": {
+      "version": "7.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2213,18 +1365,6 @@
             "is-data-descriptor": "1.0.0",
             "kind-of": "6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -2462,12 +1602,6 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "optional": true
-        },
-        "nan": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
           "optional": true
         },
         "needle": {
@@ -2740,9 +1874,9 @@
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
     "bl": {
@@ -2756,9 +1890,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
       "dev": true
     },
     "body-parser": {
@@ -2781,10 +1915,15 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -2822,26 +1961,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -2891,7 +2010,7 @@
         "extend-shallow": "2.0.1",
         "fill-range": "4.0.0",
         "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
+        "repeat-element": "1.1.3",
         "snapdragon": "0.8.2",
         "snapdragon-node": "2.1.1",
         "split-string": "3.1.0",
@@ -2921,14 +2040,13 @@
       }
     },
     "bson": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
-      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
+      "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "1.3.0",
@@ -3000,14 +2118,6 @@
         "to-object-path": "0.3.0",
         "union-value": "1.0.0",
         "unset-value": "1.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "caller-path": {
@@ -3038,9 +2148,9 @@
       "dev": true
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
     "caseless": {
@@ -3070,30 +2180,20 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "cheerio": {
@@ -3125,12 +2225,11 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "anymatch": "2.0.0",
         "async-each": "1.0.1",
         "braces": "2.3.2",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "3.1.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3138,14 +2237,14 @@
         "lodash.debounce": "4.0.8",
         "normalize-path": "2.1.1",
         "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
+        "readdirp": "2.2.1",
         "upath": "1.1.0"
       }
     },
     "ci-info": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
-      "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
     "circular-json": {
@@ -3174,12 +2273,6 @@
           "requires": {
             "is-descriptor": "0.1.6"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -3270,9 +2363,9 @@
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -3290,9 +2383,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -3315,9 +2408,9 @@
       "dev": true
     },
     "config-chain": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
         "ini": "1.3.5",
@@ -3332,7 +2425,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -3385,9 +2478,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3411,7 +2504,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "1.0.1"
       }
     },
     "cross-env": {
@@ -3422,32 +2515,19 @@
       "requires": {
         "cross-spawn": "6.0.5",
         "is-windows": "1.0.2"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        }
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.5.1",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "cryptiles": {
@@ -3526,11 +2606,11 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.1"
       }
     },
     "decode-uri-component": {
@@ -3550,7 +2630,7 @@
         "decompress-targz": "4.1.1",
         "decompress-unzip": "4.0.1",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
       }
@@ -3572,7 +2652,7 @@
       "requires": {
         "file-type": "5.2.0",
         "is-stream": "1.1.0",
-        "tar-stream": "1.6.1"
+        "tar-stream": "1.6.2"
       }
     },
     "decompress-tarbz2": {
@@ -3585,7 +2665,7 @@
         "file-type": "6.2.0",
         "is-stream": "1.1.0",
         "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.2.5"
+        "unbzip2-stream": "1.3.0"
       },
       "dependencies": {
         "file-type": {
@@ -3668,16 +2748,6 @@
         "type-detect": "4.0.8"
       }
     },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
-      }
-    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -3716,18 +2786,6 @@
             "is-data-descriptor": "1.0.0",
             "kind-of": "6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -3864,12 +2922,12 @@
       "integrity": "sha1-eQuwQkaJE2EVzpPyqhWUbG2AbQ4=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "graceful-fs": "4.1.11",
         "limiter": "1.1.3",
         "mkdirp": "0.5.1",
         "npmlog": "2.0.4",
-        "request": "2.88.0",
+        "request": "2.85.0",
         "rimraf": "2.6.2"
       },
       "dependencies": {
@@ -3893,7 +2951,7 @@
           "dev": true,
           "requires": {
             "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
+            "are-we-there-yet": "1.1.5",
             "gauge": "1.2.7"
           }
         }
@@ -3913,7 +2971,7 @@
         "filenamify": "2.1.0",
         "get-stream": "3.0.0",
         "got": "7.1.0",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "p-event": "1.3.0",
         "pify": "3.0.0"
       },
@@ -3928,7 +2986,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -4002,30 +3060,6 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
     "es5-ext": {
       "version": "0.10.46",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
@@ -4060,16 +3094,16 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "4.2.5"
       }
     },
     "es6-symbol": {
@@ -4152,29 +3186,30 @@
       }
     },
     "eslint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.0.0.tgz",
-      "integrity": "sha512-MA0YWJLeK7BPEBxJCINvKnQdKpeTwbac3Xonh0PPFjWYZkowZf+Xl30lJWJ/BWOqFQdAdPcyOh0aBqlbH6ojAg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
+      "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.1",
-        "babel-code-frame": "6.26.0",
+        "@babel/code-frame": "7.0.0",
+        "ajv": "6.5.4",
         "chalk": "2.4.1",
         "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "doctrine": "2.1.0",
         "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
         "eslint-visitor-keys": "1.0.0",
         "espree": "4.0.0",
         "esquery": "1.0.1",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "globals": "11.7.0",
-        "ignore": "3.3.10",
+        "ignore": "4.0.6",
         "imurmurhash": "0.1.4",
-        "inquirer": "5.2.0",
+        "inquirer": "6.2.0",
         "is-resolvable": "1.1.0",
         "js-yaml": "3.12.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
@@ -4187,10 +3222,9 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
-        "regexpp": "1.1.0",
+        "regexpp": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.1",
-        "string.prototype.matchall": "2.0.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.3",
@@ -4198,9 +3232,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "2.0.1",
@@ -4214,39 +3248,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
         },
         "eslint-scope": {
           "version": "4.0.0",
@@ -4264,12 +3265,6 @@
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
         },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-          "dev": true
-        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4284,22 +3279,13 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
         }
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.46.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.46.3.tgz",
-      "integrity": "sha512-VpnNeC4E6t2E2NCw8Oveda91p8CPEaujZURC1KhHe4lBRZJla3o0DVvZu1QGXQZO1ZJ4vUmy3TCp95PqGvIZgQ==",
+      "version": "2.50.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
+      "integrity": "sha512-9kRxF9hfM/O6WGZcZPszOVPd2W0TLHBtceulLTsGfwMPtiCCLnCW0ssRiOOiXyqrCA20pm1iXdXm7gQeN306zQ==",
       "dev": true,
       "requires": {
         "lodash": "4.17.11"
@@ -4315,6 +3301,12 @@
         "estraverse": "4.2.0"
       }
     },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -4327,7 +3319,7 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1",
+        "acorn": "5.7.3",
         "acorn-jsx": "4.1.1"
       }
     },
@@ -4391,29 +3383,19 @@
       }
     },
     "event-stream": {
-      "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
+      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
       "dev": true,
       "requires": {
         "duplexer": "0.1.1",
+        "flatmap-stream": "0.1.0",
         "from": "0.1.7",
-        "map-stream": "0.1.0",
+        "map-stream": "0.0.7",
         "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
+        "split": "1.0.1",
+        "stream-combiner": "0.2.2",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "split": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-          "dev": true,
-          "requires": {
-            "through": "2.3.8"
-          }
-        }
       }
     },
     "events": {
@@ -4422,12 +3404,12 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+      "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
+        "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
         "is-stream": "1.1.0",
         "npm-run-path": "2.0.2",
@@ -4437,16 +3419,14 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.1",
+            "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "which": "1.3.1"
           }
         }
       }
@@ -4498,6 +3478,12 @@
           "requires": {
             "is-extendable": "0.1.1"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -4525,7 +3511,7 @@
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
         "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
@@ -4567,6 +3553,11 @@
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "qs": {
           "version": "6.5.1",
@@ -4625,7 +3616,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "1.36.0"
       }
     },
     "ext-name": {
@@ -4639,9 +3630,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4665,14 +3656,25 @@
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
         "tmp": "0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        }
       }
     },
     "extglob": {
@@ -4737,12 +3739,6 @@
             "is-data-descriptor": "1.0.0",
             "kind-of": "6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -4872,6 +3868,11 @@
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -4912,6 +3913,12 @@
         "write": "0.2.1"
       }
     },
+    "flatmap-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.0.tgz",
+      "integrity": "sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA==",
+      "dev": true
+    },
     "flow-bin": {
       "version": "0.81.0",
       "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.81.0.tgz",
@@ -4924,18 +3931,27 @@
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "requires": {
         "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
@@ -4950,7 +3966,17 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "2.1.20"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        }
       }
     },
     "forwarded": {
@@ -5008,40 +4034,36 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "nan": "2.11.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5051,14 +4073,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -5067,40 +4087,34 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5108,30 +4122,26 @@
           }
         },
         "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+          "version": "0.5.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5140,15 +4150,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5164,8 +4172,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5179,15 +4186,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5196,8 +4201,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5206,8 +4210,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5217,14 +4220,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5232,15 +4239,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -5248,14 +4253,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1",
@@ -5264,8 +4267,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5274,8 +4276,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5283,15 +4284,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5301,9 +4300,8 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
-          "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+          "version": "0.10.0",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5313,7 +4311,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.8",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -5321,8 +4319,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5332,15 +4329,13 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5350,8 +4345,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5363,21 +4357,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -5385,22 +4376,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5410,26 +4398,23 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "version": "1.2.7",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.6.0",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -5437,8 +4422,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -5446,8 +4430,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5462,8 +4445,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5472,49 +4454,42 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -5524,8 +4499,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5534,17 +4508,21 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5559,15 +4537,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -5576,14 +4552,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -5604,7 +4578,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -5619,12 +4593,6 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5644,7 +4612,7 @@
         "signal-exit": "3.0.2",
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "wide-align": "1.1.3"
       }
     },
     "gaze": {
@@ -5653,7 +4621,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "1.2.1"
       }
     },
     "get-mongodb-version": {
@@ -5666,7 +4634,7 @@
         "lodash.startswith": "4.2.1",
         "minimist": "1.2.0",
         "mongodb": "3.1.6",
-        "which": "1.3.0"
+        "which": "1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -5680,8 +4648,14 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -5720,7 +4694,7 @@
       "requires": {
         "data-uri-to-buffer": "1.2.0",
         "debug": "2.6.9",
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "file-uri-to-path": "1.0.0",
         "ftp": "0.3.10",
         "readable-stream": "2.3.6"
@@ -5733,6 +4707,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -5751,9 +4730,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -5769,7 +4748,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "3.1.0",
         "path-dirname": "1.0.2"
@@ -5780,7 +4758,6 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "2.1.1"
           }
@@ -5810,19 +4787,19 @@
       "requires": {
         "array-union": "1.0.2",
         "arrify": "1.0.1",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
       }
     },
     "globule": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "lodash": "4.17.11",
         "minimatch": "3.0.4"
       }
@@ -5875,15 +4852,6 @@
         "har-schema": "2.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -5903,12 +4871,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-to-string-tag-x": {
@@ -5934,14 +4896,6 @@
         "get-value": "2.0.6",
         "has-values": "1.0.0",
         "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "has-values": {
@@ -5954,26 +4908,6 @@
         "kind-of": "4.0.0"
       },
       "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -6023,7 +4957,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "1.1.2",
@@ -6039,6 +4973,21 @@
       "requires": {
         "agent-base": "4.2.1",
         "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "http-signature": {
@@ -6057,42 +5006,25 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
         "agent-base": "4.2.1",
-        "debug": "3.1.0"
+        "debug": "3.2.5"
       }
     },
     "husky": {
-      "version": "1.0.0-rc.13",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-1.0.0-rc.13.tgz",
-      "integrity": "sha512-ZNNoaBgfOHRA05UHS/etBoWFDu65mjPoohPYQwOqb5155KOovBp8LMkMoNK0kn3VYdsm+HWdtuHbD4XjfzlfpQ==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-1.0.0-rc.15.tgz",
+      "integrity": "sha512-JTZhkESlc4r1YFilvGgpbEC6wkFZdi1Sm/Haa1TiMFPHOErMUBlpScrIlgN0ttXO9EBYJyanL5WF+lwCtorrZw==",
       "dev": true,
       "requires": {
         "cosmiconfig": "5.0.6",
         "execa": "0.9.0",
         "find-up": "3.0.0",
         "get-stdin": "6.0.0",
-        "is-ci": "1.2.0",
+        "is-ci": "1.2.1",
         "pkg-dir": "3.0.0",
         "please-upgrade-node": "3.1.1",
         "read-pkg": "4.0.1",
         "run-node": "1.0.0",
         "slash": "2.0.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
       }
     },
     "iconv-lite": {
@@ -6109,9 +5041,9 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "ignore-by-default": {
@@ -6165,21 +5097,21 @@
       "dev": true
     },
     "inquirer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
         "chalk": "2.4.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
+        "external-editor": "3.0.3",
         "figures": "2.0.0",
         "lodash": "4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rxjs": "5.5.11",
+        "rxjs": "6.3.2",
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
@@ -6191,26 +5123,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -6220,7 +5132,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6234,15 +5146,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
           }
         }
       }
@@ -6258,7 +5161,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "1.4.0"
       }
     },
     "ip": {
@@ -6267,9 +5170,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -6278,6 +5181,17 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -6292,7 +5206,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "1.12.0"
       }
     },
     "is-buffer": {
@@ -6303,26 +5217,20 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
     },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
-    },
     "is-ci": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
-      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.4.0"
+        "ci-info": "1.6.0"
       }
     },
     "is-data-descriptor": {
@@ -6332,13 +5240,18 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6419,6 +5332,25 @@
         "ps-node": "0.0.5"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6440,14 +5372,26 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -6471,11 +5415,22 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6492,31 +5447,6 @@
       "dev": true,
       "requires": {
         "symbol-observable": "1.2.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "dev": true
-        }
-      }
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
-      "dev": true,
-      "requires": {
-        "is-number": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
-          "dev": true
-        }
       }
     },
     "is-path-cwd": {
@@ -6556,14 +5486,6 @@
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "is-promise": {
@@ -6577,15 +5499,6 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.3"
-      }
     },
     "is-regexp": {
       "version": "1.0.0",
@@ -6609,12 +5522,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -6650,42 +5557,42 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-      "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.1.0.tgz",
-      "integrity": "sha512-3ly7GAJiPKqgbGKh2s01ysk3jd/egpE1i84PYu3BvPkssqrKMXZY9KRGX0mfZ+cmCfTR1IFVnnn/tDHxTer4nA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
+      "integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "istanbul-lib-coverage": "1.2.0",
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/traverse": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "istanbul-lib-coverage": "2.0.1",
         "semver": "5.5.1"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-          "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
           "dev": true,
           "requires": {
-            "@babel/highlight": "7.0.0-beta.49"
+            "@babel/highlight": "7.0.0-beta.51"
           }
         },
         "@babel/generator": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-          "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+          "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49",
+            "@babel/types": "7.0.0-beta.51",
             "jsesc": "2.5.1",
             "lodash": "4.17.11",
             "source-map": "0.5.7",
@@ -6693,38 +5600,38 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-          "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+          "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "7.0.0-beta.49",
-            "@babel/template": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/helper-get-function-arity": "7.0.0-beta.51",
+            "@babel/template": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-          "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+          "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/types": "7.0.0-beta.51"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-          "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+          "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.49"
+            "@babel/types": "7.0.0-beta.51"
           }
         },
         "@babel/highlight": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-          "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -6732,40 +5639,46 @@
             "js-tokens": "3.0.2"
           }
         },
+        "@babel/parser": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+          "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+          "dev": true
+        },
         "@babel/template": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-          "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+          "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.0.0-beta.49",
-            "@babel/parser": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49",
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
             "lodash": "4.17.11"
           }
         },
         "@babel/traverse": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-          "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+          "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.0.0-beta.49",
-            "@babel/generator": "7.0.0-beta.49",
-            "@babel/helper-function-name": "7.0.0-beta.49",
-            "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-            "@babel/parser": "7.0.0-beta.49",
-            "@babel/types": "7.0.0-beta.49",
-            "debug": "3.1.0",
-            "globals": "11.5.0",
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/helper-function-name": "7.0.0-beta.51",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "debug": "3.2.5",
+            "globals": "11.7.0",
             "invariant": "2.2.4",
             "lodash": "4.17.11"
           }
         },
         "@babel/types": {
-          "version": "7.0.0-beta.49",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-          "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+          "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
           "dev": true,
           "requires": {
             "esutils": "2.0.2",
@@ -6773,57 +5686,16 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        },
-        "globals": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
       }
@@ -6844,7 +5716,7 @@
       "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "jasmine-core": "3.1.0"
       }
     },
@@ -6878,37 +5750,15 @@
       "dev": true
     },
     "jest-validate": {
-      "version": "23.5.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
-      "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+      "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
         "jest-get-type": "22.4.3",
         "leven": "2.1.0",
-        "pretty-format": "23.5.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        }
+        "pretty-format": "23.6.0"
       }
     },
     "jmespath": {
@@ -6923,9 +5773,9 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -6935,13 +5785,13 @@
       "dev": true,
       "requires": {
         "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "esprima": "4.0.1"
       },
       "dependencies": {
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         }
       }
@@ -6968,7 +5818,7 @@
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.1",
+        "bluebird": "3.5.2",
         "catharsis": "0.8.9",
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
@@ -6979,23 +5829,6 @@
         "strip-json-comments": "2.0.1",
         "taffydb": "2.6.2",
         "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.19",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-          "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-          "dev": true
-        },
-        "klaw": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-          "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
       }
     },
     "jsdoc-babel": {
@@ -7005,15 +5838,7 @@
       "dev": true,
       "requires": {
         "jsdoc-regex": "1.0.1",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
+        "lodash": "4.17.11"
       }
     },
     "jsdoc-regex": {
@@ -7023,9 +5848,9 @@
       "dev": true
     },
     "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -7071,9 +5896,9 @@
       }
     },
     "jsonwebtoken": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
-      "integrity": "sha1-Mz7jmqjyOPMvpBaT56L7fkL4KzE=",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "requires": {
         "jws": "3.1.5",
         "lodash.includes": "4.3.0",
@@ -7083,15 +5908,7 @@
         "lodash.isplainobject": "4.0.6",
         "lodash.isstring": "4.0.1",
         "lodash.once": "4.1.1",
-        "ms": "2.1.1",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
-        }
+        "ms": "2.1.1"
       }
     },
     "jsprim": {
@@ -7131,18 +5948,15 @@
       "dev": true
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
@@ -7179,21 +5993,21 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.2.2.tgz",
-      "integrity": "sha512-BWT3kx242hq5oaKJ8QiazPeHwJnEXImvjmgZfjljMI5HX6RrTxI3cTJXywre6GNafMONCD/suFnEiFmC69Gscg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.3.0.tgz",
+      "integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
         "commander": "2.18.0",
         "cosmiconfig": "5.0.6",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "dedent": "0.7.0",
         "execa": "0.9.0",
         "find-parent-dir": "0.3.0",
         "is-glob": "4.0.0",
         "is-windows": "1.0.2",
-        "jest-validate": "23.5.0",
+        "jest-validate": "23.6.0",
         "listr": "0.14.2",
         "lodash": "4.17.11",
         "log-symbols": "2.2.0",
@@ -7208,41 +6022,6 @@
         "stringify-object": "3.2.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        },
-        "execa": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -7265,18 +6044,7 @@
         "listr-update-renderer": "0.4.0",
         "listr-verbose-renderer": "0.4.1",
         "p-map": "1.2.0",
-        "rxjs": "6.3.1"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.1.tgz",
-          "integrity": "sha512-hRVfb1Mcf8rLXq1AZEjYpzBnQbO7Duveu1APXkWRTvqzhmkoQ40Pl2F9Btacx+gJCOqsMiugCGG4I2HPQgJRtA==",
-          "dev": true,
-          "requires": {
-            "tslib": "1.9.3"
-          }
-        }
+        "rxjs": "6.3.2"
       }
     },
     "listr-silent-renderer": {
@@ -7301,6 +6069,25 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -7319,6 +6106,12 @@
           "requires": {
             "chalk": "1.1.3"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -7334,6 +6127,25 @@
         "figures": "1.7.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "cli-cursor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -7368,6 +6180,12 @@
             "exit-hook": "1.1.1",
             "onetime": "1.1.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -7536,28 +6354,6 @@
       "dev": true,
       "requires": {
         "chalk": "2.4.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        }
       }
     },
     "log-update": {
@@ -7604,12 +6400,12 @@
       }
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "4.0.0"
       }
     },
     "lowercase-keys": {
@@ -7647,21 +6443,36 @@
       "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.18.0.tgz",
       "integrity": "sha512-o0P6jjZlx5CQj12tvVgDTbgjTqVN0+5h6/6P1+3c6xmozVKBwniQ6Qt3MkCSF0+ueVTbobAfWyGpWRZMJu8t1g==",
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "debug": "3.1.0",
         "form-data": "2.3.2",
         "inflection": "1.12.0",
         "is-stream": "1.1.0",
         "path-proxy": "1.0.0",
         "promisify-call": "2.0.4",
-        "proxy-agent": "3.0.1",
+        "proxy-agent": "3.0.3",
         "tsscmp": "1.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha1-bWpJ7q1KrilsU7vzoaAIvWyJRps=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -7687,9 +6498,9 @@
       "dev": true
     },
     "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "map-visit": {
@@ -7765,37 +6576,29 @@
         "extglob": "2.0.4",
         "fragment-cache": "0.2.1",
         "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
+        "nanomatch": "1.2.13",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
         "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
       }
     },
     "mime": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha1-sWIcVNY7l8R9PP5/chX31kUXw2k="
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "1.36.0"
       }
     },
     "mimic-fn": {
@@ -7821,7 +6624,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -7847,7 +6650,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -7871,13 +6674,6 @@
         "require_optional": "1.0.1",
         "safe-buffer": "5.1.2",
         "saslprep": "1.0.2"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-          "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
-        }
       }
     },
     "mongodb-dbpath": {
@@ -7910,8 +6706,14 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "untildify": {
@@ -7931,12 +6733,12 @@
       "integrity": "sha1-46ilSPE+sg9aDN+GPLwGNCGjk0w=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "debug": "2.6.9",
         "lodash.defaults": "4.2.0",
         "minimist": "1.2.0",
         "mongodb-version-list": "1.0.0",
-        "request": "2.88.0",
+        "request": "2.85.0",
         "semver": "5.5.1"
       },
       "dependencies": {
@@ -7951,8 +6753,14 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -7963,9 +6771,9 @@
       "integrity": "sha512-MHisvAAo+gEhhHBMNnYWr8+r8s1n9wf83Mbrs21ftFOg/uqF96KIR1CJMdvuVKNZNGjcsaLxtpZRrVPqqq4JfA==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "clui": "0.3.6",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "fs-extra": "4.0.3",
         "is-mongodb-running": "0.0.1",
         "lodash.defaults": "4.2.0",
@@ -7976,20 +6784,57 @@
         "mongodb-tools": "github:mongodb-js/mongodb-tools#df761df21175f2c521c78b8e011a1532569f0dca",
         "mongodb-version-manager": "1.1.3",
         "untildify": "3.0.3",
-        "which": "1.3.0"
+        "which": "1.3.1"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "mongodb-tools": {
+      "version": "github:mongodb-js/mongodb-tools#df761df21175f2c521c78b8e011a1532569f0dca",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "lodash": "3.10.1",
+        "mkdirp": "0.5.0",
+        "mongodb-core": "2.1.20",
+        "rimraf": "2.2.6"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "mongodb-core": {
           "version": "2.1.20",
@@ -8001,42 +6846,11 @@
             "require_optional": "1.0.1"
           }
         },
-        "mongodb-tools": {
-          "version": "github:mongodb-js/mongodb-tools#df761df21175f2c521c78b8e011a1532569f0dca",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "lodash": "3.10.1",
-            "mkdirp": "0.5.0",
-            "mongodb-core": "2.1.20",
-            "rimraf": "2.2.6"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "0.5.0",
-              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-              "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
-          }
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "rimraf": {
           "version": "2.2.6",
@@ -8082,8 +6896,17 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
@@ -8091,8 +6914,14 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -8104,9 +6933,9 @@
       "dev": true,
       "requires": {
         "ampersand-state": "5.0.3",
-        "async": "2.6.0",
+        "async": "2.6.1",
         "chalk": "2.4.1",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "docopt": "0.6.2",
         "download": "6.2.5",
         "figures": "2.0.0",
@@ -8119,34 +6948,12 @@
         "semver": "5.5.1",
         "tildify": "1.2.0",
         "untildify": "3.0.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -8155,16 +6962,15 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "optional": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -8172,33 +6978,12 @@
         "define-property": "2.0.2",
         "extend-shallow": "3.0.2",
         "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
         "is-windows": "1.0.2",
         "kind-of": "6.0.2",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
         "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-          "dev": true
-        }
       }
     },
     "natural-compare": {
@@ -8224,15 +7009,15 @@
       "dev": true
     },
     "nice-try": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "node-forge": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-releases": {
       "version": "1.0.0-alpha.11",
@@ -8250,367 +7035,15 @@
       "dev": true,
       "requires": {
         "chokidar": "2.0.4",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "ignore-by-default": "1.0.1",
         "minimatch": "3.0.4",
         "pstree.remy": "1.1.0",
         "semver": "5.5.1",
-        "supports-color": "5.4.0",
+        "supports-color": "5.5.0",
         "touch": "3.1.0",
         "undefsafe": "2.0.2",
         "update-notifier": "2.5.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
-          }
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "chokidar": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-          "dev": true,
-          "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.2",
-            "fsevents": "1.2.3",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "lodash.debounce": "4.0.8",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0",
-            "upath": "1.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "2.1.1"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          }
-        }
       }
     },
     "nopt": {
@@ -8649,7 +7082,7 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.11",
+        "config-chain": "1.1.12",
         "pify": "3.0.0"
       },
       "dependencies": {
@@ -8667,7 +7100,7 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "npm-run-path": {
@@ -8687,7 +7120,7 @@
       "requires": {
         "commander": "2.18.0",
         "npm-path": "2.0.4",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "npmlog": {
@@ -8695,7 +7128,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
+        "are-we-there-yet": "1.1.5",
         "console-control-strings": "1.1.0",
         "gauge": "2.7.4",
         "set-blocking": "2.0.0"
@@ -8733,7 +7166,7 @@
         "glob": "7.1.2",
         "istanbul-lib-coverage": "1.2.0",
         "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "2.1.0",
+        "istanbul-lib-instrument": "2.3.2",
         "istanbul-lib-report": "1.1.3",
         "istanbul-lib-source-maps": "1.2.5",
         "istanbul-reports": "1.4.1",
@@ -8752,8 +7185,7 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2",
@@ -8763,20 +7195,17 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
@@ -8784,68 +7213,57 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "bundled": true,
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-          "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+          "bundled": true,
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+          "bundled": true,
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "bundled": true,
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+          "bundled": true,
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "bundled": true,
           "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-          "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-          "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cache-base": "1.0.1",
@@ -8859,8 +7277,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
@@ -8868,8 +7285,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -8877,8 +7293,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -8886,8 +7301,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
@@ -8897,16 +7311,14 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -8915,8 +7327,7 @@
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-flatten": "1.1.0",
@@ -8933,8 +7344,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -8944,14 +7354,12 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "bundled": true,
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-          "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "collection-visit": "1.0.0",
@@ -8967,8 +7375,7 @@
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
@@ -8978,15 +7385,13 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -8996,8 +7401,7 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-          "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-union": "3.1.0",
@@ -9008,8 +7412,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -9019,8 +7422,7 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -9031,8 +7433,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -9040,14 +7441,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-visit": "1.0.0",
@@ -9056,38 +7455,32 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "bundled": true,
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "bundled": true,
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "4.1.3",
@@ -9096,8 +7489,7 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -9105,26 +7497,22 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
@@ -9132,8 +7520,7 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-          "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-descriptor": "1.0.2",
@@ -9142,8 +7529,7 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -9151,8 +7537,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -9160,8 +7545,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
@@ -9171,16 +7555,14 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -9188,8 +7570,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
@@ -9203,8 +7584,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "lru-cache": "4.1.3",
@@ -9216,8 +7596,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debug": "2.6.9",
@@ -9231,8 +7610,7 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -9240,8 +7618,7 @@
             },
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -9249,8 +7626,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -9260,8 +7636,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assign-symbols": "1.0.0",
@@ -9270,8 +7645,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-plain-object": "2.0.4"
@@ -9281,8 +7655,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "array-unique": "0.3.2",
@@ -9297,8 +7670,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
@@ -9306,8 +7678,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -9315,8 +7686,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -9324,8 +7694,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -9333,8 +7702,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
@@ -9344,16 +7712,14 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
@@ -9364,8 +7730,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -9375,8 +7740,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -9386,8 +7750,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "2.0.0"
@@ -9395,14 +7758,12 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "bundled": true,
           "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -9411,8 +7772,7 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "map-cache": "0.2.2"
@@ -9420,32 +7780,27 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "bundled": true,
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+          "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -9458,14 +7813,12 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "async": "1.5.2",
@@ -9476,8 +7829,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -9487,8 +7839,7 @@
         },
         "has-value": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "get-value": "2.0.6",
@@ -9498,8 +7849,7 @@
         },
         "has-values": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -9508,8 +7858,7 @@
           "dependencies": {
             "kind-of": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
@@ -9519,20 +7868,17 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-          "integrity": "sha1-IyNbKasjDFdqqw1PE/wEawsDgiI=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -9541,20 +7887,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -9562,20 +7905,17 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "bundled": true,
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
@@ -9583,8 +7923,7 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -9592,8 +7931,7 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "0.1.6",
@@ -9603,28 +7941,24 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "bundled": true,
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "bundled": true,
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -9632,8 +7966,7 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-          "integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "4.0.0"
@@ -9641,16 +7974,14 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-              "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
@@ -9658,50 +7989,42 @@
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "bundled": true,
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-          "integrity": "sha1-99jy5CuX43/nlhFMsPnWi146Q0E=",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-          "integrity": "sha1-hTjZcDcss3FtU+VVI91UtVeo2Js=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "append-transform": "0.4.0"
@@ -9709,8 +8032,7 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
-          "integrity": "sha1-LfEhiMD6d5kMDSF20tC6M5QYglk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.2.0",
@@ -9721,14 +8043,12 @@
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
@@ -9738,8 +8058,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-          "integrity": "sha1-/+a+Tnq4bTYD5CkNVJkLFFBvybE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debug": "3.1.0",
@@ -9751,8 +8070,7 @@
         },
         "istanbul-reports": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.1.tgz",
-          "integrity": "sha1-Ty6OkoqnoF0dpsQn1AmLJlXsczQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "handlebars": "4.0.11"
@@ -9760,8 +8078,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
@@ -9769,15 +8086,13 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
@@ -9785,8 +8100,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -9798,8 +8112,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "2.0.0",
@@ -9808,22 +8121,19 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "bundled": true,
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -9832,14 +8142,12 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+          "bundled": true,
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-visit": "1.0.1"
@@ -9847,8 +8155,7 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -9856,14 +8163,12 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "bundled": true,
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "1.2.0"
@@ -9871,8 +8176,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-          "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "source-map": "0.6.1"
@@ -9880,16 +8184,14 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -9909,22 +8211,19 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -9932,14 +8231,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-          "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-in": "1.0.2",
@@ -9948,8 +8245,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-              "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-plain-object": "2.0.4"
@@ -9959,8 +8255,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -9968,14 +8263,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-          "integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -9994,16 +8287,14 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "2.6.0",
@@ -10014,8 +8305,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -10023,20 +8313,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "copy-descriptor": "0.1.1",
@@ -10046,8 +8333,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -10057,8 +8343,7 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
@@ -10066,8 +8351,7 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
@@ -10075,8 +8359,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -10084,8 +8367,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8",
@@ -10094,14 +8376,12 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -10111,14 +8391,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-          "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "1.0.0"
@@ -10126,8 +8404,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "1.2.0"
@@ -10135,14 +8412,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "bundled": true,
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "error-ex": "1.3.1"
@@ -10150,14 +8425,12 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+          "bundled": true,
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
@@ -10165,26 +8438,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -10194,20 +8463,17 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie": "2.0.4"
@@ -10215,8 +8481,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2"
@@ -10224,8 +8489,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -10236,20 +8500,17 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
@@ -10259,8 +8520,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2",
@@ -10269,8 +8529,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -10281,8 +8540,7 @@
         },
         "regex-not": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-          "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "3.0.2",
@@ -10291,50 +8549,42 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "bundled": true,
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "bundled": true,
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "bundled": true,
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+          "bundled": true,
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-          "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+          "bundled": true,
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10343,8 +8593,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -10352,8 +8601,7 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ret": "0.1.15"
@@ -10361,20 +8609,17 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-          "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
@@ -10385,8 +8630,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -10396,8 +8640,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
@@ -10405,26 +8648,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-          "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "base": "0.11.2",
@@ -10439,8 +8678,7 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -10448,8 +8686,7 @@
             },
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -10457,8 +8694,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -10468,8 +8704,7 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-          "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "1.0.0",
@@ -10479,8 +8714,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
@@ -10488,8 +8722,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-              "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -10497,8 +8730,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-              "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "kind-of": "6.0.2"
@@ -10506,8 +8738,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-              "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "1.0.0",
@@ -10517,16 +8748,14 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-          "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -10534,14 +8763,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "bundled": true,
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-          "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "atob": "2.1.1",
@@ -10553,14 +8780,12 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-          "integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -10573,8 +8798,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-          "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "3.0.0",
@@ -10583,14 +8807,12 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-          "integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
+          "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-exceptions": "2.1.0",
@@ -10599,14 +8821,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-          "integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc=",
+          "bundled": true,
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-          "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "extend-shallow": "3.0.2"
@@ -10614,8 +8834,7 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "0.2.5",
@@ -10624,8 +8843,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
@@ -10635,8 +8853,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -10645,8 +8862,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
@@ -10654,8 +8870,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
@@ -10663,14 +8878,12 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-          "integrity": "sha1-36Ii8DSAvKaSB8pyizfXS0X3JPo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -10682,8 +8895,7 @@
         },
         "to-object-path": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -10691,8 +8903,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-          "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "define-property": "2.0.2",
@@ -10703,8 +8914,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -10713,8 +8923,7 @@
         },
         "uglify-js": {
           "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10725,8 +8934,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -10740,15 +8948,13 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-union": "3.1.0",
@@ -10759,8 +8965,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
@@ -10768,8 +8973,7 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "extend-shallow": "2.0.1",
@@ -10782,8 +8986,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "has-value": "0.3.1",
@@ -10792,8 +8995,7 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "get-value": "2.0.6",
@@ -10803,8 +9005,7 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
@@ -10814,22 +9015,19 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+          "bundled": true,
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-          "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "6.0.2"
@@ -10837,16 +9035,14 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-          "integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "3.0.0",
@@ -10855,8 +9051,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -10864,27 +9059,23 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -10893,14 +9084,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -10908,8 +9097,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -10919,8 +9107,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -10930,14 +9117,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -10947,20 +9132,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "4.1.0",
@@ -10979,14 +9161,12 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-              "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "2.1.1",
@@ -10996,8 +9176,7 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
@@ -11007,8 +9186,7 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
@@ -11016,8 +9194,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             }
           }
@@ -11053,14 +9230,17 @@
           "requires": {
             "is-descriptor": "0.1.6"
           }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
         }
       }
-    },
-    "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -11069,14 +9249,6 @@
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "object.pick": {
@@ -11086,14 +9258,6 @@
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
       }
     },
     "on-finished": {
@@ -11225,29 +9389,18 @@
       "dev": true
     },
     "pac-proxy-agent": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
-      "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==",
       "requires": {
         "agent-base": "4.2.1",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "get-uri": "2.0.2",
         "http-proxy-agent": "2.1.0",
         "https-proxy-agent": "2.2.1",
         "pac-resolver": "3.0.0",
         "raw-body": "2.3.3",
-        "socks-proxy-agent": "3.0.1"
-      },
-      "dependencies": {
-        "socks-proxy-agent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
-          "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
-          "requires": {
-            "agent-base": "4.2.1",
-            "socks": "1.1.10"
-          }
-        }
+        "socks-proxy-agent": "4.0.1"
       }
     },
     "pac-resolver": {
@@ -11276,7 +9429,7 @@
       "dependencies": {
         "got": {
           "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -11406,7 +9559,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -11476,7 +9629,7 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
       "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
       "requires": {
-        "postgres-array": "1.0.2",
+        "postgres-array": "1.0.3",
         "postgres-bytea": "1.0.0",
         "postgres-date": "1.0.3",
         "postgres-interval": "1.1.2"
@@ -11542,9 +9695,9 @@
       "dev": true
     },
     "postgres-array": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
-      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
+      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -11582,9 +9735,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "23.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
-      "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -11596,15 +9749,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
         }
       }
     },
@@ -11640,25 +9784,25 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.6.0"
+        "ipaddr.js": "1.8.0"
       }
     },
     "proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-mAZexaz9ZxQhYPWfAjzlrloEjW+JHiBFryE4AJXFDTnaXfmH/FKqC1swTRKuEPbHWz02flQNXFOyDUF7zfEG6A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.0.3.tgz",
+      "integrity": "sha512-PXVVVuH9tiQuxQltFJVSnXWuDtNr+8aNBP6XVDDCDiUuDN8eRCm+ii4/mFWmXWEA0w8jjJSlePa4LXlM4jIzNA==",
       "requires": {
         "agent-base": "4.2.1",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "http-proxy-agent": "2.1.0",
         "https-proxy-agent": "2.2.1",
         "lru-cache": "4.1.3",
-        "pac-proxy-agent": "2.0.2",
+        "pac-proxy-agent": "3.0.0",
         "proxy-from-env": "1.0.0",
         "socks-proxy-agent": "4.0.1"
       }
@@ -11683,19 +9827,13 @@
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
-        "event-stream": "3.3.4"
+        "event-stream": "3.3.6"
       }
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -11751,7 +9889,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -11778,7 +9916,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
@@ -11791,15 +9929,14 @@
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.6"
       }
     },
     "redis": {
@@ -11861,19 +9998,10 @@
         "safe-regex": "1.1.0"
       }
     },
-    "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2"
-      }
-    },
     "regexpp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
+      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
       "dev": true
     },
     "regexpu-core": {
@@ -11922,6 +10050,14 @@
       "dev": true,
       "requires": {
         "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -11931,9 +10067,9 @@
       "dev": true
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
       "dev": true
     },
     "repeat-string": {
@@ -11943,107 +10079,32 @@
       "dev": true
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
+      "version": "2.85.0",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.8.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "1.0.7",
         "extend": "3.0.2",
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
-        "har-validator": "5.1.0",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.19",
-        "oauth-sign": "0.9.0",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.2",
         "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
+        "stringstream": "0.0.6",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.35.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.19",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.35.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
-        }
-      }
-    },
-    "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.11"
       }
     },
     "require-uncached": {
@@ -12132,7 +10193,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.3"
       }
     },
     "run-async": {
@@ -12151,12 +10212,12 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -12189,7 +10250,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "seek-bzip": {
@@ -12203,7 +10264,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -12265,6 +10326,11 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -12287,12 +10353,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
     },
     "set-value": {
       "version": "2.0.0",
@@ -12366,9 +10426,9 @@
       }
     },
     "smart-buffer": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
+      "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -12382,8 +10442,8 @@
         "extend-shallow": "2.0.1",
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "3.1.0"
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -12412,6 +10472,12 @@
           "requires": {
             "is-extendable": "0.1.1"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -12469,18 +10535,6 @@
             "is-data-descriptor": "1.0.0",
             "kind-of": "6.0.2"
           }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -12491,6 +10545,17 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "sntp": {
@@ -12502,12 +10567,12 @@
       }
     },
     "socks": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
-      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz",
+      "integrity": "sha512-0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==",
       "requires": {
         "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "smart-buffer": "4.0.1"
       }
     },
     "socks-proxy-agent": {
@@ -12517,22 +10582,6 @@
       "requires": {
         "agent-base": "4.2.1",
         "socks": "2.2.1"
-      },
-      "dependencies": {
-        "smart-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
-          "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
-        },
-        "socks": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz",
-          "integrity": "sha512-0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==",
-          "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "4.0.1"
-          }
-        }
       }
     },
     "sort-keys": {
@@ -12560,12 +10609,12 @@
       "optional": true
     },
     "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha1-etD1k/IoFZjoVN+A8ZquS5LXoRo=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
+        "atob": "2.1.2",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -12594,7 +10643,7 @@
       "dev": true,
       "requires": {
         "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-exceptions": {
@@ -12610,13 +10659,13 @@
       "dev": true,
       "requires": {
         "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
     "spex": {
@@ -12700,19 +10749,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
-    },
     "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "version": "0.2.2",
+      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "0.1.1",
+        "through": "2.3.8"
       }
     },
     "string-argv": {
@@ -12729,19 +10773,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string.prototype.matchall": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
-      "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "regexp.prototype.flags": "1.2.0"
       }
     },
     "string_decoder": {
@@ -12807,27 +10838,27 @@
       }
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
         "has-flag": "3.0.0"
       }
     },
     "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.1",
+        "ajv": "6.5.4",
         "ajv-keywords": "3.2.0",
         "chalk": "2.4.1",
         "lodash": "4.17.11",
@@ -12836,9 +10867,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "2.0.1",
@@ -12852,26 +10883,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
         },
         "fast-deep-equal": {
           "version": "2.0.1",
@@ -12894,7 +10905,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -12908,15 +10919,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
           }
         }
       }
@@ -12938,9 +10940,9 @@
       "dev": true
     },
     "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
         "bl": "1.2.2",
@@ -12961,6 +10963,17 @@
         "execa": "0.7.0"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
         "execa": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -12986,7 +10999,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -13007,7 +11020,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -13070,6 +11083,12 @@
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -13077,6 +11096,17 @@
       "dev": true,
       "requires": {
         "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "to-regex": {
@@ -13099,17 +11129,6 @@
       "requires": {
         "is-number": "3.0.0",
         "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        }
       }
     },
     "touch": {
@@ -13193,7 +11212,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "2.1.20"
       }
     },
     "ultron": {
@@ -13202,9 +11221,9 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unbzip2-stream": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-      "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.0.tgz",
+      "integrity": "sha512-kE2WkurNnPUMcryNioS68DDbhoPB8Qxsd8btHSj+sd5Pjh2GsjmeHLzMSqV9HHziAo8FzVxVCJl9ZYhk7yY1pA==",
       "dev": true,
       "requires": {
         "buffer": "3.6.0",
@@ -13219,7 +11238,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "dev": true,
           "requires": {
@@ -13247,6 +11266,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -13393,12 +11418,6 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
         }
       }
     },
@@ -13430,34 +11449,12 @@
         "chalk": "2.4.1",
         "configstore": "3.1.2",
         "import-lazy": "2.1.0",
-        "is-ci": "1.2.0",
+        "is-ci": "1.2.1",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        }
       }
     },
     "uri-js": {
@@ -13515,21 +11512,10 @@
       "dev": true
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
-      "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-          "dev": true
-        }
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "user-home": {
       "version": "1.1.1",
@@ -13548,9 +11534,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "uws": {
       "version": "10.148.1",
@@ -13584,18 +11570,18 @@
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "1.0.2"
       }
@@ -13644,8 +11630,8 @@
     },
     "winston": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
-      "integrity": "sha1-o6kmUQVWQmPGeFtFg7jIrKJv3tY=",
+      "resolved": "http://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",
@@ -13721,21 +11707,18 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "4.17.11"
-      }
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlcreate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,6 @@
     "nodemon": "1.18.4",
     "nyc": "^12.0.2",
     "prettier": "1.14.3",
-    "request": "2.88.0",
-    "request-promise": "4.2.2",
     "supports-color": "^5.4.0"
   },
   "scripts": {

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 const Parse = require('parse/node');
-const rp = require('request-promise');
+const request = require('../lib/request');
 const InMemoryCacheAdapter = require('../lib/Adapters/Cache/InMemoryCacheAdapter')
   .InMemoryCacheAdapter;
 
@@ -880,26 +880,23 @@ describe('Cloud Code', () => {
       })
       .then(user => {
         session1 = user.getSessionToken();
-        return rp({
-          uri: 'http://localhost:8378/1/login?username=test&password=moon-y',
-          json: true,
+        return request({
+          url: 'http://localhost:8378/1/login?username=test&password=moon-y',
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'rest',
           },
         });
       })
-      .then(body => {
-        session2 = body.sessionToken;
-
+      .then(response => {
+        session2 = response.data.sessionToken;
         //Ensure both session tokens are in the cache
-        return Parse.Cloud.run('checkStaleUser');
+        return Parse.Cloud.run('checkStaleUser', { sessionToken: session2 });
       })
       .then(() =>
-        rp({
+        request({
           method: 'POST',
-          uri: 'http://localhost:8378/1/functions/checkStaleUser',
-          json: true,
+          url: 'http://localhost:8378/1/functions/checkStaleUser',
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'rest',
@@ -922,10 +919,9 @@ describe('Cloud Code', () => {
         return user.save();
       })
       .then(() =>
-        rp({
+        request({
           method: 'POST',
-          uri: 'http://localhost:8378/1/functions/checkStaleUser',
-          json: true,
+          url: 'http://localhost:8378/1/functions/checkStaleUser',
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'rest',
@@ -933,11 +929,11 @@ describe('Cloud Code', () => {
           },
         })
       )
-      .then(body => {
-        expect(body.result).toEqual('second data');
+      .then(response => {
+        expect(response.data.result).toEqual('second data');
         done();
       })
-      .catch(done.fail);
+      .catch(e => done.fail(e));
   });
 
   it('trivial beforeSave should not affect fetched pointers (regression test for #1238)', done => {
@@ -1196,7 +1192,8 @@ describe('Cloud Code', () => {
         Parse.Cloud.job('myJob', () => {});
       }).not.toThrow();
 
-      rp.post({
+      request({
+        method: 'POST',
         url: 'http://localhost:8378/1/jobs/myJob',
         headers: {
           'X-Parse-Application-Id': Parse.applicationId,
@@ -1218,7 +1215,8 @@ describe('Cloud Code', () => {
         Parse.Cloud.job('myJob', () => {});
       }).not.toThrow();
 
-      rp.post({
+      request({
+        method: 'POST',
         url: 'http://localhost:8378/1/jobs/myJob',
         headers: {
           'X-Parse-Application-Id': Parse.applicationId,
@@ -1230,7 +1228,7 @@ describe('Cloud Code', () => {
           done();
         },
         err => {
-          expect(err.statusCode).toBe(403);
+          expect(err.status).toBe(403);
           done();
         }
       );
@@ -1248,7 +1246,8 @@ describe('Cloud Code', () => {
         });
       }).not.toThrow();
 
-      rp.post({
+      request({
+        method: 'POST',
         url: 'http://localhost:8378/1/jobs/myJob',
         headers: {
           'X-Parse-Application-Id': Parse.applicationId,
@@ -1275,7 +1274,8 @@ describe('Cloud Code', () => {
         });
       }).not.toThrow();
 
-      rp.post({
+      request({
+        method: 'POST',
         url: `http://${Parse.applicationId}:${
           Parse.masterKey
         }@localhost:8378/1/jobs/myJob`,
@@ -1317,7 +1317,8 @@ describe('Cloud Code', () => {
         return promise;
       });
 
-      rp.post({
+      request({
+        method: 'POST',
         url: 'http://localhost:8378/1/jobs/myJob',
         headers: {
           'X-Parse-Application-Id': Parse.applicationId,
@@ -1351,7 +1352,8 @@ describe('Cloud Code', () => {
         return promise;
       });
 
-      rp.post({
+      request({
+        method: 'POST',
         url: 'http://localhost:8378/1/jobs/myJob',
         headers: {
           'X-Parse-Application-Id': Parse.applicationId,
@@ -1580,7 +1582,7 @@ describe('beforeFind hooks', () => {
       return Parse.Query.or(req.query, otherQuery);
     });
 
-    rp.get({
+    request({
       url: 'http://localhost:8378/1/classes/MyObject',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
@@ -1639,15 +1641,16 @@ describe('beforeFind hooks', () => {
     const obj = new Parse.Object('MyObject');
     obj.set('secretField', 'SSID');
     obj.save().then(function() {
-      rp({
+      request({
         method: 'GET',
-        uri: 'http://localhost:8378/1/classes/MyObject/' + obj.id,
+        url: 'http://localhost:8378/1/classes/MyObject/' + obj.id,
         headers: {
           'X-Parse-Application-Id': 'test',
           'X-Parse-REST-API-Key': 'rest',
         },
         json: true,
-      }).then(body => {
+      }).then(response => {
+        const body = response.data;
         expect(body.secretField).toEqual('SSID');
         expect(hook.method).toHaveBeenCalled();
         done();

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const request = require('request');
-const requestp = require('request-promise');
 const Config = require('../lib/Config');
+const request = require('../lib/request');
 
 describe('Email Verification Token Expiration: ', () => {
   it('show the invalid verification link page, if the user clicks on the verify email link after the email verify token expires', done => {
@@ -32,20 +31,18 @@ describe('Email Verification Token Expiration: ', () => {
         // wait for 1 second - simulate user behavior to some extent
         setTimeout(() => {
           expect(sendEmailOptions).not.toBeUndefined();
+          console.log(sendEmailOptions.link);
 
-          request.get(
-            sendEmailOptions.link,
-            {
-              followRedirect: false,
-            },
-            (error, response) => {
-              expect(response.statusCode).toEqual(302);
-              expect(response.body).toEqual(
-                'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=testEmailVerifyTokenValidity&appId=test'
-              );
-              done();
-            }
-          );
+          request({
+            url: sendEmailOptions.link,
+            followRedirects: false,
+          }).then(response => {
+            expect(response.status).toEqual(302);
+            expect(response.text).toEqual(
+              'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=testEmailVerifyTokenValidity&appId=test'
+            );
+            done();
+          });
         }, 1000);
       })
       .catch(err => {
@@ -82,25 +79,22 @@ describe('Email Verification Token Expiration: ', () => {
         setTimeout(() => {
           expect(sendEmailOptions).not.toBeUndefined();
 
-          request.get(
-            sendEmailOptions.link,
-            {
-              followRedirect: false,
-            },
-            (error, response) => {
-              expect(response.statusCode).toEqual(302);
-              user
-                .fetch()
-                .then(() => {
-                  expect(user.get('emailVerified')).toEqual(false);
-                  done();
-                })
-                .catch(() => {
-                  jfail(error);
-                  done();
-                });
-            }
-          );
+          request({
+            url: sendEmailOptions.link,
+            followRedirects: false,
+          }).then(response => {
+            expect(response.status).toEqual(302);
+            user
+              .fetch()
+              .then(() => {
+                expect(user.get('emailVerified')).toEqual(false);
+                done();
+              })
+              .catch(error => {
+                jfail(error);
+                done();
+              });
+          });
         }, 1000);
       })
       .catch(error => {
@@ -133,19 +127,16 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
-              'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=testEmailVerifyTokenValidity'
-            );
-            done();
-          }
-        );
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          expect(response.text).toEqual(
+            'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=testEmailVerifyTokenValidity'
+          );
+          done();
+        });
       })
       .catch(error => {
         jfail(error);
@@ -177,25 +168,22 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            user
-              .fetch()
-              .then(() => {
-                expect(user.get('emailVerified')).toEqual(true);
-                done();
-              })
-              .catch(error => {
-                jfail(error);
-                done();
-              });
-          }
-        );
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          user
+            .fetch()
+            .then(() => {
+              expect(user.get('emailVerified')).toEqual(true);
+              done();
+            })
+            .catch(error => {
+              jfail(error);
+              done();
+            });
+        });
       })
       .catch(error => {
         jfail(error);
@@ -227,25 +215,22 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            Parse.User.logIn('testEmailVerifyTokenValidity', 'expiringToken')
-              .then(user => {
-                expect(typeof user).toBe('object');
-                expect(user.get('emailVerified')).toBe(true);
-                done();
-              })
-              .catch(error => {
-                jfail(error);
-                done();
-              });
-          }
-        );
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          Parse.User.logIn('testEmailVerifyTokenValidity', 'expiringToken')
+            .then(user => {
+              expect(typeof user).toBe('object');
+              expect(user.get('emailVerified')).toBe(true);
+              done();
+            })
+            .catch(error => {
+              jfail(error);
+              done();
+            });
+        });
       })
       .catch(error => {
         jfail(error);
@@ -322,37 +307,34 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            const config = Config.get('test');
-            return config.database
-              .find('_User', {
-                username: 'unsets_email_verify_token_expires_at',
-              })
-              .then(results => {
-                expect(results.length).toBe(1);
-                return results[0];
-              })
-              .then(user => {
-                expect(typeof user).toBe('object');
-                expect(user.emailVerified).toEqual(true);
-                expect(typeof user._email_verify_token).toBe('undefined');
-                expect(typeof user._email_verify_token_expires_at).toBe(
-                  'undefined'
-                );
-                done();
-              })
-              .catch(error => {
-                jfail(error);
-                done();
-              });
-          }
-        );
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          const config = Config.get('test');
+          return config.database
+            .find('_User', {
+              username: 'unsets_email_verify_token_expires_at',
+            })
+            .then(results => {
+              expect(results.length).toBe(1);
+              return results[0];
+            })
+            .then(user => {
+              expect(typeof user).toBe('object');
+              expect(user.emailVerified).toEqual(true);
+              expect(typeof user._email_verify_token).toBe('undefined');
+              expect(typeof user._email_verify_token_expires_at).toBe(
+                'undefined'
+              );
+              done();
+            })
+            .catch(error => {
+              jfail(error);
+              done();
+            });
+        });
       })
       .catch(error => {
         jfail(error);
@@ -386,14 +368,12 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        return new Promise((resolve, reject) => {
-          request
-            .get(sendEmailOptions.link, { followRedirect: false })
-            .on('error', error => reject(error))
-            .on('response', response => {
-              expect(response.statusCode).toEqual(302);
-              resolve(user.fetch());
-            });
+        return request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          return user.fetch();
         });
       })
       .then(() => {
@@ -403,19 +383,16 @@ describe('Email Verification Token Expiration: ', () => {
         return reconfigureServer(serverConfig);
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
-              'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=testEmailVerifyTokenValidity'
-            );
-            done();
-          }
-        );
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          expect(response.text).toEqual(
+            'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=testEmailVerifyTokenValidity'
+          );
+          done();
+        });
       })
       .catch(error => {
         jfail(error);
@@ -459,19 +436,16 @@ describe('Email Verification Token Expiration: ', () => {
         return reconfigureServer(serverConfig);
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
-              'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=testEmailVerifyTokenValidity&appId=test'
-            );
-            done();
-          }
-        );
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          expect(response.text).toEqual(
+            'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=testEmailVerifyTokenValidity&appId=test'
+          );
+          done();
+        });
       })
       .catch(error => {
         jfail(error);
@@ -590,22 +564,21 @@ describe('Email Verification Token Expiration: ', () => {
 
         expect(sendVerificationEmailCallCount).toBe(1);
 
-        return requestp.post({
-          uri: 'http://localhost:8378/1/verificationEmailRequest',
+        return request({
+          url: 'http://localhost:8378/1/verificationEmailRequest',
+          method: 'POST',
           body: {
             email: 'user@parse.com',
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
           },
-          json: true,
-          resolveWithFullResponse: true,
-          simple: false, // this promise is only rejected if the call itself failed
         });
       })
       .then(response => {
-        expect(response.statusCode).toBe(200);
+        expect(response.status).toBe(200);
         expect(sendVerificationEmailCallCount).toBe(2);
         expect(sendEmailOptions).toBeDefined();
 
@@ -660,36 +633,31 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        return requestp
-          .get({
-            url: sendEmailOptions.link,
-            followRedirect: false,
-            resolveWithFullResponse: true,
-            simple: false,
-          })
-          .then(response => {
-            expect(response.statusCode).toEqual(302);
-          });
+        return request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+        });
       })
       .then(() => {
         expect(sendVerificationEmailCallCount).toBe(1);
 
-        return requestp
-          .post({
-            uri: 'http://localhost:8378/1/verificationEmailRequest',
-            body: {
-              email: 'user@parse.com',
-            },
-            headers: {
-              'X-Parse-Application-Id': Parse.applicationId,
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            json: true,
-            resolveWithFullResponse: true,
-            simple: false, // this promise is only rejected if the call itself failed
-          })
+        return request({
+          url: 'http://localhost:8378/1/verificationEmailRequest',
+          method: 'POST',
+          body: {
+            email: 'user@parse.com',
+          },
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
+          },
+        })
+          .then(fail, res => res)
           .then(response => {
-            expect(response.statusCode).toBe(400);
+            expect(response.status).toBe(400);
             expect(sendVerificationEmailCallCount).toBe(1);
             done();
           });
@@ -719,22 +687,22 @@ describe('Email Verification Token Expiration: ', () => {
       publicServerURL: 'http://localhost:8378/1',
     })
       .then(() => {
-        return requestp
-          .post({
-            uri: 'http://localhost:8378/1/verificationEmailRequest',
-            body: {
-              email: 'user@parse.com',
-            },
-            headers: {
-              'X-Parse-Application-Id': Parse.applicationId,
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            json: true,
-            resolveWithFullResponse: true,
-            simple: false,
-          })
+        return request({
+          url: 'http://localhost:8378/1/verificationEmailRequest',
+          method: 'POST',
+          body: {
+            email: 'user@parse.com',
+          },
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
+          },
+        })
+          .then(fail)
+          .catch(response => response)
           .then(response => {
-            expect(response.statusCode).toBe(400);
+            expect(response.status).toBe(400);
             expect(sendVerificationEmailCallCount).toBe(0);
             expect(sendEmailOptions).not.toBeDefined();
             done();
@@ -765,27 +733,25 @@ describe('Email Verification Token Expiration: ', () => {
       publicServerURL: 'http://localhost:8378/1',
     })
       .then(() => {
-        request.post(
-          {
-            uri: 'http://localhost:8378/1/verificationEmailRequest',
-            body: {},
-            headers: {
-              'X-Parse-Application-Id': Parse.applicationId,
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            json: true,
-            resolveWithFullResponse: true,
-            simple: false,
+        request({
+          url: 'http://localhost:8378/1/verificationEmailRequest',
+          method: 'POST',
+          body: {},
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
           },
-          (err, response) => {
-            expect(response.statusCode).toBe(400);
-            expect(response.body.code).toBe(Parse.Error.EMAIL_MISSING);
-            expect(response.body.error).toBe('you must provide an email');
+        })
+          .then(fail, response => response)
+          .then(response => {
+            expect(response.status).toBe(400);
+            expect(response.data.code).toBe(Parse.Error.EMAIL_MISSING);
+            expect(response.data.error).toBe('you must provide an email');
             expect(sendVerificationEmailCallCount).toBe(0);
             expect(sendEmailOptions).not.toBeDefined();
             done();
-          }
-        );
+          });
       })
       .catch(error => {
         jfail(error);
@@ -812,29 +778,27 @@ describe('Email Verification Token Expiration: ', () => {
       publicServerURL: 'http://localhost:8378/1',
     })
       .then(() => {
-        request.post(
-          {
-            uri: 'http://localhost:8378/1/verificationEmailRequest',
-            body: { email: 3 },
-            headers: {
-              'X-Parse-Application-Id': Parse.applicationId,
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            json: true,
-            resolveWithFullResponse: true,
-            simple: false,
+        request({
+          url: 'http://localhost:8378/1/verificationEmailRequest',
+          method: 'POST',
+          body: { email: 3 },
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
           },
-          (err, response) => {
-            expect(response.statusCode).toBe(400);
-            expect(response.body.code).toBe(Parse.Error.INVALID_EMAIL_ADDRESS);
-            expect(response.body.error).toBe(
+        })
+          .then(fail, res => res)
+          .then(response => {
+            expect(response.status).toBe(400);
+            expect(response.data.code).toBe(Parse.Error.INVALID_EMAIL_ADDRESS);
+            expect(response.data.error).toBe(
               'you must provide a valid email string'
             );
             expect(sendVerificationEmailCallCount).toBe(0);
             expect(sendEmailOptions).not.toBeDefined();
             done();
-          }
-        );
+          });
       })
       .catch(error => {
         jfail(error);
@@ -911,44 +875,38 @@ describe('Email Verification Token Expiration: ', () => {
         return user.signUp();
       })
       .then(() => {
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            Parse.User.logIn('testEmailVerifyTokenValidity', 'expiringToken')
-              .then(user => {
-                expect(typeof user).toBe('object');
-                expect(user.get('emailVerified')).toBe(true);
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          Parse.User.logIn('testEmailVerifyTokenValidity', 'expiringToken')
+            .then(user => {
+              expect(typeof user).toBe('object');
+              expect(user.get('emailVerified')).toBe(true);
 
-                user.set('email', 'newEmail@parse.com');
-                return user.save();
-              })
-              .then(() => user.fetch())
-              .then(user => {
-                expect(typeof user).toBe('object');
-                expect(user.get('email')).toBe('newEmail@parse.com');
-                expect(user.get('emailVerified')).toBe(false);
+              user.set('email', 'newEmail@parse.com');
+              return user.save();
+            })
+            .then(() => user.fetch())
+            .then(user => {
+              expect(typeof user).toBe('object');
+              expect(user.get('email')).toBe('newEmail@parse.com');
+              expect(user.get('emailVerified')).toBe(false);
 
-                request.get(
-                  sendEmailOptions.link,
-                  {
-                    followRedirect: false,
-                  },
-                  (error, response) => {
-                    expect(response.statusCode).toEqual(302);
-                    done();
-                  }
-                );
-              })
-              .catch(error => {
-                jfail(error);
+              request({
+                url: sendEmailOptions.link,
+                followRedirects: false,
+              }).then(response => {
+                expect(response.status).toEqual(302);
                 done();
               });
-          }
-        );
+            })
+            .catch(error => {
+              jfail(error);
+              done();
+            });
+        });
       })
       .catch(error => {
         jfail(error);

--- a/spec/EnableExpressErrorHandler.spec.js
+++ b/spec/EnableExpressErrorHandler.spec.js
@@ -1,6 +1,6 @@
 const ParseServer = require('../lib/index');
 const express = require('express');
-const rp = require('request-promise');
+const request = require('../lib/request');
 
 describe('Enable express error handler', () => {
   it('should call the default handler in case of error, like updating a non existing object', done => {
@@ -30,22 +30,21 @@ describe('Enable express error handler', () => {
               lastError = err;
             });
 
-            rp({
+            request({
               method: 'PUT',
-              uri: serverUrl + '/classes/AnyClass/nonExistingId',
+              url: serverUrl + '/classes/AnyClass/nonExistingId',
               headers: {
                 'X-Parse-Application-Id': appId,
                 'X-Parse-Master-Key': masterKey,
+                'Content-Type': 'application/json',
               },
               body: { someField: 'blablabla' },
-              json: true,
             })
               .then(() => {
                 fail('Should throw error');
               })
-              .catch(e => {
-                expect(e).toBeDefined();
-                const reqError = e.error;
+              .catch(response => {
+                const reqError = response.data;
                 expect(reqError).toBeDefined();
                 expect(lastError).toBeDefined();
 

--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('request');
+const request = require('../lib/request');
 
 const delayPromise = delay => {
   return new Promise(resolve => {
@@ -153,19 +153,16 @@ describe('Parse.Push', () => {
       )
       .then(() => delayPromise(500))
       .then(() => {
-        request.get(
-          {
-            url: 'http://localhost:8378/1/classes/_PushStatus',
-            json: true,
-            headers: {
-              'X-Parse-Application-Id': 'test',
-            },
+        request({
+          url: 'http://localhost:8378/1/classes/_PushStatus',
+          json: true,
+          headers: {
+            'X-Parse-Application-Id': 'test',
           },
-          (error, response, body) => {
-            expect(body.error).toEqual('unauthorized');
-            done();
-          }
-        );
+        }).then(fail, response => {
+          expect(response.data.error).toEqual('unauthorized');
+          done();
+        });
       })
       .catch(err => {
         jfail(err);
@@ -191,28 +188,26 @@ describe('Parse.Push', () => {
       )
       .then(() => delayPromise(500)) // put a delay as we keep writing
       .then(() => {
-        request.get(
-          {
-            url: 'http://localhost:8378/1/classes/_PushStatus',
-            json: true,
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Master-Key': 'test',
-            },
+        request({
+          url: 'http://localhost:8378/1/classes/_PushStatus',
+          json: true,
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Master-Key': 'test',
           },
-          (error, response, body) => {
-            try {
-              expect(body.results.length).toEqual(1);
-              expect(body.results[0].query).toEqual('{"deviceType":"ios"}');
-              expect(body.results[0].payload).toEqual(
-                '{"badge":"increment","alert":"Hello world!"}'
-              );
-            } catch (e) {
-              jfail(e);
-            }
-            done();
+        }).then(response => {
+          const body = response.data;
+          try {
+            expect(body.results.length).toEqual(1);
+            expect(body.results[0].query).toEqual('{"deviceType":"ios"}');
+            expect(body.results[0].payload).toEqual(
+              '{"badge":"increment","alert":"Hello world!"}'
+            );
+          } catch (e) {
+            jfail(e);
           }
-        );
+          done();
+        });
       })
       .catch(err => {
         jfail(err);

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-const request = require('request');
+const request = require('../lib/request');
 
 const str = 'Hello World!';
 const data = [];
@@ -19,58 +19,52 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'argle bargle',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          expect(b.name).toMatch(/_file.txt$/);
-          expect(b.url).toMatch(
-            /^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/
-          );
-          request.get(b.url, (error, response, body) => {
-            expect(error).toBe(null);
-            expect(body).toEqual('argle bargle');
-            done();
-          });
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }).then(response => {
+        const b = response.data;
+        expect(b.name).toMatch(/_file.txt$/);
+        expect(b.url).toMatch(
+          /^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/
+        );
+        request({ url: b.url }).then(response => {
+          const body = response.text;
+          expect(body).toEqual('argle bargle');
+          done();
+        });
+      });
     });
 
     it('works with _ContentType', done => {
-      request.post(
-        {
-          url: 'http://localhost:8378/1/files/file',
-          body: JSON.stringify({
-            _ApplicationId: 'test',
-            _JavaScriptKey: 'test',
-            _ContentType: 'text/html',
-            base64: 'PGh0bWw+PC9odG1sPgo=',
-          }),
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          expect(b.name).toMatch(/_file.html/);
-          expect(b.url).toMatch(
-            /^http:\/\/localhost:8378\/1\/files\/test\/.*file.html$/
-          );
-          request.get(b.url, (error, response, body) => {
-            try {
-              expect(response.headers['content-type']).toMatch('^text/html');
-              expect(error).toBe(null);
-              expect(body).toEqual('<html></html>\n');
-            } catch (e) {
-              jfail(e);
-            }
-            done();
-          });
-        }
-      );
+      request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/files/file',
+        body: JSON.stringify({
+          _ApplicationId: 'test',
+          _JavaScriptKey: 'test',
+          _ContentType: 'text/html',
+          base64: 'PGh0bWw+PC9odG1sPgo=',
+        }),
+      }).then(response => {
+        const b = response.data;
+        expect(b.name).toMatch(/_file.html/);
+        expect(b.url).toMatch(
+          /^http:\/\/localhost:8378\/1\/files\/test\/.*file.html$/
+        );
+        request({ url: b.url }).then(response => {
+          const body = response.text;
+          try {
+            expect(response.headers['content-type']).toMatch('^text/html');
+            expect(body).toEqual('<html></html>\n');
+          } catch (e) {
+            jfail(e);
+          }
+          done();
+        });
+      });
     });
 
     it('works without Content-Type', done => {
@@ -78,26 +72,22 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'argle bargle',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          expect(b.name).toMatch(/_file.txt$/);
-          expect(b.url).toMatch(
-            /^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/
-          );
-          request.get(b.url, (error, response, body) => {
-            expect(error).toBe(null);
-            expect(body).toEqual('argle bargle');
-            done();
-          });
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }).then(response => {
+        const b = response.data;
+        expect(b.name).toMatch(/_file.txt$/);
+        expect(b.url).toMatch(
+          /^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/
+        );
+        request({ url: b.url }).then(response => {
+          expect(response.text).toEqual('argle bargle');
+          done();
+        });
+      });
     });
   });
 
@@ -107,57 +97,43 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/testfile.txt',
-        body: 'check one two',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        const b = JSON.parse(body);
-        expect(b.name).toMatch(/_testfile.txt$/);
-        expect(b.url).toMatch(
-          /^http:\/\/localhost:8378\/1\/files\/test\/.*testfile.txt$/
-        );
-        request.get(b.url, (error, response, body) => {
-          expect(error).toBe(null);
-          expect(body).toEqual('check one two');
-          request.del(
-            {
-              headers: {
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                'X-Parse-Master-Key': 'test',
-              },
-              url: 'http://localhost:8378/1/files/' + b.name,
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/testfile.txt',
+      body: 'check one two',
+    }).then(response => {
+      const b = response.data;
+      expect(b.name).toMatch(/_testfile.txt$/);
+      expect(b.url).toMatch(
+        /^http:\/\/localhost:8378\/1\/files\/test\/.*testfile.txt$/
+      );
+      request({ url: b.url }).then(response => {
+        const body = response.text;
+        expect(body).toEqual('check one two');
+        request({
+          method: 'DELETE',
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            'X-Parse-Master-Key': 'test',
+          },
+          url: 'http://localhost:8378/1/files/' + b.name,
+        }).then(response => {
+          expect(response.status).toEqual(200);
+          request({
+            headers: {
+              'X-Parse-Application-Id': 'test',
+              'X-Parse-REST-API-Key': 'rest',
             },
-            (error, response) => {
-              expect(error).toBe(null);
-              expect(response.statusCode).toEqual(200);
-              request.get(
-                {
-                  headers: {
-                    'X-Parse-Application-Id': 'test',
-                    'X-Parse-REST-API-Key': 'rest',
-                  },
-                  url: b.url,
-                },
-                (error, response) => {
-                  expect(error).toBe(null);
-                  try {
-                    expect(response.statusCode).toEqual(404);
-                  } catch (e) {
-                    jfail(e);
-                  }
-                  done();
-                }
-              );
-            }
-          );
+            url: b.url,
+          }).then(fail, response => {
+            expect(response.status).toEqual(404);
+            done();
+          });
         });
-      }
-    );
+      });
+    });
   });
 
   it('blocks file deletions with missing or incorrect master-key header', done => {
@@ -166,54 +142,45 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/thefile.jpg',
-        body: 'the file body',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        const b = JSON.parse(body);
-        expect(b.url).toMatch(
-          /^http:\/\/localhost:8378\/1\/files\/test\/.*thefile.jpg$/
-        );
-        // missing X-Parse-Master-Key header
-        request.del(
-          {
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            url: 'http://localhost:8378/1/files/' + b.name,
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/thefile.jpg',
+      body: 'the file body',
+    }).then(response => {
+      const b = response.data;
+      expect(b.url).toMatch(
+        /^http:\/\/localhost:8378\/1\/files\/test\/.*thefile.jpg$/
+      );
+      // missing X-Parse-Master-Key header
+      request({
+        method: 'DELETE',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        url: 'http://localhost:8378/1/files/' + b.name,
+      }).then(fail, response => {
+        const del_b = response.data;
+        expect(response.status).toEqual(403);
+        expect(del_b.error).toMatch(/unauthorized/);
+        // incorrect X-Parse-Master-Key header
+        request({
+          method: 'DELETE',
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            'X-Parse-Master-Key': 'tryagain',
           },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            const del_b = JSON.parse(body);
-            expect(response.statusCode).toEqual(403);
-            expect(del_b.error).toMatch(/unauthorized/);
-            // incorrect X-Parse-Master-Key header
-            request.del(
-              {
-                headers: {
-                  'X-Parse-Application-Id': 'test',
-                  'X-Parse-REST-API-Key': 'rest',
-                  'X-Parse-Master-Key': 'tryagain',
-                },
-                url: 'http://localhost:8378/1/files/' + b.name,
-              },
-              (error, response, body) => {
-                expect(error).toBe(null);
-                const del_b2 = JSON.parse(body);
-                expect(response.statusCode).toEqual(403);
-                expect(del_b2.error).toMatch(/unauthorized/);
-                done();
-              }
-            );
-          }
-        );
-      }
-    );
+          url: 'http://localhost:8378/1/files/' + b.name,
+        }).then(fail, response => {
+          const del_b2 = response.data;
+          expect(response.status).toEqual(403);
+          expect(del_b2.error).toMatch(/unauthorized/);
+          done();
+        });
+      });
+    });
   });
 
   it('handles other filetypes', done => {
@@ -222,26 +189,21 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/file.jpg',
-        body: 'argle bargle',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        const b = JSON.parse(body);
-        expect(b.name).toMatch(/_file.jpg$/);
-        expect(b.url).toMatch(
-          /^http:\/\/localhost:8378\/1\/files\/.*file.jpg$/
-        );
-        request.get(b.url, (error, response, body) => {
-          expect(error).toBe(null);
-          expect(body).toEqual('argle bargle');
-          done();
-        });
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/file.jpg',
+      body: 'argle bargle',
+    }).then(response => {
+      const b = response.data;
+      expect(b.name).toMatch(/_file.jpg$/);
+      expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/.*file.jpg$/);
+      request({ url: b.url }).then(response => {
+        const body = response.text;
+        expect(body).toEqual('argle bargle');
+        done();
+      });
+    });
   });
 
   it('save file', async () => {
@@ -377,26 +339,19 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/file',
-        body: 'fee fi fo',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        const b = JSON.parse(body);
-        expect(b.name).toMatch(/\.html$/);
-        request.get(b.url, (error, response) => {
-          if (!response) {
-            fail('response should be set');
-            return done();
-          }
-          expect(response.headers['content-type']).toMatch(/^text\/html/);
-          done();
-        });
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/file',
+      body: 'fee fi fo',
+    }).then(response => {
+      const b = response.data;
+      expect(b.name).toMatch(/\.html$/);
+      request({ url: b.url }).then(response => {
+        expect(response.headers['content-type']).toMatch(/^text\/html/);
+        done();
+      });
+    });
   });
 
   it('filename is url encoded', done => {
@@ -405,19 +360,16 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/hello world.txt',
-        body: 'oh emm gee',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        const b = JSON.parse(body);
-        expect(b.url).toMatch(/hello%20world/);
-        done();
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/hello world.txt',
+      body: 'oh emm gee',
+    }).then(response => {
+      const b = response.data;
+      expect(b.url).toMatch(/hello%20world/);
+      done();
+    });
   });
 
   it('supports array of files', done => {
@@ -450,18 +402,16 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/di$avowed.txt',
-        body: 'will fail',
-      },
-      (error, response, body) => {
-        const b = JSON.parse(body);
-        expect(b.code).toEqual(122);
-        done();
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/di$avowed.txt',
+      body: 'will fail',
+    }).then(fail, response => {
+      const b = response.data;
+      expect(b.code).toEqual(122);
+      done();
+    });
   });
 
   it('validates filename length', done => {
@@ -475,18 +425,16 @@ describe('Parse.File testing', () => {
       'andwearyOveramanyquaintandcuriousvolumeof' +
       'forgottenloreWhileinoddednearlynappingsud' +
       'denlytherecameatapping';
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/' + fileName,
-        body: 'will fail',
-      },
-      (error, response, body) => {
-        const b = JSON.parse(body);
-        expect(b.code).toEqual(122);
-        done();
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/' + fileName,
+      body: 'will fail',
+    }).then(fail, response => {
+      const b = response.data;
+      expect(b.code).toEqual(122);
+      done();
+    });
   });
 
   it('supports a dictionary with file', done => {
@@ -632,19 +580,17 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/file.txt',
-        body: '',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        expect(response.statusCode).toBe(400);
-        expect(body).toEqual('{"code":130,"error":"Invalid file upload."}');
-        done();
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/file.txt',
+      body: '',
+    }).then(fail, response => {
+      expect(response.status).toBe(400);
+      const body = response.text;
+      expect(body).toEqual('{"code":130,"error":"Invalid file upload."}');
+      done();
+    });
   });
 
   it('fails to upload without a file name', done => {
@@ -653,19 +599,17 @@ describe('Parse.File testing', () => {
       'X-Parse-Application-Id': 'test',
       'X-Parse-REST-API-Key': 'rest',
     };
-    request.post(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/',
-        body: 'yolo',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        expect(response.statusCode).toBe(400);
-        expect(body).toEqual('{"code":122,"error":"Filename not provided."}');
-        done();
-      }
-    );
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/',
+      body: 'yolo',
+    }).then(fail, response => {
+      expect(response.status).toBe(400);
+      const body = response.text;
+      expect(body).toEqual('{"code":122,"error":"Filename not provided."}');
+      done();
+    });
   });
 
   it('fails to delete an unkown file', done => {
@@ -675,18 +619,16 @@ describe('Parse.File testing', () => {
       'X-Parse-REST-API-Key': 'rest',
       'X-Parse-Master-Key': 'test',
     };
-    request.delete(
-      {
-        headers: headers,
-        url: 'http://localhost:8378/1/files/file.txt',
-      },
-      (error, response, body) => {
-        expect(error).toBe(null);
-        expect(response.statusCode).toBe(400);
-        expect(body).toEqual('{"code":153,"error":"Could not delete file."}');
-        done();
-      }
-    );
+    request({
+      method: 'DELETE',
+      headers: headers,
+      url: 'http://localhost:8378/1/files/file.txt',
+    }).then(fail, response => {
+      expect(response.status).toBe(400);
+      const body = response.text;
+      expect(body).toEqual('{"code":153,"error":"Could not delete file."}');
+      done();
+    });
   });
 
   xdescribe('Gridstore Range tests', () => {
@@ -696,33 +638,27 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'argle bargle',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=0-5',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body).toEqual('argle ');
-              done();
-            }
-          );
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            Range: 'bytes=0-5',
+          },
+        }).then(response => {
+          const body = response.text;
+          expect(body).toEqual('argle ');
+          done();
+        });
+      });
     });
 
     it('supports small range requests', done => {
@@ -731,33 +667,27 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'argle bargle',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=0-2',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body).toEqual('arg');
-              done();
-            }
-          );
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            Range: 'bytes=0-2',
+          },
+        }).then(response => {
+          const body = response.text;
+          expect(body).toEqual('arg');
+          done();
+        });
+      });
     });
 
     // See specs https://www.greenbytes.de/tech/webdav/draft-ietf-httpbis-p5-range-latest.html#byte.ranges
@@ -767,33 +697,27 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'argle bargle',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=2-2',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body).toEqual('g');
-              done();
-            }
-          );
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            Range: 'bytes=2-2',
+          },
+        }).then(response => {
+          const body = response.text;
+          expect(body).toEqual('g');
+          done();
+        });
+      });
     });
 
     xit('supports getting last n bytes', done => {
@@ -802,34 +726,28 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'something different',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=-4',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body.length).toBe(4);
-              expect(body).toEqual('rent');
-              done();
-            }
-          );
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'something different',
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            Range: 'bytes=-4',
+          },
+        }).then(response => {
+          const body = response.text;
+          expect(body.length).toBe(4);
+          expect(body).toEqual('rent');
+          done();
+        });
+      });
     });
 
     it('supports getting first n bytes', done => {
@@ -838,33 +756,27 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'something different',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=10-',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body).toEqual('different');
-              done();
-            }
-          );
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'something different',
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            Range: 'bytes=10-',
+          },
+        }).then(response => {
+          const body = response.text;
+          expect(body).toEqual('different');
+          done();
+        });
+      });
     });
 
     function repeat(string, count) {
@@ -882,54 +794,45 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: repeat('argle bargle', 100),
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=13-240',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body.length).toEqual(228);
-              expect(body.indexOf('rgle barglea')).toBe(0);
-              done();
-            }
-          );
-        }
-      );
-    });
-
-    it('fails to stream unknown file', done => {
-      request.get(
-        {
-          url: 'http://localhost:8378/1/files/test/file.txt',
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: repeat('argle bargle', 100),
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
           headers: {
             'Content-Type': 'application/octet-stream',
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'rest',
             Range: 'bytes=13-240',
           },
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          expect(response.statusCode).toBe(404);
-          expect(body).toEqual('File not found.');
+        }).then(response => {
+          const body = response.text;
+          expect(body.length).toEqual(228);
+          expect(body.indexOf('rgle barglea')).toBe(0);
           done();
-        }
-      );
+        });
+      });
+    });
+
+    it('fails to stream unknown file', done => {
+      request({
+        url: 'http://localhost:8378/1/files/test/file.txt',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          Range: 'bytes=13-240',
+        },
+      }).then(response => {
+        expect(response.status).toBe(404);
+        const body = response.text;
+        expect(body).toEqual('File not found.');
+        done();
+      });
     });
   });
 
@@ -942,33 +845,27 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      request.post(
-        {
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.txt',
-          body: 'argle bargle',
-        },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          request.get(
-            {
-              url: b.url,
-              headers: {
-                'Content-Type': 'application/octet-stream',
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-REST-API-Key': 'rest',
-                Range: 'bytes=0-5',
-              },
-            },
-            (error, response, body) => {
-              expect(error).toBe(null);
-              expect(body).toEqual('argle bargle');
-              done();
-            }
-          );
-        }
-      );
+      request({
+        method: 'POST',
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }).then(response => {
+        const b = response.data;
+        request({
+          url: b.url,
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+            Range: 'bytes=0-5',
+          },
+        }).then(response => {
+          const body = response.text;
+          expect(body).toEqual('argle bargle');
+          done();
+        });
+      });
     });
   });
 });

--- a/spec/ParseGeoPoint.spec.js
+++ b/spec/ParseGeoPoint.spec.js
@@ -1,7 +1,7 @@
 // This is a port of the test suite:
 // hungry/js/test/parse_geo_point_test.js
 
-const rp = require('request-promise');
+const request = require('../lib/request');
 const TestObject = Parse.Object.extend('TestObject');
 
 describe('Parse.GeoPoint testing', () => {
@@ -381,17 +381,19 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(resp => {
-        expect(resp.results.length).toBe(2);
+        expect(resp.data.results.length).toBe(2);
         done();
       }, done.fail);
   });
@@ -418,17 +420,19 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(resp => {
-        expect(resp.results.length).toBe(2);
+        expect(resp.data.results.length).toBe(2);
         done();
       }, done.fail);
   });
@@ -453,17 +457,19 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(resp => {
-        expect(resp.results.length).toBe(2);
+        expect(resp.data.results.length).toBe(2);
         done();
       }, done.fail);
   });
@@ -485,12 +491,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -499,7 +507,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -521,12 +529,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -535,7 +545,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(1);
+        expect(err.data.code).toEqual(1);
         done();
       });
   });
@@ -553,12 +563,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -567,7 +579,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -585,12 +597,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -599,7 +613,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -621,12 +635,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -635,7 +651,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(1);
+        expect(err.data.code).toEqual(1);
         done();
       });
   });
@@ -657,12 +673,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -671,7 +689,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(1);
+        expect(err.data.code).toEqual(1);
         done();
       });
   });
@@ -689,12 +707,14 @@ describe('Parse.GeoPoint testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Polygon',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -703,7 +723,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(107);
+        expect(err.data.code).toEqual(107);
         done();
       });
   });

--- a/spec/ParseGlobalConfig.spec.js
+++ b/spec/ParseGlobalConfig.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('request');
+const request = require('../lib/request');
 const Config = require('../lib/Config');
 
 describe('a GlobalConfig', () => {
@@ -31,154 +31,134 @@ describe('a GlobalConfig', () => {
       });
   });
 
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Parse-Application-Id': 'test',
+    'X-Parse-Master-Key': 'test',
+  };
+
   it('can be retrieved', done => {
-    request.get(
-      {
-        url: 'http://localhost:8378/1/config',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      },
-      (error, response, body) => {
-        try {
-          expect(response.statusCode).toEqual(200);
-          expect(body.params.companies).toEqual(['US', 'DK']);
-        } catch (e) {
-          jfail(e);
-        }
-        done();
+    request({
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      headers,
+    }).then(response => {
+      const body = response.data;
+      try {
+        expect(response.status).toEqual(200);
+        expect(body.params.companies).toEqual(['US', 'DK']);
+      } catch (e) {
+        jfail(e);
       }
-    );
+      done();
+    });
   });
 
   it('can be updated when a master key exists', done => {
-    request.put(
-      {
-        url: 'http://localhost:8378/1/config',
-        json: true,
-        body: { params: { companies: ['US', 'DK', 'SE'] } },
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(200);
-        expect(body.result).toEqual(true);
-        done();
-      }
-    );
+    request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { companies: ['US', 'DK', 'SE'] } },
+      headers,
+    }).then(response => {
+      const body = response.data;
+      expect(response.status).toEqual(200);
+      expect(body.result).toEqual(true);
+      done();
+    });
   });
 
   it('can add and retrive files', done => {
-    request.put(
-      {
-        url: 'http://localhost:8378/1/config',
-        json: true,
-        body: {
-          params: { file: { __type: 'File', name: 'name', url: 'http://url' } },
-        },
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
+    request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: {
+        params: { file: { __type: 'File', name: 'name', url: 'http://url' } },
       },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(200);
-        expect(body.result).toEqual(true);
-        Parse.Config.get().then(res => {
-          const file = res.get('file');
-          expect(file.name()).toBe('name');
-          expect(file.url()).toBe('http://url');
-          done();
-        });
-      }
-    );
+      headers,
+    }).then(response => {
+      const body = response.data;
+      expect(response.status).toEqual(200);
+      expect(body.result).toEqual(true);
+      Parse.Config.get().then(res => {
+        const file = res.get('file');
+        expect(file.name()).toBe('name');
+        expect(file.url()).toBe('http://url');
+        done();
+      });
+    });
   });
 
   it('can add and retrive Geopoints', done => {
     const geopoint = new Parse.GeoPoint(10, -20);
-    request.put(
-      {
-        url: 'http://localhost:8378/1/config',
-        json: true,
-        body: { params: { point: geopoint.toJSON() } },
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(200);
-        expect(body.result).toEqual(true);
-        Parse.Config.get().then(res => {
-          const point = res.get('point');
-          expect(point.latitude).toBe(10);
-          expect(point.longitude).toBe(-20);
-          done();
-        });
-      }
-    );
+    request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { point: geopoint.toJSON() } },
+      headers,
+    }).then(response => {
+      const body = response.data;
+      expect(response.status).toEqual(200);
+      expect(body.result).toEqual(true);
+      Parse.Config.get().then(res => {
+        const point = res.get('point');
+        expect(point.latitude).toBe(10);
+        expect(point.longitude).toBe(-20);
+        done();
+      });
+    });
   });
 
   it('properly handles delete op', done => {
-    request.put(
-      {
+    request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { companies: { __op: 'Delete' }, foo: 'bar' } },
+      headers,
+    }).then(response => {
+      const body = response.data;
+      expect(response.status).toEqual(200);
+      expect(body.result).toEqual(true);
+      request({
         url: 'http://localhost:8378/1/config',
         json: true,
-        body: { params: { companies: { __op: 'Delete' }, foo: 'bar' } },
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(200);
-        expect(body.result).toEqual(true);
-        request.get(
-          {
-            url: 'http://localhost:8378/1/config',
-            json: true,
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Master-Key': 'test',
-            },
-          },
-          (error, response, body) => {
-            try {
-              expect(response.statusCode).toEqual(200);
-              expect(body.params.companies).toBeUndefined();
-              expect(body.params.foo).toBe('bar');
-              expect(Object.keys(body.params).length).toBe(1);
-            } catch (e) {
-              jfail(e);
-            }
-            done();
-          }
-        );
-      }
-    );
+        headers,
+      }).then(response => {
+        const body = response.data;
+        try {
+          expect(response.status).toEqual(200);
+          expect(body.params.companies).toBeUndefined();
+          expect(body.params.foo).toBe('bar');
+          expect(Object.keys(body.params).length).toBe(1);
+        } catch (e) {
+          jfail(e);
+        }
+        done();
+      });
+    });
   });
 
   it('fail to update if master key is missing', done => {
-    request.put(
-      {
-        url: 'http://localhost:8378/1/config',
-        json: true,
-        body: { params: { companies: [] } },
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-REST-API-Key': 'rest',
-        },
+    request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { companies: [] } },
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized: master key is required');
-        done();
-      }
-    );
+    }).then(fail, response => {
+      const body = response.data;
+      expect(response.status).toEqual(403);
+      expect(body.error).toEqual('unauthorized: master key is required');
+      done();
+    });
   });
 
   it('failed getting config when it is missing', done => {
@@ -190,21 +170,16 @@ describe('a GlobalConfig', () => {
         { objectId: '1' }
       )
       .then(() => {
-        request.get(
-          {
-            url: 'http://localhost:8378/1/config',
-            json: true,
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Master-Key': 'test',
-            },
-          },
-          (error, response, body) => {
-            expect(response.statusCode).toEqual(200);
-            expect(body.params).toEqual({});
-            done();
-          }
-        );
+        request({
+          url: 'http://localhost:8378/1/config',
+          json: true,
+          headers,
+        }).then(response => {
+          const body = response.data;
+          expect(response.status).toEqual(200);
+          expect(body.params).toEqual({});
+          done();
+        });
       })
       .catch(e => {
         jfail(e);

--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 /* global describe, it, expect, fail, Parse */
-const request = require('request');
+const request = require('../lib/request');
 const triggers = require('../lib/triggers');
 const HooksController = require('../lib/Controllers/HooksController').default;
 const express = require('express');
@@ -177,24 +177,21 @@ describe('Hooks', () => {
   });
 
   it('should fail to register hooks without Master Key', done => {
-    request.post(
-      Parse.serverURL + '/hooks/functions',
-      {
-        headers: {
-          'X-Parse-Application-Id': Parse.applicationId,
-          'X-Parse-REST-API-Key': Parse.restKey,
-        },
-        body: JSON.stringify({
-          url: 'http://hello.word',
-          functionName: 'SomeFunction',
-        }),
+    request({
+      method: 'POST',
+      url: Parse.serverURL + '/hooks/functions',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
       },
-      (err, res, body) => {
-        body = JSON.parse(body);
-        expect(body.error).toBe('unauthorized');
-        done();
-      }
-    );
+      body: JSON.stringify({
+        url: 'http://hello.word',
+        functionName: 'SomeFunction',
+      }),
+    }).then(fail, response => {
+      const body = response.data;
+      expect(body.error).toBe('unauthorized');
+      done();
+    });
   });
 
   it('should fail trying to create two times the same function', done => {
@@ -367,22 +364,20 @@ describe('Hooks', () => {
   });
 
   it('should fail trying to create a malformed function (REST)', done => {
-    request.post(
-      Parse.serverURL + '/hooks/functions',
-      {
-        headers: {
-          'X-Parse-Application-Id': Parse.applicationId,
-          'X-Parse-Master-Key': Parse.masterKey,
-        },
-        body: JSON.stringify({ functionName: 'SomeFunction' }),
+    request({
+      method: 'POST',
+      url: Parse.serverURL + '/hooks/functions',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': Parse.masterKey,
       },
-      (err, res, body) => {
-        body = JSON.parse(body);
-        expect(body.error).toBe('invalid hook declaration');
-        expect(body.code).toBe(143);
-        done();
-      }
-    );
+      body: JSON.stringify({ functionName: 'SomeFunction' }),
+    }).then(fail, response => {
+      const body = response.data;
+      expect(body.error).toBe('invalid hook declaration');
+      expect(body.code).toBe(143);
+      done();
+    });
   });
 
   it('should create hooks and properly preload them', done => {

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -6,7 +6,7 @@ const auth = require('../lib/Auth');
 const Config = require('../lib/Config');
 const Parse = require('parse/node').Parse;
 const rest = require('../lib/rest');
-const request = require('request');
+const request = require('../lib/request');
 
 let config;
 let database;
@@ -1223,19 +1223,16 @@ describe('Installations', () => {
           'X-Parse-Application-Id': 'test',
           'X-Parse-REST-API-Key': 'rest',
         };
-        request.get(
-          {
-            headers: headers,
-            url:
-              'http://localhost:8378/1/installations/' +
-              createResult.response.objectId,
-            json: true,
-          },
-          (error, response, body) => {
-            expect(body.objectId).toEqual(createResult.response.objectId);
-            done();
-          }
-        );
+        return request({
+          headers: headers,
+          url:
+            'http://localhost:8378/1/installations/' +
+            createResult.response.objectId,
+        }).then(response => {
+          const body = response.data;
+          expect(body.objectId).toEqual(createResult.response.objectId);
+          done();
+        });
       })
       .catch(error => {
         console.log(error);
@@ -1259,21 +1256,20 @@ describe('Installations', () => {
           'X-Parse-REST-API-Key': 'rest',
           'X-Parse-Installation-Id': installId,
         };
-        request.post(
-          {
-            headers: headers,
-            url: 'http://localhost:8378/1/classes/_Installation',
-            json: true,
-            body: {
-              date: new Date(),
-            },
+        request({
+          method: 'POST',
+          headers: headers,
+          url: 'http://localhost:8378/1/classes/_Installation',
+          json: true,
+          body: {
+            date: new Date(),
           },
-          (error, response, body) => {
-            expect(response.statusCode).toBe(200);
-            expect(body.updatedAt).not.toBeUndefined();
-            done();
-          }
-        );
+        }).then(response => {
+          const body = response.data;
+          expect(response.status).toBe(200);
+          expect(body.updatedAt).not.toBeUndefined();
+          done();
+        });
       })
       .catch(error => {
         console.log(error);

--- a/spec/ParsePolygon.spec.js
+++ b/spec/ParsePolygon.spec.js
@@ -3,10 +3,11 @@ const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageA
   .default;
 const mongoURI =
   'mongodb://localhost:27017/parseServerMongoAdapterTestDatabase';
-const rp = require('request-promise');
+const request = require('../lib/request');
 const defaultHeaders = {
   'X-Parse-Application-Id': 'test',
   'X-Parse-Rest-API-Key': 'rest',
+  'Content-Type': 'application/json',
 };
 
 describe('Parse.Polygon testing', () => {
@@ -174,17 +175,19 @@ describe('Parse.Polygon testing', () => {
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: Parse.serverURL + '/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toBe(2);
+          expect(resp.data.results.length).toBe(2);
           done();
         }, done.fail);
     });
@@ -208,17 +211,19 @@ describe('Parse.Polygon testing', () => {
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: Parse.serverURL + '/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toBe(2);
+          expect(resp.data.results.length).toBe(2);
           done();
         }, done.fail);
     });
@@ -247,17 +252,19 @@ describe('Parse.Polygon testing', () => {
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: Parse.serverURL + '/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toBe(1);
+          expect(resp.data.results.length).toBe(1);
           done();
         }, done.fail);
     });
@@ -276,9 +283,10 @@ describe('Parse.Polygon testing', () => {
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: Parse.serverURL + '/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
@@ -302,9 +310,10 @@ describe('Parse.Polygon testing', () => {
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: Parse.serverURL + '/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
@@ -339,9 +348,10 @@ describe_only_db('mongo')('Parse.Polygon testing', () => {
         });
       })
       .then(() => {
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: {
+          body: {
             _method: 'POST',
             location,
             polygon,
@@ -351,16 +361,19 @@ describe_only_db('mongo')('Parse.Polygon testing', () => {
         });
       })
       .then(resp => {
-        return rp.post({
-          url: `http://localhost:8378/1/classes/TestObject/${resp.objectId}`,
-          json: { _method: 'GET' },
+        return request({
+          method: 'POST',
+          url: `http://localhost:8378/1/classes/TestObject/${
+            resp.data.objectId
+          }`,
+          body: { _method: 'GET' },
           headers: defaultHeaders,
         });
       })
       .then(resp => {
-        equal(resp.location, location);
-        equal(resp.polygon, polygon);
-        equal(resp.polygon2, polygon);
+        equal(resp.data.location, location);
+        equal(resp.data.polygon, polygon);
+        equal(resp.data.polygon2, polygon);
         return databaseAdapter.getIndexes('TestObject');
       })
       .then(indexes => {

--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -1,11 +1,12 @@
 'use strict';
 const Parse = require('parse/node');
-const rp = require('request-promise');
+const request = require('../lib/request');
 
 const masterKeyHeaders = {
   'X-Parse-Application-Id': 'test',
   'X-Parse-Rest-API-Key': 'test',
   'X-Parse-Master-Key': 'test',
+  'Content-Type': 'application/json',
 };
 
 const masterKeyOptions = {
@@ -53,6 +54,19 @@ const loadTestData = () => {
   return Parse.Object.saveAll([obj1, obj2, obj3, obj4]);
 };
 
+const get = function(url, options) {
+  options.qs = options.body;
+  delete options.body;
+  Object.keys(options.qs).forEach(key => {
+    options.qs[key] = JSON.stringify(options.qs[key]);
+  });
+  return request(Object.assign({}, { url }, options))
+    .then(response => response.data)
+    .catch(response => {
+      throw { error: response.data };
+    });
+};
+
 describe('Parse.Query Aggregate testing', () => {
   beforeEach(done => {
     loadTestData().then(done, done);
@@ -74,7 +88,7 @@ describe('Parse.Query Aggregate testing', () => {
         unknown: {},
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options).catch(error => {
+    get(Parse.serverURL + '/aggregate/TestObject', options).catch(error => {
       expect(error.error.code).toEqual(Parse.Error.INVALID_QUERY);
       done();
     });
@@ -86,7 +100,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { _id: null },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options).catch(error => {
+    get(Parse.serverURL + '/aggregate/TestObject', options).catch(error => {
       expect(error.error.code).toEqual(Parse.Error.INVALID_QUERY);
       done();
     });
@@ -98,7 +112,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: {},
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options).catch(error => {
+    get(Parse.serverURL + '/aggregate/TestObject', options).catch(error => {
       expect(error.error.code).toEqual(Parse.Error.INVALID_QUERY);
       done();
     });
@@ -110,7 +124,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: '$name' },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(3);
         expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
@@ -132,10 +146,7 @@ describe('Parse.Query Aggregate testing', () => {
         },
       },
     });
-    const resp = await rp.get(
-      Parse.serverURL + '/aggregate/TestObject',
-      options
-    );
+    const resp = await get(Parse.serverURL + '/aggregate/TestObject', options);
     expect(resp.results.length).toBe(3);
     expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
     expect(resp.results[1].hasOwnProperty('objectId')).toBe(true);
@@ -429,7 +440,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, total: { $sum: '$score' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
         expect(resp.results[0].objectId).toBe(null);
@@ -445,7 +456,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, total: { $sum: 1 } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
         expect(resp.results[0].objectId).toBe(null);
@@ -461,7 +472,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, minScore: { $min: '$score' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
         expect(resp.results[0].objectId).toBe(null);
@@ -477,7 +488,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, maxScore: { $max: '$score' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
         expect(resp.results[0].objectId).toBe(null);
@@ -493,7 +504,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, avgScore: { $avg: '$score' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0].hasOwnProperty('objectId')).toBe(true);
         expect(resp.results[0].objectId).toBe(null);
@@ -509,7 +520,7 @@ describe('Parse.Query Aggregate testing', () => {
         limit: 2,
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(2);
         done();
@@ -523,7 +534,7 @@ describe('Parse.Query Aggregate testing', () => {
         sort: { name: 1 },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(4);
         expect(resp.results[0].name).toBe('bar');
@@ -541,7 +552,7 @@ describe('Parse.Query Aggregate testing', () => {
         sort: { name: -1 },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(4);
         expect(resp.results[0].name).toBe('foo');
@@ -559,7 +570,7 @@ describe('Parse.Query Aggregate testing', () => {
         skip: 2,
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(2);
         done();
@@ -594,7 +605,7 @@ describe('Parse.Query Aggregate testing', () => {
         match: { score: { $gt: 15 } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(1);
         expect(resp.results[0].score).toBe(20);
@@ -609,7 +620,7 @@ describe('Parse.Query Aggregate testing', () => {
         match: { score: { $gt: 5, $lt: 15 } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(3);
         expect(resp.results[0].score).toBe(10);
@@ -626,7 +637,7 @@ describe('Parse.Query Aggregate testing', () => {
         match: { score: { $gt: 5, $lt: 15 }, views: { $gt: 850, $lt: 1000 } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(1);
         expect(resp.results[0].score).toBe(10);
@@ -642,7 +653,7 @@ describe('Parse.Query Aggregate testing', () => {
         match: { score: { $gt: 5, $lt: 15 }, views: 900 },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(1);
         expect(resp.results[0].score).toBe(10);
@@ -663,7 +674,7 @@ describe('Parse.Query Aggregate testing', () => {
         },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(2);
         // Match score { $gt: 15, $lt: 25 }
@@ -847,7 +858,7 @@ describe('Parse.Query Aggregate testing', () => {
         project: { name: 1 },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         resp.results.forEach(result => {
           expect(result.objectId).not.toBe(undefined);
@@ -867,7 +878,7 @@ describe('Parse.Query Aggregate testing', () => {
         project: { name: 1, score: 1, sender: 1 },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         resp.results.forEach(result => {
           expect(result.objectId).not.toBe(undefined);
@@ -911,7 +922,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: '$score', score: { $sum: '$score' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(2);
         resp.results.forEach(result => {
@@ -938,7 +949,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, total: { $sum: '$score' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/UnknownClass', options)
+    get(Parse.serverURL + '/aggregate/UnknownClass', options)
       .then(resp => {
         expect(resp.results.length).toBe(0);
         done();
@@ -952,7 +963,7 @@ describe('Parse.Query Aggregate testing', () => {
         group: { objectId: null, total: { $sum: '$unknownfield' } },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/UnknownClass', options)
+    get(Parse.serverURL + '/aggregate/UnknownClass', options)
       .then(resp => {
         expect(resp.results.length).toBe(0);
         done();
@@ -964,7 +975,7 @@ describe('Parse.Query Aggregate testing', () => {
     const options = Object.assign({}, masterKeyOptions, {
       body: { distinct: 'score' },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(2);
         expect(resp.results.includes(10)).toBe(true);
@@ -983,7 +994,7 @@ describe('Parse.Query Aggregate testing', () => {
         },
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0]).toBe(10);
         done();
@@ -998,7 +1009,7 @@ describe('Parse.Query Aggregate testing', () => {
         where: JSON.stringify({ name: 'bar' }),
       },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results[0]).toBe(10);
         done();
@@ -1010,7 +1021,7 @@ describe('Parse.Query Aggregate testing', () => {
     const options = Object.assign({}, masterKeyOptions, {
       body: { distinct: 'sender.group' },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(2);
         expect(resp.results.includes('A')).toBe(true);
@@ -1047,7 +1058,7 @@ describe('Parse.Query Aggregate testing', () => {
     const options = Object.assign({}, masterKeyOptions, {
       body: { distinct: 'unknown' },
     });
-    rp.get(Parse.serverURL + '/aggregate/UnknownClass', options)
+    get(Parse.serverURL + '/aggregate/UnknownClass', options)
       .then(resp => {
         expect(resp.results.length).toBe(0);
         done();
@@ -1063,7 +1074,7 @@ describe('Parse.Query Aggregate testing', () => {
     obj
       .save()
       .then(() => {
-        return rp.get(Parse.serverURL + '/aggregate/TestObject', options);
+        return get(Parse.serverURL + '/aggregate/TestObject', options);
       })
       .then(resp => {
         expect(resp.results.length).toBe(0);
@@ -1076,7 +1087,7 @@ describe('Parse.Query Aggregate testing', () => {
     const options = Object.assign({}, masterKeyOptions, {
       body: { distinct: 'size' },
     });
-    rp.get(Parse.serverURL + '/aggregate/TestObject', options)
+    get(Parse.serverURL + '/aggregate/TestObject', options)
       .then(resp => {
         expect(resp.results.length).toBe(3);
         expect(resp.results.includes('S')).toBe(true);
@@ -1106,7 +1117,7 @@ describe('Parse.Query Aggregate testing', () => {
         return user2.signUp();
       })
       .then(() => {
-        return rp.get(Parse.serverURL + '/aggregate/_User', options);
+        return get(Parse.serverURL + '/aggregate/_User', options);
       })
       .then(resp => {
         expect(resp.results.length).toEqual(1);
@@ -1137,7 +1148,7 @@ describe('Parse.Query Aggregate testing', () => {
     user
       .signUp()
       .then(function() {
-        return rp.get(Parse.serverURL + '/aggregate/_User', options);
+        return get(Parse.serverURL + '/aggregate/_User', options);
       })
       .then(function(resp) {
         expect(resp.results.length).toBe(1);
@@ -1177,39 +1188,41 @@ describe('Parse.Query Aggregate testing', () => {
       const obj3 = new TestObject({ pointer: pointer3, name: 'World' });
 
       const options = Object.assign({}, masterKeyOptions, {
-        body: [
-          {
-            match: { name: 'Hello' },
-          },
-          {
-            // Transform className$objectId to objectId and store in new field tempPointer
-            project: {
-              tempPointer: { $substr: ['$_p_pointer', 11, -1] }, // Remove TestObject$
+        body: {
+          pipeline: [
+            {
+              match: { name: 'Hello' },
             },
-          },
-          {
-            // Left Join, replace objectId stored in tempPointer with an actual object
-            lookup: {
-              from: 'test_TestObject',
-              localField: 'tempPointer',
-              foreignField: '_id',
-              as: 'tempPointer',
+            {
+              // Transform className$objectId to objectId and store in new field tempPointer
+              project: {
+                tempPointer: { $substr: ['$_p_pointer', 11, -1] }, // Remove TestObject$
+              },
             },
-          },
-          {
-            // lookup returns an array, Deconstructs an array field to objects
-            unwind: {
-              path: '$tempPointer',
+            {
+              // Left Join, replace objectId stored in tempPointer with an actual object
+              lookup: {
+                from: 'test_TestObject',
+                localField: 'tempPointer',
+                foreignField: '_id',
+                as: 'tempPointer',
+              },
             },
-          },
-          {
-            match: { 'tempPointer.value': 2 },
-          },
-        ],
+            {
+              // lookup returns an array, Deconstructs an array field to objects
+              unwind: {
+                path: '$tempPointer',
+              },
+            },
+            {
+              match: { 'tempPointer.value': 2 },
+            },
+          ],
+        },
       });
       Parse.Object.saveAll([pointer1, pointer2, pointer3, obj1, obj2, obj3])
         .then(() => {
-          return rp.get(Parse.serverURL + '/aggregate/TestObject', options);
+          return get(Parse.serverURL + '/aggregate/TestObject', options);
         })
         .then(resp => {
           expect(resp.results.length).toEqual(1);

--- a/spec/ParseQuery.FullTextSearch.spec.js
+++ b/spec/ParseQuery.FullTextSearch.spec.js
@@ -9,7 +9,7 @@ const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/Postgre
 const postgresURI =
   'postgres://localhost:5432/parse_server_postgres_adapter_test_database';
 const Parse = require('parse/node');
-const rp = require('request-promise');
+const request = require('../lib/request');
 let databaseAdapter;
 
 const fullTextHelper = () => {
@@ -48,15 +48,16 @@ const fullTextHelper = () => {
     publicServerURL: 'http://localhost:8378/1',
     databaseAdapter,
   }).then(() => {
-    return rp.post({
+    return request({
+      method: 'POST',
       url: 'http://localhost:8378/1/batch',
       body: {
         requests,
       },
-      json: true,
       headers: {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'test',
+        'Content-Type': 'application/json',
       },
     });
   });
@@ -75,19 +76,24 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
-      .then(resp => {
-        expect(resp.results.length).toBe(3);
-        done();
-      }, done.fail);
+      .then(
+        resp => {
+          expect(resp.data.results.length).toBe(3);
+          done();
+        },
+        e => done.fail(e)
+      );
   });
 
   it('fullTextSearch: $search, sort', done => {
@@ -104,16 +110,19 @@ describe('Parse.Query Full Text Search testing', () => {
         };
         const order = '$score';
         const keys = '$score';
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, order, keys, _method: 'GET' },
+          body: { where, order, keys, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
-      .then(resp => {
+      .then(response => {
+        const resp = response.data;
         expect(resp.results.length).toBe(3);
         expect(resp.results[0].score);
         expect(resp.results[1].score);
@@ -135,17 +144,19 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(resp => {
-        expect(resp.results.length).toBe(2);
+        expect(resp.data.results.length).toBe(2);
         done();
       }, done.fail);
   });
@@ -163,17 +174,19 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(resp => {
-        expect(resp.results.length).toBe(1);
+        expect(resp.data.results.length).toBe(1);
         done();
       }, done.fail);
   });
@@ -188,12 +201,14 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -202,7 +217,7 @@ describe('Parse.Query Full Text Search testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -220,12 +235,14 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -234,7 +251,7 @@ describe('Parse.Query Full Text Search testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -252,12 +269,14 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -266,7 +285,7 @@ describe('Parse.Query Full Text Search testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -284,12 +303,14 @@ describe('Parse.Query Full Text Search testing', () => {
             },
           },
         };
-        return rp.post({
+        return request({
+          method: 'POST',
           url: 'http://localhost:8378/1/classes/TestObject',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-REST-API-Key': 'test',
+            'Content-Type': 'application/json',
           },
         });
       })
@@ -298,7 +319,7 @@ describe('Parse.Query Full Text Search testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
         done();
       });
   });
@@ -336,43 +357,43 @@ describe_only_db('mongo')(
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: 'http://localhost:8378/1/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toEqual(3);
+          expect(resp.data.results.length).toEqual(3);
           return databaseAdapter.getIndexes('TestObject');
         })
         .then(indexes => {
           expect(indexes.length).toEqual(2);
-          rp.get(
-            {
-              url: 'http://localhost:8378/1/schemas/TestObject',
-              headers: {
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-Master-Key': 'test',
-              },
-              json: true,
+          request({
+            url: 'http://localhost:8378/1/schemas/TestObject',
+            headers: {
+              'X-Parse-Application-Id': 'test',
+              'X-Parse-Master-Key': 'test',
+              'Content-Type': 'application/json',
             },
-            (error, response, body) => {
-              expect(body.indexes._id_).toBeDefined();
-              expect(body.indexes._id_._id).toEqual(1);
-              expect(body.indexes.subject_text_comment_text).toBeDefined();
-              expect(body.indexes.subject_text_comment_text.subject).toEqual(
-                'text'
-              );
-              expect(body.indexes.subject_text_comment_text.comment).toEqual(
-                'text'
-              );
-              done();
-            }
-          );
+          }).then(response => {
+            const body = response.data;
+            expect(body.indexes._id_).toBeDefined();
+            expect(body.indexes._id_._id).toEqual(1);
+            expect(body.indexes.subject_text_comment_text).toBeDefined();
+            expect(body.indexes.subject_text_comment_text.subject).toEqual(
+              'text'
+            );
+            expect(body.indexes.subject_text_comment_text.comment).toEqual(
+              'text'
+            );
+            done();
+          });
         })
         .catch(done.fail);
     });
@@ -387,13 +408,14 @@ describe_only_db('mongo')(
         })
         .then(indexes => {
           expect(indexes.length).toEqual(1);
-          return rp.put({
+          return request({
+            method: 'PUT',
             url: 'http://localhost:8378/1/schemas/TestObject',
-            json: true,
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
               'X-Parse-Master-Key': 'test',
+              'Content-Type': 'application/json',
             },
             body: {
               indexes: {
@@ -416,39 +438,39 @@ describe_only_db('mongo')(
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: 'http://localhost:8378/1/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toEqual(3);
+          expect(resp.data.results.length).toEqual(3);
           return databaseAdapter.getIndexes('TestObject');
         })
         .then(indexes => {
           expect(indexes.length).toEqual(2);
-          rp.get(
-            {
-              url: 'http://localhost:8378/1/schemas/TestObject',
-              headers: {
-                'X-Parse-Application-Id': 'test',
-                'X-Parse-Master-Key': 'test',
-              },
-              json: true,
+          request({
+            url: 'http://localhost:8378/1/schemas/TestObject',
+            headers: {
+              'X-Parse-Application-Id': 'test',
+              'X-Parse-Master-Key': 'test',
+              'Content-Type': 'application/json',
             },
-            (error, response, body) => {
-              expect(body.indexes._id_).toBeDefined();
-              expect(body.indexes._id_._id).toEqual(1);
-              expect(body.indexes.text_test).toBeDefined();
-              expect(body.indexes.text_test.subject).toEqual('text');
-              expect(body.indexes.text_test.comment).toEqual('text');
-              done();
-            }
-          );
+          }).then(response => {
+            const body = response.data;
+            expect(body.indexes._id_).toBeDefined();
+            expect(body.indexes._id_._id).toEqual(1);
+            expect(body.indexes.text_test).toBeDefined();
+            expect(body.indexes.text_test.subject).toEqual('text');
+            expect(body.indexes.text_test.comment).toEqual('text');
+            done();
+          });
         })
         .catch(done.fail);
     });
@@ -466,17 +488,19 @@ describe_only_db('mongo')(
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: 'http://localhost:8378/1/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toBe(2);
+          expect(resp.data.results.length).toBe(2);
           done();
         }, done.fail);
     });
@@ -494,17 +518,19 @@ describe_only_db('mongo')(
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: 'http://localhost:8378/1/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
+              'Content-Type': 'application/json',
             },
           });
         })
         .then(resp => {
-          expect(resp.results.length).toBe(1);
+          expect(resp.data.results.length).toBe(1);
           done();
         }, done.fail);
     });
@@ -527,12 +553,14 @@ describe_only_db('postgres')(
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: 'http://localhost:8378/1/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
+              'Content-Type': 'application/json',
             },
           });
         })
@@ -545,7 +573,7 @@ describe_only_db('postgres')(
           done();
         })
         .catch(err => {
-          expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+          expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
           done();
         });
     });
@@ -563,12 +591,14 @@ describe_only_db('postgres')(
               },
             },
           };
-          return rp.post({
+          return request({
+            method: 'POST',
             url: 'http://localhost:8378/1/classes/TestObject',
-            json: { where, _method: 'GET' },
+            body: { where, _method: 'GET' },
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-REST-API-Key': 'test',
+              'Content-Type': 'application/json',
             },
           });
         })
@@ -577,7 +607,7 @@ describe_only_db('postgres')(
           done();
         })
         .catch(err => {
-          expect(err.error.code).toEqual(Parse.Error.INVALID_JSON);
+          expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
           done();
         });
     });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -5,17 +5,17 @@
 'use strict';
 
 const Parse = require('parse/node');
-const rp = require('request-promise');
+const request = require('../lib/request');
 
 const masterKeyHeaders = {
   'X-Parse-Application-Id': 'test',
   'X-Parse-Rest-API-Key': 'test',
   'X-Parse-Master-Key': 'test',
+  'Content-Type': 'application/json',
 };
 
 const masterKeyOptions = {
   headers: masterKeyHeaders,
-  json: true,
 };
 
 describe('Parse.Query testing', () => {
@@ -540,65 +540,70 @@ describe('Parse.Query testing', () => {
     Parse.Object.saveAll(objectList).then(results => {
       equal(objectList.length, results.length);
 
-      return require('request-promise')
-        .get({
-          url: Parse.serverURL + '/classes/Object',
-          json: {
-            where: {
-              strings: {
-                $all: [
-                  { $regex: '^\\Qthe\\E' },
-                  { $regex: '^\\Qfox\\E' },
-                  { $regex: '^\\Qlazy\\E' },
-                ],
-              },
+      return request({
+        url: Parse.serverURL + '/classes/Object',
+        qs: {
+          where: JSON.stringify({
+            strings: {
+              $all: [
+                { $regex: '^\\Qthe\\E' },
+                { $regex: '^\\Qfox\\E' },
+                { $regex: '^\\Qlazy\\E' },
+              ],
             },
-          },
-          headers: {
-            'X-Parse-Application-Id': Parse.applicationId,
-            'X-Parse-Javascript-Key': Parse.javaScriptKey,
-          },
-        })
-        .then(function(results) {
+          }),
+        },
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-Javascript-Key': Parse.javaScriptKey,
+          'Content-Type': 'application/json',
+        },
+      })
+        .then(function(response) {
+          const results = response.data;
           equal(results.results.length, 1);
           arrayContains(results.results, object);
 
-          return require('request-promise').get({
+          return request({
             url: Parse.serverURL + '/classes/Object',
-            json: {
-              where: {
+            qs: {
+              where: JSON.stringify({
                 strings: {
                   $all: [{ $regex: '^\\Qthe\\E' }, { $regex: '^\\Qlazy\\E' }],
                 },
-              },
+              }),
             },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
-        .then(function(results) {
+        .then(function(response) {
+          const results = response.data;
           equal(results.results.length, 2);
           arrayContains(results.results, object);
           arrayContains(results.results, object3);
 
-          return require('request-promise').get({
+          return request({
             url: Parse.serverURL + '/classes/Object',
-            json: {
-              where: {
+            qs: {
+              where: JSON.stringify({
                 strings: {
                   $all: [{ $regex: '^\\Qhe\\E' }, { $regex: '^\\Qlazy\\E' }],
                 },
-              },
+              }),
             },
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
-        .then(function(results) {
+        .then(function(response) {
+          const results = response.data;
           equal(results.results.length, 0);
 
           done();
@@ -615,10 +620,10 @@ describe('Parse.Query testing', () => {
       .then(() => {
         equal(object.isNew(), false);
 
-        return require('request-promise').get({
+        return request({
           url: Parse.serverURL + '/classes/Object',
-          json: {
-            where: {
+          qs: {
+            where: JSON.stringify({
               strings: {
                 $all: [
                   { $regex: '^\\Qthe\\E' },
@@ -627,20 +632,18 @@ describe('Parse.Query testing', () => {
                   { $unknown: /unknown/ },
                 ],
               },
-            },
+            }),
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
-      .then(
-        function() {},
-        function() {
-          done();
-        }
-      );
+      .then(done.fail, function() {
+        done();
+      });
   });
 
   it('containsAllStartingWith empty array values should return empty results', done => {
@@ -652,23 +655,25 @@ describe('Parse.Query testing', () => {
       .then(() => {
         equal(object.isNew(), false);
 
-        return require('request-promise').get({
+        return request({
           url: Parse.serverURL + '/classes/Object',
-          json: {
-            where: {
+          qs: {
+            where: JSON.stringify({
               strings: {
                 $all: [],
               },
-            },
+            }),
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(
-        function(results) {
+        function(response) {
+          const results = response.data;
           equal(results.results.length, 0);
           done();
         },
@@ -685,23 +690,25 @@ describe('Parse.Query testing', () => {
       .then(() => {
         equal(object.isNew(), false);
 
-        return require('request-promise').get({
+        return request({
           url: Parse.serverURL + '/classes/Object',
-          json: {
-            where: {
+          qs: {
+            where: JSON.stringify({
               strings: {
                 $all: [{}],
               },
-            },
+            }),
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(
-        function(results) {
+        function(response) {
+          const results = response.data;
           equal(results.results.length, 0);
           done();
         },
@@ -723,23 +730,25 @@ describe('Parse.Query testing', () => {
       .then(results => {
         equal(objectList.length, results.length);
 
-        return require('request-promise').get({
+        return request({
           url: Parse.serverURL + '/classes/Object',
-          json: {
-            where: {
+          qs: {
+            where: JSON.stringify({
               strings: {
                 $all: [{ $regex: '^\\Qlazy\\E' }],
               },
-            },
+            }),
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
       .then(
-        function(results) {
+        function(response) {
+          const results = response.data;
           equal(results.results.length, 2);
           done();
         },
@@ -756,14 +765,14 @@ describe('Parse.Query testing', () => {
       .then(() => {
         equal(object.isNew(), false);
 
-        return require('request-promise').get({
+        return request({
           url: Parse.serverURL + '/classes/Object',
-          json: {
-            where: {
+          qs: {
+            where: JSON.stringify({
               strings: {
                 $all: [{ $unknown: '^\\Qlazy\\E' }],
               },
-            },
+            }),
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -772,7 +781,8 @@ describe('Parse.Query testing', () => {
         });
       })
       .then(
-        function(results) {
+        function(response) {
+          const results = response.data;
           equal(results.results.length, 0);
           done();
         },
@@ -810,22 +820,24 @@ describe('Parse.Query testing', () => {
         const pointers = objects.map(object => object.toPointer());
 
         // Return all Parent where all parent.objects are contained in objects
-        return rp.get({
+        return request({
           url: Parse.serverURL + '/classes/Parent',
-          json: {
-            where: {
+          qs: {
+            where: JSON.stringify({
               objects: {
                 $containedBy: pointers,
               },
-            },
+            }),
           },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
-      .then(results => {
+      .then(response => {
+        const results = response.data;
         expect(results.results[0].objectId).not.toBeUndefined();
         expect(results.results[0].objectId).toBe(parent3.id);
         expect(results.results.length).toBe(1);
@@ -835,8 +847,10 @@ describe('Parse.Query testing', () => {
 
   it('containedBy number array', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { numbers: { $containedBy: [1, 2, 3, 4, 5, 6, 7, 8, 9] } },
+      qs: {
+        where: JSON.stringify({
+          numbers: { $containedBy: [1, 2, 3, 4, 5, 6, 7, 8, 9] },
+        }),
       },
     });
     const obj1 = new TestObject({ numbers: [0, 1, 2] });
@@ -844,9 +858,15 @@ describe('Parse.Query testing', () => {
     const obj3 = new TestObject({ numbers: [1, 2, 3, 4] });
     Parse.Object.saveAll([obj1, obj2, obj3])
       .then(() => {
-        return rp.get(Parse.serverURL + '/classes/TestObject', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/TestObject' },
+            options
+          )
+        );
       })
-      .then(results => {
+      .then(response => {
+        const results = response.data;
         expect(results.results[0].objectId).not.toBeUndefined();
         expect(results.results[0].objectId).toBe(obj3.id);
         expect(results.results.length).toBe(1);
@@ -856,8 +876,8 @@ describe('Parse.Query testing', () => {
 
   it('containedBy empty array', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { numbers: { $containedBy: [] } },
+      qs: {
+        where: JSON.stringify({ numbers: { $containedBy: [] } }),
       },
     });
     const obj1 = new TestObject({ numbers: [0, 1, 2] });
@@ -865,9 +885,15 @@ describe('Parse.Query testing', () => {
     const obj3 = new TestObject({ numbers: [1, 2, 3, 4] });
     Parse.Object.saveAll([obj1, obj2, obj3])
       .then(() => {
-        return rp.get(Parse.serverURL + '/classes/TestObject', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/TestObject' },
+            options
+          )
+        );
       })
-      .then(results => {
+      .then(response => {
+        const results = response.data;
         expect(results.results.length).toBe(0);
         done();
       });
@@ -875,20 +901,25 @@ describe('Parse.Query testing', () => {
 
   it('containedBy invalid query', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { objects: { $containedBy: 1234 } },
+      qs: {
+        where: JSON.stringify({ objects: { $containedBy: 1234 } }),
       },
     });
     const obj = new TestObject();
     obj
       .save()
       .then(() => {
-        return rp.get(Parse.serverURL + '/classes/TestObject', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/TestObject' },
+            options
+          )
+        );
       })
       .then(done.fail)
-      .catch(error => {
-        equal(error.error.code, Parse.Error.INVALID_JSON);
-        equal(error.error.error, 'bad $containedBy: should be an array');
+      .catch(response => {
+        equal(response.data.code, Parse.Error.INVALID_JSON);
+        equal(response.data.error, 'bad $containedBy: should be an array');
         done();
       });
   });
@@ -1186,15 +1217,17 @@ describe('Parse.Query testing', () => {
 
   it('where $eq false queries (rest)', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { field: { $eq: false } },
+      qs: {
+        where: JSON.stringify({ field: { $eq: false } }),
       },
     });
     const obj1 = new TestObject({ field: false });
     const obj2 = new TestObject({ field: true });
     Parse.Object.saveAll([obj1, obj2]).then(() => {
-      rp.get(Parse.serverURL + '/classes/TestObject', options).then(resp => {
-        equal(resp.results.length, 1);
+      request(
+        Object.assign({ url: Parse.serverURL + '/classes/TestObject' }, options)
+      ).then(resp => {
+        equal(resp.data.results.length, 1);
         done();
       });
     });
@@ -1202,15 +1235,17 @@ describe('Parse.Query testing', () => {
 
   it('where $eq null queries (rest)', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { field: { $eq: null } },
+      qs: {
+        where: JSON.stringify({ field: { $eq: null } }),
       },
     });
     const obj1 = new TestObject({ field: false });
     const obj2 = new TestObject({ field: null });
     Parse.Object.saveAll([obj1, obj2]).then(() => {
-      rp.get(Parse.serverURL + '/classes/TestObject', options).then(resp => {
-        equal(resp.results.length, 1);
+      return request(
+        Object.assign({ url: Parse.serverURL + '/classes/TestObject' }, options)
+      ).then(resp => {
+        equal(resp.data.results.length, 1);
         done();
       });
     });
@@ -2698,21 +2733,27 @@ describe('Parse.Query testing', () => {
     const highValue = 5;
     const lowValue = 3;
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: {
+      qs: {
+        where: JSON.stringify({
           $nor: [
             { rating: { $gt: highValue } },
             { rating: { $lte: lowValue } },
           ],
-        },
+        }),
       },
     });
 
     Parse.Object.saveAll(objects)
       .then(() => {
-        return rp.get(Parse.serverURL + '/classes/TestObject', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/TestObject' },
+            options
+          )
+        );
       })
-      .then(results => {
+      .then(response => {
+        const results = response.data;
         expect(results.results.length).toBe(highValue - lowValue);
         expect(
           results.results.every(
@@ -2725,38 +2766,48 @@ describe('Parse.Query testing', () => {
 
   it('$nor invalid query - empty array', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { $nor: [] },
+      qs: {
+        where: JSON.stringify({ $nor: [] }),
       },
     });
     const obj = new TestObject();
     obj
       .save()
       .then(() => {
-        return rp.get(Parse.serverURL + '/classes/TestObject', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/TestObject' },
+            options
+          )
+        );
       })
       .then(done.fail)
-      .catch(error => {
-        equal(error.error.code, Parse.Error.INVALID_QUERY);
+      .catch(response => {
+        equal(response.data.code, Parse.Error.INVALID_QUERY);
         done();
       });
   });
 
   it('$nor invalid query - wrong type', done => {
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { $nor: 1337 },
+      qs: {
+        where: JSON.stringify({ $nor: 1337 }),
       },
     });
     const obj = new TestObject();
     obj
       .save()
       .then(() => {
-        return rp.get(Parse.serverURL + '/classes/TestObject', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/TestObject' },
+            options
+          )
+        );
       })
       .then(done.fail)
-      .catch(error => {
-        equal(error.error.code, Parse.Error.INVALID_QUERY);
+      .catch(response => {
+        equal(response.data.code, Parse.Error.INVALID_QUERY);
         done();
       });
   });
@@ -3892,13 +3943,15 @@ describe('Parse.Query testing', () => {
     const parent = new Container({ child1, child2, child3 });
     await Parse.Object.saveAll([parent, child1, child2, child3]);
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { objectId: parent.id },
+      qs: {
+        where: JSON.stringify({ objectId: parent.id }),
         include: '*',
       },
     });
-    const resp = await rp.get(Parse.serverURL + '/classes/Container', options);
-    const result = resp.results[0];
+    const resp = await request(
+      Object.assign({ url: Parse.serverURL + '/classes/Container' }, options)
+    );
+    const result = resp.data.results[0];
     equal(result.child1.foo, 'bar');
     equal(result.child2.foo, 'baz');
     equal(result.child3.foo, 'bad');
@@ -3914,13 +3967,15 @@ describe('Parse.Query testing', () => {
     const parent = new Container({ child1, child2, child3 });
     await Parse.Object.saveAll([parent, child1, child2, child3]);
     const options = Object.assign({}, masterKeyOptions, {
-      body: {
-        where: { objectId: parent.id },
+      qs: {
+        where: JSON.stringify({ objectId: parent.id }),
         include: 'child2,*',
       },
     });
-    const resp = await rp.get(Parse.serverURL + '/classes/Container', options);
-    const result = resp.results[0];
+    const resp = await request(
+      Object.assign({ url: Parse.serverURL + '/classes/Container' }, options)
+    );
+    const result = resp.data.results[0];
     equal(result.child1.foo, 'bar');
     equal(result.child2.foo, 'baz');
     equal(result.child3.foo, 'bad');
@@ -3937,15 +3992,20 @@ describe('Parse.Query testing', () => {
     Parse.Object.saveAll([parent, child1, child2, child3])
       .then(() => {
         const options = Object.assign({}, masterKeyOptions, {
-          body: {
-            where: { objectId: parent.id },
+          qs: {
+            where: JSON.stringify({ objectId: parent.id }),
             includeAll: true,
           },
         });
-        return rp.get(Parse.serverURL + '/classes/Container', options);
+        return request(
+          Object.assign(
+            { url: Parse.serverURL + '/classes/Container' },
+            options
+          )
+        );
       })
       .then(resp => {
-        const result = resp.results[0];
+        const result = resp.data.results[0];
         equal(result.child1.foo, 'bar');
         equal(result.child2.foo, 'baz');
         equal(result.child3.foo, 'bad');
@@ -3983,17 +4043,23 @@ describe('Parse.Query testing', () => {
         return Foobar.save();
       })
       .then(savedFoobar => {
-        const options = Object.assign({}, masterKeyOptions, {
-          body: {
-            where: { objectId: savedFoobar.id },
-            includeAll: true,
-            keys: 'fizz,barBaz.key,barBaz.bazoo.some',
+        const options = Object.assign(
+          {
+            url: Parse.serverURL + '/classes/Foobar',
           },
-        });
-        return rp.get(Parse.serverURL + '/classes/Foobar', options);
+          masterKeyOptions,
+          {
+            qs: {
+              where: JSON.stringify({ objectId: savedFoobar.id }),
+              includeAll: true,
+              keys: 'fizz,barBaz.key,barBaz.bazoo.some',
+            },
+          }
+        );
+        return request(options);
       })
       .then(resp => {
-        const result = resp.results[0];
+        const result = resp.data.results[0];
         equal(result.group.clan, 'wu');
         equal(result.foo, undefined);
         equal(result.fizz, 'buzz');
@@ -4002,7 +4068,8 @@ describe('Parse.Query testing', () => {
         equal(result.barBaz.bazoo.some, 'thing');
         equal(result.barBaz.bazoo.otherSome, undefined);
         done();
-      });
+      })
+      .catch(done.fail);
   });
 
   it('select nested keys 2 level without include (issue #3185)', function(done) {
@@ -4109,19 +4176,25 @@ describe('Parse.Query testing', () => {
             __type: 'Pointer',
           },
         };
-        return require('request-promise').post({
+        return request({
+          method: 'POST',
           url: Parse.serverURL + '/classes/Game',
-          json: { where, _method: 'GET' },
+          body: { where, _method: 'GET' },
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
           },
         });
       })
-      .then(response => {
-        expect(response.results.length).toBe(1);
-        done();
-      }, done.fail);
+      .then(
+        response => {
+          const results = response.data;
+          expect(results.results.length).toBe(1);
+          done();
+        },
+        res => done.fail(res.data)
+      );
   });
 
   it('should not interfere with has when using select on field with undefined value #3999', done => {

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -9,10 +9,9 @@
 
 const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageAdapter')
   .default;
-const request = require('request');
+const request = require('../lib/request');
 const passwordCrypto = require('../lib/password');
 const Config = require('../lib/Config');
-const rp = require('request-promise');
 
 function verifyACL(user) {
   const ACL = user.getACL();
@@ -67,13 +66,15 @@ describe('Parse.User testing', () => {
 
   it('user login with non-string username with REST API', async done => {
     await Parse.User.signUp('asdf', 'zxcv');
-    rp.post({
+    request({
+      method: 'POST',
       url: 'http://localhost:8378/1/login',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      json: {
+      body: {
         _method: 'GET',
         username: { $regex: '^asd' },
         password: 'zxcv',
@@ -84,8 +85,8 @@ describe('Parse.User testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.statusCode).toBe(404);
-        expect(err.message).toMatch(
+        expect(err.status).toBe(404);
+        expect(err.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -94,13 +95,15 @@ describe('Parse.User testing', () => {
 
   it('user login with non-string username with REST API (again)', async done => {
     await Parse.User.signUp('asdf', 'zxcv');
-    rp.post({
+    request({
+      method: 'POST',
       url: 'http://localhost:8378/1/login',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      json: {
+      body: {
         _method: 'GET',
         username: 'asdf',
         password: { $regex: '^zx' },
@@ -111,8 +114,8 @@ describe('Parse.User testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.statusCode).toBe(404);
-        expect(err.message).toMatch(
+        expect(err.status).toBe(404);
+        expect(err.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -121,19 +124,20 @@ describe('Parse.User testing', () => {
 
   it('user login using POST with REST API', async done => {
     await Parse.User.signUp('some_user', 'some_password');
-    rp.post({
+    request({
+      method: 'POST',
       url: 'http://localhost:8378/1/login',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
       },
-      json: {
+      body: {
         username: 'some_user',
         password: 'some_password',
       },
     })
       .then(res => {
-        expect(res.username).toBe('some_user');
+        expect(res.data.username).toBe('some_user');
         done();
       })
       .catch(err => {
@@ -278,17 +282,20 @@ describe('Parse.User testing', () => {
   });
 
   it('should be let masterKey lock user out with authData', async () => {
-    const body = await rp.post({
+    const response = await request({
+      method: 'POST',
       url: 'http://localhost:8378/1/classes/_User',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      json: {
+      body: {
         key: 'value',
         authData: { anonymous: { id: '00000000-0000-0000-0000-000000000001' } },
       },
     });
+    const body = response.data;
     const objectId = body.objectId;
     const sessionToken = body.sessionToken;
     expect(sessionToken).toBeDefined();
@@ -300,20 +307,22 @@ describe('Parse.User testing', () => {
     await user.save(null, { useMasterKey: true });
     // update the user
     const options = {
+      method: 'POST',
       url: `http://localhost:8378/1/classes/_User/`,
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      json: {
+      body: {
         key: 'otherValue',
         authData: {
           anonymous: { id: '00000000-0000-0000-0000-000000000001' },
         },
       },
     };
-    const res = await rp.post(options);
-    expect(res.objectId).not.toEqual(objectId);
+    const res = await request(options);
+    expect(res.data.objectId).not.toEqual(objectId);
   });
 
   it('user login with files', done => {
@@ -823,7 +832,6 @@ describe('Parse.User testing', () => {
       ok(userAgain.dirty('username'));
       const query = new Parse.Query(Parse.User);
       query.get(user.id).then(freshUser => {
-        console.log(freshUser.toJSON());
         equal(freshUser.id, user.id);
         equal(freshUser.get('username'), 'alice');
         Parse.Object.enableSingleInstance();
@@ -1635,25 +1643,25 @@ describe('Parse.User testing', () => {
     const model = await Parse.User._logInWith('facebook');
     const userId = model.id;
     Parse.User.logOut().then(() => {
-      request.post(
-        {
-          url: Parse.serverURL + '/classes/_User',
-          headers: {
-            'X-Parse-Application-Id': Parse.applicationId,
-            'X-Parse-REST-API-Key': 'rest',
-          },
-          json: { authData: { facebook: provider.authData } },
+      request({
+        method: 'POST',
+        url: Parse.serverURL + '/classes/_User',
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
         },
-        (err, res, body) => {
-          // make sure the location header is properly set
-          expect(userId).not.toBeUndefined();
-          expect(body.objectId).toEqual(userId);
-          expect(res.headers.location).toEqual(
-            Parse.serverURL + '/users/' + userId
-          );
-          done();
-        }
-      );
+        body: { authData: { facebook: provider.authData } },
+      }).then(response => {
+        const body = response.data;
+        // make sure the location header is properly set
+        expect(userId).not.toBeUndefined();
+        expect(body.objectId).toEqual(userId);
+        expect(response.headers.location).toEqual(
+          Parse.serverURL + '/users/' + userId
+        );
+        done();
+      });
     });
   });
 
@@ -1727,7 +1735,8 @@ describe('Parse.User testing', () => {
         defaultConfiguration.auth.shortLivedAuth.setValidAccessToken(
           'otherToken'
         );
-        return rp.put({
+        return request({
+          method: 'PUT',
           url: Parse.serverURL + '/users/' + Parse.User.current().id,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -1735,7 +1744,7 @@ describe('Parse.User testing', () => {
             'X-Parse-Session-Token': Parse.User.current().getSessionToken(),
             'Content-Type': 'application/json',
           },
-          json: {
+          body: {
             key: 'value', // update a key
             authData: {
               // pass the original auth data
@@ -1983,23 +1992,19 @@ describe('Parse.User testing', () => {
 
   it('querying for users only gets the expected fields', done => {
     Parse.User.signUp('finn', 'human', { foo: 'bar' }).then(() => {
-      request.get(
-        {
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-REST-API-Key': 'rest',
-          },
-          url: 'http://localhost:8378/1/users',
+      request({
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
         },
-        (error, response, body) => {
-          expect(error).toBe(null);
-          const b = JSON.parse(body);
-          expect(b.results.length).toEqual(1);
-          const user = b.results[0];
-          expect(Object.keys(user).length).toEqual(6);
-          done();
-        }
-      );
+        url: 'http://localhost:8378/1/users',
+      }).then(response => {
+        const b = response.data;
+        expect(b.results.length).toEqual(1);
+        const user = b.results[0];
+        expect(Object.keys(user).length).toEqual(6);
+        done();
+      });
     });
   });
 
@@ -2124,26 +2129,23 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('finn', 'human', { foo: 'bar' });
       })
       .then(user => {
-        request.post(
-          {
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Session-Token': user.getSessionToken(),
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            url: 'http://localhost:8378/1/sessions',
+        request({
+          method: 'POST',
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
           },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            const b = JSON.parse(body);
-            expect(typeof b.sessionToken).toEqual('string');
-            expect(typeof b.createdWith).toEqual('object');
-            expect(b.createdWith.action).toEqual('create');
-            expect(typeof b.user).toEqual('object');
-            expect(b.user.objectId).toEqual(user.id);
-            done();
-          }
-        );
+          url: 'http://localhost:8378/1/sessions',
+        }).then(response => {
+          const b = response.data;
+          expect(typeof b.sessionToken).toEqual('string');
+          expect(typeof b.createdWith).toEqual('object');
+          expect(b.createdWith.action).toEqual('create');
+          expect(typeof b.user).toEqual('object');
+          expect(b.user.objectId).toEqual(user.id);
+          done();
+        });
       });
   });
 
@@ -2153,26 +2155,22 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('finn', 'human', { foo: 'bar' });
       })
       .then(user => {
-        request.get(
-          {
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Session-Token': user.getSessionToken(),
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            url: 'http://localhost:8378/1/sessions/me',
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
           },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            const b = JSON.parse(body);
-            expect(typeof b.sessionToken).toEqual('string');
-            expect(typeof b.createdWith).toEqual('object');
-            expect(b.createdWith.action).toEqual('signup');
-            expect(typeof b.user).toEqual('object');
-            expect(b.user.objectId).toEqual(user.id);
-            done();
-          }
-        );
+          url: 'http://localhost:8378/1/sessions/me',
+        }).then(response => {
+          const b = response.data;
+          expect(typeof b.sessionToken).toEqual('string');
+          expect(typeof b.createdWith).toEqual('object');
+          expect(b.createdWith.action).toEqual('signup');
+          expect(typeof b.user).toEqual('object');
+          expect(b.user.objectId).toEqual(user.id);
+          done();
+        });
       });
   });
 
@@ -2187,26 +2185,22 @@ describe('Parse.User testing', () => {
         });
       })
       .then(user => {
-        request.get(
-          {
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Session-Token': user.getSessionToken(),
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            url: 'http://localhost:8378/1/sessions/me',
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
           },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            const b = JSON.parse(body);
-            expect(typeof b.sessionToken).toEqual('string');
-            expect(typeof b.createdWith).toEqual('object');
-            expect(b.createdWith.action).toEqual('login');
-            expect(typeof b.user).toEqual('object');
-            expect(b.user.objectId).toEqual(user.id);
-            done();
-          }
-        );
+          url: 'http://localhost:8378/1/sessions/me',
+        }).then(response => {
+          const b = response.data;
+          expect(typeof b.sessionToken).toEqual('string');
+          expect(typeof b.createdWith).toEqual('object');
+          expect(b.createdWith.action).toEqual('login');
+          expect(typeof b.user).toEqual('object');
+          expect(b.user.objectId).toEqual(user.id);
+          done();
+        });
       });
   });
 
@@ -2216,36 +2210,28 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('finn', 'human', { foo: 'bar' });
       })
       .then(user => {
-        request.get(
-          {
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          url: 'http://localhost:8378/1/sessions/me',
+        }).then(response => {
+          const b = response.data;
+          request({
+            method: 'PUT',
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-Session-Token': user.getSessionToken(),
               'X-Parse-REST-API-Key': 'rest',
             },
-            url: 'http://localhost:8378/1/sessions/me',
-          },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            const b = JSON.parse(body);
-            request.put(
-              {
-                headers: {
-                  'X-Parse-Application-Id': 'test',
-                  'X-Parse-Session-Token': user.getSessionToken(),
-                  'X-Parse-REST-API-Key': 'rest',
-                },
-                url: 'http://localhost:8378/1/sessions/' + b.objectId,
-                body: JSON.stringify({ foo: 'bar' }),
-              },
-              (error, response, body) => {
-                expect(error).toBe(null);
-                JSON.parse(body);
-                done();
-              }
-            );
-          }
-        );
+            url: 'http://localhost:8378/1/sessions/' + b.objectId,
+            body: JSON.stringify({ foo: 'bar' }),
+          }).then(() => {
+            done();
+          });
+        });
       });
   });
 
@@ -2255,52 +2241,43 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('finn', 'human', { foo: 'bar' });
       })
       .then(user => {
-        request.get(
-          {
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          url: 'http://localhost:8378/1/sessions/me',
+        }).then(response => {
+          const b = response.data;
+          request({
+            method: 'PUT',
             headers: {
               'X-Parse-Application-Id': 'test',
-              'X-Parse-Session-Token': user.getSessionToken(),
+              'X-Parse-Session-Token': 'foo',
               'X-Parse-REST-API-Key': 'rest',
+              'Content-Type': 'application/json',
             },
-            url: 'http://localhost:8378/1/sessions/me',
-          },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            const b = JSON.parse(body);
-            request.put(
-              {
-                headers: {
-                  'X-Parse-Application-Id': 'test',
-                  'X-Parse-Session-Token': 'foo',
-                  'X-Parse-REST-API-Key': 'rest',
-                },
-                url: 'http://localhost:8378/1/sessions/' + b.objectId,
-                body: JSON.stringify({ foo: 'bar' }),
+            url: 'http://localhost:8378/1/sessions/' + b.objectId,
+            body: JSON.stringify({ foo: 'bar' }),
+          }).then(fail, response => {
+            const b = response.data;
+            expect(b.error).toBe('Invalid session token');
+            request({
+              method: 'PUT',
+              headers: {
+                'X-Parse-Application-Id': 'test',
+                'X-Parse-REST-API-Key': 'rest',
               },
-              (error, response, body) => {
-                expect(error).toBe(null);
-                const b = JSON.parse(body);
-                expect(b.error).toBe('Invalid session token');
-                request.put(
-                  {
-                    headers: {
-                      'X-Parse-Application-Id': 'test',
-                      'X-Parse-REST-API-Key': 'rest',
-                    },
-                    url: 'http://localhost:8378/1/sessions/' + b.objectId,
-                    body: JSON.stringify({ foo: 'bar' }),
-                  },
-                  (error, response, body) => {
-                    expect(error).toBe(null);
-                    const b = JSON.parse(body);
-                    expect(b.error).toBe('Session token required.');
-                    done();
-                  }
-                );
-              }
-            );
-          }
-        );
+              url: 'http://localhost:8378/1/sessions/' + b.objectId,
+              body: JSON.stringify({ foo: 'bar' }),
+            }).then(fail, response => {
+              const b = response.data;
+              expect(b.error).toBe('Session token required.');
+              done();
+            });
+          });
+        });
       });
   });
 
@@ -2313,28 +2290,20 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('test2', 'test', { foo: 'bar' });
       })
       .then(user => {
-        request.get(
-          {
-            headers: {
-              'X-Parse-Application-Id': 'test',
-              'X-Parse-Session-Token': user.getSessionToken(),
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            url: 'http://localhost:8378/1/sessions',
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
           },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            try {
-              const b = JSON.parse(body);
-              expect(b.results.length).toEqual(1);
-              expect(typeof b.results[0].user).toEqual('object');
-              expect(b.results[0].user.objectId).toEqual(user.id);
-            } catch (e) {
-              jfail(e);
-            }
-            done();
-          }
-        );
+          url: 'http://localhost:8378/1/sessions',
+        }).then(response => {
+          const b = response.data;
+          expect(b.results.length).toEqual(1);
+          expect(typeof b.results[0].user).toEqual('object');
+          expect(b.results[0].user.objectId).toEqual(user.id);
+          done();
+        });
       });
   });
 
@@ -2347,59 +2316,48 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('test2', 'test', { foo: 'bar' });
       })
       .then(user => {
-        request.get(
-          {
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          url: 'http://localhost:8378/1/sessions',
+        }).then(response => {
+          const b = response.data;
+          let objId;
+          try {
+            expect(b.results.length).toEqual(1);
+            objId = b.results[0].objectId;
+          } catch (e) {
+            jfail(e);
+            done();
+            return;
+          }
+          request({
+            method: 'DELETE',
             headers: {
               'X-Parse-Application-Id': 'test',
               'X-Parse-Session-Token': user.getSessionToken(),
               'X-Parse-REST-API-Key': 'rest',
             },
-            url: 'http://localhost:8378/1/sessions',
-          },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            let objId;
-            try {
-              const b = JSON.parse(body);
-              expect(b.results.length).toEqual(1);
-              objId = b.results[0].objectId;
-            } catch (e) {
-              jfail(e);
-              done();
-              return;
-            }
-            request.del(
-              {
-                headers: {
-                  'X-Parse-Application-Id': 'test',
-                  'X-Parse-Session-Token': user.getSessionToken(),
-                  'X-Parse-REST-API-Key': 'rest',
-                },
-                url: 'http://localhost:8378/1/sessions/' + objId,
+            url: 'http://localhost:8378/1/sessions/' + objId,
+          }).then(() => {
+            request({
+              headers: {
+                'X-Parse-Application-Id': 'test',
+                'X-Parse-Session-Token': user.getSessionToken(),
+                'X-Parse-REST-API-Key': 'rest',
               },
-              error => {
-                expect(error).toBe(null);
-                request.get(
-                  {
-                    headers: {
-                      'X-Parse-Application-Id': 'test',
-                      'X-Parse-Session-Token': user.getSessionToken(),
-                      'X-Parse-REST-API-Key': 'rest',
-                    },
-                    url: 'http://localhost:8378/1/sessions',
-                  },
-                  (error, response, body) => {
-                    expect(error).toBe(null);
-                    const b = JSON.parse(body);
-                    expect(b.code).toEqual(209);
-                    expect(b.error).toBe('Invalid session token');
-                    done();
-                  }
-                );
-              }
-            );
-          }
-        );
+              url: 'http://localhost:8378/1/sessions',
+            }).then(fail, response => {
+              const b = response.data;
+              expect(b.code).toEqual(209);
+              expect(b.error).toBe('Invalid session token');
+              done();
+            });
+          });
+        });
       });
   });
 
@@ -2412,44 +2370,31 @@ describe('Parse.User testing', () => {
         return Parse.User.signUp('test2', 'test', { foo: 'bar' });
       })
       .then(user => {
-        request.get(
-          {
+        request({
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Session-Token': user.getSessionToken(),
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          url: 'http://localhost:8378/1/sessions',
+        }).then(response => {
+          const b = response.data;
+          expect(b.results.length).toEqual(1);
+          const objId = b.results[0].objectId;
+          request({
+            method: 'DELETE',
             headers: {
               'X-Parse-Application-Id': 'test',
-              'X-Parse-Session-Token': user.getSessionToken(),
               'X-Parse-REST-API-Key': 'rest',
             },
-            url: 'http://localhost:8378/1/sessions',
-          },
-          (error, response, body) => {
-            expect(error).toBe(null);
-            let objId;
-            try {
-              const b = JSON.parse(body);
-              expect(b.results.length).toEqual(1);
-              objId = b.results[0].objectId;
-            } catch (e) {
-              jfail(e);
-              done();
-              return;
-            }
-            request.del(
-              {
-                headers: {
-                  'X-Parse-Application-Id': 'test',
-                  'X-Parse-REST-API-Key': 'rest',
-                },
-                url: 'http://localhost:8378/1/sessions/' + objId,
-              },
-              (error, response, body) => {
-                const b = JSON.parse(body);
-                expect(b.code).toEqual(209);
-                expect(b.error).toBe('Invalid session token');
-                done();
-              }
-            );
-          }
-        );
+            url: 'http://localhost:8378/1/sessions/' + objId,
+          }).then(fail, response => {
+            const b = response.data;
+            expect(b.code).toEqual(209);
+            expect(b.error).toBe('Invalid session token');
+            done();
+          });
+        });
       });
   });
 
@@ -2570,40 +2515,34 @@ describe('Parse.User testing', () => {
 
   it('session expiresAt correct format', async done => {
     await Parse.User.signUp('asdf', 'zxcv');
-    request.get(
-      {
-        url: 'http://localhost:8378/1/classes/_Session',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
+    request({
+      url: 'http://localhost:8378/1/classes/_Session',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Master-Key': 'test',
       },
-      (error, response, body) => {
-        expect(body.results[0].expiresAt.__type).toEqual('Date');
-        done();
-      }
-    );
+    }).then(response => {
+      const body = response.data;
+      expect(body.results[0].expiresAt.__type).toEqual('Date');
+      done();
+    });
   });
 
   it('Invalid session tokens are rejected', async done => {
     await Parse.User.signUp('asdf', 'zxcv');
-    request.get(
-      {
-        url: 'http://localhost:8378/1/classes/AClass',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Rest-API-Key': 'rest',
-          'X-Parse-Session-Token': 'text',
-        },
+    request({
+      url: 'http://localhost:8378/1/classes/AClass',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Rest-API-Key': 'rest',
+        'X-Parse-Session-Token': 'text',
       },
-      (error, response, body) => {
-        expect(body.code).toBe(209);
-        expect(body.error).toBe('Invalid session token');
-        done();
-      }
-    );
+    }).then(fail, response => {
+      const body = response.data;
+      expect(body.code).toBe(209);
+      expect(body.error).toBe('Invalid session token');
+      done();
+    });
   });
 
   it_exclude_dbs(['postgres'])(
@@ -2622,26 +2561,13 @@ describe('Parse.User testing', () => {
           {}
         )
         .then(() => {
-          return new Promise((resolve, reject) => {
-            request.get(
-              {
-                url:
-                  'http://localhost:8378/1/login?username=user&password=test',
-                headers: {
-                  'X-Parse-Application-Id': 'test',
-                  'X-Parse-Master-Key': 'test',
-                },
-                json: true,
-              },
-              (err, res, body) => {
-                if (err) {
-                  reject(err);
-                } else {
-                  resolve(body);
-                }
-              }
-            );
-          });
+          return request({
+            url: 'http://localhost:8378/1/login?username=user&password=test',
+            headers: {
+              'X-Parse-Application-Id': 'test',
+              'X-Parse-Master-Key': 'test',
+            },
+          }).then(res => res.data);
         })
         .then(user => {
           const authData = user.authData;
@@ -2694,56 +2620,41 @@ describe('Parse.User testing', () => {
     let originalSessionToken;
     let originalUserId;
     // Simulate anonymous user save
-    new Promise((resolve, reject) => {
-      request.post(
-        {
-          url: 'http://localhost:8378/1/classes/_User',
-          headers: {
-            'X-Parse-Application-Id': Parse.applicationId,
-            'X-Parse-REST-API-Key': 'rest',
-          },
-          json: {
-            authData: {
-              anonymous: { id: '00000000-0000-0000-0000-000000000001' },
-            },
-          },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/classes/_User',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {
+        authData: {
+          anonymous: { id: '00000000-0000-0000-0000-000000000001' },
         },
-        (err, res, body) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(body);
-          }
-        }
-      );
+      },
     })
+      .then(response => response.data)
       .then(user => {
         originalSessionToken = user.sessionToken;
         originalUserId = user.objectId;
         // Simulate registration
-        return new Promise((resolve, reject) => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/classes/_User/' + user.objectId,
-              headers: {
-                'X-Parse-Application-Id': Parse.applicationId,
-                'X-Parse-Session-Token': user.sessionToken,
-                'X-Parse-REST-API-Key': 'rest',
-              },
-              json: {
-                authData: { anonymous: null },
-                username: 'user',
-                password: 'password',
-              },
-            },
-            (err, res, body) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve(body);
-              }
-            }
-          );
+        return request({
+          method: 'PUT',
+          url: 'http://localhost:8378/1/classes/_User/' + user.objectId,
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-Session-Token': user.sessionToken,
+            'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
+          },
+          body: {
+            authData: { anonymous: null },
+            username: 'user',
+            password: 'password',
+          },
+        }).then(response => {
+          return response.data;
         });
       })
       .then(user => {
@@ -2753,28 +2664,19 @@ describe('Parse.User testing', () => {
         // Session token should have changed
         expect(user.sessionToken).not.toEqual(originalSessionToken);
         // test that the sessionToken is valid
-        return new Promise((resolve, reject) => {
-          request.get(
-            {
-              url: 'http://localhost:8378/1/users/me',
-              headers: {
-                'X-Parse-Application-Id': Parse.applicationId,
-                'X-Parse-Session-Token': user.sessionToken,
-                'X-Parse-REST-API-Key': 'rest',
-              },
-              json: true,
-            },
-            (err, res, body) => {
-              expect(body.username).toEqual('user');
-              expect(body.objectId).toEqual(originalUserId);
-              if (err) {
-                reject(err);
-              } else {
-                resolve(body);
-              }
-              done();
-            }
-          );
+        return request({
+          url: 'http://localhost:8378/1/users/me',
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-Session-Token': user.sessionToken,
+            'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
+          },
+        }).then(response => {
+          const body = response.data;
+          expect(body.username).toEqual('user');
+          expect(body.objectId).toEqual(originalUserId);
+          done();
         });
       })
       .catch(err => {
@@ -2801,28 +2703,32 @@ describe('Parse.User testing', () => {
       publicServerURL: 'http://localhost:8378/1',
     });
     // Simulate anonymous user save
-    return rp
-      .post({
-        url: 'http://localhost:8378/1/classes/_User',
-        headers: {
-          'X-Parse-Application-Id': Parse.applicationId,
-          'X-Parse-REST-API-Key': 'rest',
+    return request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/classes/_User',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {
+        authData: {
+          anonymous: { id: '00000000-0000-0000-0000-000000000001' },
         },
-        json: {
-          authData: {
-            anonymous: { id: '00000000-0000-0000-0000-000000000001' },
-          },
-        },
-      })
-      .then(user => {
-        return rp.put({
+      },
+    })
+      .then(response => {
+        const user = response.data;
+        return request({
+          method: 'PUT',
           url: 'http://localhost:8378/1/classes/_User/' + user.objectId,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Session-Token': user.sessionToken,
             'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
           },
-          json: {
+          body: {
             authData: { anonymous: null },
             username: 'user',
             email: 'user@email.com',
@@ -2854,7 +2760,7 @@ describe('Parse.User testing', () => {
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
-    reconfigureServer({
+    await reconfigureServer({
       appName: 'unused',
       verifyUserEmails: true,
       emailAdapter: emailAdapter,
@@ -2865,14 +2771,16 @@ describe('Parse.User testing', () => {
     user.set('password', 'zxcv');
     user.set('email', 'asdf@jkl.com');
     await user.signUp();
-    rp.post({
+    request({
+      method: 'POST',
       url: 'http://localhost:8378/1/requestPasswordReset',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-Session-Token': user.sessionToken,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      json: {
+      body: {
         email: { $regex: '^asd' },
       },
     })
@@ -2883,8 +2791,8 @@ describe('Parse.User testing', () => {
       .catch(err => {
         expect(emailCalled).toBeTruthy();
         expect(emailOptions).toBeDefined();
-        expect(err.statusCode).toBe(400);
-        expect(err.message).toMatch(
+        expect(err.status).toBe(400);
+        expect(err.text).toMatch(
           '{"code":125,"error":"you must provide a valid email string"}'
         );
         done();
@@ -2945,27 +2853,27 @@ describe('Parse.User testing', () => {
     let token;
     Parse.User.signUp('auser', 'somepass', null)
       .then(() =>
-        rp({
+        request({
           method: 'GET',
           url: 'http://localhost:8378/1/classes/_Session',
-          json: true,
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-Master-Key': 'test',
           },
         })
       )
-      .then(body => {
+      .then(response => {
+        const body = response.data;
         const id = body.results[0].objectId;
         const expiresAt = new Date(new Date().setYear(2015));
         token = body.results[0].sessionToken;
-        return rp({
+        return request({
           method: 'PUT',
           url: 'http://localhost:8378/1/classes/_Session/' + id,
-          json: true,
           headers: {
             'X-Parse-Application-Id': 'test',
             'X-Parse-Master-Key': 'test',
+            'Content-Type': 'application/json',
           },
           body: {
             expiresAt: { __type: 'Date', iso: expiresAt.toISOString() },
@@ -2983,7 +2891,8 @@ describe('Parse.User testing', () => {
           expect(error.message).toEqual('Session token is expired.');
           done();
         }
-      );
+      )
+      .catch(done.fail);
   });
 
   it('should not create extraneous session tokens', done => {
@@ -3042,83 +2951,83 @@ describe('Parse.User testing', () => {
   });
 
   it('should revoke sessions when converting anonymous user to "normal" user', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/classes/_User',
-        headers: {
-          'X-Parse-Application-Id': Parse.applicationId,
-          'X-Parse-REST-API-Key': 'rest',
-        },
-        json: {
-          authData: {
-            anonymous: { id: '00000000-0000-0000-0000-000000000001' },
-          },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/classes/_User',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {
+        authData: {
+          anonymous: { id: '00000000-0000-0000-0000-000000000001' },
         },
       },
-      (err, res, body) => {
-        Parse.User.become(body.sessionToken).then(user => {
-          const obj = new Parse.Object('TestObject');
-          obj.setACL(new Parse.ACL(user));
-          return obj
-            .save()
-            .then(() => {
-              // Change password, revoking session
-              user.set('username', 'no longer anonymous');
-              user.set('password', 'password');
-              return user.save();
-            })
-            .then(() => {
-              // Session token should have been recycled
-              expect(body.sessionToken).not.toEqual(user.getSessionToken());
-            })
-            .then(() => obj.fetch())
-            .then(() => {
-              done();
-            })
-            .catch(() => {
-              fail('should not fail');
-              done();
-            });
-        });
-      }
-    );
+    }).then(response => {
+      const body = response.data;
+      Parse.User.become(body.sessionToken).then(user => {
+        const obj = new Parse.Object('TestObject');
+        obj.setACL(new Parse.ACL(user));
+        return obj
+          .save()
+          .then(() => {
+            // Change password, revoking session
+            user.set('username', 'no longer anonymous');
+            user.set('password', 'password');
+            return user.save();
+          })
+          .then(() => {
+            // Session token should have been recycled
+            expect(body.sessionToken).not.toEqual(user.getSessionToken());
+          })
+          .then(() => obj.fetch())
+          .then(() => {
+            done();
+          })
+          .catch(() => {
+            fail('should not fail');
+            done();
+          });
+      });
+    });
   });
 
   it('should not revoke session tokens if the server is configures to not revoke session tokens', done => {
     reconfigureServer({ revokeSessionOnPasswordReset: false }).then(() => {
-      request.post(
-        {
-          url: 'http://localhost:8378/1/classes/_User',
-          headers: {
-            'X-Parse-Application-Id': Parse.applicationId,
-            'X-Parse-REST-API-Key': 'rest',
-          },
-          json: {
-            authData: {
-              anonymous: { id: '00000000-0000-0000-0000-000000000001' },
-            },
+      request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/classes/_User',
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {
+          authData: {
+            anonymous: { id: '00000000-0000-0000-0000-000000000001' },
           },
         },
-        (err, res, body) => {
-          Parse.User.become(body.sessionToken).then(user => {
-            const obj = new Parse.Object('TestObject');
-            obj.setACL(new Parse.ACL(user));
-            return (
-              obj
-                .save()
-                .then(() => {
-                  // Change password, revoking session
-                  user.set('username', 'no longer anonymous');
-                  user.set('password', 'password');
-                  return user.save();
-                })
-                .then(() => obj.fetch())
-                // fetch should succeed as we still have our session token
-                .then(done, fail)
-            );
-          });
-        }
-      );
+      }).then(response => {
+        const body = response.data;
+        Parse.User.become(body.sessionToken).then(user => {
+          const obj = new Parse.Object('TestObject');
+          obj.setACL(new Parse.ACL(user));
+          return (
+            obj
+              .save()
+              .then(() => {
+                // Change password, revoking session
+                user.set('username', 'no longer anonymous');
+                user.set('password', 'password');
+                return user.save();
+              })
+              .then(() => obj.fetch())
+              // fetch should succeed as we still have our session token
+              .then(done, fail)
+          );
+        });
+      });
     });
   });
 
@@ -3210,10 +3119,9 @@ describe('Parse.User testing', () => {
         return user.signUp();
       })
       .then(() =>
-        rp({
+        request({
           method: 'GET',
           url: 'http://localhost:8378/1/users/me',
-          json: true,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-Session-Token': Parse.User.current().getSessionToken(),
@@ -3221,15 +3129,13 @@ describe('Parse.User testing', () => {
           },
         })
       )
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(res.emailVerified).toBe(false);
         expect(res._email_verify_token).toBeUndefined();
         done();
       })
-      .catch(err => {
-        fail(JSON.stringify(err));
-        done();
-      });
+      .catch(done.fail);
   });
 
   it('should not retrieve hidden fields on GET users/id (#3432)', done => {
@@ -3256,17 +3162,17 @@ describe('Parse.User testing', () => {
         return user.signUp();
       })
       .then(() =>
-        rp({
+        request({
           method: 'GET',
           url: 'http://localhost:8378/1/users/' + Parse.User.current().id,
-          json: true,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
         })
       )
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(res.emailVerified).toBe(false);
         expect(res._email_verify_token).toBeUndefined();
         done();
@@ -3301,17 +3207,17 @@ describe('Parse.User testing', () => {
         return user.signUp();
       })
       .then(() =>
-        rp.get({
+        request({
           url:
             'http://localhost:8378/1/login?email=test@email.com&username=hello&password=world',
-          json: true,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
         })
       )
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(res.emailVerified).toBe(false);
         expect(res._email_verify_token).toBeUndefined();
         done();
@@ -3415,31 +3321,31 @@ describe('Parse.User testing', () => {
     let sessionToken;
 
     function validate(block) {
-      return rp
-        .get({
-          url: `http://localhost:8378/1/classes/_User/${objectId}`,
-          headers: {
-            'X-Parse-Application-Id': Parse.applicationId,
-            'X-Parse-REST-API-Key': 'rest',
-            'X-Parse-Session-Token': sessionToken,
-          },
-          json: true,
-        })
-        .then(block);
+      return request({
+        url: `http://localhost:8378/1/classes/_User/${objectId}`,
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-REST-API-Key': 'rest',
+          'X-Parse-Session-Token': sessionToken,
+        },
+      }).then(response => block(response.data));
     }
 
-    rp.post({
+    request({
+      method: 'POST',
       url: 'http://localhost:8378/1/classes/_User',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      json: {
+      body: {
         key: 'value',
         authData: { anonymous: { id: '00000000-0000-0000-0000-000000000001' } },
       },
     })
-      .then(body => {
+      .then(response => {
+        const body = response.data;
         objectId = body.objectId;
         sessionToken = body.sessionToken;
         expect(sessionToken).toBeDefined();
@@ -3452,20 +3358,22 @@ describe('Parse.User testing', () => {
       .then(() => {
         // update the user
         const options = {
+          method: 'PUT',
           url: `http://localhost:8378/1/classes/_User/${objectId}`,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
             'X-Parse-Session-Token': sessionToken,
+            'Content-Type': 'application/json',
           },
-          json: {
+          body: {
             key: 'otherValue',
             authData: {
               anonymous: { id: '00000000-0000-0000-0000-000000000001' },
             },
           },
         };
-        return rp.put(options);
+        return request(options);
       })
       .then(() => {
         return validate(user => {
@@ -3495,9 +3403,9 @@ describe('Parse.User testing', () => {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
-          json: { email: 'yo@lo.com', password: 'yolopass' },
+          qs: { email: 'yo@lo.com', password: 'yolopass' },
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done)
       .catch(done.fail);
@@ -3513,14 +3421,16 @@ describe('Parse.User testing', () => {
       })
       .then(() => {
         const options = {
+          method: 'POST',
           url: `http://localhost:8378/1/login`,
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
+            'Content-Type': 'application/json',
           },
-          json: { email: 'yo@lo.com', password: 'yolopass2' },
+          body: { email: 'yo@lo.com', password: 'yolopass2' },
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done.fail)
       .catch(() => done());
@@ -3542,7 +3452,7 @@ describe('Parse.User testing', () => {
             'X-Parse-REST-API-Key': 'rest',
           },
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done)
       .catch(done.fail);
@@ -3564,7 +3474,7 @@ describe('Parse.User testing', () => {
             'X-Parse-REST-API-Key': 'rest',
           },
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done)
       .catch(done.fail);
@@ -3585,13 +3495,12 @@ describe('Parse.User testing', () => {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
-          json: true,
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done.fail)
       .catch(err => {
-        expect(err.response.body.error).toEqual('Invalid username/password.');
+        expect(err.data.error).toEqual('Invalid username/password.');
         done();
       });
   });
@@ -3611,13 +3520,12 @@ describe('Parse.User testing', () => {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
-          json: true,
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done.fail)
       .catch(err => {
-        expect(err.response.body.error).toEqual('Invalid username/password.');
+        expect(err.data.error).toEqual('Invalid username/password.');
         done();
       });
   });
@@ -3637,13 +3545,12 @@ describe('Parse.User testing', () => {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
-          json: true,
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done.fail)
       .catch(err => {
-        expect(err.response.body.error).toEqual('username/email is required.');
+        expect(err.data.error).toEqual('username/email is required.');
         done();
       });
   });
@@ -3729,13 +3636,12 @@ describe('Parse.User testing', () => {
             'X-Parse-Application-Id': Parse.applicationId,
             'X-Parse-REST-API-Key': 'rest',
           },
-          json: true,
         };
-        return rp.get(options);
+        return request(options);
       })
       .then(done.fail)
       .catch(err => {
-        expect(err.response.body.error).toEqual('password is required.');
+        expect(err.data.error).toEqual('password is required.');
         done();
       });
   });

--- a/spec/PasswordPolicy.spec.js
+++ b/spec/PasswordPolicy.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const requestp = require('request-promise');
+const request = require('../lib/request');
 
 describe('Password Policy: ', () => {
   it('should show the invalid link page if the user clicks on the password reset link after the token expires', done => {
@@ -39,16 +39,15 @@ describe('Password Policy: ', () => {
         setTimeout(() => {
           expect(sendEmailOptions).not.toBeUndefined();
 
-          requestp
-            .get({
-              uri: sendEmailOptions.link,
-              followRedirect: false,
-              simple: false,
-              resolveWithFullResponse: true,
-            })
+          request({
+            url: sendEmailOptions.link,
+            followRedirects: false,
+            simple: false,
+            resolveWithFullResponse: true,
+          })
             .then(response => {
-              expect(response.statusCode).toEqual(302);
-              expect(response.body).toEqual(
+              expect(response.status).toEqual(302);
+              expect(response.text).toEqual(
                 'Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html'
               );
               done();
@@ -100,17 +99,16 @@ describe('Password Policy: ', () => {
         setTimeout(() => {
           expect(sendEmailOptions).not.toBeUndefined();
 
-          requestp
-            .get({
-              uri: sendEmailOptions.link,
-              simple: false,
-              resolveWithFullResponse: true,
-              followRedirect: false,
-            })
+          request({
+            url: sendEmailOptions.link,
+            simple: false,
+            resolveWithFullResponse: true,
+            followRedirects: false,
+          })
             .then(response => {
-              expect(response.statusCode).toEqual(302);
+              expect(response.status).toEqual(302);
               const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=[a-zA-Z0-9]+\&id=test\&username=testResetTokenValidity/;
-              expect(response.body.match(re)).not.toBe(null);
+              expect(response.text.match(re)).not.toBe(null);
               done();
             })
             .catch(error => {
@@ -546,17 +544,16 @@ describe('Password Policy: ', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        requestp
-          .get({
-            uri: options.link,
-            followRedirect: false,
-            simple: false,
-            resolveWithFullResponse: true,
-          })
+        request({
+          url: options.link,
+          followRedirects: false,
+          simple: false,
+          resolveWithFullResponse: true,
+        })
           .then(response => {
-            expect(response.statusCode).toEqual(302);
+            expect(response.status).toEqual(302);
             const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-            const match = response.body.match(re);
+            const match = response.text.match(re);
             if (!match) {
               fail('should have a token');
               done();
@@ -564,20 +561,20 @@ describe('Password Policy: ', () => {
             }
             const token = match[1];
 
-            requestp
-              .post({
-                uri: 'http://localhost:8378/1/apps/test/request_password_reset',
-                body: `new_password=has2init&token=${token}&username=user1`,
-                headers: {
-                  'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                followRedirect: false,
-                simple: false,
-                resolveWithFullResponse: true,
-              })
+            request({
+              method: 'POST',
+              url: 'http://localhost:8378/1/apps/test/request_password_reset',
+              body: `new_password=has2init&token=${token}&username=user1`,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              followRedirects: false,
+              simple: false,
+              resolveWithFullResponse: true,
+            })
               .then(response => {
-                expect(response.statusCode).toEqual(302);
-                expect(response.body).toEqual(
+                expect(response.status).toEqual(302);
+                expect(response.text).toEqual(
                   'Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=user1'
                 );
 
@@ -639,17 +636,16 @@ describe('Password Policy: ', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        requestp
-          .get({
-            uri: options.link,
-            followRedirect: false,
-            simple: false,
-            resolveWithFullResponse: true,
-          })
+        request({
+          url: options.link,
+          followRedirects: false,
+          simple: false,
+          resolveWithFullResponse: true,
+        })
           .then(response => {
-            expect(response.statusCode).toEqual(302);
+            expect(response.status).toEqual(302);
             const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-            const match = response.body.match(re);
+            const match = response.text.match(re);
             if (!match) {
               fail('should have a token');
               done();
@@ -657,20 +653,20 @@ describe('Password Policy: ', () => {
             }
             const token = match[1];
 
-            requestp
-              .post({
-                uri: 'http://localhost:8378/1/apps/test/request_password_reset',
-                body: `new_password=hasnodigit&token=${token}&username=user1`,
-                headers: {
-                  'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                followRedirect: false,
-                simple: false,
-                resolveWithFullResponse: true,
-              })
+            request({
+              method: 'POST',
+              url: 'http://localhost:8378/1/apps/test/request_password_reset',
+              body: `new_password=hasnodigit&token=${token}&username=user1`,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              followRedirects: false,
+              simple: false,
+              resolveWithFullResponse: true,
+            })
               .then(response => {
-                expect(response.statusCode).toEqual(302);
-                expect(response.body).toEqual(
+                expect(response.status).toEqual(302);
+                expect(response.text).toEqual(
                   `Found. Redirecting to http://localhost:8378/1/apps/choose_password?username=user1&token=${token}&id=test&error=Password%20does%20not%20meet%20the%20Password%20Policy%20requirements.&app=passwordPolicy`
                 );
 
@@ -826,17 +822,16 @@ describe('Password Policy: ', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        requestp
-          .get({
-            uri: options.link,
-            followRedirect: false,
-            simple: false,
-            resolveWithFullResponse: true,
-          })
+        request({
+          url: options.link,
+          followRedirects: false,
+          simple: false,
+          resolveWithFullResponse: true,
+        })
           .then(response => {
-            expect(response.statusCode).toEqual(302);
+            expect(response.status).toEqual(302);
             const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-            const match = response.body.match(re);
+            const match = response.text.match(re);
             if (!match) {
               fail('should have a token');
               done();
@@ -844,20 +839,20 @@ describe('Password Policy: ', () => {
             }
             const token = match[1];
 
-            requestp
-              .post({
-                uri: 'http://localhost:8378/1/apps/test/request_password_reset',
-                body: `new_password=xuser12&token=${token}&username=user1`,
-                headers: {
-                  'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                followRedirect: false,
-                simple: false,
-                resolveWithFullResponse: true,
-              })
+            request({
+              method: 'POST',
+              url: 'http://localhost:8378/1/apps/test/request_password_reset',
+              body: `new_password=xuser12&token=${token}&username=user1`,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              followRedirects: false,
+              simple: false,
+              resolveWithFullResponse: true,
+            })
               .then(response => {
-                expect(response.statusCode).toEqual(302);
-                expect(response.body).toEqual(
+                expect(response.status).toEqual(302);
+                expect(response.text).toEqual(
                   `Found. Redirecting to http://localhost:8378/1/apps/choose_password?username=user1&token=${token}&id=test&error=Password%20does%20not%20meet%20the%20Password%20Policy%20requirements.&app=passwordPolicy`
                 );
 
@@ -919,17 +914,16 @@ describe('Password Policy: ', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        requestp
-          .get({
-            uri: options.link,
-            followRedirect: false,
-            simple: false,
-            resolveWithFullResponse: true,
-          })
+        request({
+          url: options.link,
+          followRedirects: false,
+          simple: false,
+          resolveWithFullResponse: true,
+        })
           .then(response => {
-            expect(response.statusCode).toEqual(302);
+            expect(response.status).toEqual(302);
             const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-            const match = response.body.match(re);
+            const match = response.text.match(re);
             if (!match) {
               fail('should have a token');
               done();
@@ -937,20 +931,20 @@ describe('Password Policy: ', () => {
             }
             const token = match[1];
 
-            requestp
-              .post({
-                uri: 'http://localhost:8378/1/apps/test/request_password_reset',
-                body: `new_password=uuser11&token=${token}&username=user1`,
-                headers: {
-                  'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                followRedirect: false,
-                simple: false,
-                resolveWithFullResponse: true,
-              })
+            request({
+              method: 'POST',
+              url: 'http://localhost:8378/1/apps/test/request_password_reset',
+              body: `new_password=uuser11&token=${token}&username=user1`,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              followRedirects: false,
+              simple: false,
+              resolveWithFullResponse: true,
+            })
               .then(response => {
-                expect(response.statusCode).toEqual(302);
-                expect(response.body).toEqual(
+                expect(response.status).toEqual(302);
+                expect(response.text).toEqual(
                   'Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=user1'
                 );
 
@@ -1192,17 +1186,16 @@ describe('Password Policy: ', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        requestp
-          .get({
-            uri: options.link,
-            followRedirect: false,
-            simple: false,
-            resolveWithFullResponse: true,
-          })
+        request({
+          url: options.link,
+          followRedirects: false,
+          simple: false,
+          resolveWithFullResponse: true,
+        })
           .then(response => {
-            expect(response.statusCode).toEqual(302);
+            expect(response.status).toEqual(302);
             const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-            const match = response.body.match(re);
+            const match = response.text.match(re);
             if (!match) {
               fail('should have a token');
               done();
@@ -1210,20 +1203,20 @@ describe('Password Policy: ', () => {
             }
             const token = match[1];
 
-            requestp
-              .post({
-                uri: 'http://localhost:8378/1/apps/test/request_password_reset',
-                body: `new_password=uuser11&token=${token}&username=user1`,
-                headers: {
-                  'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                followRedirect: false,
-                simple: false,
-                resolveWithFullResponse: true,
-              })
+            request({
+              method: 'POST',
+              url: 'http://localhost:8378/1/apps/test/request_password_reset',
+              body: `new_password=uuser11&token=${token}&username=user1`,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              followRedirects: false,
+              simple: false,
+              resolveWithFullResponse: true,
+            })
               .then(response => {
-                expect(response.statusCode).toEqual(302);
-                expect(response.body).toEqual(
+                expect(response.status).toEqual(302);
+                expect(response.text).toEqual(
                   'Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=user1'
                 );
 
@@ -1358,17 +1351,14 @@ describe('Password Policy: ', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        requestp
-          .get({
-            uri: options.link,
-            followRedirect: false,
-            simple: false,
-            resolveWithFullResponse: true,
-          })
+        request({
+          url: options.link,
+          followRedirects: false,
+        })
           .then(response => {
-            expect(response.statusCode).toEqual(302);
+            expect(response.status).toEqual(302);
             const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-            const match = response.body.match(re);
+            const match = response.text.match(re);
             if (!match) {
               fail('should have a token');
               return Promise.reject('Invalid password link');
@@ -1376,39 +1366,32 @@ describe('Password Policy: ', () => {
             return Promise.resolve(match[1]); // token
           })
           .then(token => {
-            return new Promise((resolve, reject) => {
-              requestp
-                .post({
-                  uri:
-                    'http://localhost:8378/1/apps/test/request_password_reset',
-                  body: `new_password=user1&token=${token}&username=user1`,
-                  headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                  },
-                  followRedirect: false,
-                  simple: false,
-                  resolveWithFullResponse: true,
-                })
-                .then(response => {
-                  resolve([response, token]);
-                })
-                .catch(error => {
-                  reject(error);
-                });
+            return request({
+              method: 'POST',
+              url: 'http://localhost:8378/1/apps/test/request_password_reset',
+              body: `new_password=user1&token=${token}&username=user1`,
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              followRedirects: false,
+              simple: false,
+              resolveWithFullResponse: true,
+            }).then(response => {
+              return [response, token];
             });
           })
           .then(data => {
             const response = data[0];
             const token = data[1];
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
+            expect(response.status).toEqual(302);
+            expect(response.text).toEqual(
               `Found. Redirecting to http://localhost:8378/1/apps/choose_password?username=user1&token=${token}&id=test&error=New%20password%20should%20not%20be%20the%20same%20as%20last%201%20passwords.&app=passwordPolicy`
             );
             done();
             return Promise.resolve();
           })
           .catch(error => {
-            jfail(error);
+            fail(error);
             fail('Repeat password test failed');
             done();
           });

--- a/spec/PublicAPI.spec.js
+++ b/spec/PublicAPI.spec.js
@@ -1,11 +1,17 @@
-const request = require('request');
+const req = require('../lib/request');
+
+const request = function(url, callback) {
+  return req({
+    url,
+  }).then(response => callback(null, response), err => callback(err, err));
+};
 
 describe('public API', () => {
   it('should get invalid_link.html', done => {
     request(
       'http://localhost:8378/1/apps/invalid_link.html',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(200);
+        expect(httpResponse.status).toBe(200);
         done();
       }
     );
@@ -19,7 +25,7 @@ describe('public API', () => {
       request(
         'http://localhost:8378/1/apps/choose_password?id=test',
         (err, httpResponse) => {
-          expect(httpResponse.statusCode).toBe(200);
+          expect(httpResponse.status).toBe(200);
           done();
         }
       );
@@ -30,7 +36,7 @@ describe('public API', () => {
     request(
       'http://localhost:8378/1/apps/verify_email_success.html',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(200);
+        expect(httpResponse.status).toBe(200);
         done();
       }
     );
@@ -40,7 +46,7 @@ describe('public API', () => {
     request(
       'http://localhost:8378/1/apps/password_reset_success.html',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(200);
+        expect(httpResponse.status).toBe(200);
         done();
       }
     );
@@ -55,7 +61,7 @@ describe('public API without publicServerURL', () => {
     request(
       'http://localhost:8378/1/apps/test/verify_email',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(404);
+        expect(httpResponse.status).toBe(404);
         done();
       }
     );
@@ -65,7 +71,7 @@ describe('public API without publicServerURL', () => {
     request(
       'http://localhost:8378/1/apps/choose_password?id=test',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(404);
+        expect(httpResponse.status).toBe(404);
         done();
       }
     );
@@ -75,7 +81,7 @@ describe('public API without publicServerURL', () => {
     request(
       'http://localhost:8378/1/apps/test/request_password_reset',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(404);
+        expect(httpResponse.status).toBe(404);
         done();
       }
     );
@@ -91,7 +97,7 @@ describe('public API supplied with invalid application id', () => {
     request(
       'http://localhost:8378/1/apps/invalid/verify_email',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(403);
+        expect(httpResponse.status).toBe(403);
         done();
       }
     );
@@ -101,7 +107,7 @@ describe('public API supplied with invalid application id', () => {
     request(
       'http://localhost:8378/1/apps/choose_password?id=invalid',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(403);
+        expect(httpResponse.status).toBe(403);
         done();
       }
     );
@@ -111,27 +117,27 @@ describe('public API supplied with invalid application id', () => {
     request(
       'http://localhost:8378/1/apps/invalid/request_password_reset',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(403);
+        expect(httpResponse.status).toBe(403);
         done();
       }
     );
   });
 
   it('should get 403 on post of request_password_reset', done => {
-    request.post(
-      'http://localhost:8378/1/apps/invalid/request_password_reset',
-      (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(403);
-        done();
-      }
-    );
+    req({
+      url: 'http://localhost:8378/1/apps/invalid/request_password_reset',
+      method: 'POST',
+    }).then(done.fail, httpResponse => {
+      expect(httpResponse.status).toBe(403);
+      done();
+    });
   });
 
   it('should get 403 on resendVerificationEmail', done => {
     request(
       'http://localhost:8378/1/apps/invalid/resend_verification_email',
       (err, httpResponse) => {
-        expect(httpResponse.statusCode).toBe(403);
+        expect(httpResponse.status).toBe(403);
         done();
       }
     );

--- a/spec/PushRouter.spec.js
+++ b/spec/PushRouter.spec.js
@@ -1,5 +1,5 @@
 const PushRouter = require('../lib/Routers/PushRouter').PushRouter;
-const request = require('request');
+const request = require('../lib/request');
 
 describe('PushRouter', () => {
   it('can get query condition when channels is set', done => {
@@ -68,27 +68,24 @@ describe('PushRouter', () => {
   });
 
   it('sends a push through REST', done => {
-    request.post(
-      {
-        url: Parse.serverURL + '/push',
-        json: true,
-        body: {
-          channels: {
-            $in: ['Giants', 'Mets'],
-          },
-        },
-        headers: {
-          'X-Parse-Application-Id': Parse.applicationId,
-          'X-Parse-Master-Key': Parse.masterKey,
+    request({
+      method: 'POST',
+      url: Parse.serverURL + '/push',
+      body: {
+        channels: {
+          $in: ['Giants', 'Mets'],
         },
       },
-      function(err, res, body) {
-        expect(res.headers['x-parse-push-status-id']).not.toBe(undefined);
-        expect(res.headers['x-parse-push-status-id'].length).toBe(10);
-        expect(res.headers['']);
-        expect(body.result).toBe(true);
-        done();
-      }
-    );
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': Parse.masterKey,
+        'Content-Type': 'application/json',
+      },
+    }).then(res => {
+      expect(res.headers['x-parse-push-status-id']).not.toBe(undefined);
+      expect(res.headers['x-parse-push-status-id'].length).toBe(10);
+      expect(res.data.result).toBe(true);
+      done();
+    });
   });
 });

--- a/spec/ReadPreferenceOption.spec.js
+++ b/spec/ReadPreferenceOption.spec.js
@@ -2,7 +2,7 @@
 
 const Parse = require('parse/node');
 const ReadPreference = require('mongodb').ReadPreference;
-const rp = require('request-promise');
+const request = require('../lib/request');
 const Config = require('../lib/Config');
 
 describe_only_db('mongo')('Read preference option', () => {
@@ -420,15 +420,16 @@ describe_only_db('mongo')('Read preference option', () => {
         req.readPreference = 'SECONDARY';
       });
 
-      rp({
+      request({
         method: 'GET',
-        uri: 'http://localhost:8378/1/classes/MyObject/' + obj0.id,
+        url: 'http://localhost:8378/1/classes/MyObject/' + obj0.id,
         headers: {
           'X-Parse-Application-Id': 'test',
           'X-Parse-REST-API-Key': 'rest',
         },
         json: true,
-      }).then(body => {
+      }).then(response => {
+        const body = response.data;
         expect(body.boolKey).toBe(false);
 
         let myObjectReadPreference = null;

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -3,9 +3,9 @@
 const auth = require('../lib/Auth');
 const Config = require('../lib/Config');
 const rest = require('../lib/rest');
+const request = require('../lib/request');
 
 const querystring = require('querystring');
-const rp = require('request-promise');
 
 let config;
 let database;
@@ -221,40 +221,34 @@ describe('rest query', () => {
           'X-Parse-REST-API-Key': 'rest',
         };
 
-        const p0 = rp
-          .get({
-            headers: headers,
-            url:
-              'http://localhost:8378/1/classes/TestParameterEncode?' +
-              querystring
-                .stringify({
-                  where: '{"foo":{"$ne": "baz"}}',
-                  limit: 1,
-                })
-                .replace('=', '%3D'),
-          })
-          .then(fail, response => {
-            const error = response.error;
-            const b = JSON.parse(error);
-            expect(b.code).toEqual(Parse.Error.INVALID_QUERY);
-          });
+        const p0 = request({
+          headers: headers,
+          url:
+            'http://localhost:8378/1/classes/TestParameterEncode?' +
+            querystring
+              .stringify({
+                where: '{"foo":{"$ne": "baz"}}',
+                limit: 1,
+              })
+              .replace('=', '%3D'),
+        }).then(fail, response => {
+          const error = response.data;
+          expect(error.code).toEqual(Parse.Error.INVALID_QUERY);
+        });
 
-        const p1 = rp
-          .get({
-            headers: headers,
-            url:
-              'http://localhost:8378/1/classes/TestParameterEncode?' +
-              querystring
-                .stringify({
-                  limit: 1,
-                })
-                .replace('=', '%3D'),
-          })
-          .then(fail, response => {
-            const error = response.error;
-            const b = JSON.parse(error);
-            expect(b.code).toEqual(Parse.Error.INVALID_QUERY);
-          });
+        const p1 = request({
+          headers: headers,
+          url:
+            'http://localhost:8378/1/classes/TestParameterEncode?' +
+            querystring
+              .stringify({
+                limit: 1,
+              })
+              .replace('=', '%3D'),
+        }).then(fail, response => {
+          const error = response.data;
+          expect(error.code).toEqual(Parse.Error.INVALID_QUERY);
+        });
         return Promise.all([p0, p1]);
       })
       .then(done)

--- a/spec/RevocableSessionsUpgrade.spec.js
+++ b/spec/RevocableSessionsUpgrade.spec.js
@@ -1,6 +1,6 @@
 const Config = require('../lib/Config');
 const sessionToken = 'legacySessionToken';
-const rp = require('request-promise');
+const request = require('../lib/request');
 const Parse = require('parse/node');
 
 function createUser() {
@@ -92,24 +92,24 @@ describe_only_db('mongo')('revocable sessions', () => {
   });
 
   it('should not upgrade bad legacy session token', done => {
-    rp.post({
+    request({
+      method: 'POST',
       url: Parse.serverURL + '/upgradeToRevocableSession',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-Rest-API-Key': 'rest',
         'X-Parse-Session-Token': 'badSessionToken',
       },
-      json: true,
     })
       .then(
         () => {
           fail('should not be able to upgrade a bad token');
         },
         response => {
-          expect(response.statusCode).toBe(400);
-          expect(response.error).not.toBeUndefined();
-          expect(response.error.code).toBe(Parse.Error.INVALID_SESSION_TOKEN);
-          expect(response.error.error).toEqual('invalid legacy session token');
+          expect(response.status).toBe(400);
+          expect(response.data).not.toBeUndefined();
+          expect(response.data.code).toBe(Parse.Error.INVALID_SESSION_TOKEN);
+          expect(response.data.error).toEqual('invalid legacy session token');
         }
       )
       .then(() => {
@@ -118,23 +118,23 @@ describe_only_db('mongo')('revocable sessions', () => {
   });
 
   it('should not crash without session token #2720', done => {
-    rp.post({
+    request({
+      method: 'POST',
       url: Parse.serverURL + '/upgradeToRevocableSession',
       headers: {
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-Rest-API-Key': 'rest',
       },
-      json: true,
     })
       .then(
         () => {
           fail('should not be able to upgrade a bad token');
         },
         response => {
-          expect(response.statusCode).toBe(404);
-          expect(response.error).not.toBeUndefined();
-          expect(response.error.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
-          expect(response.error.error).toEqual('invalid session');
+          expect(response.status).toBe(404);
+          expect(response.data).not.toBeUndefined();
+          expect(response.data.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
+          expect(response.data.error).toEqual('invalid session');
         }
       )
       .then(() => {

--- a/spec/UserPII.spec.js
+++ b/spec/UserPII.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Parse = require('parse/node');
-const request = require('request-promise');
+const request = require('../lib/request');
 
 // const Config = require('../lib/Config');
 
@@ -143,132 +143,130 @@ describe('Personally Identifiable Information', () => {
   });
 
   it('should not get PII via REST', done => {
-    request
-      .get({
-        url: 'http://localhost:8378/1/classes/_User',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Javascript-Key': 'test',
-        },
-      })
+    request({
+      url: 'http://localhost:8378/1/classes/_User',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Javascript-Key': 'test',
+      },
+    })
       .then(
-        result => {
+        response => {
+          const result = response.data;
           const fetchedUser = result.results[0];
           expect(fetchedUser.zip).toBe(ZIP);
           expect(fetchedUser.email).toBe(undefined);
         },
         e => console.error('error', e.message)
       )
-      .done(() => done());
+      .then(done)
+      .catch(done.fail);
   });
 
   it('should get PII via REST with self credentials', done => {
-    request
-      .get({
-        url: 'http://localhost:8378/1/classes/_User',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Javascript-Key': 'test',
-          'X-Parse-Session-Token': user.getSessionToken(),
-        },
-      })
+    request({
+      url: 'http://localhost:8378/1/classes/_User',
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Javascript-Key': 'test',
+        'X-Parse-Session-Token': user.getSessionToken(),
+      },
+    })
       .then(
-        result => {
+        response => {
+          const result = response.data;
           const fetchedUser = result.results[0];
           expect(fetchedUser.zip).toBe(ZIP);
           expect(fetchedUser.email).toBe(EMAIL);
         },
         e => console.error('error', e.message)
       )
-      .done(() => done());
+      .then(done);
   });
 
   it('should get PII via REST using master key', done => {
-    request
-      .get({
-        url: 'http://localhost:8378/1/classes/_User',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      })
+    request({
+      url: 'http://localhost:8378/1/classes/_User',
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Master-Key': 'test',
+      },
+    })
       .then(
-        result => {
+        response => {
+          const result = response.data;
           const fetchedUser = result.results[0];
           expect(fetchedUser.zip).toBe(ZIP);
           expect(fetchedUser.email).toBe(EMAIL);
         },
         e => console.error('error', e.message)
       )
-      .done(() => done());
+      .then(() => done());
   });
 
   it('should not get PII via REST by ID', done => {
-    request
-      .get({
-        url: `http://localhost:8378/1/classes/_User/${user.id}`,
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Javascript-Key': 'test',
-        },
-      })
+    request({
+      url: `http://localhost:8378/1/classes/_User/${user.id}`,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Javascript-Key': 'test',
+      },
+    })
       .then(
-        result => {
-          const fetchedUser = result;
+        response => {
+          const fetchedUser = response.data;
           expect(fetchedUser.zip).toBe(ZIP);
           expect(fetchedUser.email).toBe(undefined);
         },
-        e => console.error('error', e.message)
+        e => done.fail(e)
       )
-      .done(() => done());
+      .then(() => done());
   });
 
   it('should get PII via REST by ID  with self credentials', done => {
-    request
-      .get({
-        url: `http://localhost:8378/1/classes/_User/${user.id}`,
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Javascript-Key': 'test',
-          'X-Parse-Session-Token': user.getSessionToken(),
-        },
-      })
+    request({
+      url: `http://localhost:8378/1/classes/_User/${user.id}`,
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Javascript-Key': 'test',
+        'X-Parse-Session-Token': user.getSessionToken(),
+      },
+    })
       .then(
-        result => {
+        response => {
+          const result = response.data;
           const fetchedUser = result;
           expect(fetchedUser.zip).toBe(ZIP);
           expect(fetchedUser.email).toBe(EMAIL);
         },
         e => console.error('error', e.message)
       )
-      .done(() => done());
+      .then(() => done());
   });
 
   it('should get PII via REST by ID  with master key', done => {
-    request
-      .get({
-        url: `http://localhost:8378/1/classes/_User/${user.id}`,
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Javascript-Key': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      })
+    request({
+      url: `http://localhost:8378/1/classes/_User/${user.id}`,
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Javascript-Key': 'test',
+        'X-Parse-Master-Key': 'test',
+      },
+    })
       .then(
-        result => {
+        response => {
+          const result = response.data;
           const fetchedUser = result;
           expect(fetchedUser.zip).toBe(ZIP);
           expect(fetchedUser.email).toBe(EMAIL);
         },
         e => console.error('error', e.message)
       )
-      .done(() => done());
+      .then(() => done());
   });
 
   describe('with configured sensitive fields', () => {
@@ -317,14 +315,11 @@ describe('Personally Identifiable Information', () => {
         userObj.id = user.id;
         userObj
           .fetch({ useMasterKey: true })
-          .then(
-            fetchedUser => {
-              expect(fetchedUser.get('email')).toBe(EMAIL);
-              expect(fetchedUser.get('zip')).toBe(ZIP);
-              expect(fetchedUser.get('ssn')).toBe(SSN);
-            },
-            e => console.error('error', e)
-          )
+          .then(fetchedUser => {
+            expect(fetchedUser.get('email')).toBe(EMAIL);
+            expect(fetchedUser.get('zip')).toBe(ZIP);
+            expect(fetchedUser.get('ssn')).toBe(SSN);
+          }, done.fail)
           .then(done)
           .catch(done.fail);
       });
@@ -397,138 +392,131 @@ describe('Personally Identifiable Information', () => {
     });
 
     it('should not get PII via REST', done => {
-      request
-        .get({
-          url: 'http://localhost:8378/1/classes/_User',
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Javascript-Key': 'test',
-          },
-        })
-        .then(
-          result => {
-            const fetchedUser = result.results[0];
-            expect(fetchedUser.zip).toBe(undefined);
-            expect(fetchedUser.ssn).toBe(undefined);
-            expect(fetchedUser.email).toBe(undefined);
-          },
-          e => console.error('error', e.message)
-        )
+      request({
+        url: 'http://localhost:8378/1/classes/_User',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-Javascript-Key': 'test',
+        },
+      })
+        .then(response => {
+          const result = response.data;
+          const fetchedUser = result.results[0];
+          expect(fetchedUser.zip).toBe(undefined);
+          expect(fetchedUser.ssn).toBe(undefined);
+          expect(fetchedUser.email).toBe(undefined);
+        }, done.fail)
         .then(done)
         .catch(done.fail);
     });
 
     it('should get PII via REST with self credentials', done => {
-      request
-        .get({
-          url: 'http://localhost:8378/1/classes/_User',
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Javascript-Key': 'test',
-            'X-Parse-Session-Token': user.getSessionToken(),
-          },
-        })
+      request({
+        url: 'http://localhost:8378/1/classes/_User',
+        json: true,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-Javascript-Key': 'test',
+          'X-Parse-Session-Token': user.getSessionToken(),
+        },
+      })
         .then(
-          result => {
+          response => {
+            const result = response.data;
             const fetchedUser = result.results[0];
             expect(fetchedUser.zip).toBe(ZIP);
             expect(fetchedUser.email).toBe(EMAIL);
             expect(fetchedUser.ssn).toBe(SSN);
           },
-          e => console.error('error', e.message)
+          () => {}
         )
         .then(done)
         .catch(done.fail);
     });
 
     it('should get PII via REST using master key', done => {
-      request
-        .get({
-          url: 'http://localhost:8378/1/classes/_User',
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Master-Key': 'test',
-          },
-        })
+      request({
+        url: 'http://localhost:8378/1/classes/_User',
+        json: true,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-Master-Key': 'test',
+        },
+      })
         .then(
-          result => {
+          response => {
+            const result = response.data;
             const fetchedUser = result.results[0];
             expect(fetchedUser.zip).toBe(ZIP);
             expect(fetchedUser.email).toBe(EMAIL);
             expect(fetchedUser.ssn).toBe(SSN);
           },
-          e => console.error('error', e.message)
+          e => done.fail(e.data)
         )
         .then(done)
         .catch(done.fail);
     });
 
     it('should not get PII via REST by ID', done => {
-      request
-        .get({
-          url: `http://localhost:8378/1/classes/_User/${user.id}`,
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Javascript-Key': 'test',
-          },
-        })
+      request({
+        url: `http://localhost:8378/1/classes/_User/${user.id}`,
+        json: true,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-Javascript-Key': 'test',
+        },
+      })
         .then(
-          result => {
-            const fetchedUser = result;
+          response => {
+            const fetchedUser = response.data;
             expect(fetchedUser.zip).toBe(undefined);
             expect(fetchedUser.email).toBe(undefined);
           },
-          e => console.error('error', e.message)
+          e => done.fail(e.data)
         )
         .then(done)
         .catch(done.fail);
     });
 
     it('should get PII via REST by ID  with self credentials', done => {
-      request
-        .get({
-          url: `http://localhost:8378/1/classes/_User/${user.id}`,
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Javascript-Key': 'test',
-            'X-Parse-Session-Token': user.getSessionToken(),
-          },
-        })
+      request({
+        url: `http://localhost:8378/1/classes/_User/${user.id}`,
+        json: true,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-Javascript-Key': 'test',
+          'X-Parse-Session-Token': user.getSessionToken(),
+        },
+      })
         .then(
-          result => {
-            const fetchedUser = result;
+          response => {
+            const fetchedUser = response.data;
             expect(fetchedUser.zip).toBe(ZIP);
             expect(fetchedUser.email).toBe(EMAIL);
           },
-          e => console.error('error', e.message)
+          () => {}
         )
         .then(done)
         .catch(done.fail);
     });
 
     it('should get PII via REST by ID  with master key', done => {
-      request
-        .get({
-          url: `http://localhost:8378/1/classes/_User/${user.id}`,
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Javascript-Key': 'test',
-            'X-Parse-Master-Key': 'test',
-          },
-        })
+      request({
+        url: `http://localhost:8378/1/classes/_User/${user.id}`,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-Javascript-Key': 'test',
+          'X-Parse-Master-Key': 'test',
+        },
+      })
         .then(
-          result => {
+          response => {
+            const result = response.data;
             const fetchedUser = result;
             expect(fetchedUser.zip).toBe(ZIP);
             expect(fetchedUser.email).toBe(EMAIL);
           },
-          e => console.error('error', e.message)
+          e => done.fail(e.data)
         )
         .then(done)
         .catch(done.fail);

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const MockEmailAdapterWithOptions = require('./MockEmailAdapterWithOptions');
-const request = require('request');
+const request = require('../lib/request');
 const Config = require('../lib/Config');
 
 describe('Custom Pages, Email Verification, Password Reset', () => {
@@ -273,46 +273,43 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       })
       .then(() => {
         expect(sendEmailOptions).not.toBeUndefined();
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
-              'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=user'
-            );
-            user
-              .fetch()
-              .then(
-                () => {
-                  expect(user.get('emailVerified')).toEqual(true);
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          expect(response.text).toEqual(
+            'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=user'
+          );
+          user
+            .fetch()
+            .then(
+              () => {
+                expect(user.get('emailVerified')).toEqual(true);
 
-                  Parse.User.logIn('user', 'other-password').then(
-                    user => {
-                      expect(typeof user).toBe('object');
-                      expect(user.get('emailVerified')).toBe(true);
-                      done();
-                    },
-                    () => {
-                      fail('login should have succeeded');
-                      done();
-                    }
-                  );
-                },
-                err => {
-                  jfail(err);
-                  fail('this should not fail');
-                  done();
-                }
-              )
-              .catch(err => {
+                Parse.User.logIn('user', 'other-password').then(
+                  user => {
+                    expect(typeof user).toBe('object');
+                    expect(user.get('emailVerified')).toBe(true);
+                    done();
+                  },
+                  () => {
+                    fail('login should have succeeded');
+                    done();
+                  }
+                );
+              },
+              err => {
                 jfail(err);
+                fail('this should not fail');
                 done();
-              });
-          }
-        );
+              }
+            )
+            .catch(err => {
+              jfail(err);
+              done();
+            });
+        });
       });
   });
 
@@ -375,8 +372,7 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
             Parse.User.requestPasswordReset('testInvalidConfig@parse.com')
           )
           .then(
-            result => {
-              console.log(result);
+            () => {
               fail('sending password reset email should not have succeeded');
               done();
             },
@@ -414,8 +410,7 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
             Parse.User.requestPasswordReset('testInvalidConfig@parse.com')
           )
           .then(
-            result => {
-              console.log(result);
+            () => {
               fail('sending password reset email should not have succeeded');
               done();
             },
@@ -450,8 +445,7 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
             Parse.User.requestPasswordReset('testInvalidConfig@parse.com')
           )
           .then(
-            result => {
-              console.log(result);
+            () => {
               fail('sending password reset email should not have succeeded');
               done();
             },
@@ -624,35 +618,32 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       })
       .then(() => {
         expect(sendEmailOptions).not.toBeUndefined();
-        request.get(
-          sendEmailOptions.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
-              'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=user'
-            );
-            user
-              .fetch()
-              .then(
-                () => {
-                  expect(user.get('emailVerified')).toEqual(true);
-                  done();
-                },
-                err => {
-                  jfail(err);
-                  fail('this should not fail');
-                  done();
-                }
-              )
-              .catch(err => {
-                jfail(err);
+        request({
+          url: sendEmailOptions.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          expect(response.text).toEqual(
+            'Found. Redirecting to http://localhost:8378/1/apps/verify_email_success.html?username=user'
+          );
+          user
+            .fetch()
+            .then(
+              () => {
+                expect(user.get('emailVerified')).toEqual(true);
                 done();
-              });
-          }
-        );
+              },
+              err => {
+                jfail(err);
+                fail('this should not fail');
+                done();
+              }
+            )
+            .catch(err => {
+              jfail(err);
+              done();
+            });
+        });
       });
   });
 
@@ -667,19 +658,16 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       },
       publicServerURL: 'http://localhost:8378/1',
     }).then(() => {
-      request.get(
-        'http://localhost:8378/1/apps/test/verify_email',
-        {
-          followRedirect: false,
-        },
-        (error, response) => {
-          expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual(
-            'Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html'
-          );
-          done();
-        }
-      );
+      request({
+        url: 'http://localhost:8378/1/apps/test/verify_email',
+        followRedirects: false,
+      }).then(response => {
+        expect(response.status).toEqual(302);
+        expect(response.text).toEqual(
+          'Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html'
+        );
+        done();
+      });
     });
   });
 
@@ -694,19 +682,17 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       },
       publicServerURL: 'http://localhost:8378/1',
     }).then(() => {
-      request.get(
-        'http://localhost:8378/1/apps/test/verify_email?token=asdfasdf&username=sadfasga',
-        {
-          followRedirect: false,
-        },
-        (error, response) => {
-          expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual(
-            'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=sadfasga&appId=test'
-          );
-          done();
-        }
-      );
+      request({
+        url:
+          'http://localhost:8378/1/apps/test/verify_email?token=asdfasdf&username=sadfasga',
+        followRedirects: false,
+      }).then(response => {
+        expect(response.status).toEqual(302);
+        expect(response.text).toEqual(
+          'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=sadfasga&appId=test'
+        );
+        done();
+      });
     });
   });
 
@@ -721,22 +707,20 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       },
       publicServerURL: 'http://localhost:8378/1',
     }).then(() => {
-      request.post(
-        'http://localhost:8378/1/apps/test/resend_verification_email',
-        {
-          followRedirect: false,
-          form: {
-            username: 'sadfasga',
-          },
+      request({
+        url: 'http://localhost:8378/1/apps/test/resend_verification_email',
+        method: 'POST',
+        followRedirects: false,
+        body: {
+          username: 'sadfasga',
         },
-        (error, response) => {
-          expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual(
-            'Found. Redirecting to http://localhost:8378/1/apps/link_send_fail.html'
-          );
-          done();
-        }
-      );
+      }).then(response => {
+        expect(response.status).toEqual(302);
+        expect(response.text).toEqual(
+          'Found. Redirecting to http://localhost:8378/1/apps/link_send_fail.html'
+        );
+        done();
+      });
     });
   });
 
@@ -744,22 +728,20 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
     const user = new Parse.User();
     const emailAdapter = {
       sendVerificationEmail: () => {
-        request.get(
-          'http://localhost:8378/1/apps/test/verify_email?token=invalid&username=zxcv',
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(
-              'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=zxcv&appId=test'
-            );
-            user.fetch().then(() => {
-              expect(user.get('emailVerified')).toEqual(false);
-              done();
-            });
-          }
-        );
+        request({
+          url:
+            'http://localhost:8378/1/apps/test/verify_email?token=invalid&username=zxcv',
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          expect(response.text).toEqual(
+            'Found. Redirecting to http://localhost:8378/1/apps/invalid_verification_link.html?username=zxcv&appId=test'
+          );
+          user.fetch().then(() => {
+            expect(user.get('emailVerified')).toEqual(false);
+            done();
+          });
+        });
       },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => {},
@@ -788,23 +770,15 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        request.get(
-          options.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            if (error) {
-              jfail(error);
-              fail('Failed to get the reset link');
-              return;
-            }
-            expect(response.statusCode).toEqual(302);
-            const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=[a-zA-Z0-9]+\&id=test\&username=zxcv%2Bzxcv/;
-            expect(response.body.match(re)).not.toBe(null);
-            done();
-          }
-        );
+        request({
+          url: options.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=[a-zA-Z0-9]+\&id=test\&username=zxcv%2Bzxcv/;
+          expect(response.text.match(re)).not.toBe(null);
+          done();
+        });
       },
       sendMail: () => {},
     };
@@ -840,19 +814,17 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       },
       publicServerURL: 'http://localhost:8378/1',
     }).then(() => {
-      request.get(
-        'http://localhost:8378/1/apps/test/request_password_reset?token=asdfasdf&username=sadfasga',
-        {
-          followRedirect: false,
-        },
-        (error, response) => {
-          expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual(
-            'Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html'
-          );
-          done();
-        }
-      );
+      request({
+        url:
+          'http://localhost:8378/1/apps/test/request_password_reset?token=asdfasdf&username=sadfasga',
+        followRedirects: false,
+      }).then(response => {
+        expect(response.status).toEqual(302);
+        expect(response.text).toEqual(
+          'Found. Redirecting to http://localhost:8378/1/apps/invalid_link.html'
+        );
+        done();
+      });
     });
   });
 
@@ -861,76 +833,59 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
       sendPasswordResetEmail: options => {
-        request.get(
-          options.link,
-          {
-            followRedirect: false,
-          },
-          (error, response) => {
-            if (error) {
-              jfail(error);
-              fail('Failed to get the reset link');
-              return;
-            }
-            expect(response.statusCode).toEqual(302);
-            const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=zxcv/;
-            const match = response.body.match(re);
-            if (!match) {
-              fail('should have a token');
-              done();
-              return;
-            }
-            const token = match[1];
+        request({
+          url: options.link,
+          followRedirects: false,
+        }).then(response => {
+          expect(response.status).toEqual(302);
+          const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=zxcv/;
+          const match = response.text.match(re);
+          if (!match) {
+            fail('should have a token');
+            done();
+            return;
+          }
+          const token = match[1];
 
-            request.post(
-              {
-                url: 'http://localhost:8378/1/apps/test/request_password_reset',
-                body: `new_password=hello&token=${token}&username=zxcv`,
-                headers: {
-                  'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                followRedirect: false,
-              },
-              (error, response) => {
-                if (error) {
-                  jfail(error);
-                  fail('Failed to POST request password reset');
-                  return;
-                }
-                expect(response.statusCode).toEqual(302);
-                expect(response.body).toEqual(
-                  'Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=zxcv'
-                );
+          request({
+            url: 'http://localhost:8378/1/apps/test/request_password_reset',
+            method: 'POST',
+            body: { new_password: 'hello', token, username: 'zxcv' },
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            followRedirects: false,
+          }).then(response => {
+            expect(response.status).toEqual(302);
+            expect(response.text).toEqual(
+              'Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=zxcv'
+            );
 
-                Parse.User.logIn('zxcv', 'hello').then(
-                  function() {
-                    const config = Config.get('test');
-                    config.database.adapter
-                      .find(
-                        '_User',
-                        { fields: {} },
-                        { username: 'zxcv' },
-                        { limit: 1 }
-                      )
-                      .then(results => {
-                        // _perishable_token should be unset after reset password
-                        expect(results.length).toEqual(1);
-                        expect(results[0]['_perishable_token']).toEqual(
-                          undefined
-                        );
-                        done();
-                      });
-                  },
-                  err => {
-                    jfail(err);
-                    fail('should login with new password');
+            Parse.User.logIn('zxcv', 'hello').then(
+              function() {
+                const config = Config.get('test');
+                config.database.adapter
+                  .find(
+                    '_User',
+                    { fields: {} },
+                    { username: 'zxcv' },
+                    { limit: 1 }
+                  )
+                  .then(results => {
+                    // _perishable_token should be unset after reset password
+                    expect(results.length).toEqual(1);
+                    expect(results[0]['_perishable_token']).toEqual(undefined);
                     done();
-                  }
-                );
+                  });
+              },
+              err => {
+                jfail(err);
+                fail('should login with new password');
+                done();
               }
             );
-          }
-        );
+          });
+        });
       },
       sendMail: () => {},
     };

--- a/spec/VerifyUserPassword.spec.js
+++ b/spec/VerifyUserPassword.spec.js
@@ -1,22 +1,20 @@
 'use strict';
 
-const rp = require('request-promise');
+const request = require('../lib/request');
 const MockEmailAdapterWithOptions = require('./MockEmailAdapterWithOptions');
 
 const verifyPassword = function(login, password, isEmail = false) {
   const body = !isEmail
     ? { username: login, password }
     : { email: login, password };
-  return rp
-    .get({
-      url: Parse.serverURL + '/verifyPassword',
-      headers: {
-        'X-Parse-Application-Id': Parse.applicationId,
-        'X-Parse-REST-API-Key': 'rest',
-      },
-      body,
-      json: true,
-    })
+  return request({
+    url: Parse.serverURL + '/verifyPassword',
+    headers: {
+      'X-Parse-Application-Id': Parse.applicationId,
+      'X-Parse-REST-API-Key': 'rest',
+    },
+    qs: body,
+  })
     .then(res => res)
     .catch(err => err);
 };
@@ -65,7 +63,7 @@ describe('Verify User Password', () => {
       })
       .then(() => {
         expect(user.getACL().getPublicReadAccess()).toBe(false);
-        return rp.get({
+        return request({
           url: Parse.serverURL + '/verifyPassword',
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -82,8 +80,8 @@ describe('Verify User Password', () => {
         done();
       })
       .catch(err => {
-        expect(err.statusCode).toBe(404);
-        expect(err.error).toMatch(
+        expect(err.status).toBe(404);
+        expect(err.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -98,7 +96,7 @@ describe('Verify User Password', () => {
         email: 'my@user.com',
       })
       .then(() => {
-        return rp.get({
+        return request({
           url: Parse.serverURL + '/verifyPassword',
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -115,8 +113,8 @@ describe('Verify User Password', () => {
         done();
       })
       .catch(err => {
-        expect(err.statusCode).toBe(400);
-        expect(err.error).toMatch(
+        expect(err.status).toBe(400);
+        expect(err.text).toMatch(
           '{"code":200,"error":"username/email is required."}'
         );
         done();
@@ -131,7 +129,7 @@ describe('Verify User Password', () => {
         email: 'my@user.com',
       })
       .then(() => {
-        return rp.get({
+        return request({
           url: Parse.serverURL + '/verifyPassword',
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -148,8 +146,8 @@ describe('Verify User Password', () => {
         done();
       })
       .catch(err => {
-        expect(err.statusCode).toBe(400);
-        expect(err.error).toMatch(
+        expect(err.status).toBe(400);
+        expect(err.text).toMatch(
           '{"code":200,"error":"username/email is required."}'
         );
         done();
@@ -167,8 +165,8 @@ describe('Verify User Password', () => {
         return verifyPassword('', 'mypass');
       })
       .then(res => {
-        expect(res.statusCode).toBe(400);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(400);
+        expect(res.text).toMatch(
           '{"code":200,"error":"username/email is required."}'
         );
         done();
@@ -190,8 +188,8 @@ describe('Verify User Password', () => {
         return verifyPassword('', 'mypass', true);
       })
       .then(res => {
-        expect(res.statusCode).toBe(400);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(400);
+        expect(res.text).toMatch(
           '{"code":200,"error":"username/email is required."}'
         );
         done();
@@ -213,8 +211,8 @@ describe('Verify User Password', () => {
         return verifyPassword('testuser', '');
       })
       .then(res => {
-        expect(res.statusCode).toBe(400);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(400);
+        expect(res.text).toMatch(
           '{"code":201,"error":"password is required."}'
         );
         done();
@@ -236,8 +234,8 @@ describe('Verify User Password', () => {
         return verifyPassword('testuser', 'wrong password');
       })
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -259,8 +257,8 @@ describe('Verify User Password', () => {
         return verifyPassword('my@user.com', 'wrong password', true);
       })
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -282,8 +280,8 @@ describe('Verify User Password', () => {
         return verifyPassword(123, 'mypass');
       })
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -305,8 +303,8 @@ describe('Verify User Password', () => {
         return verifyPassword(123, 'mypass', true);
       })
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -328,8 +326,8 @@ describe('Verify User Password', () => {
         return verifyPassword('my@user.com', 123, true);
       })
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -342,8 +340,8 @@ describe('Verify User Password', () => {
   it('fails to verify password when username cannot be found REST API', done => {
     verifyPassword('mytestuser', 'mypass')
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -356,8 +354,8 @@ describe('Verify User Password', () => {
   it('fails to verify password when email cannot be found REST API', done => {
     verifyPassword('my@user.com', 'mypass', true)
       .then(res => {
-        expect(res.statusCode).toBe(404);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(404);
+        expect(res.text).toMatch(
           '{"code":101,"error":"Invalid username/password."}'
         );
         done();
@@ -391,8 +389,8 @@ describe('Verify User Password', () => {
         return verifyPassword('unverified-email@user.com', 'mypass', true);
       })
       .then(res => {
-        expect(res.statusCode).toBe(400);
-        expect(JSON.stringify(res.error)).toMatch(
+        expect(res.status).toBe(400);
+        expect(res.text).toMatch(
           '{"code":205,"error":"User email is not verified."}'
         );
         done();
@@ -451,24 +449,24 @@ describe('Verify User Password', () => {
         email: 'my@user.com',
       })
       .then(() => {
-        return rp
-          .get({
-            url: Parse.serverURL + '/verifyPassword',
-            headers: {
-              'X-Parse-Application-Id': Parse.applicationId,
-              'X-Parse-REST-API-Key': 'rest',
-            },
-            body: {
-              username: 'testuser',
-              email: 'my@user.com',
-              password: 'mypass',
-            },
-            json: true,
-          })
+        return request({
+          url: Parse.serverURL + '/verifyPassword',
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          qs: {
+            username: 'testuser',
+            email: 'my@user.com',
+            password: 'mypass',
+          },
+          json: true,
+        })
           .then(res => res)
           .catch(err => err);
       })
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(typeof res).toBe('object');
         expect(typeof res['objectId']).toEqual('string');
         expect(res.hasOwnProperty('sessionToken')).toEqual(false);
@@ -491,7 +489,8 @@ describe('Verify User Password', () => {
       .then(() => {
         return verifyPassword('testuser', 'mypass');
       })
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(typeof res).toBe('object');
         expect(typeof res['objectId']).toEqual('string');
         expect(res.hasOwnProperty('sessionToken')).toEqual(false);
@@ -510,7 +509,8 @@ describe('Verify User Password', () => {
       .then(() => {
         return verifyPassword('my@user.com', 'mypass', true);
       })
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(typeof res).toBe('object');
         expect(typeof res['objectId']).toEqual('string');
         expect(res.hasOwnProperty('sessionToken')).toEqual(false);
@@ -527,7 +527,7 @@ describe('Verify User Password', () => {
         email: 'my@user.com',
       })
       .then(() => {
-        return rp.get({
+        return request({
           url: Parse.serverURL + '/verifyPassword',
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -539,7 +539,8 @@ describe('Verify User Password', () => {
           },
         });
       })
-      .then(res => {
+      .then(response => {
+        const res = response.text;
         expect(typeof res).toBe('string');
         const body = JSON.parse(res);
         expect(typeof body['objectId']).toEqual('string');
@@ -557,7 +558,7 @@ describe('Verify User Password', () => {
         email: 'my@user.com',
       })
       .then(() => {
-        return rp.get({
+        return request({
           url: Parse.serverURL + '/verifyPassword',
           headers: {
             'X-Parse-Application-Id': Parse.applicationId,
@@ -569,7 +570,8 @@ describe('Verify User Password', () => {
           },
         });
       })
-      .then(res => {
+      .then(response => {
+        const res = response.text;
         expect(typeof res).toBe('string');
         const body = JSON.parse(res);
         expect(typeof body['objectId']).toEqual('string');
@@ -597,7 +599,8 @@ describe('Verify User Password', () => {
       .then(() => {
         return verifyPassword('email@user.com', 'mypass1');
       })
-      .then(res => {
+      .then(response => {
+        const res = response.data;
         expect(typeof res).toBe('object');
         expect(typeof res['objectId']).toEqual('string');
         expect(res.hasOwnProperty('sessionToken')).toEqual(false);

--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -2,7 +2,7 @@
 
 const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapter')
   .WinstonLoggerAdapter;
-const request = require('request');
+const request = require('../lib/request');
 
 describe('info logs', () => {
   it('Verify INFO logs', done => {
@@ -84,27 +84,24 @@ describe('verbose logs', () => {
           'X-Parse-Application-Id': 'test',
           'X-Parse-REST-API-Key': 'rest',
         };
-        request.get(
-          {
-            headers: headers,
-            url: 'http://localhost:8378/1/login?username=test&password=moon-y',
-          },
-          () => {
-            const winstonLoggerAdapter = new WinstonLoggerAdapter();
-            return winstonLoggerAdapter
-              .query({
-                from: new Date(Date.now() - 500),
-                size: 100,
-                level: 'verbose',
-              })
-              .then(results => {
-                const logString = JSON.stringify(results);
-                expect(logString.match(/\*\*\*\*\*\*\*\*/g).length).not.toBe(0);
-                expect(logString.match(/moon-y/g)).toBe(null);
-                done();
-              });
-          }
-        );
+        request({
+          headers: headers,
+          url: 'http://localhost:8378/1/login?username=test&password=moon-y',
+        }).then(() => {
+          const winstonLoggerAdapter = new WinstonLoggerAdapter();
+          return winstonLoggerAdapter
+            .query({
+              from: new Date(Date.now() - 500),
+              size: 100,
+              level: 'verbose',
+            })
+            .then(results => {
+              const logString = JSON.stringify(results);
+              expect(logString.match(/\*\*\*\*\*\*\*\*/g).length).not.toBe(0);
+              expect(logString.match(/moon-y/g)).toBe(null);
+              done();
+            });
+        });
       })
       .catch(err => {
         fail(JSON.stringify(err));

--- a/spec/features.spec.js
+++ b/spec/features.spec.js
@@ -1,23 +1,22 @@
 'use strict';
 
-const request = require('request');
+const request = require('../lib/request');
 
 describe('features', () => {
   it('requires the master key to get features', done => {
-    request.get(
-      {
-        url: 'http://localhost:8378/1/serverInfo',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-REST-API-Key': 'rest',
-        },
+    request({
+      url: 'http://localhost:8378/1/serverInfo',
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
       },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized: master key is required');
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.status).toEqual(403);
+      expect(response.data.error).toEqual(
+        'unauthorized: master key is required'
+      );
+      done();
+    });
   });
 });

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const Parse = require('parse/node').Parse;
-const request = require('request');
-const rp = require('request-promise');
 const dd = require('deep-diff');
 const Config = require('../lib/Config');
+const request = require('../lib/request');
 
 let config;
 
@@ -127,11 +126,13 @@ const noAuthHeaders = {
 const restKeyHeaders = {
   'X-Parse-Application-Id': 'test',
   'X-Parse-REST-API-Key': 'rest',
+  'Content-Type': 'application/json',
 };
 
 const masterKeyHeaders = {
   'X-Parse-Application-Id': 'test',
   'X-Parse-Master-Key': 'test',
+  'Content-Type': 'application/json',
 };
 
 describe('schemas', () => {
@@ -144,72 +145,64 @@ describe('schemas', () => {
   });
 
   it('requires the master key to get all schemas', done => {
-    request.get(
-      {
-        url: 'http://localhost:8378/1/schemas',
-        json: true,
-        headers: noAuthHeaders,
-      },
-      (error, response, body) => {
-        //api.parse.com uses status code 401, but due to the lack of keys
-        //being necessary in parse-server, 403 makes more sense
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized');
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      json: true,
+      headers: noAuthHeaders,
+    }).then(fail, response => {
+      //api.parse.com uses status code 401, but due to the lack of keys
+      //being necessary in parse-server, 403 makes more sense
+      expect(response.status).toEqual(403);
+      expect(response.data.error).toEqual('unauthorized');
+      done();
+    });
   });
 
   it('requires the master key to get one schema', done => {
-    request.get(
-      {
-        url: 'http://localhost:8378/1/schemas/SomeSchema',
-        json: true,
-        headers: restKeyHeaders,
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized: master key is required');
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas/SomeSchema',
+      json: true,
+      headers: restKeyHeaders,
+    }).then(fail, response => {
+      expect(response.status).toEqual(403);
+      expect(response.data.error).toEqual(
+        'unauthorized: master key is required'
+      );
+      done();
+    });
   });
 
   it('asks for the master key if you use the rest key', done => {
-    request.get(
-      {
-        url: 'http://localhost:8378/1/schemas',
-        json: true,
-        headers: restKeyHeaders,
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized: master key is required');
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      json: true,
+      headers: restKeyHeaders,
+    }).then(fail, response => {
+      expect(response.status).toEqual(403);
+      expect(response.data.error).toEqual(
+        'unauthorized: master key is required'
+      );
+      done();
+    });
   });
 
   it('creates _User schema when server starts', done => {
-    request.get(
-      {
-        url: 'http://localhost:8378/1/schemas',
-        json: true,
-        headers: masterKeyHeaders,
-      },
-      (error, response, body) => {
-        const expected = {
-          results: [userSchema, roleSchema],
-        };
-        expect(
-          dd(
-            body.results.sort((s1, s2) => s1.className > s2.className),
-            expected.results.sort((s1, s2) => s1.className > s2.className)
-          )
-        ).toEqual(undefined);
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      json: true,
+      headers: masterKeyHeaders,
+    }).then(response => {
+      const expected = {
+        results: [userSchema, roleSchema],
+      };
+      expect(
+        dd(
+          response.data.results.sort((s1, s2) => s1.className > s2.className),
+          expected.results.sort((s1, s2) => s1.className > s2.className)
+        )
+      ).toEqual(undefined);
+      done();
+    });
   });
 
   it('responds with a list of schemas after creating objects', done => {
@@ -224,193 +217,173 @@ describe('schemas', () => {
         return obj2.save();
       })
       .then(() => {
-        request.get(
-          {
-            url: 'http://localhost:8378/1/schemas',
-            json: true,
-            headers: masterKeyHeaders,
-          },
-          (error, response, body) => {
-            const expected = {
-              results: [
-                userSchema,
-                roleSchema,
-                plainOldDataSchema,
-                pointersAndRelationsSchema,
-              ],
-            };
-            expect(
-              dd(
-                body.results.sort((s1, s2) => s1.className > s2.className),
-                expected.results.sort((s1, s2) => s1.className > s2.className)
-              )
-            ).toEqual(undefined);
-            done();
-          }
-        );
+        request({
+          url: 'http://localhost:8378/1/schemas',
+          json: true,
+          headers: masterKeyHeaders,
+        }).then(response => {
+          const expected = {
+            results: [
+              userSchema,
+              roleSchema,
+              plainOldDataSchema,
+              pointersAndRelationsSchema,
+            ],
+          };
+          expect(
+            dd(
+              response.data.results.sort(
+                (s1, s2) => s1.className > s2.className
+              ),
+              expected.results.sort((s1, s2) => s1.className > s2.className)
+            )
+          ).toEqual(undefined);
+          done();
+        });
       });
   });
 
   it('responds with a single schema', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.get(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
-          json: true,
-          headers: masterKeyHeaders,
-        },
-        (error, response, body) => {
-          expect(body).toEqual(plainOldDataSchema);
-          done();
-        }
-      );
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        json: true,
+        headers: masterKeyHeaders,
+      }).then(response => {
+        expect(response.data).toEqual(plainOldDataSchema);
+        done();
+      });
     });
   });
 
   it('treats class names case sensitively', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.get(
-        {
-          url: 'http://localhost:8378/1/schemas/HASALLPOD',
-          json: true,
-          headers: masterKeyHeaders,
-        },
-        (error, response, body) => {
-          expect(response.statusCode).toEqual(400);
-          expect(body).toEqual({
-            code: 103,
-            error: 'Class HASALLPOD does not exist.',
-          });
-          done();
-        }
-      );
+      request({
+        url: 'http://localhost:8378/1/schemas/HASALLPOD',
+        json: true,
+        headers: masterKeyHeaders,
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data).toEqual({
+          code: 103,
+          error: 'Class HASALLPOD does not exist.',
+        });
+        done();
+      });
     });
   });
 
   it('requires the master key to create a schema', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas',
-        json: true,
-        headers: noAuthHeaders,
-        body: {
-          className: 'MyClass',
-        },
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      method: 'POST',
+      json: true,
+      headers: noAuthHeaders,
+      body: {
+        className: 'MyClass',
       },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized');
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.status).toEqual(403);
+      expect(response.data.error).toEqual('unauthorized');
+      done();
+    });
   });
 
   it('sends an error if you use mismatching class names', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/A',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          className: 'B',
-        },
+    request({
+      url: 'http://localhost:8378/1/schemas/A',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        className: 'B',
       },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(400);
-        expect(body).toEqual({
-          code: Parse.Error.INVALID_CLASS_NAME,
-          error: 'Class name mismatch between B and A.',
-        });
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.status).toEqual(400);
+      expect(response.data).toEqual({
+        code: Parse.Error.INVALID_CLASS_NAME,
+        error: 'Class name mismatch between B and A.',
+      });
+      done();
+    });
   });
 
   it('sends an error if you use no class name', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {},
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(400);
-        expect(body).toEqual({
-          code: 135,
-          error: 'POST /schemas needs a class name.',
-        });
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {},
+    }).then(fail, response => {
+      expect(response.status).toEqual(400);
+      expect(response.data).toEqual({
+        code: 135,
+        error: 'POST /schemas needs a class name.',
+      });
+      done();
+    });
   });
 
   it('sends an error if you try to create the same class twice', done => {
-    request.post(
-      {
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        className: 'A',
+      },
+    }).then(() => {
+      request({
         url: 'http://localhost:8378/1/schemas',
+        method: 'POST',
         headers: masterKeyHeaders,
         json: true,
         body: {
           className: 'A',
         },
-      },
-      error => {
-        expect(error).toEqual(null);
-        request.post(
-          {
-            url: 'http://localhost:8378/1/schemas',
-            headers: masterKeyHeaders,
-            json: true,
-            body: {
-              className: 'A',
-            },
-          },
-          (error, response, body) => {
-            expect(response.statusCode).toEqual(400);
-            expect(body).toEqual({
-              code: Parse.Error.INVALID_CLASS_NAME,
-              error: 'Class A already exists.',
-            });
-            done();
-          }
-        );
-      }
-    );
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data).toEqual({
+          code: Parse.Error.INVALID_CLASS_NAME,
+          error: 'Class A already exists.',
+        });
+        done();
+      });
+    });
   });
 
   it('responds with all fields when you create a class', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          className: 'NewClass',
-          fields: {
-            foo: { type: 'Number' },
-            ptr: { type: 'Pointer', targetClass: 'SomeClass' },
-          },
+    request({
+      url: 'http://localhost:8378/1/schemas',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        className: 'NewClass',
+        fields: {
+          foo: { type: 'Number' },
+          ptr: { type: 'Pointer', targetClass: 'SomeClass' },
         },
       },
-      (error, response, body) => {
-        expect(body).toEqual({
-          className: 'NewClass',
-          fields: {
-            ACL: { type: 'ACL' },
-            createdAt: { type: 'Date' },
-            updatedAt: { type: 'Date' },
-            objectId: { type: 'String' },
-            foo: { type: 'Number' },
-            ptr: { type: 'Pointer', targetClass: 'SomeClass' },
-          },
-          classLevelPermissions: defaultClassLevelPermissions,
-        });
-        done();
-      }
-    );
+    }).then(response => {
+      expect(response.data).toEqual({
+        className: 'NewClass',
+        fields: {
+          ACL: { type: 'ACL' },
+          createdAt: { type: 'Date' },
+          updatedAt: { type: 'Date' },
+          objectId: { type: 'String' },
+          foo: { type: 'Number' },
+          ptr: { type: 'Pointer', targetClass: 'SomeClass' },
+        },
+        classLevelPermissions: defaultClassLevelPermissions,
+      });
+      done();
+    });
   });
 
   it('responds with all fields when getting incomplete schema', done => {
@@ -424,41 +397,38 @@ describe('schemas', () => {
         )
       )
       .then(() => {
-        request.get(
-          {
-            url: 'http://localhost:8378/1/schemas/_Installation',
-            headers: masterKeyHeaders,
-            json: true,
-          },
-          (error, response, body) => {
-            expect(
-              dd(body, {
-                className: '_Installation',
-                fields: {
-                  objectId: { type: 'String' },
-                  updatedAt: { type: 'Date' },
-                  createdAt: { type: 'Date' },
-                  installationId: { type: 'String' },
-                  deviceToken: { type: 'String' },
-                  channels: { type: 'Array' },
-                  deviceType: { type: 'String' },
-                  pushType: { type: 'String' },
-                  GCMSenderId: { type: 'String' },
-                  timeZone: { type: 'String' },
-                  badge: { type: 'Number' },
-                  appIdentifier: { type: 'String' },
-                  localeIdentifier: { type: 'String' },
-                  appVersion: { type: 'String' },
-                  appName: { type: 'String' },
-                  parseVersion: { type: 'String' },
-                  ACL: { type: 'ACL' },
-                },
-                classLevelPermissions: defaultClassLevelPermissions,
-              })
-            ).toBeUndefined();
-            done();
-          }
-        );
+        request({
+          url: 'http://localhost:8378/1/schemas/_Installation',
+          headers: masterKeyHeaders,
+          json: true,
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: '_Installation',
+              fields: {
+                objectId: { type: 'String' },
+                updatedAt: { type: 'Date' },
+                createdAt: { type: 'Date' },
+                installationId: { type: 'String' },
+                deviceToken: { type: 'String' },
+                channels: { type: 'Array' },
+                deviceType: { type: 'String' },
+                pushType: { type: 'String' },
+                GCMSenderId: { type: 'String' },
+                timeZone: { type: 'String' },
+                badge: { type: 'Number' },
+                appIdentifier: { type: 'String' },
+                localeIdentifier: { type: 'String' },
+                appVersion: { type: 'String' },
+                appName: { type: 'String' },
+                parseVersion: { type: 'String' },
+                ACL: { type: 'ACL' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+            })
+          ).toBeUndefined();
+          done();
+        });
       })
       .catch(error => {
         fail(JSON.stringify(error));
@@ -467,170 +437,156 @@ describe('schemas', () => {
   });
 
   it('lets you specify class name in both places', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/NewClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          className: 'NewClass',
-        },
+    request({
+      url: 'http://localhost:8378/1/schemas/NewClass',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        className: 'NewClass',
       },
-      (error, response, body) => {
-        expect(body).toEqual({
-          className: 'NewClass',
-          fields: {
-            ACL: { type: 'ACL' },
-            createdAt: { type: 'Date' },
-            updatedAt: { type: 'Date' },
-            objectId: { type: 'String' },
-          },
-          classLevelPermissions: defaultClassLevelPermissions,
-        });
-        done();
-      }
-    );
+    }).then(response => {
+      expect(response.data).toEqual({
+        className: 'NewClass',
+        fields: {
+          ACL: { type: 'ACL' },
+          createdAt: { type: 'Date' },
+          updatedAt: { type: 'Date' },
+          objectId: { type: 'String' },
+        },
+        classLevelPermissions: defaultClassLevelPermissions,
+      });
+      done();
+    });
   });
 
   it('requires the master key to modify schemas', done => {
-    request.post(
-      {
+    request({
+      url: 'http://localhost:8378/1/schemas/NewClass',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {},
+    }).then(() => {
+      request({
         url: 'http://localhost:8378/1/schemas/NewClass',
-        headers: masterKeyHeaders,
+        method: 'PUT',
+        headers: noAuthHeaders,
         json: true,
         body: {},
-      },
-      () => {
-        request.put(
-          {
-            url: 'http://localhost:8378/1/schemas/NewClass',
-            headers: noAuthHeaders,
-            json: true,
-            body: {},
-          },
-          (error, response, body) => {
-            expect(response.statusCode).toEqual(403);
-            expect(body.error).toEqual('unauthorized');
-            done();
-          }
-        );
-      }
-    );
+      }).then(fail, response => {
+        expect(response.status).toEqual(403);
+        expect(response.data.error).toEqual('unauthorized');
+        done();
+      });
+    });
   });
 
   it('rejects class name mis-matches in put', done => {
-    request.put(
-      {
-        url: 'http://localhost:8378/1/schemas/NewClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: { className: 'WrongClassName' },
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(400);
-        expect(body.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
-        expect(body.error).toEqual(
-          'Class name mismatch between WrongClassName and NewClass.'
-        );
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas/NewClass',
+      method: 'PUT',
+      headers: masterKeyHeaders,
+      json: true,
+      body: { className: 'WrongClassName' },
+    }).then(fail, response => {
+      expect(response.status).toEqual(400);
+      expect(response.data.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
+      expect(response.data.error).toEqual(
+        'Class name mismatch between WrongClassName and NewClass.'
+      );
+      done();
+    });
   });
 
   it('refuses to add fields to non-existent classes', done => {
-    request.put(
-      {
-        url: 'http://localhost:8378/1/schemas/NoClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          fields: {
-            newField: { type: 'String' },
-          },
+    request({
+      url: 'http://localhost:8378/1/schemas/NoClass',
+      method: 'PUT',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        fields: {
+          newField: { type: 'String' },
         },
       },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(400);
-        expect(body.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
-        expect(body.error).toEqual('Class NoClass does not exist.');
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.status).toEqual(400);
+      expect(response.data.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
+      expect(response.data.error).toEqual('Class NoClass does not exist.');
+      done();
+    });
   });
 
   it('refuses to put to existing fields, even if it would not be a change', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            fields: {
-              aString: { type: 'String' },
-            },
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            aString: { type: 'String' },
           },
         },
-        (error, response, body) => {
-          expect(response.statusCode).toEqual(400);
-          expect(body.code).toEqual(255);
-          expect(body.error).toEqual('Field aString exists, cannot update.');
-          done();
-        }
-      );
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data.code).toEqual(255);
+        expect(response.data.error).toEqual(
+          'Field aString exists, cannot update.'
+        );
+        done();
+      });
     });
   });
 
   it('refuses to delete non-existent fields', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            fields: {
-              nonExistentKey: { __op: 'Delete' },
-            },
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            nonExistentKey: { __op: 'Delete' },
           },
         },
-        (error, response, body) => {
-          expect(response.statusCode).toEqual(400);
-          expect(body.code).toEqual(255);
-          expect(body.error).toEqual(
-            'Field nonExistentKey does not exist, cannot delete.'
-          );
-          done();
-        }
-      );
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data.code).toEqual(255);
+        expect(response.data.error).toEqual(
+          'Field nonExistentKey does not exist, cannot delete.'
+        );
+        done();
+      });
     });
   });
 
   it('refuses to add a geopoint to a class that already has one', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            fields: {
-              newGeo: { type: 'GeoPoint' },
-            },
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            newGeo: { type: 'GeoPoint' },
           },
         },
-        (error, response, body) => {
-          expect(response.statusCode).toEqual(400);
-          expect(body.code).toEqual(Parse.Error.INCORRECT_TYPE);
-          expect(body.error).toEqual(
-            'currently, only one GeoPoint field may exist in an object. Adding newGeo when aGeoPoint already exists.'
-          );
-          done();
-        }
-      );
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data.code).toEqual(Parse.Error.INCORRECT_TYPE);
+        expect(response.data.error).toEqual(
+          'currently, only one GeoPoint field may exist in an object. Adding newGeo when aGeoPoint already exists.'
+        );
+        done();
+      });
     });
   });
 
@@ -638,27 +594,25 @@ describe('schemas', () => {
     const obj = new Parse.Object('NewClass');
     obj.set('aString', 'aString');
     obj.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/NewClass',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            fields: {
-              newGeo1: { type: 'GeoPoint' },
-              newGeo2: { type: 'GeoPoint' },
-            },
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            newGeo1: { type: 'GeoPoint' },
+            newGeo2: { type: 'GeoPoint' },
           },
         },
-        (error, response, body) => {
-          expect(response.statusCode).toEqual(400);
-          expect(body.code).toEqual(Parse.Error.INCORRECT_TYPE);
-          expect(body.error).toEqual(
-            'currently, only one GeoPoint field may exist in an object. Adding newGeo2 when newGeo1 already exists.'
-          );
-          done();
-        }
-      );
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data.code).toEqual(Parse.Error.INCORRECT_TYPE);
+        expect(response.data.error).toEqual(
+          'currently, only one GeoPoint field may exist in an object. Adding newGeo2 when newGeo1 already exists.'
+        );
+        done();
+      });
     });
   });
 
@@ -666,187 +620,169 @@ describe('schemas', () => {
     const obj = new Parse.Object('NewClass');
     obj.set('geo1', new Parse.GeoPoint({ latitude: 0, longitude: 0 }));
     obj.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/NewClass',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            fields: {
-              geo2: { type: 'GeoPoint' },
-              geo1: { __op: 'Delete' },
-            },
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            geo2: { type: 'GeoPoint' },
+            geo1: { __op: 'Delete' },
           },
         },
-        (error, response, body) => {
-          expect(
-            dd(body, {
-              className: 'NewClass',
-              fields: {
-                ACL: { type: 'ACL' },
-                createdAt: { type: 'Date' },
-                objectId: { type: 'String' },
-                updatedAt: { type: 'Date' },
-                geo2: { type: 'GeoPoint' },
-              },
-              classLevelPermissions: defaultClassLevelPermissions,
-            })
-          ).toEqual(undefined);
-          done();
-        }
-      );
+      }).then(response => {
+        expect(
+          dd(response.data, {
+            className: 'NewClass',
+            fields: {
+              ACL: { type: 'ACL' },
+              createdAt: { type: 'Date' },
+              objectId: { type: 'String' },
+              updatedAt: { type: 'Date' },
+              geo2: { type: 'GeoPoint' },
+            },
+            classLevelPermissions: defaultClassLevelPermissions,
+          })
+        ).toEqual(undefined);
+        done();
+      });
     });
   });
 
   it('put with no modifications returns all fields', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {},
-        },
-        (error, response, body) => {
-          expect(body).toEqual(plainOldDataSchema);
-          done();
-        }
-      );
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(response => {
+        expect(response.data).toEqual(plainOldDataSchema);
+        done();
+      });
     });
   });
 
   it('lets you add fields', done => {
-    request.post(
-      {
+    request({
+      url: 'http://localhost:8378/1/schemas/NewClass',
+      method: 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {},
+    }).then(() => {
+      request({
+        method: 'PUT',
         url: 'http://localhost:8378/1/schemas/NewClass',
         headers: masterKeyHeaders,
         json: true,
-        body: {},
-      },
-      () => {
-        request.put(
-          {
-            url: 'http://localhost:8378/1/schemas/NewClass',
-            headers: masterKeyHeaders,
-            json: true,
-            body: {
-              fields: {
-                newField: { type: 'String' },
-              },
-            },
+        body: {
+          fields: {
+            newField: { type: 'String' },
           },
-          (error, response, body) => {
-            expect(
-              dd(body, {
-                className: 'NewClass',
-                fields: {
-                  ACL: { type: 'ACL' },
-                  createdAt: { type: 'Date' },
-                  objectId: { type: 'String' },
-                  updatedAt: { type: 'Date' },
-                  newField: { type: 'String' },
-                },
-                classLevelPermissions: defaultClassLevelPermissions,
-              })
-            ).toEqual(undefined);
-            request.get(
-              {
-                url: 'http://localhost:8378/1/schemas/NewClass',
-                headers: masterKeyHeaders,
-                json: true,
-              },
-              (error, response, body) => {
-                expect(body).toEqual({
-                  className: 'NewClass',
-                  fields: {
-                    ACL: { type: 'ACL' },
-                    createdAt: { type: 'Date' },
-                    updatedAt: { type: 'Date' },
-                    objectId: { type: 'String' },
-                    newField: { type: 'String' },
-                  },
-                  classLevelPermissions: defaultClassLevelPermissions,
-                });
-                done();
-              }
-            );
-          }
-        );
-      }
-    );
+        },
+      }).then(response => {
+        expect(
+          dd(response.data, {
+            className: 'NewClass',
+            fields: {
+              ACL: { type: 'ACL' },
+              createdAt: { type: 'Date' },
+              objectId: { type: 'String' },
+              updatedAt: { type: 'Date' },
+              newField: { type: 'String' },
+            },
+            classLevelPermissions: defaultClassLevelPermissions,
+          })
+        ).toEqual(undefined);
+        request({
+          url: 'http://localhost:8378/1/schemas/NewClass',
+          headers: masterKeyHeaders,
+          json: true,
+        }).then(response => {
+          expect(response.data).toEqual({
+            className: 'NewClass',
+            fields: {
+              ACL: { type: 'ACL' },
+              createdAt: { type: 'Date' },
+              updatedAt: { type: 'Date' },
+              objectId: { type: 'String' },
+              newField: { type: 'String' },
+            },
+            classLevelPermissions: defaultClassLevelPermissions,
+          });
+          done();
+        });
+      });
+    });
   });
 
   it('lets you add fields to system schema', done => {
-    request.post(
-      {
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/_User',
+      headers: masterKeyHeaders,
+      json: true,
+    }).then(fail, () => {
+      request({
         url: 'http://localhost:8378/1/schemas/_User',
+        method: 'PUT',
         headers: masterKeyHeaders,
         json: true,
-      },
-      () => {
-        request.put(
-          {
-            url: 'http://localhost:8378/1/schemas/_User',
-            headers: masterKeyHeaders,
-            json: true,
-            body: {
-              fields: {
-                newField: { type: 'String' },
-              },
-            },
+        body: {
+          fields: {
+            newField: { type: 'String' },
           },
-          (error, response, body) => {
-            expect(
-              dd(body, {
-                className: '_User',
-                fields: {
-                  objectId: { type: 'String' },
-                  updatedAt: { type: 'Date' },
-                  createdAt: { type: 'Date' },
-                  username: { type: 'String' },
-                  password: { type: 'String' },
-                  email: { type: 'String' },
-                  emailVerified: { type: 'Boolean' },
-                  authData: { type: 'Object' },
-                  newField: { type: 'String' },
-                  ACL: { type: 'ACL' },
-                },
-                classLevelPermissions: defaultClassLevelPermissions,
-              })
-            ).toBeUndefined();
-            request.get(
-              {
-                url: 'http://localhost:8378/1/schemas/_User',
-                headers: masterKeyHeaders,
-                json: true,
+        },
+      }).then(response => {
+        expect(
+          dd(response.data, {
+            className: '_User',
+            fields: {
+              objectId: { type: 'String' },
+              updatedAt: { type: 'Date' },
+              createdAt: { type: 'Date' },
+              username: { type: 'String' },
+              password: { type: 'String' },
+              email: { type: 'String' },
+              emailVerified: { type: 'Boolean' },
+              authData: { type: 'Object' },
+              newField: { type: 'String' },
+              ACL: { type: 'ACL' },
+            },
+            classLevelPermissions: defaultClassLevelPermissions,
+          })
+        ).toBeUndefined();
+        request({
+          url: 'http://localhost:8378/1/schemas/_User',
+          headers: masterKeyHeaders,
+          json: true,
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: '_User',
+              fields: {
+                objectId: { type: 'String' },
+                updatedAt: { type: 'Date' },
+                createdAt: { type: 'Date' },
+                username: { type: 'String' },
+                password: { type: 'String' },
+                email: { type: 'String' },
+                emailVerified: { type: 'Boolean' },
+                authData: { type: 'Object' },
+                newField: { type: 'String' },
+                ACL: { type: 'ACL' },
               },
-              (error, response, body) => {
-                expect(
-                  dd(body, {
-                    className: '_User',
-                    fields: {
-                      objectId: { type: 'String' },
-                      updatedAt: { type: 'Date' },
-                      createdAt: { type: 'Date' },
-                      username: { type: 'String' },
-                      password: { type: 'String' },
-                      email: { type: 'String' },
-                      emailVerified: { type: 'Boolean' },
-                      authData: { type: 'Object' },
-                      newField: { type: 'String' },
-                      ACL: { type: 'ACL' },
-                    },
-                    classLevelPermissions: defaultClassLevelPermissions,
-                  })
-                ).toBeUndefined();
-                done();
-              }
-            );
-          }
-        );
-      }
-    );
+              classLevelPermissions: defaultClassLevelPermissions,
+            })
+          ).toBeUndefined();
+          done();
+        });
+      });
+    });
   });
 
   it('lets you delete multiple fields and check schema', done => {
@@ -861,61 +797,20 @@ describe('schemas', () => {
     simpleOneObject()
       .save()
       .then(() => {
-        request.put(
-          {
-            url: 'http://localhost:8378/1/schemas/SimpleOne',
-            headers: masterKeyHeaders,
-            json: true,
-            body: {
-              fields: {
-                aString: { __op: 'Delete' },
-                aNumber: { __op: 'Delete' },
-              },
-            },
-          },
-          (error, response, body) => {
-            expect(body).toEqual({
-              className: 'SimpleOne',
-              fields: {
-                //Default fields
-                ACL: { type: 'ACL' },
-                createdAt: { type: 'Date' },
-                updatedAt: { type: 'Date' },
-                objectId: { type: 'String' },
-                //Custom fields
-                aBool: { type: 'Boolean' },
-              },
-              classLevelPermissions: defaultClassLevelPermissions,
-            });
-
-            done();
-          }
-        );
-      });
-  });
-
-  it('lets you delete multiple fields and add fields', done => {
-    const obj1 = hasAllPODobject();
-    obj1.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        request({
+          url: 'http://localhost:8378/1/schemas/SimpleOne',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
           body: {
             fields: {
               aString: { __op: 'Delete' },
               aNumber: { __op: 'Delete' },
-              aNewString: { type: 'String' },
-              aNewNumber: { type: 'Number' },
-              aNewRelation: { type: 'Relation', targetClass: 'HasAllPOD' },
-              aNewPointer: { type: 'Pointer', targetClass: 'HasAllPOD' },
             },
           },
-        },
-        (error, response, body) => {
-          expect(body).toEqual({
-            className: 'HasAllPOD',
+        }).then(response => {
+          expect(response.data).toEqual({
+            className: 'SimpleOne',
             fields: {
               //Default fields
               ACL: { type: 'ACL' },
@@ -924,128 +819,153 @@ describe('schemas', () => {
               objectId: { type: 'String' },
               //Custom fields
               aBool: { type: 'Boolean' },
-              aDate: { type: 'Date' },
-              aObject: { type: 'Object' },
-              aArray: { type: 'Array' },
-              aGeoPoint: { type: 'GeoPoint' },
-              aFile: { type: 'File' },
-              aNewNumber: { type: 'Number' },
-              aNewString: { type: 'String' },
-              aNewPointer: { type: 'Pointer', targetClass: 'HasAllPOD' },
-              aNewRelation: { type: 'Relation', targetClass: 'HasAllPOD' },
             },
             classLevelPermissions: defaultClassLevelPermissions,
           });
-          const obj2 = new Parse.Object('HasAllPOD');
-          obj2.set('aNewPointer', obj1);
-          const relation = obj2.relation('aNewRelation');
-          relation.add(obj1);
-          obj2.save().then(done); //Just need to make sure saving works on the new object.
-        }
-      );
+
+          done();
+        });
+      });
+  });
+
+  it('lets you delete multiple fields and add fields', done => {
+    const obj1 = hasAllPODobject();
+    obj1.save().then(() => {
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            aString: { __op: 'Delete' },
+            aNumber: { __op: 'Delete' },
+            aNewString: { type: 'String' },
+            aNewNumber: { type: 'Number' },
+            aNewRelation: { type: 'Relation', targetClass: 'HasAllPOD' },
+            aNewPointer: { type: 'Pointer', targetClass: 'HasAllPOD' },
+          },
+        },
+      }).then(response => {
+        expect(response.data).toEqual({
+          className: 'HasAllPOD',
+          fields: {
+            //Default fields
+            ACL: { type: 'ACL' },
+            createdAt: { type: 'Date' },
+            updatedAt: { type: 'Date' },
+            objectId: { type: 'String' },
+            //Custom fields
+            aBool: { type: 'Boolean' },
+            aDate: { type: 'Date' },
+            aObject: { type: 'Object' },
+            aArray: { type: 'Array' },
+            aGeoPoint: { type: 'GeoPoint' },
+            aFile: { type: 'File' },
+            aNewNumber: { type: 'Number' },
+            aNewString: { type: 'String' },
+            aNewPointer: { type: 'Pointer', targetClass: 'HasAllPOD' },
+            aNewRelation: { type: 'Relation', targetClass: 'HasAllPOD' },
+          },
+          classLevelPermissions: defaultClassLevelPermissions,
+        });
+        const obj2 = new Parse.Object('HasAllPOD');
+        obj2.set('aNewPointer', obj1);
+        const relation = obj2.relation('aNewRelation');
+        relation.add(obj1);
+        obj2.save().then(done); //Just need to make sure saving works on the new object.
+      });
     });
   });
 
   it('will not delete any fields if the additions are invalid', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.put(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'PUT',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          fields: {
+            fakeNewField: { type: 'fake type' },
+            aString: { __op: 'Delete' },
+          },
+        },
+      }).then(fail, response => {
+        expect(response.data.code).toEqual(Parse.Error.INCORRECT_TYPE);
+        expect(response.data.error).toEqual('invalid field type: fake type');
+        request({
+          method: 'PUT',
           url: 'http://localhost:8378/1/schemas/HasAllPOD',
           headers: masterKeyHeaders,
           json: true,
-          body: {
-            fields: {
-              fakeNewField: { type: 'fake type' },
-              aString: { __op: 'Delete' },
-            },
-          },
-        },
-        (error, response, body) => {
-          expect(body.code).toEqual(Parse.Error.INCORRECT_TYPE);
-          expect(body.error).toEqual('invalid field type: fake type');
-          request.get(
-            {
-              url: 'http://localhost:8378/1/schemas/HasAllPOD',
-              headers: masterKeyHeaders,
-              json: true,
-            },
-            (error, response) => {
-              expect(response.body).toEqual(plainOldDataSchema);
-              done();
-            }
-          );
-        }
-      );
+        }).then(response => {
+          expect(response.data).toEqual(plainOldDataSchema);
+          done();
+        });
+      });
     });
   });
 
   it('requires the master key to delete schemas', done => {
-    request.del(
-      {
-        url: 'http://localhost:8378/1/schemas/DoesntMatter',
-        headers: noAuthHeaders,
-        json: true,
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(403);
-        expect(body.error).toEqual('unauthorized');
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas/DoesntMatter',
+      method: 'DELETE',
+      headers: noAuthHeaders,
+      json: true,
+    }).then(fail, response => {
+      expect(response.status).toEqual(403);
+      expect(response.data.error).toEqual('unauthorized');
+      done();
+    });
   });
 
   it('refuses to delete non-empty collection', done => {
     const obj = hasAllPODobject();
     obj.save().then(() => {
-      request.del(
-        {
-          url: 'http://localhost:8378/1/schemas/HasAllPOD',
-          headers: masterKeyHeaders,
-          json: true,
-        },
-        (error, response, body) => {
-          expect(response.statusCode).toEqual(400);
-          expect(body.code).toEqual(255);
-          expect(body.error).toMatch(/HasAllPOD/);
-          expect(body.error).toMatch(/contains 1/);
-          done();
-        }
-      );
+      request({
+        url: 'http://localhost:8378/1/schemas/HasAllPOD',
+        method: 'DELETE',
+        headers: masterKeyHeaders,
+        json: true,
+      }).then(fail, response => {
+        expect(response.status).toEqual(400);
+        expect(response.data.code).toEqual(255);
+        expect(response.data.error).toMatch(/HasAllPOD/);
+        expect(response.data.error).toMatch(/contains 1/);
+        done();
+      });
     });
   });
 
   it('fails when deleting collections with invalid class names', done => {
-    request.del(
-      {
-        url: 'http://localhost:8378/1/schemas/_GlobalConfig',
-        headers: masterKeyHeaders,
-        json: true,
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(400);
-        expect(body.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
-        expect(body.error).toEqual(
-          'Invalid classname: _GlobalConfig, classnames can only have alphanumeric characters and _, and must start with an alpha character '
-        );
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas/_GlobalConfig',
+      method: 'DELETE',
+      headers: masterKeyHeaders,
+      json: true,
+    }).then(fail, response => {
+      expect(response.status).toEqual(400);
+      expect(response.data.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
+      expect(response.data.error).toEqual(
+        'Invalid classname: _GlobalConfig, classnames can only have alphanumeric characters and _, and must start with an alpha character '
+      );
+      done();
+    });
   });
 
   it('does not fail when deleting nonexistant collections', done => {
-    request.del(
-      {
-        url: 'http://localhost:8378/1/schemas/Missing',
-        headers: masterKeyHeaders,
-        json: true,
-      },
-      (error, response, body) => {
-        expect(response.statusCode).toEqual(200);
-        expect(body).toEqual({});
-        done();
-      }
-    );
+    request({
+      url: 'http://localhost:8378/1/schemas/Missing',
+      method: 'DELETE',
+      headers: masterKeyHeaders,
+      json: true,
+    }).then(response => {
+      expect(response.status).toEqual(200);
+      expect(response.data).toEqual({});
+      done();
+    });
   });
 
   it('deletes collections including join tables', done => {
@@ -1061,50 +981,47 @@ describe('schemas', () => {
       })
       .then(obj2 => obj2.destroy())
       .then(() => {
-        request.del(
-          {
-            url: 'http://localhost:8378/1/schemas/MyOtherClass',
-            headers: masterKeyHeaders,
-            json: true,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(200);
-            expect(response.body).toEqual({});
-            config.database
-              .collectionExists('_Join:aRelation:MyOtherClass')
-              .then(exists => {
-                if (exists) {
-                  fail('Relation collection should be deleted.');
-                  done();
-                }
-                return config.database.collectionExists('MyOtherClass');
-              })
-              .then(exists => {
-                if (exists) {
-                  fail('Class collection should be deleted.');
-                  done();
-                }
-              })
-              .then(() => {
-                request.get(
-                  {
-                    url: 'http://localhost:8378/1/schemas/MyOtherClass',
-                    headers: masterKeyHeaders,
-                    json: true,
-                  },
-                  (error, response, body) => {
-                    //Expect _SCHEMA entry to be gone.
-                    expect(response.statusCode).toEqual(400);
-                    expect(body.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
-                    expect(body.error).toEqual(
-                      'Class MyOtherClass does not exist.'
-                    );
-                    done();
-                  }
+        request({
+          url: 'http://localhost:8378/1/schemas/MyOtherClass',
+          method: 'DELETE',
+          headers: masterKeyHeaders,
+          json: true,
+        }).then(response => {
+          expect(response.status).toEqual(200);
+          expect(response.data).toEqual({});
+          config.database
+            .collectionExists('_Join:aRelation:MyOtherClass')
+            .then(exists => {
+              if (exists) {
+                fail('Relation collection should be deleted.');
+                done();
+              }
+              return config.database.collectionExists('MyOtherClass');
+            })
+            .then(exists => {
+              if (exists) {
+                fail('Class collection should be deleted.');
+                done();
+              }
+            })
+            .then(() => {
+              request({
+                url: 'http://localhost:8378/1/schemas/MyOtherClass',
+                headers: masterKeyHeaders,
+                json: true,
+              }).then(fail, response => {
+                //Expect _SCHEMA entry to be gone.
+                expect(response.status).toEqual(400);
+                expect(response.data.code).toEqual(
+                  Parse.Error.INVALID_CLASS_NAME
                 );
+                expect(response.data.error).toEqual(
+                  'Class MyOtherClass does not exist.'
+                );
+                done();
               });
-          }
-        );
+            });
+        });
       })
       .then(
         () => {},
@@ -1116,99 +1033,125 @@ describe('schemas', () => {
   });
 
   it('deletes schema when actual collection does not exist', done => {
-    request.post(
-      {
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/NewClassForDelete',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        className: 'NewClassForDelete',
+      },
+    }).then(response => {
+      expect(response.data.className).toEqual('NewClassForDelete');
+      request({
         url: 'http://localhost:8378/1/schemas/NewClassForDelete',
+        method: 'DELETE',
         headers: masterKeyHeaders,
         json: true,
-        body: {
-          className: 'NewClassForDelete',
-        },
+      }).then(response => {
+        expect(response.status).toEqual(200);
+        expect(response.data).toEqual({});
+        config.database.loadSchema().then(schema => {
+          schema.hasClass('NewClassForDelete').then(exist => {
+            expect(exist).toEqual(false);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('deletes schema when actual collection exists', done => {
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/NewClassForDelete',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        className: 'NewClassForDelete',
       },
-      (error, response) => {
-        expect(error).toEqual(null);
-        expect(response.body.className).toEqual('NewClassForDelete');
-        request.del(
-          {
+    }).then(response => {
+      expect(response.data.className).toEqual('NewClassForDelete');
+      request({
+        url: 'http://localhost:8378/1/classes/NewClassForDelete',
+        method: 'POST',
+        headers: restKeyHeaders,
+        json: true,
+      }).then(response => {
+        expect(typeof response.data.objectId).toEqual('string');
+        request({
+          method: 'DELETE',
+          url:
+            'http://localhost:8378/1/classes/NewClassForDelete/' +
+            response.data.objectId,
+          headers: restKeyHeaders,
+          json: true,
+        }).then(() => {
+          request({
+            method: 'DELETE',
             url: 'http://localhost:8378/1/schemas/NewClassForDelete',
             headers: masterKeyHeaders,
             json: true,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(200);
-            expect(response.body).toEqual({});
+          }).then(response => {
+            expect(response.status).toEqual(200);
+            expect(response.data).toEqual({});
             config.database.loadSchema().then(schema => {
               schema.hasClass('NewClassForDelete').then(exist => {
                 expect(exist).toEqual(false);
                 done();
               });
             });
-          }
-        );
-      }
-    );
-  });
-
-  it('deletes schema when actual collection exists', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/NewClassForDelete',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          className: 'NewClassForDelete',
-        },
-      },
-      (error, response) => {
-        expect(error).toEqual(null);
-        expect(response.body.className).toEqual('NewClassForDelete');
-        request.post(
-          {
-            url: 'http://localhost:8378/1/classes/NewClassForDelete',
-            headers: restKeyHeaders,
-            json: true,
-          },
-          (error, response) => {
-            expect(error).toEqual(null);
-            expect(typeof response.body.objectId).toEqual('string');
-            request.del(
-              {
-                url:
-                  'http://localhost:8378/1/classes/NewClassForDelete/' +
-                  response.body.objectId,
-                headers: restKeyHeaders,
-                json: true,
-              },
-              error => {
-                expect(error).toEqual(null);
-                request.del(
-                  {
-                    url: 'http://localhost:8378/1/schemas/NewClassForDelete',
-                    headers: masterKeyHeaders,
-                    json: true,
-                  },
-                  (error, response) => {
-                    expect(response.statusCode).toEqual(200);
-                    expect(response.body).toEqual({});
-                    config.database.loadSchema().then(schema => {
-                      schema.hasClass('NewClassForDelete').then(exist => {
-                        expect(exist).toEqual(false);
-                        done();
-                      });
-                    });
-                  }
-                );
-              }
-            );
-          }
-        );
-      }
-    );
+          });
+        });
+      });
+    });
   });
 
   it('should set/get schema permissions', done => {
-    request.post(
-      {
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            '*': true,
+          },
+          create: {
+            'role:admin': true,
+          },
+        },
+      },
+    }).then(() => {
+      request({
+        url: 'http://localhost:8378/1/schemas/AClass',
+        headers: masterKeyHeaders,
+        json: true,
+      }).then(response => {
+        expect(response.status).toEqual(200);
+        expect(response.data.classLevelPermissions).toEqual({
+          find: {
+            '*': true,
+          },
+          create: {
+            'role:admin': true,
+          },
+          get: {},
+          update: {},
+          delete: {},
+          addField: {},
+        });
+        done();
+      });
+    });
+  });
+
+  it('should fail setting schema permissions with invalid key', done => {
+    const object = new Parse.Object('AClass');
+    object.save().then(() => {
+      request({
+        method: 'PUT',
         url: 'http://localhost:8378/1/schemas/AClass',
         headers: masterKeyHeaders,
         json: true,
@@ -1220,65 +1163,51 @@ describe('schemas', () => {
             create: {
               'role:admin': true,
             },
-          },
-        },
-      },
-      error => {
-        expect(error).toEqual(null);
-        request.get(
-          {
-            url: 'http://localhost:8378/1/schemas/AClass',
-            headers: masterKeyHeaders,
-            json: true,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(200);
-            expect(response.body.classLevelPermissions).toEqual({
-              find: {
-                '*': true,
-              },
-              create: {
-                'role:admin': true,
-              },
-              get: {},
-              update: {},
-              delete: {},
-              addField: {},
-            });
-            done();
-          }
-        );
-      }
-    );
-  });
-
-  it('should fail setting schema permissions with invalid key', done => {
-    const object = new Parse.Object('AClass');
-    object.save().then(() => {
-      request.put(
-        {
-          url: 'http://localhost:8378/1/schemas/AClass',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            classLevelPermissions: {
-              find: {
-                '*': true,
-              },
-              create: {
-                'role:admin': true,
-              },
-              dummy: {
-                some: true,
-              },
+            dummy: {
+              some: true,
             },
           },
         },
-        (error, response, body) => {
-          expect(error).toEqual(null);
-          expect(body.code).toEqual(107);
-          expect(body.error).toEqual(
-            'dummy is not a valid operation for class level permissions'
+      }).then(fail, response => {
+        expect(response.data.code).toEqual(107);
+        expect(response.data.error).toEqual(
+          'dummy is not a valid operation for class level permissions'
+        );
+        done();
+      });
+    });
+  });
+
+  it('should not be able to add a field', done => {
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          create: {
+            '*': true,
+          },
+          find: {
+            '*': true,
+          },
+          addField: {
+            'role:admin': true,
+          },
+        },
+      },
+    }).then(() => {
+      const object = new Parse.Object('AClass');
+      object.set('hello', 'world');
+      return object.save().then(
+        () => {
+          fail('should not be able to add a field');
+          done();
+        },
+        err => {
+          expect(err.message).toEqual(
+            'Permission denied for action addField on class AClass.'
           );
           done();
         }
@@ -1286,266 +1215,198 @@ describe('schemas', () => {
     });
   });
 
-  it('should not be able to add a field', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            create: {
-              '*': true,
-            },
-            find: {
-              '*': true,
-            },
-            addField: {
-              'role:admin': true,
-            },
-          },
-        },
-      },
-      error => {
-        expect(error).toEqual(null);
-        const object = new Parse.Object('AClass');
-        object.set('hello', 'world');
-        return object.save().then(
-          () => {
-            fail('should not be able to add a field');
-            done();
-          },
-          err => {
-            expect(err.message).toEqual(
-              'Permission denied for action addField on class AClass.'
-            );
-            done();
-          }
-        );
-      }
-    );
-  });
-
   it('should be able to add a field', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            create: {
-              '*': true,
-            },
-            addField: {
-              '*': true,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          create: {
+            '*': true,
+          },
+          addField: {
+            '*': true,
           },
         },
       },
-      error => {
-        expect(error).toEqual(null);
-        const object = new Parse.Object('AClass');
-        object.set('hello', 'world');
-        return object.save().then(
-          () => {
-            done();
-          },
-          () => {
-            fail('should be able to add a field');
-            done();
-          }
-        );
-      }
-    );
+    }).then(() => {
+      const object = new Parse.Object('AClass');
+      object.set('hello', 'world');
+      return object.save().then(
+        () => {
+          done();
+        },
+        () => {
+          fail('should be able to add a field');
+          done();
+        }
+      );
+    });
   });
 
   it('should throw with invalid userId (>10 chars)', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              '1234567890A': true,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            '1234567890A': true,
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "'1234567890A' is not a valid key for class level permissions"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "'1234567890A' is not a valid key for class level permissions"
+      );
+      done();
+    });
   });
 
   it('should throw with invalid userId (<10 chars)', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              a12345678: true,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            a12345678: true,
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "'a12345678' is not a valid key for class level permissions"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "'a12345678' is not a valid key for class level permissions"
+      );
+      done();
+    });
   });
 
   it('should throw with invalid userId (invalid char)', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              '12345_6789': true,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            '12345_6789': true,
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "'12345_6789' is not a valid key for class level permissions"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "'12345_6789' is not a valid key for class level permissions"
+      );
+      done();
+    });
   });
 
   it('should throw with invalid * (spaces before)', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              ' *': true,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            ' *': true,
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "' *' is not a valid key for class level permissions"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "' *' is not a valid key for class level permissions"
+      );
+      done();
+    });
   });
 
   it('should throw with invalid * (spaces after)', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              '* ': true,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            '* ': true,
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "'* ' is not a valid key for class level permissions"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "'* ' is not a valid key for class level permissions"
+      );
+      done();
+    });
   });
 
   it('should throw if permission is number', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              '*': 1,
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            '*': 1,
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "'1' is not a valid value for class level permissions find:*:1"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "'1' is not a valid value for class level permissions find:*:1"
+      );
+      done();
+    });
   });
 
   it('should throw if permission is empty string', done => {
-    request.post(
-      {
-        url: 'http://localhost:8378/1/schemas/AClass',
-        headers: masterKeyHeaders,
-        json: true,
-        body: {
-          classLevelPermissions: {
-            find: {
-              '*': '',
-            },
+    request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/schemas/AClass',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: {
+          find: {
+            '*': '',
           },
         },
       },
-      (error, response, body) => {
-        expect(body.error).toEqual(
-          "'' is not a valid value for class level permissions find:*:"
-        );
-        done();
-      }
-    );
+    }).then(fail, response => {
+      expect(response.data.error).toEqual(
+        "'' is not a valid value for class level permissions find:*:"
+      );
+      done();
+    });
   });
 
   function setPermissionsOnClass(className, permissions, doPut) {
-    let op = request.post;
-    if (doPut) {
-      op = request.put;
-    }
-    return new Promise((resolve, reject) => {
-      op(
-        {
-          url: 'http://localhost:8378/1/schemas/' + className,
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            classLevelPermissions: permissions,
-          },
-        },
-        (error, response, body) => {
-          if (error) {
-            return reject(error);
-          }
-          if (body.error) {
-            return reject(body);
-          }
-          return resolve(body);
-        }
-      );
+    return request({
+      url: 'http://localhost:8378/1/schemas/' + className,
+      method: doPut ? 'PUT' : 'POST',
+      headers: masterKeyHeaders,
+      json: true,
+      body: {
+        classLevelPermissions: permissions,
+      },
+    }).then(response => {
+      if (response.data.error) {
+        throw response.data;
+      }
+      return response.data;
     });
   }
 
@@ -2090,18 +1951,16 @@ describe('schemas', () => {
       .then(obj => obj.destroy())
       .then(() => setPermissionsOnClass('MyClass', { find: {}, get: {} }, true))
       .then(() => {
-        request.del(
-          {
-            url: 'http://localhost:8378/1/schemas/MyClass',
-            headers: masterKeyHeaders,
-            json: true,
-          },
-          (error, response) => {
-            expect(response.statusCode).toEqual(200);
-            expect(response.body).toEqual({});
-            done();
-          }
-        );
+        request({
+          method: 'DELETE',
+          url: 'http://localhost:8378/1/schemas/MyClass',
+          headers: masterKeyHeaders,
+          json: true,
+        }).then(response => {
+          expect(response.status).toEqual(200);
+          expect(response.data).toEqual({});
+          done();
+        });
       });
   });
 
@@ -2164,14 +2023,14 @@ describe('schemas', () => {
         return config.database.adapter.updateSchemaWithIndexes();
       })
       .then(() => {
-        return rp.get({
+        return request({
           url: 'http://localhost:8378/1/schemas/_Role',
           headers: masterKeyHeaders,
           json: true,
         });
       })
       .then(res => {
-        expect(res.classLevelPermissions).toEqual({
+        expect(res.data.classLevelPermissions).toEqual({
           get: { '*': true },
           find: { '*': true },
           create: { '*': true },
@@ -2239,689 +2098,623 @@ describe('schemas', () => {
   describe('index management', () => {
     beforeEach(() => require('../lib/TestUtils').destroyAllDataPermanently());
     it('cannot create index if field does not exist', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                indexes: {
-                  name1: { aString: 1 },
-                },
-              },
+          body: {
+            indexes: {
+              name1: { aString: 1 },
             },
-            (error, response, body) => {
-              expect(body.code).toBe(Parse.Error.INVALID_QUERY);
-              expect(body.error).toBe(
-                'Field aString does not exist, cannot add index.'
-              );
-              done();
-            }
+          },
+        }).then(fail, response => {
+          expect(response.data.code).toBe(Parse.Error.INVALID_QUERY);
+          expect(response.data.error).toBe(
+            'Field aString does not exist, cannot add index.'
           );
-        }
-      );
+          done();
+        });
+      });
     });
 
     it('can create index on default field', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                indexes: {
-                  name1: { createdAt: 1 },
-                },
-              },
+          body: {
+            indexes: {
+              name1: { createdAt: 1 },
             },
-            (error, response, body) => {
-              expect(body.indexes.name1).toEqual({ createdAt: 1 });
-              done();
-            }
-          );
-        }
-      );
+          },
+        }).then(response => {
+          expect(response.data.indexes.name1).toEqual({ createdAt: 1 });
+          done();
+        });
+      });
     });
 
     it('cannot create compound index if field does not exist', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1, bString: 1 },
-                },
-              },
+          body: {
+            fields: {
+              aString: { type: 'String' },
             },
-            (error, response, body) => {
-              expect(body.code).toBe(Parse.Error.INVALID_QUERY);
-              expect(body.error).toBe(
-                'Field bString does not exist, cannot add index.'
-              );
-              done();
-            }
+            indexes: {
+              name1: { aString: 1, bString: 1 },
+            },
+          },
+        }).then(fail, response => {
+          expect(response.data.code).toBe(Parse.Error.INVALID_QUERY);
+          expect(response.data.error).toBe(
+            'Field bString does not exist, cannot add index.'
           );
-        }
-      );
+          done();
+        });
+      });
     });
 
     it('allows add index when you create a class', done => {
-      request.post(
-        {
-          url: 'http://localhost:8378/1/schemas',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            className: 'NewClass',
-            fields: {
-              aString: { type: 'String' },
-            },
-            indexes: {
-              name1: { aString: 1 },
-            },
+      request({
+        url: 'http://localhost:8378/1/schemas',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          className: 'NewClass',
+          fields: {
+            aString: { type: 'String' },
+          },
+          indexes: {
+            name1: { aString: 1 },
           },
         },
-        (error, response, body) => {
-          expect(body).toEqual({
-            className: 'NewClass',
-            fields: {
-              ACL: { type: 'ACL' },
-              createdAt: { type: 'Date' },
-              updatedAt: { type: 'Date' },
-              objectId: { type: 'String' },
-              aString: { type: 'String' },
-            },
-            classLevelPermissions: defaultClassLevelPermissions,
-            indexes: {
-              name1: { aString: 1 },
-            },
-          });
-          config.database.adapter.getIndexes('NewClass').then(indexes => {
-            expect(indexes.length).toBe(2);
-            done();
-          });
-        }
-      );
+      }).then(response => {
+        expect(response.data).toEqual({
+          className: 'NewClass',
+          fields: {
+            ACL: { type: 'ACL' },
+            createdAt: { type: 'Date' },
+            updatedAt: { type: 'Date' },
+            objectId: { type: 'String' },
+            aString: { type: 'String' },
+          },
+          classLevelPermissions: defaultClassLevelPermissions,
+          indexes: {
+            name1: { aString: 1 },
+          },
+        });
+        config.database.adapter.getIndexes('NewClass').then(indexes => {
+          expect(indexes.length).toBe(2);
+          done();
+        });
+      });
     });
 
     it('empty index returns nothing', done => {
-      request.post(
-        {
-          url: 'http://localhost:8378/1/schemas',
-          headers: masterKeyHeaders,
-          json: true,
-          body: {
-            className: 'NewClass',
-            fields: {
-              aString: { type: 'String' },
-            },
-            indexes: {},
+      request({
+        url: 'http://localhost:8378/1/schemas',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {
+          className: 'NewClass',
+          fields: {
+            aString: { type: 'String' },
           },
+          indexes: {},
         },
-        (error, response, body) => {
-          expect(body).toEqual({
-            className: 'NewClass',
-            fields: {
-              ACL: { type: 'ACL' },
-              createdAt: { type: 'Date' },
-              updatedAt: { type: 'Date' },
-              objectId: { type: 'String' },
-              aString: { type: 'String' },
-            },
-            classLevelPermissions: defaultClassLevelPermissions,
-          });
-          done();
-        }
-      );
+      }).then(response => {
+        expect(response.data).toEqual({
+          className: 'NewClass',
+          fields: {
+            ACL: { type: 'ACL' },
+            createdAt: { type: 'Date' },
+            updatedAt: { type: 'Date' },
+            objectId: { type: 'String' },
+            aString: { type: 'String' },
+          },
+          classLevelPermissions: defaultClassLevelPermissions,
+        });
+        done();
+      });
     });
 
     it('lets you add indexes', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1 },
-                },
-              },
+          body: {
+            fields: {
+              aString: { type: 'String' },
             },
-            (error, response, body) => {
-              expect(
-                dd(body, {
-                  className: 'NewClass',
-                  fields: {
-                    ACL: { type: 'ACL' },
-                    createdAt: { type: 'Date' },
-                    updatedAt: { type: 'Date' },
-                    objectId: { type: 'String' },
-                    aString: { type: 'String' },
-                  },
-                  classLevelPermissions: defaultClassLevelPermissions,
-                  indexes: {
-                    _id_: { _id: 1 },
-                    name1: { aString: 1 },
-                  },
-                })
-              ).toEqual(undefined);
-              request.get(
-                {
-                  url: 'http://localhost:8378/1/schemas/NewClass',
-                  headers: masterKeyHeaders,
-                  json: true,
-                },
-                (error, response, body) => {
-                  expect(body).toEqual({
-                    className: 'NewClass',
-                    fields: {
-                      ACL: { type: 'ACL' },
-                      createdAt: { type: 'Date' },
-                      updatedAt: { type: 'Date' },
-                      objectId: { type: 'String' },
-                      aString: { type: 'String' },
-                    },
-                    classLevelPermissions: defaultClassLevelPermissions,
-                    indexes: {
-                      _id_: { _id: 1 },
-                      name1: { aString: 1 },
-                    },
-                  });
-                  config.database.adapter
-                    .getIndexes('NewClass')
-                    .then(indexes => {
-                      expect(indexes.length).toEqual(2);
-                      done();
-                    });
-                }
-              );
-            }
-          );
-        }
-      );
+            indexes: {
+              name1: { aString: 1 },
+            },
+          },
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+              },
+            })
+          ).toEqual(undefined);
+          request({
+            url: 'http://localhost:8378/1/schemas/NewClass',
+            headers: masterKeyHeaders,
+            json: true,
+          }).then(response => {
+            expect(response.data).toEqual({
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+              },
+            });
+            config.database.adapter.getIndexes('NewClass').then(indexes => {
+              expect(indexes.length).toEqual(2);
+              done();
+            });
+          });
+        });
+      });
     });
 
     it('lets you add multiple indexes', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                  bString: { type: 'String' },
-                  cString: { type: 'String' },
-                  dString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1 },
-                  name2: { bString: 1 },
-                  name3: { cString: 1, dString: 1 },
-                },
-              },
+          body: {
+            fields: {
+              aString: { type: 'String' },
+              bString: { type: 'String' },
+              cString: { type: 'String' },
+              dString: { type: 'String' },
             },
-            (error, response, body) => {
-              expect(
-                dd(body, {
-                  className: 'NewClass',
-                  fields: {
-                    ACL: { type: 'ACL' },
-                    createdAt: { type: 'Date' },
-                    updatedAt: { type: 'Date' },
-                    objectId: { type: 'String' },
-                    aString: { type: 'String' },
-                    bString: { type: 'String' },
-                    cString: { type: 'String' },
-                    dString: { type: 'String' },
-                  },
-                  classLevelPermissions: defaultClassLevelPermissions,
-                  indexes: {
-                    _id_: { _id: 1 },
-                    name1: { aString: 1 },
-                    name2: { bString: 1 },
-                    name3: { cString: 1, dString: 1 },
-                  },
-                })
-              ).toEqual(undefined);
-              request.get(
-                {
-                  url: 'http://localhost:8378/1/schemas/NewClass',
-                  headers: masterKeyHeaders,
-                  json: true,
-                },
-                (error, response, body) => {
-                  expect(body).toEqual({
-                    className: 'NewClass',
-                    fields: {
-                      ACL: { type: 'ACL' },
-                      createdAt: { type: 'Date' },
-                      updatedAt: { type: 'Date' },
-                      objectId: { type: 'String' },
-                      aString: { type: 'String' },
-                      bString: { type: 'String' },
-                      cString: { type: 'String' },
-                      dString: { type: 'String' },
-                    },
-                    classLevelPermissions: defaultClassLevelPermissions,
-                    indexes: {
-                      _id_: { _id: 1 },
-                      name1: { aString: 1 },
-                      name2: { bString: 1 },
-                      name3: { cString: 1, dString: 1 },
-                    },
-                  });
-                  config.database.adapter
-                    .getIndexes('NewClass')
-                    .then(indexes => {
-                      expect(indexes.length).toEqual(4);
-                      done();
-                    });
-                }
-              );
-            }
-          );
-        }
-      );
+            indexes: {
+              name1: { aString: 1 },
+              name2: { bString: 1 },
+              name3: { cString: 1, dString: 1 },
+            },
+          },
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+                bString: { type: 'String' },
+                cString: { type: 'String' },
+                dString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+                name2: { bString: 1 },
+                name3: { cString: 1, dString: 1 },
+              },
+            })
+          ).toEqual(undefined);
+          request({
+            url: 'http://localhost:8378/1/schemas/NewClass',
+            headers: masterKeyHeaders,
+            json: true,
+          }).then(response => {
+            expect(response.data).toEqual({
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+                bString: { type: 'String' },
+                cString: { type: 'String' },
+                dString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+                name2: { bString: 1 },
+                name3: { cString: 1, dString: 1 },
+              },
+            });
+            config.database.adapter.getIndexes('NewClass').then(indexes => {
+              expect(indexes.length).toEqual(4);
+              done();
+            });
+          });
+        });
+      });
     });
 
     it('lets you delete indexes', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1 },
-                },
+          body: {
+            fields: {
+              aString: { type: 'String' },
+            },
+            indexes: {
+              name1: { aString: 1 },
+            },
+          },
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+              },
+            })
+          ).toEqual(undefined);
+          request({
+            url: 'http://localhost:8378/1/schemas/NewClass',
+            method: 'PUT',
+            headers: masterKeyHeaders,
+            json: true,
+            body: {
+              indexes: {
+                name1: { __op: 'Delete' },
               },
             },
-            (error, response, body) => {
-              expect(
-                dd(body, {
-                  className: 'NewClass',
-                  fields: {
-                    ACL: { type: 'ACL' },
-                    createdAt: { type: 'Date' },
-                    updatedAt: { type: 'Date' },
-                    objectId: { type: 'String' },
-                    aString: { type: 'String' },
-                  },
-                  classLevelPermissions: defaultClassLevelPermissions,
-                  indexes: {
-                    _id_: { _id: 1 },
-                    name1: { aString: 1 },
-                  },
-                })
-              ).toEqual(undefined);
-              request.put(
-                {
-                  url: 'http://localhost:8378/1/schemas/NewClass',
-                  headers: masterKeyHeaders,
-                  json: true,
-                  body: {
-                    indexes: {
-                      name1: { __op: 'Delete' },
-                    },
-                  },
-                },
-                (error, response, body) => {
-                  expect(body).toEqual({
-                    className: 'NewClass',
-                    fields: {
-                      ACL: { type: 'ACL' },
-                      createdAt: { type: 'Date' },
-                      updatedAt: { type: 'Date' },
-                      objectId: { type: 'String' },
-                      aString: { type: 'String' },
-                    },
-                    classLevelPermissions: defaultClassLevelPermissions,
-                    indexes: {
-                      _id_: { _id: 1 },
-                    },
-                  });
-                  config.database.adapter
-                    .getIndexes('NewClass')
-                    .then(indexes => {
-                      expect(indexes.length).toEqual(1);
-                      done();
-                    });
-                }
-              );
-            }
-          );
-        }
-      );
+          }).then(response => {
+            expect(response.data).toEqual({
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+              },
+            });
+            config.database.adapter.getIndexes('NewClass').then(indexes => {
+              expect(indexes.length).toEqual(1);
+              done();
+            });
+          });
+        });
+      });
     });
 
     it('lets you delete multiple indexes', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                  bString: { type: 'String' },
-                  cString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1 },
-                  name2: { bString: 1 },
-                  name3: { cString: 1 },
-                },
+          body: {
+            fields: {
+              aString: { type: 'String' },
+              bString: { type: 'String' },
+              cString: { type: 'String' },
+            },
+            indexes: {
+              name1: { aString: 1 },
+              name2: { bString: 1 },
+              name3: { cString: 1 },
+            },
+          },
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+                bString: { type: 'String' },
+                cString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+                name2: { bString: 1 },
+                name3: { cString: 1 },
+              },
+            })
+          ).toEqual(undefined);
+          request({
+            url: 'http://localhost:8378/1/schemas/NewClass',
+            method: 'PUT',
+            headers: masterKeyHeaders,
+            json: true,
+            body: {
+              indexes: {
+                name1: { __op: 'Delete' },
+                name2: { __op: 'Delete' },
               },
             },
-            (error, response, body) => {
-              expect(
-                dd(body, {
-                  className: 'NewClass',
-                  fields: {
-                    ACL: { type: 'ACL' },
-                    createdAt: { type: 'Date' },
-                    updatedAt: { type: 'Date' },
-                    objectId: { type: 'String' },
-                    aString: { type: 'String' },
-                    bString: { type: 'String' },
-                    cString: { type: 'String' },
-                  },
-                  classLevelPermissions: defaultClassLevelPermissions,
-                  indexes: {
-                    _id_: { _id: 1 },
-                    name1: { aString: 1 },
-                    name2: { bString: 1 },
-                    name3: { cString: 1 },
-                  },
-                })
-              ).toEqual(undefined);
-              request.put(
-                {
-                  url: 'http://localhost:8378/1/schemas/NewClass',
-                  headers: masterKeyHeaders,
-                  json: true,
-                  body: {
-                    indexes: {
-                      name1: { __op: 'Delete' },
-                      name2: { __op: 'Delete' },
-                    },
-                  },
-                },
-                (error, response, body) => {
-                  expect(body).toEqual({
-                    className: 'NewClass',
-                    fields: {
-                      ACL: { type: 'ACL' },
-                      createdAt: { type: 'Date' },
-                      updatedAt: { type: 'Date' },
-                      objectId: { type: 'String' },
-                      aString: { type: 'String' },
-                      bString: { type: 'String' },
-                      cString: { type: 'String' },
-                    },
-                    classLevelPermissions: defaultClassLevelPermissions,
-                    indexes: {
-                      _id_: { _id: 1 },
-                      name3: { cString: 1 },
-                    },
-                  });
-                  config.database.adapter
-                    .getIndexes('NewClass')
-                    .then(indexes => {
-                      expect(indexes.length).toEqual(2);
-                      done();
-                    });
-                }
-              );
-            }
-          );
-        }
-      );
+          }).then(response => {
+            expect(response.data).toEqual({
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+                bString: { type: 'String' },
+                cString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name3: { cString: 1 },
+              },
+            });
+            config.database.adapter.getIndexes('NewClass').then(indexes => {
+              expect(indexes.length).toEqual(2);
+              done();
+            });
+          });
+        });
+      });
     });
 
     it('lets you add and delete indexes', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                  bString: { type: 'String' },
-                  cString: { type: 'String' },
-                  dString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1 },
-                  name2: { bString: 1 },
-                  name3: { cString: 1 },
-                },
+          body: {
+            fields: {
+              aString: { type: 'String' },
+              bString: { type: 'String' },
+              cString: { type: 'String' },
+              dString: { type: 'String' },
+            },
+            indexes: {
+              name1: { aString: 1 },
+              name2: { bString: 1 },
+              name3: { cString: 1 },
+            },
+          },
+        }).then(response => {
+          expect(
+            dd(response.data, {
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+                bString: { type: 'String' },
+                cString: { type: 'String' },
+                dString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name1: { aString: 1 },
+                name2: { bString: 1 },
+                name3: { cString: 1 },
+              },
+            })
+          ).toEqual(undefined);
+          request({
+            url: 'http://localhost:8378/1/schemas/NewClass',
+            method: 'PUT',
+            headers: masterKeyHeaders,
+            json: true,
+            body: {
+              indexes: {
+                name1: { __op: 'Delete' },
+                name2: { __op: 'Delete' },
+                name4: { dString: 1 },
               },
             },
-            (error, response, body) => {
-              expect(
-                dd(body, {
-                  className: 'NewClass',
-                  fields: {
-                    ACL: { type: 'ACL' },
-                    createdAt: { type: 'Date' },
-                    updatedAt: { type: 'Date' },
-                    objectId: { type: 'String' },
-                    aString: { type: 'String' },
-                    bString: { type: 'String' },
-                    cString: { type: 'String' },
-                    dString: { type: 'String' },
-                  },
-                  classLevelPermissions: defaultClassLevelPermissions,
-                  indexes: {
-                    _id_: { _id: 1 },
-                    name1: { aString: 1 },
-                    name2: { bString: 1 },
-                    name3: { cString: 1 },
-                  },
-                })
-              ).toEqual(undefined);
-              request.put(
-                {
-                  url: 'http://localhost:8378/1/schemas/NewClass',
-                  headers: masterKeyHeaders,
-                  json: true,
-                  body: {
-                    indexes: {
-                      name1: { __op: 'Delete' },
-                      name2: { __op: 'Delete' },
-                      name4: { dString: 1 },
-                    },
-                  },
-                },
-                (error, response, body) => {
-                  expect(body).toEqual({
-                    className: 'NewClass',
-                    fields: {
-                      ACL: { type: 'ACL' },
-                      createdAt: { type: 'Date' },
-                      updatedAt: { type: 'Date' },
-                      objectId: { type: 'String' },
-                      aString: { type: 'String' },
-                      bString: { type: 'String' },
-                      cString: { type: 'String' },
-                      dString: { type: 'String' },
-                    },
-                    classLevelPermissions: defaultClassLevelPermissions,
-                    indexes: {
-                      _id_: { _id: 1 },
-                      name3: { cString: 1 },
-                      name4: { dString: 1 },
-                    },
-                  });
-                  config.database.adapter
-                    .getIndexes('NewClass')
-                    .then(indexes => {
-                      expect(indexes.length).toEqual(3);
-                      done();
-                    });
-                }
-              );
-            }
-          );
-        }
-      );
+          }).then(response => {
+            expect(response.data).toEqual({
+              className: 'NewClass',
+              fields: {
+                ACL: { type: 'ACL' },
+                createdAt: { type: 'Date' },
+                updatedAt: { type: 'Date' },
+                objectId: { type: 'String' },
+                aString: { type: 'String' },
+                bString: { type: 'String' },
+                cString: { type: 'String' },
+                dString: { type: 'String' },
+              },
+              classLevelPermissions: defaultClassLevelPermissions,
+              indexes: {
+                _id_: { _id: 1 },
+                name3: { cString: 1 },
+                name4: { dString: 1 },
+              },
+            });
+            config.database.adapter.getIndexes('NewClass').then(indexes => {
+              expect(indexes.length).toEqual(3);
+              done();
+            });
+          });
+        });
+      });
     });
 
     it('cannot delete index that does not exist', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                indexes: {
-                  unknownIndex: { __op: 'Delete' },
-                },
-              },
+          body: {
+            indexes: {
+              unknownIndex: { __op: 'Delete' },
             },
-            (error, response, body) => {
-              expect(body.code).toBe(Parse.Error.INVALID_QUERY);
-              expect(body.error).toBe(
-                'Index unknownIndex does not exist, cannot delete.'
-              );
-              done();
-            }
+          },
+        }).then(fail, response => {
+          expect(response.data.code).toBe(Parse.Error.INVALID_QUERY);
+          expect(response.data.error).toBe(
+            'Index unknownIndex does not exist, cannot delete.'
           );
-        }
-      );
+          done();
+        });
+      });
     });
 
     it('cannot update index that exist', done => {
-      request.post(
-        {
+      request({
+        url: 'http://localhost:8378/1/schemas/NewClass',
+        method: 'POST',
+        headers: masterKeyHeaders,
+        json: true,
+        body: {},
+      }).then(() => {
+        request({
           url: 'http://localhost:8378/1/schemas/NewClass',
+          method: 'PUT',
           headers: masterKeyHeaders,
           json: true,
-          body: {},
-        },
-        () => {
-          request.put(
-            {
-              url: 'http://localhost:8378/1/schemas/NewClass',
-              headers: masterKeyHeaders,
-              json: true,
-              body: {
-                fields: {
-                  aString: { type: 'String' },
-                },
-                indexes: {
-                  name1: { aString: 1 },
-                },
+          body: {
+            fields: {
+              aString: { type: 'String' },
+            },
+            indexes: {
+              name1: { aString: 1 },
+            },
+          },
+        }).then(() => {
+          request({
+            url: 'http://localhost:8378/1/schemas/NewClass',
+            method: 'PUT',
+            headers: masterKeyHeaders,
+            json: true,
+            body: {
+              indexes: {
+                name1: { field2: 1 },
               },
             },
-            () => {
-              request.put(
-                {
-                  url: 'http://localhost:8378/1/schemas/NewClass',
-                  headers: masterKeyHeaders,
-                  json: true,
-                  body: {
-                    indexes: {
-                      name1: { field2: 1 },
-                    },
-                  },
-                },
-                (error, response, body) => {
-                  expect(body.code).toBe(Parse.Error.INVALID_QUERY);
-                  expect(body.error).toBe('Index name1 exists, cannot update.');
-                  done();
-                }
-              );
-            }
-          );
-        }
-      );
+          }).then(fail, response => {
+            expect(response.data.code).toBe(Parse.Error.INVALID_QUERY);
+            expect(response.data.error).toBe(
+              'Index name1 exists, cannot update.'
+            );
+            done();
+          });
+        });
+      });
     });
 
     it_exclude_dbs(['postgres'])('get indexes on startup', done => {
@@ -2936,17 +2729,14 @@ describe('schemas', () => {
           });
         })
         .then(() => {
-          request.get(
-            {
-              url: 'http://localhost:8378/1/schemas/TestObject',
-              headers: masterKeyHeaders,
-              json: true,
-            },
-            (error, response, body) => {
-              expect(body.indexes._id_).toBeDefined();
-              done();
-            }
-          );
+          request({
+            url: 'http://localhost:8378/1/schemas/TestObject',
+            headers: masterKeyHeaders,
+            json: true,
+          }).then(response => {
+            expect(response.data.indexes._id_).toBeDefined();
+            done();
+          });
         });
     });
 
@@ -2970,25 +2760,24 @@ describe('schemas', () => {
           });
         })
         .then(() => {
-          request.get(
-            {
-              url: 'http://localhost:8378/1/schemas/TestObject',
-              headers: masterKeyHeaders,
-              json: true,
-            },
-            (error, response, body) => {
-              expect(body.indexes._id_).toBeDefined();
-              expect(body.indexes._id_._id).toEqual(1);
-              expect(body.indexes.subject_text_comment_text).toBeDefined();
-              expect(body.indexes.subject_text_comment_text.subject).toEqual(
-                'text'
-              );
-              expect(body.indexes.subject_text_comment_text.comment).toEqual(
-                'text'
-              );
-              done();
-            }
-          );
+          request({
+            url: 'http://localhost:8378/1/schemas/TestObject',
+            headers: masterKeyHeaders,
+            json: true,
+          }).then(response => {
+            expect(response.data.indexes._id_).toBeDefined();
+            expect(response.data.indexes._id_._id).toEqual(1);
+            expect(
+              response.data.indexes.subject_text_comment_text
+            ).toBeDefined();
+            expect(
+              response.data.indexes.subject_text_comment_text.subject
+            ).toEqual('text');
+            expect(
+              response.data.indexes.subject_text_comment_text.comment
+            ).toEqual('text');
+            done();
+          });
         });
     });
 

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -2,7 +2,7 @@ import HTTPResponse from './HTTPResponse';
 import querystring from 'querystring';
 import log from '../logger';
 import { http, https } from 'follow-redirects';
-import { URL } from 'url';
+import { parse } from 'url';
 
 const clients = {
   'http:': http,
@@ -93,7 +93,7 @@ const encodeBody = function({ body, headers = {} }) {
 module.exports = function httpRequest(options) {
   let url;
   try {
-    url = new URL(options.url);
+    url = parse(options.url);
   } catch (e) {
     return Promise.reject(e);
   }
@@ -117,6 +117,9 @@ module.exports = function httpRequest(options) {
     encoding: null,
     followRedirects: options.followRedirects === true,
   };
+  if (url.search) {
+    options.qs = Object.assign({}, options.qs, querystring.parse(url.query));
+  }
   if (options.qs) {
     requestOptions.path += `?${querystring.stringify(options.qs)}`;
   }

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -117,6 +117,13 @@ module.exports = function httpRequest(options) {
     encoding: null,
     followRedirects: options.followRedirects === true,
   };
+  if (requestOptions.headers) {
+    Object.keys(requestOptions.headers).forEach(key => {
+      if (typeof requestOptions.headers[key] === 'undefined') {
+        delete requestOptions.headers[key];
+      }
+    });
+  }
   if (url.search) {
     options.qs = Object.assign({}, options.qs, querystring.parse(url.query));
   }

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -144,6 +144,9 @@ module.exports = function httpRequest(options) {
     if (options.body) {
       req.write(options.body);
     }
+    req.on('error', error => {
+      reject(error);
+    });
     req.end();
   });
 };

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -127,6 +127,9 @@ module.exports = function httpRequest(options) {
   if (url.search) {
     options.qs = Object.assign({}, options.qs, querystring.parse(url.query));
   }
+  if (url.auth) {
+    requestOptions.auth = url.auth;
+  }
   if (options.qs) {
     requestOptions.path += `?${querystring.stringify(options.qs)}`;
   }


### PR DESCRIPTION
Let's dogfood our own http request APi, this will likely encourage use to make it better and easier.

Insead of 20 dependencies from request + 4 direct dependencies from request-promise.

We used none of the features while pulling all this dead weight.