### PR TITLE
#4538 Encodes the error object in resetPassword method like a string

### DIFF
--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -174,11 +174,16 @@ export class PublicAPIRouter extends PromiseRouter {
           });
         },
         err => {
+          const whitelistError = Object.getOwnPropertyNames(err).filter(
+            key => key !== 'stack'
+          );
+          const errString = JSON.stringify(err, whitelistError);
+
           const params = qs.stringify({
             username: username,
             token: token,
             id: config.applicationId,
-            error: err,
+            error: encodeURI(errString),
             app: config.appName,
           });
           return Promise.resolve({


### PR DESCRIPTION
Follow the @montymxb idea https://github.com/parse-community/parse-server/issues/4538#issuecomment-368722995, I believe wich this PR can solve the problem.

I can't figure out if needs test and how can I test this one.