### PR TITLE
Fix intense CPU usage when sessionToken is invalid in liveQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Expire password reset tokens on email change. See #5104
 #### Bug fixes:
 * Fixes issue with vkontatke authentication
+* Improves performance for roles and ACL's in live query server
 
 
 ### 3.0.0

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -497,10 +497,16 @@ class ParseLiveQueryServer {
       return false;
     }
 
-    // TODO: get auth there and de-duplicate code below to work with the same Auth obj.
     const { auth, userId } = await this.getAuthForSessionToken(
       subscriptionInfo.sessionToken
     );
+
+    // Getting the session token failed
+    // This means that no additional auth is available
+    // At this point, just bail out as no additional visibility can be inferred.
+    if (!auth || !userId) {
+      return false;
+    }
     const isSubscriptionSessionTokenMatched = acl.getReadAccess(userId);
     if (isSubscriptionSessionTokenMatched) {
       return true;


### PR DESCRIPTION
When sessionToken fetch failed through getAuthForSessionToken auth and userId would be undefined. 

This PR ensure we do not throw an exception in this case.