### PR TITLE
Fix Limitation Role #5131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### master
 [Full Changelog](https://github.com/parse-community/parse-server/compare/3.1.0...master)
 
+#### Improvements:
+* Fixes issue that would prevent users with large number of roles to resolve all of them [@Moumouls]() (#5131, #5132)
+
+
 ### 3.1.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/3.0.0...3.1.0)
 

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -152,10 +152,7 @@ describe('Auth', () => {
 
   it('should load all roles', async () => {
     const user = new Parse.User();
-    await user.signUp({
-      username: 'hello',
-      password: 'password',
-    });
+    user.id = currentUserId
     const roles = [];
     for(var i=0; i < 200;i++){
       const acl = new Parse.ACL();

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -90,6 +90,23 @@ describe('Auth', () => {
         });
       });
     });
+
+    it('should load all roles', async () => {
+      const user = new Parse.User();
+      user.id = currentUserId;
+      const roles = [];
+      for(let i = 0; i < 200;i++){
+        const acl = new Parse.ACL();
+        const role = new Parse.Role("roleloadtest" + i, acl);
+        role.getUsers().add([user]);
+        roles.push(role.save())
+      }
+      const savedRoles = await Promise.all(roles);
+      //Additionnal length check
+      expect(savedRoles).to.have.lengthOf(200);
+      const cloudRoles = auth.getUserRoles();
+      expect(cloudRoles).to.have.lengthOf(200);
+    });
   });
 
   it('should load auth without a config', async () => {
@@ -148,22 +165,5 @@ describe('Auth', () => {
     });
     expect(userAuth.user instanceof Parse.User).toBe(true);
     expect(userAuth.user.id).toBe(user.id);
-  });
-
-  it('should load all roles', async () => {
-    const user = new Parse.User();
-    user.id = currentUserId
-    const roles = [];
-    for(var i=0; i < 200;i++){
-      const acl = new Parse.ACL();
-      const role = new Parse.Role("roleloadtest"+i, acl);
-      role.getUsers().add([user]);
-      roles.push(role.save())
-    }
-    const savedRoles = await Promise.all(roles)
-    //Additionnal length check
-    expect(savedRoles).to.have.lengthOf(200)
-    const cloudRoles = auth.getUserRoles()
-    expect(cloudRoles).to.have.lengthOf(200)
   });
 });

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -152,7 +152,7 @@ describe('Auth', () => {
 
   describe('getRolesForUser', () => {
 
-    let rolesNumber = 300;
+    const rolesNumber = 300;
 
     it('should load all roles without config', async () => {
       const user = new Parse.User();

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -90,80 +90,115 @@ describe('Auth', () => {
         });
       });
     });
+  });
 
-    it('should load all roles', async () => {
+  it('should load auth without a config', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password',
+    });
+    expect(user.getSessionToken()).not.toBeUndefined();
+    const userAuth = await getAuthForSessionToken({
+      sessionToken: user.getSessionToken(),
+    });
+    expect(userAuth.user instanceof Parse.User).toBe(true);
+    expect(userAuth.user.id).toBe(user.id);
+  });
+
+  it('should load auth with a config', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password',
+    });
+    expect(user.getSessionToken()).not.toBeUndefined();
+    const userAuth = await getAuthForSessionToken({
+      sessionToken: user.getSessionToken(),
+      config: Config.get('test'),
+    });
+    expect(userAuth.user instanceof Parse.User).toBe(true);
+    expect(userAuth.user.id).toBe(user.id);
+  });
+
+  it('should load auth without a config', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password',
+    });
+    expect(user.getSessionToken()).not.toBeUndefined();
+    const userAuth = await getAuthForSessionToken({
+      sessionToken: user.getSessionToken(),
+    });
+    expect(userAuth.user instanceof Parse.User).toBe(true);
+    expect(userAuth.user.id).toBe(user.id);
+  });
+
+  it('should load auth with a config', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password',
+    });
+    expect(user.getSessionToken()).not.toBeUndefined();
+    const userAuth = await getAuthForSessionToken({
+      sessionToken: user.getSessionToken(),
+      config: Config.get('test'),
+    });
+    expect(userAuth.user instanceof Parse.User).toBe(true);
+    expect(userAuth.user.id).toBe(user.id);
+  });
+
+  describe('getRolesForUser', () => {
+
+    let rolesNumber = 300;
+
+    it('should load all roles without config', async () => {
       const user = new Parse.User();
-      user.id = currentUserId;
+      await user.signUp({
+        username: 'hello',
+        password: 'password',
+      });
+      expect(user.getSessionToken()).not.toBeUndefined();
+      const userAuth = await getAuthForSessionToken({
+        sessionToken: user.getSessionToken(),
+      });
       const roles = [];
-      for(let i = 0; i < 200;i++){
+      for(let i = 0; i < rolesNumber;i++){
         const acl = new Parse.ACL();
         const role = new Parse.Role("roleloadtest" + i, acl);
         role.getUsers().add([user]);
         roles.push(role.save())
       }
       const savedRoles = await Promise.all(roles);
-      //Additionnal length check
-      expect(savedRoles).to.have.lengthOf(200);
-      const cloudRoles = auth.getUserRoles();
-      expect(cloudRoles).to.have.lengthOf(200);
+      expect(savedRoles.length).toBe(rolesNumber);
+      const cloudRoles = await userAuth.getRolesForUser();
+      expect(cloudRoles.length).toBe(rolesNumber);
     });
-  });
 
-  it('should load auth without a config', async () => {
-    const user = new Parse.User();
-    await user.signUp({
-      username: 'hello',
-      password: 'password',
+    it('should load all roles with config', async () => {
+      const user = new Parse.User();
+      await user.signUp({
+        username: 'hello',
+        password: 'password',
+      });
+      expect(user.getSessionToken()).not.toBeUndefined();
+      const userAuth = await getAuthForSessionToken({
+        sessionToken: user.getSessionToken(),
+        config: Config.get('test'),
+      });
+      const roles = [];
+      for(let i = 0; i < rolesNumber;i++){
+        const acl = new Parse.ACL();
+        const role = new Parse.Role("roleloadtest" + i, acl);
+        role.getUsers().add([user]);
+        roles.push(role.save())
+      }
+      const savedRoles = await Promise.all(roles);
+      expect(savedRoles.length).toBe(rolesNumber);
+      const cloudRoles = await userAuth.getRolesForUser();
+      expect(cloudRoles.length).toBe(rolesNumber);
     });
-    expect(user.getSessionToken()).not.toBeUndefined();
-    const userAuth = await getAuthForSessionToken({
-      sessionToken: user.getSessionToken(),
-    });
-    expect(userAuth.user instanceof Parse.User).toBe(true);
-    expect(userAuth.user.id).toBe(user.id);
-  });
-
-  it('should load auth with a config', async () => {
-    const user = new Parse.User();
-    await user.signUp({
-      username: 'hello',
-      password: 'password',
-    });
-    expect(user.getSessionToken()).not.toBeUndefined();
-    const userAuth = await getAuthForSessionToken({
-      sessionToken: user.getSessionToken(),
-      config: Config.get('test'),
-    });
-    expect(userAuth.user instanceof Parse.User).toBe(true);
-    expect(userAuth.user.id).toBe(user.id);
-  });
-
-  it('should load auth without a config', async () => {
-    const user = new Parse.User();
-    await user.signUp({
-      username: 'hello',
-      password: 'password',
-    });
-    expect(user.getSessionToken()).not.toBeUndefined();
-    const userAuth = await getAuthForSessionToken({
-      sessionToken: user.getSessionToken(),
-    });
-    expect(userAuth.user instanceof Parse.User).toBe(true);
-    expect(userAuth.user.id).toBe(user.id);
-  });
-
-  it('should load auth with a config', async () => {
-    const user = new Parse.User();
-    await user.signUp({
-      username: 'hello',
-      password: 'password',
-    });
-    expect(user.getSessionToken()).not.toBeUndefined();
-    const userAuth = await getAuthForSessionToken({
-      sessionToken: user.getSessionToken(),
-      config: Config.get('test'),
-    });
-    expect(userAuth.user instanceof Parse.User).toBe(true);
-    expect(userAuth.user.id).toBe(user.id);
   });
 });

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -149,4 +149,24 @@ describe('Auth', () => {
     expect(userAuth.user instanceof Parse.User).toBe(true);
     expect(userAuth.user.id).toBe(user.id);
   });
+
+  it('should load all roles', async () => {
+    const user = new Parse.User();
+    await user.signUp({
+      username: 'hello',
+      password: 'password',
+    });
+    const roles = [];
+    for(var i=0; i < 200;i++){
+      const acl = new Parse.ACL();
+      const role = new Parse.Role("roleloadtest"+i, acl);
+      role.getUsers().add([user]);
+      roles.push(role.save())
+    }
+    const savedRoles = await Promise.all(roles)
+    //Additionnal length check
+    expect(savedRoles).to.have.lengthOf(200)
+    const cloudRoles = auth.getUserRoles()
+    expect(cloudRoles).to.have.lengthOf(200)
+  });
 });

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -1295,6 +1295,18 @@ describe('ParseLiveQueryServer', function() {
           shouldReturn = false;
           return this;
         },
+        find() {
+          if (!shouldReturn) {
+            return Promise.resolve([]);
+          }
+          //Return a role with the name "liveQueryRead" as that is what was set on the ACL
+          const liveQueryRole = new Parse.Role(
+            'liveQueryRead',
+            new Parse.ACL()
+          );
+          liveQueryRole.id = 'abcdef1234';
+          return Promise.resolve([liveQueryRole]);
+        },
         each(callback) {
           //Return a role with the name "liveQueryRead" as that is what was set on the ACL
           const liveQueryRole = new Parse.Role(

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -1296,9 +1296,6 @@ describe('ParseLiveQueryServer', function() {
           return this;
         },
         each(callback) {
-          if (!shouldReturn) {
-            return Promise.resolve();
-          }
           //Return a role with the name "liveQueryRead" as that is what was set on the ACL
           const liveQueryRole = new Parse.Role(
             'liveQueryRead',
@@ -1310,13 +1307,6 @@ describe('ParseLiveQueryServer', function() {
         },
       };
     });
-
-    parseLiveQueryServer
-      ._matchesACL(acl, client, requestId)
-      .then(function(isMatched) {
-        expect(isMatched).toBe(true);
-        done();
-      });
 
     parseLiveQueryServer
       ._matchesACL(acl, client, requestId)

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -1295,9 +1295,9 @@ describe('ParseLiveQueryServer', function() {
           shouldReturn = false;
           return this;
         },
-        find() {
+        each(callback) {
           if (!shouldReturn) {
-            return Promise.resolve([]);
+            return Promise.resolve();
           }
           //Return a role with the name "liveQueryRead" as that is what was set on the ACL
           const liveQueryRole = new Parse.Role(
@@ -1305,7 +1305,8 @@ describe('ParseLiveQueryServer', function() {
             new Parse.ACL()
           );
           liveQueryRole.id = 'abcdef1234';
-          return Promise.resolve([liveQueryRole]);
+          callback(liveQueryRole)
+          return Promise.resolve();
         },
       };
     });

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -203,10 +203,13 @@ Auth.prototype.getRolesForUser = function() {
     return query.execute().then(({ results }) => results);
   }
 
+  //Stack all Parse.Role
+  var _tmpUserRoles = [];
+
   return new Parse.Query(Parse.Role)
     .equalTo('users', this.user)
-    .find({ useMasterKey: true })
-    .then(results => results.map(obj => obj.toJSON()));
+    .each(result => _tmpUserRoles.push(result),{useMasterKey:true})
+    .then(() => _tmpUserRoles.map(obj => obj.toJSON()));
 };
 
 // Iterates through the role tree and compiles a user's roles

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -276,12 +276,7 @@ Auth.prototype.getRolesByIds = async function(ins) {
           return role;
         })
       )
-      .each(
-        result => {
-          results.push(result.toJSON());
-        },
-        { useMasterKey: true }
-      );
+      .each(result => results.push(result.toJSON()), { useMasterKey: true });
   } else {
     const roles = ins.map(id => {
       return {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -1,8 +1,6 @@
 const cryptoUtils = require('./cryptoUtils');
 const RestQuery = require('./RestQuery');
 const Parse = require('parse/node');
-
-//Needed for getRolesForUser()
 const { continueWhile } = require('parse/lib/node/promiseUtils');
 
 // An Auth object tells you who is requesting something and whether
@@ -220,11 +218,11 @@ Auth.prototype.getRolesForUser = async function() {
       const currentResults = await query.execute().then(({ results }) => results);
       finished = currentResults.length < queryOptions.limit;
       if (!finished) {
-        restWhere.objectId = { '$gt': currentResults[currentResults.length - 1].id}
+        restWhere.objectId = { '$gt': currentResults[currentResults.length - 1].objectId}
       }
       results = results.concat(currentResults);
     });
-    return results.map(obj => obj.toJSON());
+    return results;
   }
 
   //Stack all Parse.Role
@@ -232,8 +230,8 @@ Auth.prototype.getRolesForUser = async function() {
 
   await new Parse.Query(Parse.Role)
     .equalTo('users', this.user)
-    .each(result => results.push(result),{useMasterKey:true})
-  return results.map(obj => obj.toJSON());
+    .each(result => results.push(result.toJSON()),{useMasterKey:true})
+  return results;
 };
 
 // Iterates through the role tree and compiles a user's roles

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -204,12 +204,12 @@ Auth.prototype.getRolesForUser = function() {
   }
 
   //Stack all Parse.Role
-  var _tmpUserRoles = [];
+  const results = [];
 
   return new Parse.Query(Parse.Role)
     .equalTo('users', this.user)
-    .each(result => _tmpUserRoles.push(result),{useMasterKey:true})
-    .then(() => _tmpUserRoles.map(obj => obj.toJSON()));
+    .each(result => results.push(result),{useMasterKey:true})
+    .then(() => results.map(obj => obj.toJSON()));
 };
 
 // Iterates through the role tree and compiles a user's roles

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -190,6 +190,13 @@ Auth.prototype.getUserRoles = function() {
 Auth.prototype.getRolesForUser = async function() {
   if (this.config) {
     const masterConfig = master(this.config);
+    const restWhere = {
+      users: {
+        __type: 'Pointer',
+        className: '_User',
+        objectId: this.user.id,
+      },
+    };
     const queryOptions = {
       limit: 100,
       order: 'objectId'

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -187,7 +187,7 @@ Auth.prototype.getUserRoles = function() {
   return this.rolePromise;
 };
 
-Auth.prototype.getRolesForUser = function() {
+Auth.prototype.getRolesForUser = async function() {
   if (this.config) {
     const masterConfig = master(this.config);
     const queryOptions = {
@@ -199,7 +199,7 @@ Auth.prototype.getRolesForUser = function() {
     //Stack all Parse.Role
     let results = [];
 
-    //Get All Parse.Role from the User
+    //Get All Parse.Role for User
     await continueWhile(() => {
       return !finished;
     }, async () => {
@@ -217,16 +217,16 @@ Auth.prototype.getRolesForUser = function() {
       }
       results = results.concat(currentResults);
     });
-    return results;
+    return results.map(obj => obj.toJSON());
   }
 
   //Stack all Parse.Role
   const results = [];
 
-  return new Parse.Query(Parse.Role)
+  await new Parse.Query(Parse.Role)
     .equalTo('users', this.user)
     .each(result => results.push(result),{useMasterKey:true})
-    .then(() => results.map(obj => obj.toJSON()));
+  return results.map(obj => obj.toJSON());
 };
 
 // Iterates through the role tree and compiles a user's roles


### PR DESCRIPTION
Allow to manage Live Query on Role based Object for Parse.User that have more than 100 Parse.Role