### PR TITLE
"Object not found." instead of "Insufficient auth." when using master key

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3314,7 +3314,9 @@ describe('Parse.User testing', () => {
         done();
       });
     });
-  }).pend('this test fails.  See: https://github.com/parse-community/parse-server/issues/5097');
+  }).pend(
+    'this test fails.  See: https://github.com/parse-community/parse-server/issues/5097'
+  );
 
   it('should be able to update user with authData passed', done => {
     let objectId;
@@ -3684,6 +3686,26 @@ describe('Parse.User testing', () => {
         expect(results.length).toBe(1);
       })
       .then(done, done.fail);
+  });
+
+  it('should throw OBJECT_NOT_FOUND instead of SESSION_MISSING when using masterKey', async done => {
+    // create a fake user (just so we simulate an object not found)
+    try {
+      const non_existent_user = Parse.User.createWithoutData('fake_id');
+      await non_existent_user.destroy({ useMasterKey: true });
+      done.fail();
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
+    }
+    // simulate object not found without master key
+    try {
+      const existent_user = await Parse.User.signUp('asdf', 'zxcv');
+      await existent_user.destroy({ sessionToken: undefined });
+      done.fail();
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.SESSION_MISSING);
+      done();
+    }
   });
 
   describe('issue #4897', () => {

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3688,21 +3688,32 @@ describe('Parse.User testing', () => {
       .then(done, done.fail);
   });
 
-  it('should throw OBJECT_NOT_FOUND instead of SESSION_MISSING when using masterKey', async done => {
+  it('should throw OBJECT_NOT_FOUND instead of SESSION_MISSING when using masterKey', async () => {
     // create a fake user (just so we simulate an object not found)
     const non_existent_user = Parse.User.createWithoutData('fake_id');
     try {
       await non_existent_user.destroy({ useMasterKey: true });
-      done.fail();
+      throw '';
     } catch (e) {
       expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
     }
     try {
-      await non_existent_user.destroy();
-      done.fail();
+      await non_existent_user.save({}, { useMasterKey: true });
+      throw '';
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
+    }
+    try {
+      await non_existent_user.save();
+      throw '';
     } catch (e) {
       expect(e.code).toBe(Parse.Error.SESSION_MISSING);
-      done();
+    }
+    try {
+      await non_existent_user.destroy();
+      throw '';
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.SESSION_MISSING);
     }
   });
 

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3690,17 +3690,15 @@ describe('Parse.User testing', () => {
 
   it('should throw OBJECT_NOT_FOUND instead of SESSION_MISSING when using masterKey', async done => {
     // create a fake user (just so we simulate an object not found)
+    const non_existent_user = Parse.User.createWithoutData('fake_id');
     try {
-      const non_existent_user = Parse.User.createWithoutData('fake_id');
       await non_existent_user.destroy({ useMasterKey: true });
       done.fail();
     } catch (e) {
       expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
     }
-    // simulate object not found without master key
     try {
-      const existent_user = await Parse.User.signUp('asdf', 'zxcv');
-      await existent_user.destroy({ sessionToken: undefined });
+      await non_existent_user.destroy();
       done.fail();
     } catch (e) {
       expect(e.code).toBe(Parse.Error.SESSION_MISSING);

--- a/src/rest.js
+++ b/src/rest.js
@@ -250,9 +250,13 @@ function update(config, auth, className, restWhere, restObject, clientSDK) {
     });
 }
 
-function handleSessionMissingError(error, className) {
+function handleSessionMissingError(error, className, auth) {
   // If we're trying to update a user without / with bad session token
-  if (className === '_User' && error.code === Parse.Error.OBJECT_NOT_FOUND) {
+  if (
+    className === '_User' &&
+    error.code === Parse.Error.OBJECT_NOT_FOUND &&
+    !auth.isMaster
+  ) {
     throw new Parse.Error(Parse.Error.SESSION_MISSING, 'Insufficient auth.');
   }
   throw error;


### PR DESCRIPTION
A minor change that will return "Object not found.", instead of "Insufficient auth." when using a master key. Which seems to be more appropriate since the masterKey has the highest authority.
Issue: #5129 