### PR TITLE
Concept of readonly triggers

### DIFF
--- a/spec/ReadonlyTriggers.spec.js
+++ b/spec/ReadonlyTriggers.spec.js
@@ -1,0 +1,49 @@
+'use strict';
+const Parse = require('parse/node');
+
+describe('ReadonlyTrigger tests', () => {
+  it('beforeSave should be read only', async () => {
+    Parse.Cloud.beforeSave('SomeUltraSecureClass', function(req) {
+      req.object.set('KeyA', 'EDITED_VALUE');
+      req.object.set('KeyB', 'EDITED_VALUE');
+    });
+    const object = new Parse.Object('SomeUltraSecureClass');
+    object.set('KeyA', 'ValueA');
+    object.set('KeyB', 'ValueB');
+    await object.save();
+    const query = new Parse.Query('SomeUltraSecureClass');
+    query.equalTo('objectId', object.id);
+    const serverObject = await query.first({ useMasterKey: true });
+    expect(serverObject.get('KeyA')).toBe('ValueA');
+    expect(serverObject.get('KeyB')).toBe('ValueB');
+  });
+  it('beforeSave should fail on throw', async () => {
+    Parse.Cloud.beforeSave('SomeUltraSecureClass', function() {
+      throw new Parse.Error(12345678, 'Nop');
+    });
+    const object = new Parse.Object('SomeUltraSecureClass');
+    object.set('KeyA', 'ValueA');
+    object.set('KeyB', 'ValueB');
+    try {
+      await object.save();
+      throw 'Should not have passed';
+    } catch (error) {
+      expect(error.code).toBe(12345678);
+      expect(error.message).toBe('Nop');
+    }
+  });
+  it('beforeDelete should ignore thrown error', async () => {
+    Parse.Cloud.beforeDelete('SomeUltraSecureClass', function() {
+      throw new Parse.Error(12345678, 'Nop');
+    });
+    const object = new Parse.Object('SomeUltraSecureClass');
+    object.set('KeyA', 'ValueA');
+    object.set('KeyB', 'ValueB');
+    await object.save();
+    try {
+      await object.destroy({}, { useMasterKey: true });
+    } catch (error) {
+      throw 'should have succeeded';
+    }
+  });
+});

--- a/spec/ReadonlyTriggers.spec.js
+++ b/spec/ReadonlyTriggers.spec.js
@@ -1,49 +1,49 @@
-'use strict';
-const Parse = require('parse/node');
+// 'use strict';
+// const Parse = require('parse/node');
 
-describe('ReadonlyTrigger tests', () => {
-  it('beforeSave should be read only', async () => {
-    Parse.Cloud.beforeSave('SomeUltraSecureClass', function(req) {
-      req.object.set('KeyA', 'EDITED_VALUE');
-      req.object.set('KeyB', 'EDITED_VALUE');
-    });
-    const object = new Parse.Object('SomeUltraSecureClass');
-    object.set('KeyA', 'ValueA');
-    object.set('KeyB', 'ValueB');
-    await object.save();
-    const query = new Parse.Query('SomeUltraSecureClass');
-    query.equalTo('objectId', object.id);
-    const serverObject = await query.first({ useMasterKey: true });
-    expect(serverObject.get('KeyA')).toBe('ValueA');
-    expect(serverObject.get('KeyB')).toBe('ValueB');
-  });
-  it('beforeSave should fail on throw', async () => {
-    Parse.Cloud.beforeSave('SomeUltraSecureClass', function() {
-      throw new Parse.Error(12345678, 'Nop');
-    });
-    const object = new Parse.Object('SomeUltraSecureClass');
-    object.set('KeyA', 'ValueA');
-    object.set('KeyB', 'ValueB');
-    try {
-      await object.save();
-      throw 'Should not have passed';
-    } catch (error) {
-      expect(error.code).toBe(12345678);
-      expect(error.message).toBe('Nop');
-    }
-  });
-  it('beforeDelete should ignore thrown error', async () => {
-    Parse.Cloud.beforeDelete('SomeUltraSecureClass', function() {
-      throw new Parse.Error(12345678, 'Nop');
-    });
-    const object = new Parse.Object('SomeUltraSecureClass');
-    object.set('KeyA', 'ValueA');
-    object.set('KeyB', 'ValueB');
-    await object.save();
-    try {
-      await object.destroy({}, { useMasterKey: true });
-    } catch (error) {
-      throw 'should have succeeded';
-    }
-  });
-});
+// describe('ReadonlyTrigger tests', () => {
+//   it('beforeSave should be read only', async () => {
+//     Parse.Cloud.beforeSave('SomeUltraSecureClass', function(req) {
+//       req.object.set('KeyA', 'EDITED_VALUE');
+//       req.object.set('KeyB', 'EDITED_VALUE');
+//     });
+//     const object = new Parse.Object('SomeUltraSecureClass');
+//     object.set('KeyA', 'ValueA');
+//     object.set('KeyB', 'ValueB');
+//     await object.save();
+//     const query = new Parse.Query('SomeUltraSecureClass');
+//     query.equalTo('objectId', object.id);
+//     const serverObject = await query.first({ useMasterKey: true });
+//     expect(serverObject.get('KeyA')).toBe('ValueA');
+//     expect(serverObject.get('KeyB')).toBe('ValueB');
+//   });
+//   it('beforeSave should fail on throw', async () => {
+//     Parse.Cloud.beforeSave('SomeUltraSecureClass', function() {
+//       throw new Parse.Error(12345678, 'Nop');
+//     });
+//     const object = new Parse.Object('SomeUltraSecureClass');
+//     object.set('KeyA', 'ValueA');
+//     object.set('KeyB', 'ValueB');
+//     try {
+//       await object.save();
+//       throw 'Should not have passed';
+//     } catch (error) {
+//       expect(error.code).toBe(12345678);
+//       expect(error.message).toBe('Nop');
+//     }
+//   });
+//   it('beforeDelete should ignore thrown error', async () => {
+//     Parse.Cloud.beforeDelete('SomeUltraSecureClass', function() {
+//       throw new Parse.Error(12345678, 'Nop');
+//     });
+//     const object = new Parse.Object('SomeUltraSecureClass');
+//     object.set('KeyA', 'ValueA');
+//     object.set('KeyB', 'ValueB');
+//     await object.save();
+//     try {
+//       await object.destroy({}, { useMasterKey: true });
+//     } catch (error) {
+//       throw 'should have succeeded';
+//     }
+//   });
+// });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "spec",
-  "spec_files": ["*spec.js"],
+  "spec_files": ["ReadonlyTriggers.spec.js"],
   "helpers": ["helper.js"],
   "random": false
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,6 +1,6 @@
 {
   "spec_dir": "spec",
-  "spec_files": ["ReadonlyTriggers.spec.js"],
+  "spec_files": ["*spec.js"],
   "helpers": ["helper.js"],
   "random": false
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -12,10 +12,10 @@ export const Types = {
 };
 
 /** classes where readonly trigger is enforced */
-const ReadonlyTriggerClasses = Object.freeze(['SomeUltraSecureClass']);
-const isTriggerReadonlyForClass = function(className) {
-  return ReadonlyTriggerClasses.indexOf(className) != -1;
-};
+// const ReadonlyTriggerClasses = Object.freeze(['SomeUltraSecureClass']);
+// const isTriggerReadonlyForClass = function(className) {
+//   return ReadonlyTriggerClasses.indexOf(className) != -1;
+// };
 
 const baseStore = function() {
   const Validators = {};
@@ -264,12 +264,12 @@ export function getResponseObject(request, resolve, reject) {
         return resolve(response);
       }
       // if readonly, resolve ignoring edits
-      if (
-        isTriggerReadonlyForClass(request.object.className) &&
-        request.triggerName === Types.beforeSave
-      ) {
-        return resolve();
-      }
+      // if (
+      //   isTriggerReadonlyForClass(request.object.className) &&
+      //   request.triggerName === Types.beforeSave
+      // ) {
+      //   return resolve();
+      // }
       // Use the JSON response
       if (
         response &&
@@ -286,12 +286,12 @@ export function getResponseObject(request, resolve, reject) {
     },
     error: function(error) {
       // if readonly and beforeDelete. Ignore error.
-      if (
-        isTriggerReadonlyForClass(request.object.className) &&
-        request.triggerName === Types.beforeDelete
-      ) {
-        return Promise.resolve(resolve());
-      }
+      // if (
+      //   isTriggerReadonlyForClass(request.object.className) &&
+      //   request.triggerName === Types.beforeDelete
+      // ) {
+      //   return Promise.resolve(resolve());
+      // }
       if (error instanceof Parse.Error) {
         reject(error);
       } else if (error instanceof Error) {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -14,7 +14,7 @@ export const Types = {
 /** classes where readonly trigger is enforced */
 const ReadonlyTriggerClasses = Object.freeze(['SomeUltraSecureClass']);
 const isTriggerReadonlyForClass = function(className) {
-  return ReadonlyTriggerClasses.indexOf(className) > -1;
+  return ReadonlyTriggerClasses.indexOf(className) != -1;
 };
 
 const baseStore = function() {
@@ -290,7 +290,7 @@ export function getResponseObject(request, resolve, reject) {
         isTriggerReadonlyForClass(request.object.className) &&
         request.triggerName === Types.beforeDelete
       ) {
-        return resolve();
+        return Promise.resolve(resolve());
       }
       if (error instanceof Parse.Error) {
         reject(error);

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -11,6 +11,12 @@ export const Types = {
   afterFind: 'afterFind',
 };
 
+/** classes where readonly trigger is enforced */
+const ReadonlyTriggerClasses = Object.freeze(['SomeUltraSecureClass']);
+const isTriggerReadonlyForClass = function(className) {
+  return ReadonlyTriggerClasses.indexOf(className) > -1;
+};
+
 const baseStore = function() {
   const Validators = {};
   const Functions = {};
@@ -40,6 +46,12 @@ function validateClassNameForTriggers(className, type) {
     // allowing beforeSave would mess up the objects big time
     // TODO: Allow proper documented way of using nested increment ops
     throw 'Only afterSave is allowed on _PushStatus';
+  }
+  if (type == Types.beforeFind && className === 'SomeUltraSecureClass') {
+    throw 'beforeFind is not allowed on SomeUltraSecureClass';
+  }
+  if (type == Types.afterFind && className === 'SomeUltraSecureClass') {
+    throw 'afterFind is not allowed on SomeUltraSecureClass';
   }
   return className;
 }
@@ -251,6 +263,13 @@ export function getResponseObject(request, resolve, reject) {
         });
         return resolve(response);
       }
+      // if readonly, resolve ignoring edits
+      if (
+        isTriggerReadonlyForClass(request.object.className) &&
+        request.triggerName === Types.beforeSave
+      ) {
+        return resolve();
+      }
       // Use the JSON response
       if (
         response &&
@@ -266,6 +285,13 @@ export function getResponseObject(request, resolve, reject) {
       return resolve(response);
     },
     error: function(error) {
+      // if readonly and beforeDelete. Ignore error.
+      if (
+        isTriggerReadonlyForClass(request.object.className) &&
+        request.triggerName === Types.beforeDelete
+      ) {
+        return resolve();
+      }
       if (error instanceof Parse.Error) {
         reject(error);
       } else if (error instanceof Error) {
@@ -515,7 +541,9 @@ export function maybeRunTrigger(
       triggerType,
       config.applicationId
     );
+    // resolving with no object means no change (or no trigger)
     if (!trigger) return resolve();
+    // build our cloud request
     var request = getRequestObject(
       triggerType,
       auth,
@@ -553,7 +581,6 @@ export function maybeRunTrigger(
         reject(error);
       }
     );
-
     // AfterSave and afterDelete triggers can return a promise, which if they
     // do, needs to be resolved before this promise is resolved,
     // so trigger execution is synced with RestWrite.execute() call.


### PR DESCRIPTION
This is just a working concept of readonly triggers on custom class as explained here:
https://github.com/parse-community/parse-server/issues/4020#issuecomment-432089462

The changes implements the functionality on a custom class "_SomeUltraSecureClass_" not session "__Session_" because of one main problem in session that still needs to be solved.

Problem:
In order for "Trigger.js" to call a cloud trigger, the object must to be transformed from REST to Parse.Object (or any of its sublcasses), because cloud expects it. This is done here:
https://github.com/parse-community/parse-server/blob/961abda4eb349490888c78ca2556aacc8f703d53/src/RestWrite.js#L216
For "_Session" it will not work, and the internal code, this:
https://github.com/parse-community/parse-server/blob/961abda4eb349490888c78ca2556aacc8f703d53/src/RestWrite.js#L1515
throws since **ParseSession** prohibits "SessionToken" from being modified, so during a create when "this.sanitizedData()" equal { "sessionToken" : "..", ... } the above code will throw. (from ParseJsSDK)
Any suggestions ?


@flovilmart is this specifically the problems you meantioned here ? becuase it look like its straightforward unless i havent thought it through.
https://github.com/parse-community/parse-server/issues/4020#issuecomment-432428318
Anyway, i am curious to know what others have faced, if you remember which PR or Issue to look for, let me know.

