### PR TITLE
PG: Support multiple global config

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -4553,17 +4553,17 @@ describe('Parse.Query testing', () => {
   it('can set object type key', async () => {
     const data = { bar: true, baz: 100 };
     const object = new TestObject();
-    object.set('foo', data);
+    object.set('objectField', data);
     await object.save();
 
     const query = new Parse.Query(TestObject);
     let result = await query.get(object.id);
-    equal(result.get('foo'), data);
+    equal(result.get('objectField'), data);
 
-    object.set('foo.baz', 50, { ignoreValidation: true });
+    object.set('objectField.baz', 50, { ignoreValidation: true });
     await object.save();
 
     result = await query.get(object.id);
-    equal(result.get('foo'), { bar: true, baz: 50 });
+    equal(result.get('objectField'), { bar: true, baz: 50 });
   });
 });

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -4517,4 +4517,53 @@ describe('Parse.Query testing', () => {
       .then(done.fail)
       .catch(() => done());
   });
+
+  it('can add new config to existing config', async () => {
+    await request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: {
+        params: {
+          files: [{ __type: 'File', name: 'name', url: 'http://url' }],
+        },
+      },
+      headers: masterKeyHeaders,
+    });
+
+    await request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: {
+        params: { newConfig: 'good' },
+      },
+      headers: masterKeyHeaders,
+    });
+
+    const result = await Parse.Config.get();
+    equal(result.get('files')[0].toJSON(), {
+      __type: 'File',
+      name: 'name',
+      url: 'http://url',
+    });
+    equal(result.get('newConfig'), 'good');
+  });
+
+  it('can set object type key', async () => {
+    const data = { bar: true, baz: 100 };
+    const object = new TestObject();
+    object.set('foo', data);
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    let result = await query.get(object.id);
+    equal(result.get('foo'), data);
+
+    object.set('foo.baz', 50, { ignoreValidation: true });
+    await object.save();
+
+    result = await query.get(object.id);
+    equal(result.get('foo'), { bar: true, baz: 50 });
+  });
 });

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1628,21 +1628,18 @@ export class PostgresStorageAdapter implements StorageAdapter {
           },
           ''
         );
+        // Override Object
+        let updateObject = "'{}'::jsonb";
+
         if (dotNotationOptions[fieldName]) {
           // Merge Object
-          updatePatterns.push(
-            `$${index}:name = ( COALESCE($${index}:name, '{}'::jsonb) ${deletePatterns} ${incrementPatterns} || $${index +
-              1 +
-              keysToDelete.length}::jsonb )`
-          );
-        } else {
-          // Override Object
-          updatePatterns.push(
-            `$${index}:name = ('{}'::jsonb ${deletePatterns} ${incrementPatterns} || $${index +
-              1 +
-              keysToDelete.length}::jsonb )`
-          );
+          updateObject = `COALESCE($${index}:name, '{}'::jsonb)`;
         }
+        updatePatterns.push(
+          `$${index}:name = (${updateObject} ${deletePatterns} ${incrementPatterns} || $${index +
+            1 +
+            keysToDelete.length}::jsonb )`
+        );
         values.push(fieldName, ...keysToDelete, JSON.stringify(fieldValue));
         index += 2 + keysToDelete.length;
       } else if (


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/5176

Fixes dot notation support on postgres.

Allows for more than one config

Add support for setting key of type object.
