### PR TITLE
Fix issue #5274 on RestQuery.each and relations

### DIFF
--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -151,7 +151,6 @@ describe('Auth', () => {
   });
 
   describe('getRolesForUser', () => {
-
     const rolesNumber = 300;
 
     it('should load all roles without config', async () => {
@@ -165,11 +164,11 @@ describe('Auth', () => {
         sessionToken: user.getSessionToken(),
       });
       const roles = [];
-      for(let i = 0; i < rolesNumber;i++){
+      for (let i = 0; i < rolesNumber; i++) {
         const acl = new Parse.ACL();
-        const role = new Parse.Role("roleloadtest" + i, acl);
+        const role = new Parse.Role('roleloadtest' + i, acl);
         role.getUsers().add([user]);
-        roles.push(role.save())
+        roles.push(role.save());
       }
       const savedRoles = await Promise.all(roles);
       expect(savedRoles.length).toBe(rolesNumber);
@@ -189,16 +188,56 @@ describe('Auth', () => {
         config: Config.get('test'),
       });
       const roles = [];
-      for(let i = 0; i < rolesNumber;i++){
+      for (let i = 0; i < rolesNumber; i++) {
         const acl = new Parse.ACL();
-        const role = new Parse.Role("roleloadtest" + i, acl);
+        const role = new Parse.Role('roleloadtest' + i, acl);
         role.getUsers().add([user]);
-        roles.push(role.save())
+        roles.push(role.save());
       }
       const savedRoles = await Promise.all(roles);
       expect(savedRoles.length).toBe(rolesNumber);
       const cloudRoles = await userAuth.getRolesForUser();
       expect(cloudRoles.length).toBe(rolesNumber);
+    });
+
+    fit('should load all roles for different users with config', async () => {
+      const rolesNumber = 100;
+      const user = new Parse.User();
+      await user.signUp({
+        username: 'hello',
+        password: 'password',
+      });
+      const user2 = new Parse.User();
+      await user2.signUp({
+        username: 'world',
+        password: '1234',
+      });
+      expect(user.getSessionToken()).not.toBeUndefined();
+      const userAuth = await getAuthForSessionToken({
+        sessionToken: user.getSessionToken(),
+        config: Config.get('test'),
+      });
+      const user2Auth = await getAuthForSessionToken({
+        sessionToken: user2.getSessionToken(),
+        config: Config.get('test'),
+      });
+      const roles = [];
+      for (let i = 0; i < rolesNumber; i += 1) {
+        const acl = new Parse.ACL();
+        const acl2 = new Parse.ACL();
+        const role = new Parse.Role('roleloadtest' + i, acl);
+        const role2 = new Parse.Role('role2loadtest' + i, acl2);
+        role.getUsers().add([user]);
+        role2.getUsers().add([user2]);
+        roles.push(role.save());
+        roles.push(role2.save());
+      }
+      const savedRoles = await Promise.all(roles);
+      expect(savedRoles.length).toBe(rolesNumber * 2);
+      const cloudRoles = await userAuth.getRolesForUser();
+      const cloudRoles2 = await user2Auth.getRolesForUser();
+      expect(cloudRoles.length).toBe(rolesNumber);
+      expect(cloudRoles2.length).toBe(rolesNumber);
     });
   });
 });

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -200,7 +200,7 @@ describe('Auth', () => {
       expect(cloudRoles.length).toBe(rolesNumber);
     });
 
-    fit('should load all roles for different users with config', async () => {
+    it('should load all roles for different users with config', async () => {
       const rolesNumber = 100;
       const user = new Parse.User();
       await user.signUp({

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -363,4 +363,63 @@ describe('RestQuery.each', () => {
     expect(classSpy.calls.count()).toBe(4);
     expect(results.length).toBe(7);
   });
+
+  it('should work with query on relations', async () => {
+    const objectA = new Parse.Object('Letter', { value: 'A' });
+    const objectB = new Parse.Object('Letter', { value: 'B' });
+
+    const object1 = new Parse.Object('Number', { value: '1' });
+    const object2 = new Parse.Object('Number', { value: '2' });
+    const object3 = new Parse.Object('Number', { value: '3' });
+    const object4 = new Parse.Object('Number', { value: '4' });
+    await Parse.Object.saveAll([object1, object2, object3, object4]);
+
+    objectA.relation('numbers').add(object1);
+    objectB.relation('numbers').add(object2);
+    await Parse.Object.saveAll([objectA, objectB]);
+
+    const config = Config.get('test');
+
+    /* Two query needed since objectId are sorted and we can't know wich one
+     ** going to be the first and then skip by the $gt added by each */
+    const queryOne = new RestQuery(
+      config,
+      auth.master(config),
+      'Letter',
+      {
+        numbers: {
+          __type: 'Pointer',
+          className: 'Number',
+          objectId: object1.id,
+        },
+      },
+      { limit: 1 }
+    );
+    const queryTwo = new RestQuery(
+      config,
+      auth.master(config),
+      'Letter',
+      {
+        numbers: {
+          __type: 'Pointer',
+          className: 'Number',
+          objectId: object2.id,
+        },
+      },
+      { limit: 1 }
+    );
+
+    const classSpy = spyOn(RestQuery.prototype, 'execute').and.callThrough();
+    const resultsOne = [];
+    const resultsTwo = [];
+    await queryOne.each(result => {
+      resultsOne.push(result);
+    });
+    await queryTwo.each(result => {
+      resultsTwo.push(result);
+    });
+    expect(classSpy.calls.count()).toBe(4);
+    expect(resultsOne.length).toBe(1);
+    expect(resultsTwo.length).toBe(1);
+  });
 });

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -380,8 +380,10 @@ describe('RestQuery.each', () => {
 
     const config = Config.get('test');
 
-    // Two queries needed since objectId are sorted and we can't know which one
-    // going to be the first and then skip by the $gt added by each
+    /**
+     * Two queries needed since objectId are sorted and we can't know which one
+     * going to be the first and then skip by the $gt added by each
+     */
     const queryOne = new RestQuery(
       config,
       auth.master(config),

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -380,8 +380,8 @@ describe('RestQuery.each', () => {
 
     const config = Config.get('test');
 
-    /* Two query needed since objectId are sorted and we can't know wich one
-     ** going to be the first and then skip by the $gt added by each */
+    // Two queries needed since objectId are sorted and we can't know which one
+    // going to be the first and then skip by the $gt added by each
     const queryOne = new RestQuery(
       config,
       auth.master(config),

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -223,7 +223,9 @@ RestQuery.prototype.each = function(callback) {
       results.forEach(callback);
       finished = results.length < restOptions.limit;
       if (!finished) {
-        restWhere.objectId = { $gt: results[results.length - 1].objectId };
+        restWhere.objectId = Object.assign({}, restWhere.objectId, {
+          $gt: results[results.length - 1].objectId,
+        });
       }
     }
   );


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/5274

The RestQuery.prototype.each method was going through all results by adding a filter on `objectId` field of the concerned class when the results length exceed the limit. The problem was that if any constraint has been done on `objectId` field, it was overridden. That was the case for the all relation queries (like the `_Role`s of a user for any user authenticated queries).
To fix this, replace the assignation of an arbitrary object by the merge of the existing constraint with the new one.

The fix provided allows .each to only query on roles for this specific user instead of all roles