### PR TITLE
Added route to reset password with token

### DIFF
--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -398,14 +398,14 @@ export class UsersRouter extends ClassesRouter {
           'invalid token'
         );
       }
-    )
-    .then(() => {
-      return Promise.resolve({
-        response: {}
+      )
+      .then(() => {
+        return Promise.resolve({
+          response: {}
+        });
+      }, err => {
+        throw err;
       });
-    }, err => {
-      throw err;
-    });
   }
 
   handleVerificationEmailRequest(req) {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -389,23 +389,23 @@ export class UsersRouter extends ClassesRouter {
     }
 
     return config.userController.checkResetTokenValidity(username, token)
-        .then(() => {
-              return config.userController.updatePassword(username, token, new_password);
-          },
-          () => {
-            throw new Parse.Error(
-              Parse.Error.OPERATION_FORBIDDEN,
-              'invalid token'
-            );
-          }
-        )
-        .then(() => {
-          return Promise.resolve({
-            response: {}
-          });
-        }, err => {
-          throw err;
+      .then(() => {
+          return config.userController.updatePassword(username, token, new_password);
+        },
+        () => {
+          throw new Parse.Error(
+            Parse.Error.OPERATION_FORBIDDEN,
+            'invalid token'
+          );
+        }
+      )
+      .then(() => {
+        return Promise.resolve({
+          response: {}
         });
+      }, err => {
+        throw err;
+      });
   }
 
   handleVerificationEmailRequest(req) {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -390,22 +390,22 @@ export class UsersRouter extends ClassesRouter {
 
     return config.userController.checkResetTokenValidity(username, token)
       .then(() => {
-          return config.userController.updatePassword(username, token, new_password);
-        },
-        () => {
-          throw new Parse.Error(
-            Parse.Error.OPERATION_FORBIDDEN,
-            'invalid token'
-          );
-        }
-      )
-      .then(() => {
-        return Promise.resolve({
-          response: {}
-        });
-      }, err => {
-        throw err;
+        return config.userController.updatePassword(username, token, new_password);
+      },
+      () => {
+        throw new Parse.Error(
+          Parse.Error.OPERATION_FORBIDDEN,
+          'invalid token'
+        );
+      }
+    )
+    .then(() => {
+      return Promise.resolve({
+        response: {}
       });
+    }, err => {
+      throw err;
+    });
   }
 
   handleVerificationEmailRequest(req) {


### PR DESCRIPTION
Server side route for this pull request https://github.com/parse-community/Parse-SDK-JS/pull/716

Created to be able to use Parse function on client side to set new password for user that requested password reset, using token he receives by email. 