### PR TITLE
Docs Typo #2

### DIFF
--- a/3.0.0.md
+++ b/3.0.0.md
@@ -134,8 +134,8 @@ Parse.Cloud.define('downloadImage', function(request, response) {
 You would call this method with:
 
 ```js
-Parse.Cloud.run({
-  url: '....',
+Parse.Cloud.run('downloadImage',{
+  url: 'https://example.com/file',
   name: 'my-file'
 });
 ```


### PR DESCRIPTION
Plus added example.com url instead of '....'