### PR TITLE
Hides token contents in logStartupOptions if they arrive as a buffer

### DIFF
--- a/src/cli/utils/runner.js
+++ b/src/cli/utils/runner.js
@@ -6,10 +6,8 @@ function logStartupOptions(options) {
     if (key == 'masterKey') {
       value = '***REDACTED***';
     }
-    if (key == 'push') {
-      if (Buffer.isBuffer(value.ios.token.key)) {
-        value.ios.token.key = '***REDACTED***';
-      }
+    if (key == 'push' && process.env.VERBOSE != true) {
+      value = '***REDACTED***';
     }
     if (typeof value === 'object') {
       try {

--- a/src/cli/utils/runner.js
+++ b/src/cli/utils/runner.js
@@ -6,6 +6,11 @@ function logStartupOptions(options) {
     if (key == 'masterKey') {
       value = '***REDACTED***';
     }
+    if (key == 'push') {
+      if (Buffer.isBuffer(value.ios.token.key)) {
+        value.ios.token.key = '***REDACTED***';
+      }
+    }
     if (typeof value === 'object') {
       try {
         value = JSON.stringify(value);


### PR DESCRIPTION
@flovilmart So this change hides the crypto data for my specific case. But as I've created this PR, it occurs to me that this probably needs to be done in a lot of places:

https://github.com/node-apn/node-apn/blob/master/doc/provider.markdown

There are numerous parameters in there that can end up dumping sensitive info in the log. Maybe it's best to just redact the whole thing?