### PR TITLE
Fix a couple Postgres adapter bugs

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -287,7 +287,9 @@ const buildWhereClause = ({ schema, query, index }): WhereClause => {
               inPatterns.push(`${listElem}`);
             }
           });
-          patterns.push(`(${name})::jsonb @> '[${inPatterns.join()}]'::jsonb`);
+          patterns.push(
+            `(${name})::jsonb @> '[${inPatterns.join(',')}]'::jsonb`
+          );
         } else if (fieldValue.$regex) {
           // Handle later
         } else {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -291,7 +291,9 @@ const buildWhereClause = ({ schema, query, index }): WhereClause => {
         } else if (fieldValue.$regex) {
           // Handle later
         } else {
-          patterns.push(`${name} = '${fieldValue}'`);
+          patterns.push(`${name} = $${index}`);
+          values.push(fieldValue);
+          index += 1;
         }
       }
     } else if (fieldValue === null || fieldValue === undefined) {


### PR DESCRIPTION
Note: the commit about separating values I've not tested, but reading the spec should be correct. The adapter is currently pushing strings together like `'["hello""world"]'::jsonb`.