### PR TITLE
Add beforeLogin trigger with support for auth providers

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2021,6 +2021,24 @@ describe('afterFind hooks', () => {
     expect(() => {
       Parse.Cloud.afterSave('_PushStatus', () => {});
     }).not.toThrow();
+    expect(() => {
+      Parse.Cloud.beforeLogin(() => {});
+    }).not.toThrow(
+      'Only the _User class is allowed for the beforeLogin trigger'
+    );
+    expect(() => {
+      Parse.Cloud.beforeLogin('_User', () => {});
+    }).not.toThrow(
+      'Only the _User class is allowed for the beforeLogin trigger'
+    );
+    expect(() => {
+      Parse.Cloud.beforeLogin(Parse.User, () => {});
+    }).not.toThrow(
+      'Only the _User class is allowed for the beforeLogin trigger'
+    );
+    expect(() => {
+      Parse.Cloud.beforeLogin('SomeClass', () => {});
+    }).toThrow('Only the _User class is allowed for the beforeLogin trigger');
   });
 
   it('should skip afterFind hooks for aggregate', done => {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -267,8 +267,7 @@ RestWrite.prototype.runBeforeLoginTrigger = async function(userData) {
   const extraData = { className: this.className };
   const user = triggers.inflate(extraData, userData);
 
-  // no need to return a response, the
-  // only purpose here is to reject a login
+  // no need to return a response
   await triggers.maybeRunTrigger(
     triggers.Types.beforeLogin,
     this.auth,

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -93,7 +93,7 @@ RestWrite.prototype.execute = function() {
       return this.validateAuthData();
     })
     .then(() => {
-      return this.runBeforeTrigger();
+      return this.runBeforeSaveTrigger();
     })
     .then(() => {
       return this.deleteEmailResetTokenIfNeeded();
@@ -123,7 +123,7 @@ RestWrite.prototype.execute = function() {
       return this.handleFollowup();
     })
     .then(() => {
-      return this.runAfterTrigger();
+      return this.runAfterSaveTrigger();
     })
     .then(() => {
       return this.cleanUserAuthData();
@@ -190,7 +190,7 @@ RestWrite.prototype.validateSchema = function() {
 
 // Runs any beforeSave triggers against this operation.
 // Any change leads to our data being mutated.
-RestWrite.prototype.runBeforeTrigger = function() {
+RestWrite.prototype.runBeforeSaveTrigger = function() {
   if (this.response) {
     return;
   }
@@ -249,6 +249,34 @@ RestWrite.prototype.runBeforeTrigger = function() {
         }
       }
     });
+};
+
+RestWrite.prototype.runBeforeLoginTrigger = async function(userData) {
+  // Avoid doing any setup for triggers if there is no 'beforeLogin' trigger
+  if (
+    !triggers.triggerExists(
+      this.className,
+      triggers.Types.beforeLogin,
+      this.config.applicationId
+    )
+  ) {
+    return;
+  }
+
+  // Cloud code gets a bit of extra data for its objects
+  const extraData = { className: this.className };
+  const user = triggers.inflate(extraData, userData);
+
+  // no need to return a response, the
+  // only purpose here is to reject a login
+  await triggers.maybeRunTrigger(
+    triggers.Types.beforeLogin,
+    this.auth,
+    user,
+    null,
+    this.config,
+    this.context
+  );
 };
 
 RestWrite.prototype.setRequiredFieldsIfNeeded = function() {
@@ -377,7 +405,7 @@ RestWrite.prototype.filteredObjectsByACL = function(objects) {
 
 RestWrite.prototype.handleAuthData = function(authData) {
   let results;
-  return this.findUsersWithAuthData(authData).then(r => {
+  return this.findUsersWithAuthData(authData).then(async r => {
     results = this.filteredObjectsByACL(r);
     if (results.length > 1) {
       // More than 1 user with the passed id's
@@ -421,7 +449,12 @@ RestWrite.prototype.handleAuthData = function(authData) {
             response: userResult,
             location: this.location(),
           };
+          // Run beforeLogin hook before storing any updates
+          // to authData on the db; changes to userResult
+          // will be ignored.
+          await this.runBeforeLoginTrigger(deepcopy(userResult));
         }
+
         // If we didn't change the auth data, just keep going
         if (!hasMutatedAuthData) {
           return;
@@ -430,7 +463,7 @@ RestWrite.prototype.handleAuthData = function(authData) {
         // that can happen when token are refreshed,
         // We should update the token and let the user in
         // We should only check the mutated keys
-        return this.handleAuthDataValidation(mutatedAuthData).then(() => {
+        return this.handleAuthDataValidation(mutatedAuthData).then(async () => {
           // IF we have a response, we'll skip the database operation / beforeSave / afterSave etc...
           // we need to set it up there.
           // We are supposed to have a response only on LOGIN with authData, so we skip those
@@ -441,6 +474,7 @@ RestWrite.prototype.handleAuthData = function(authData) {
               this.response.response.authData[provider] =
                 mutatedAuthData[provider];
             });
+
             // Run the DB update directly, as 'master'
             // Just update the authData part
             // Then we're good for the user, early exit of sorts
@@ -1415,7 +1449,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
 };
 
 // Returns nothing - doesn't wait for the trigger.
-RestWrite.prototype.runAfterTrigger = function() {
+RestWrite.prototype.runAfterSaveTrigger = function() {
   if (!this.response || !this.response.response) {
     return;
   }

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -7,6 +7,7 @@ import ClassesRouter from './ClassesRouter';
 import rest from '../rest';
 import Auth from '../Auth';
 import passwordCrypto from '../password';
+import { maybeRunTrigger, Types as TriggerTypes } from '../triggers';
 
 export class UsersRouter extends ClassesRouter {
   className() {
@@ -202,68 +203,68 @@ export class UsersRouter extends ClassesRouter {
       });
   }
 
-  handleLogIn(req) {
-    let user;
-    return this._authenticateUserFromRequest(req)
-      .then(res => {
-        user = res;
+  async handleLogIn(req) {
+    const user = await this._authenticateUserFromRequest(req);
 
-        // handle password expiry policy
-        if (
-          req.config.passwordPolicy &&
-          req.config.passwordPolicy.maxPasswordAge
-        ) {
-          let changedAt = user._password_changed_at;
+    // handle password expiry policy
+    if (req.config.passwordPolicy && req.config.passwordPolicy.maxPasswordAge) {
+      let changedAt = user._password_changed_at;
 
-          if (!changedAt) {
-            // password was created before expiry policy was enabled.
-            // simply update _User object so that it will start enforcing from now
-            changedAt = new Date();
-            req.config.database.update(
-              '_User',
-              { username: user.username },
-              { _password_changed_at: Parse._encode(changedAt) }
-            );
-          } else {
-            // check whether the password has expired
-            if (changedAt.__type == 'Date') {
-              changedAt = new Date(changedAt.iso);
-            }
-            // Calculate the expiry time.
-            const expiresAt = new Date(
-              changedAt.getTime() +
-                86400000 * req.config.passwordPolicy.maxPasswordAge
-            );
-            if (expiresAt < new Date())
-              // fail of current time is past password expiry time
-              throw new Parse.Error(
-                Parse.Error.OBJECT_NOT_FOUND,
-                'Your password has expired. Please reset your password.'
-              );
-          }
+      if (!changedAt) {
+        // password was created before expiry policy was enabled.
+        // simply update _User object so that it will start enforcing from now
+        changedAt = new Date();
+        req.config.database.update(
+          '_User',
+          { username: user.username },
+          { _password_changed_at: Parse._encode(changedAt) }
+        );
+      } else {
+        // check whether the password has expired
+        if (changedAt.__type == 'Date') {
+          changedAt = new Date(changedAt.iso);
         }
+        // Calculate the expiry time.
+        const expiresAt = new Date(
+          changedAt.getTime() +
+            86400000 * req.config.passwordPolicy.maxPasswordAge
+        );
+        if (expiresAt < new Date())
+          // fail of current time is past password expiry time
+          throw new Parse.Error(
+            Parse.Error.OBJECT_NOT_FOUND,
+            'Your password has expired. Please reset your password.'
+          );
+      }
+    }
 
-        // Remove hidden properties.
-        UsersRouter.removeHiddenProperties(user);
+    // Remove hidden properties.
+    UsersRouter.removeHiddenProperties(user);
 
-        const { sessionData, createSession } = Auth.createSession(req.config, {
-          userId: user.objectId,
-          createdWith: {
-            action: 'login',
-            authProvider: 'password',
-          },
-          installationId: req.info.installationId,
-        });
+    // Before login trigger; throws if failure
+    await maybeRunTrigger(
+      TriggerTypes.beforeLogin,
+      req.auth,
+      Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
+      null,
+      req.config
+    );
 
-        user.sessionToken = sessionData.sessionToken;
+    const { sessionData, createSession } = Auth.createSession(req.config, {
+      userId: user.objectId,
+      createdWith: {
+        action: 'login',
+        authProvider: 'password',
+      },
+      installationId: req.info.installationId,
+    });
 
-        req.config.filesController.expandFilesInObject(req.config, user);
+    user.sessionToken = sessionData.sessionToken;
 
-        return createSession();
-      })
-      .then(() => {
-        return { response: user };
-      });
+    req.config.filesController.expandFilesInObject(req.config, user);
+
+    await createSession();
+    return { response: user };
   }
 
   handleVerifyPassword(req) {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -1,6 +1,10 @@
 import { Parse } from 'parse/node';
 import * as triggers from '../triggers';
 
+function isParseObjectConstructor(object) {
+  return typeof object === 'function' && object.hasOwnProperty('className');
+}
+
 function getClassName(parseClass) {
   if (parseClass && parseClass.className) {
     return parseClass.className;
@@ -143,7 +147,13 @@ ParseCloud.beforeDelete = function(parseClass, handler) {
  * @param {Function} func The function to run before a login. This function can be async and should take one parameter a {@link Parse.Cloud.TriggerRequest};
  */
 ParseCloud.beforeLogin = function(handler) {
-  const className = '_User';
+  let className = '_User';
+  if (typeof handler === 'string' || isParseObjectConstructor(handler)) {
+    // validation will occur downstream, this is to maintain internal
+    // code consistency with the other hook types.
+    className = getClassName(handler);
+    handler = arguments[1];
+  }
   triggers.addTrigger(
     triggers.Types.beforeLogin,
     className,

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -120,6 +120,39 @@ ParseCloud.beforeDelete = function(parseClass, handler) {
 };
 
 /**
+ *
+ * Registers the before login function.
+ *
+ * **Available in Cloud Code only.**
+ *
+ * This function provides further control
+ * in validating a login attempt. Specifically,
+ * it is triggered after a user enters
+ * correct credentials (or other valid authData),
+ * but prior to a session being generated.
+ *
+ * ```
+ * Parse.Cloud.beforeLogin((request) => {
+ *   // code here
+ * })
+ *
+ * ```
+ *
+ * @method beforeLogin
+ * @name Parse.Cloud.beforeLogin
+ * @param {Function} func The function to run before a login. This function can be async and should take one parameter a {@link Parse.Cloud.TriggerRequest};
+ */
+ParseCloud.beforeLogin = function(handler) {
+  const className = '_User';
+  triggers.addTrigger(
+    triggers.Types.beforeLogin,
+    className,
+    handler,
+    Parse.applicationId
+  );
+};
+
+/**
  * Registers an after save function.
  *
  * **Available in Cloud Code only.**

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -3,6 +3,7 @@ import Parse from 'parse/node';
 import { logger } from './logger';
 
 export const Types = {
+  beforeLogin: 'beforeLogin',
   beforeSave: 'beforeSave',
   afterSave: 'afterSave',
   beforeDelete: 'beforeDelete',

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -42,6 +42,11 @@ function validateClassNameForTriggers(className, type) {
     // TODO: Allow proper documented way of using nested increment ops
     throw 'Only afterSave is allowed on _PushStatus';
   }
+  if (type === Types.beforeLogin && className !== '_User') {
+    // TODO: check if upstream code will handle `Error` instance rather
+    // than this anti-pattern of throwing strings
+    throw 'Only the _User class is allowed for the beforeLogin trigger';
+  }
   return className;
 }
 


### PR DESCRIPTION
This has been attempted [before](https://github.com/parse-community/parse-server/pull/4524) a couple of times but never seen to completion. I used some of the ideas by @carlosapgomes in his now closed PR, however most of the work was too out of sync with the current state of the library.

**Currently:**
User sign ups can be validated, rejected and side-effects issued in `beforeSave` on `Parse.User`. There is no similar functionality for user logins. 

**Use cases:**
- Blocking an account from logging in (for example, if they are banned).
- Recording a login event for analytics.
- Notifying user by email if a login occurred at an unusual IP address.

**Motivation / Bias:**
We have a multi-tenanted platform wherein each client has their own subdomain. They share the same database and so, theoretically users from subdomain-a can legally login to subdomain-b. This new trigger allows us to check the request `headers` against the user to verify if the login is appropriate.

**Example usage:**

```js
// In cloud code
Parse.Cloud.beforeLogin(async request => { 
  const { object: user }  = request;
  if(user.get('isBanned')) {
   throw new Error('Sorry, you are a naughty boy.')
  }
});

// On the client
await Parse.User.logIn('naughty', 'pass123'); // rejected with "Sorry, you are a naughty boy."
```

**Considerations:**
This trigger behaves in a similar manner to other triggers:
- It sends a `TriggerRequest` that contains `object`, `headers`, `ip`, `installationId`, etc
- Like `afterSave` on `Parse.User`, it will not save mutations to the user unless explicitly `save`d.
- It will return a `Parse.Error` if an exception is thrown
- It waits for any promises to resolve

The trigger has some unique behaviours not seen in other triggers:
- It does not accept a `className` or `Parse.Object` constructor as the first argument; it is only meant for `Parse.User`
- It does not set the `user` on the request object - technically, the user has not yet been provided a `session` until after `beforeLogin` is successfully completed

Some specific behaviours with regards to signup/login:
- It does not run on sign up
- It does run on username/pass AND `authProvider` logins
- It will not run if the login credentials are incorrect

Please let me know if there are side-effects that I have not accounted for in the added unit tests.