### PR TITLE
Local tests failing for timezones <= -7

### DIFF
--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -1506,14 +1506,19 @@ describe('PushController', () => {
       ).toBe('2007-04-05T14:30:00.000Z', 'Timezone offset');
 
       const noTimezone = new Date('2017-09-06T17:14:01.048');
-      const expectedHour = 17 + noTimezone.getTimezoneOffset() / 60;
+      let expectedHour = 17 + noTimezone.getTimezoneOffset() / 60;
+      let day = '06';
+      if (expectedHour >= 24) {
+        expectedHour = expectedHour - 24;
+        day = '07';
+      }
       expect(
         PushController.formatPushTime({
           date: noTimezone,
           isLocalTime: true,
         })
       ).toBe(
-        `2017-09-06T${expectedHour.toString().padStart(2, '0')}:14:01.048`,
+        `2017-09-${day}T${expectedHour.toString().padStart(2, '0')}:14:01.048`,
         'No timezone'
       );
       expect(
@@ -1538,7 +1543,12 @@ describe('PushController', () => {
       };
 
       const pushTime = '2017-09-06T17:14:01.048';
-      const expectedHour = 17 + new Date(pushTime).getTimezoneOffset() / 60;
+      let expectedHour = 17 + new Date(pushTime).getTimezoneOffset() / 60;
+      let day = '06';
+      if (expectedHour >= 24) {
+        expectedHour = expectedHour - 24;
+        day = '07';
+      }
 
       reconfigureServer({
         push: { adapter: pushAdapter },
@@ -1572,7 +1582,9 @@ describe('PushController', () => {
         .then(pushStatus => {
           expect(pushStatus.get('status')).toBe('scheduled');
           expect(pushStatus.get('pushTime')).toBe(
-            `2017-09-06T${expectedHour.toString().padStart(2, '0')}:14:01.048`
+            `2017-09-${day}T${expectedHour
+              .toString()
+              .padStart(2, '0')}:14:01.048`
           );
         })
         .then(done, done.fail);


### PR DESCRIPTION
This PR fixes two tests regarding the way that PushController handles local times. These tests are failing only in timezones <= -7 and that's probably why nobody has noticed before.