### PR TITLE
Aggregate supports group by date fields

### DIFF
--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -386,6 +386,11 @@ describe('Parse.Query Aggregate testing', () => {
       const obj3 = new TestObject({ dateField2019: new Date(1990, 11, 1) });
       const pipeline = [
         {
+          match: {
+            dateField2019: { $exists: true },
+          },
+        },
+        {
           group: {
             objectId: {
               day: { $dayOfMonth: '$dateField2019' },
@@ -403,8 +408,8 @@ describe('Parse.Query Aggregate testing', () => {
         })
         .then(results => {
           const counts = results.map(result => result.count);
-          expect(counts.length).toBe(3);
-          expect(counts.sort()).toEqual([1, 2, 4]);
+          expect(counts.length).toBe(2);
+          expect(counts.sort()).toEqual([1, 2]);
           done();
         })
         .catch(done.fail);

--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -381,16 +381,16 @@ describe('Parse.Query Aggregate testing', () => {
   it_exclude_dbs(['postgres'])(
     'can group by any date field (it does not work if you have dirty data)', // rows in your collection with non date data in the field that is supposed to be a date
     done => {
-      const obj1 = new TestObject({ dateField2: new Date(1990, 11, 1) });
-      const obj2 = new TestObject({ dateField2: new Date(1990, 5, 1) });
-      const obj3 = new TestObject({ dateField2: new Date(1990, 11, 1) });
+      const obj1 = new TestObject({ dateField2019: new Date(1990, 11, 1) });
+      const obj2 = new TestObject({ dateField2019: new Date(1990, 5, 1) });
+      const obj3 = new TestObject({ dateField2019: new Date(1990, 11, 1) });
       const pipeline = [
         {
           group: {
             objectId: {
-              day: { $dayOfMonth: '$dateField2' },
-              month: { $month: '$dateField2' },
-              year: { $year: '$dateField2' },
+              day: { $dayOfMonth: '$dateField2019' },
+              month: { $month: '$dateField2019' },
+              year: { $year: '$dateField2019' },
             },
             count: { $sum: 1 },
           },
@@ -401,13 +401,13 @@ describe('Parse.Query Aggregate testing', () => {
           const query = new Parse.Query(TestObject);
           return query.aggregate(pipeline);
         })
-        .catch(done.fail)
         .then(results => {
           const counts = results.map(result => result.count);
           expect(counts.length).toBe(3);
           expect(counts.sort()).toEqual([1, 2, 4]);
           done();
-        });
+        })
+        .catch(done.fail);
     }
   );
 

--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -416,6 +416,39 @@ describe('Parse.Query Aggregate testing', () => {
     }
   );
 
+  it_only_db('postgres')(
+    'can group by any date field (it does not work if you have dirty data)', // rows in your collection with non date data in the field that is supposed to be a date
+    done => {
+      const obj1 = new TestObject({ dateField2019: new Date(1990, 11, 1) });
+      const obj2 = new TestObject({ dateField2019: new Date(1990, 5, 1) });
+      const obj3 = new TestObject({ dateField2019: new Date(1990, 11, 1) });
+      const pipeline = [
+        {
+          group: {
+            objectId: {
+              day: { $dayOfMonth: '$dateField2019' },
+              month: { $month: '$dateField2019' },
+              year: { $year: '$dateField2019' },
+            },
+            count: { $sum: 1 },
+          },
+        },
+      ];
+      Parse.Object.saveAll([obj1, obj2, obj3])
+        .then(() => {
+          const query = new Parse.Query(TestObject);
+          return query.aggregate(pipeline);
+        })
+        .then(results => {
+          const counts = results.map(result => result.count);
+          expect(counts.length).toBe(3);
+          expect(counts.sort()).toEqual([1, 2, 4]);
+          done();
+        })
+        .catch(done.fail);
+    }
+  );
+
   it('group by pointer', done => {
     const pointer1 = new TestObject();
     const pointer2 = new TestObject();

--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -379,18 +379,18 @@ describe('Parse.Query Aggregate testing', () => {
   });
 
   it_exclude_dbs(['postgres'])(
-    'cannot group by date field (excluding createdAt and updatedAt)',
+    'can group by any date field (it does not work if you have dirty data)', // rows in your collection with non date data in the field that is supposed to be a date
     done => {
-      const obj1 = new TestObject({ dateField: new Date(1990, 11, 1) });
-      const obj2 = new TestObject({ dateField: new Date(1990, 5, 1) });
-      const obj3 = new TestObject({ dateField: new Date(1990, 11, 1) });
+      const obj1 = new TestObject({ dateField2: new Date(1990, 11, 1) });
+      const obj2 = new TestObject({ dateField2: new Date(1990, 5, 1) });
+      const obj3 = new TestObject({ dateField2: new Date(1990, 11, 1) });
       const pipeline = [
         {
           group: {
             objectId: {
-              day: { $dayOfMonth: '$dateField' },
-              month: { $month: '$dateField' },
-              year: { $year: '$dateField' },
+              day: { $dayOfMonth: '$dateField2' },
+              month: { $month: '$dateField2' },
+              year: { $year: '$dateField2' },
             },
             count: { $sum: 1 },
           },
@@ -401,9 +401,11 @@ describe('Parse.Query Aggregate testing', () => {
           const query = new Parse.Query(TestObject);
           return query.aggregate(pipeline);
         })
-        .then(done.fail)
-        .catch(error => {
-          expect(error.code).toEqual(Parse.Error.INVALID_QUERY);
+        .catch(done.fail)
+        .then(results => {
+          const counts = results.map(result => result.count);
+          expect(counts.length).toBe(3);
+          expect(counts.sort()).toEqual([1, 2, 4]);
           done();
         });
     }

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -765,12 +765,6 @@ export class MongoStorageAdapter implements StorageAdapter {
           maxTimeMS: this._maxTimeMS,
         })
       )
-      .catch(error => {
-        if (error.code === 16006) {
-          throw new Parse.Error(Parse.Error.INVALID_QUERY, error.message);
-        }
-        throw error;
-      })
       .then(results => {
         results.forEach(result => {
           if (result.hasOwnProperty('_id')) {


### PR DESCRIPTION
This PR aims to affirm that Parse Server currently DOES support group by date fields.

I started working on this because I've just setup a brand new environment for contributing to Parse Server and the test below keeps failing to me when I run coverage npm script on master:
https://github.com/parse-community/parse-server/blob/master/spec/ParseQuery.Aggregate.spec.js#L381

I found out that the group by date fields actually works for normal cases and only does not work when you have dirty data, meaning a non date value in a field that is expected to be a date. I was only able to simulate this problem by doing:
1) I dropped the test database
2) I used the api to save a data in the TestObject class with value '' in the field dateField
3) I run the tests

After this, I've just dropped the database again and run the tests. Then the group by was working again.

Probably this test is passing in Travis and maintainers' environments because they have legacy data in their databases. According to my tests, if any of them drop the current test database and run the tests again, this test will fail.

In summary, what I did in this PR:
- Changed the test to affirm that group by field dates actually works;
- Changed the date field name to dateField2 to avoid problem in environments with legacy dirty data;
- Removed the error handler below, since the error is related to dirty data and not bad query; it will make the original mongodb error to be thrown and I think it will be easier for the developer to find out what is happening since it is possible to find some information about this error in internet;
https://github.com/parse-community/parse-server/blob/master/src/Adapters/Storage/Mongo/MongoStorageAdapter.js#L768

@dplewis do you mind to take a look on this and check if you agree?