### PR TITLE
Decode Date JSON value at LiveQuery

### DIFF
--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -587,4 +587,49 @@ describe('matchesQuery', function() {
     q.notContainedIn('profile', ['abc', 'def', 'ghi']);
     expect(matchesQuery(message, q)).toBe(false);
   });
+
+  it('matches on Date', () => {
+    // given
+    const now = new Date();
+    const obj = {
+      id: new Id('Person', '01'),
+      dateObject: now,
+      dateJSON: {
+        __type: 'Date',
+        iso: now.toISOString(),
+      },
+    };
+
+    // when, then: Equal
+    let q = new Parse.Query('Person');
+    q.equalTo('dateObject', now);
+    q.equalTo('dateJSON', now);
+    expect(matchesQuery(Object.assign({}, obj), q)).toBe(true);
+
+    // when, then: lessThan
+    const future = Date(now.getTime() + 1000);
+    q = new Parse.Query('Person');
+    q.lessThan('dateObject', future);
+    q.lessThan('dateJSON', future);
+    expect(matchesQuery(Object.assign({}, obj), q)).toBe(true);
+
+    // when, then: lessThanOrEqualTo
+    q = new Parse.Query('Person');
+    q.lessThanOrEqualTo('dateObject', now);
+    q.lessThanOrEqualTo('dateJSON', now);
+    expect(matchesQuery(Object.assign({}, obj), q)).toBe(true);
+
+    // when, then: greaterThan
+    const past = Date(now.getTime() - 1000);
+    q = new Parse.Query('Person');
+    q.greaterThan('dateObject', past);
+    q.greaterThan('dateJSON', past);
+    expect(matchesQuery(Object.assign({}, obj), q)).toBe(true);
+
+    // when, then: greaterThanOrEqualTo
+    q = new Parse.Query('Person');
+    q.greaterThanOrEqualTo('dateObject', now);
+    q.greaterThanOrEqualTo('dateJSON', now);
+    expect(matchesQuery(Object.assign({}, obj), q)).toBe(true);
+  });
 });

--- a/src/LiveQuery/QueryTools.js
+++ b/src/LiveQuery/QueryTools.js
@@ -177,6 +177,10 @@ function matchesKeyConstraints(object, key, constraints) {
     // Bail! We can't handle relational queries locally
     return false;
   }
+  // Decode Date JSON value
+  if (object[key] && object[key].__type == 'Date') {
+    object[key] = new Date(object[key].iso);
+  }
   // Equality (or Array contains) cases
   if (typeof constraints !== 'object') {
     if (Array.isArray(object[key])) {


### PR DESCRIPTION
Date value stored in object is represented in JSON format like this:
``
{"__type": "Date", "iso": "2006-04-22T00:13:00.520Z"}
``

It should be transformed to Date object before comparing, or it will always be failed.
That means all Date constraints at LiveQuery are actually failed.

P.S. 
iOS / Mac client library should be modified as well, please check parse-community/ParseLiveQuery-iOS-OSX#186