### PR TITLE
Remove video series reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Parse Server works with the Express web application framework. It can be added t
 
 # Getting Started
 
-April 2016 - We created a series of video screencasts, please check them out here: [http://blog.parseplatform.org/learn/parse-server-video-series-april-2016/](http://blog.parseplatform.org/learn/parse-server-video-series-april-2016/)
-
 The fastest and easiest way to get started is to run MongoDB and Parse Server locally.
 
 ## Running Parse Server


### PR DESCRIPTION
The blog post referenced here does not have the said video embedded or linked to (I suspect it was never migrated from the old docs).

The video series does still exist on YouTube so we could just link to that here (or add the link to the blog post) although I suspect the videos are now somewhat out of date.