### PR TITLE
fixed logger not applying timestamp to logs

### DIFF
--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -20,8 +20,7 @@ function configureTransports(options) {
             filename: 'parse-server.info',
             json: true,
           },
-          options,
-          { timestamp: true }
+          options
         )
       );
       parseServer.name = 'parse-server';
@@ -34,7 +33,7 @@ function configureTransports(options) {
             json: true,
           },
           options,
-          { level: 'error', timestamp: true }
+          { level: 'error' }
         )
       );
       parseServerError.name = 'parse-server-error';

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -1,4 +1,4 @@
-import winston from 'winston';
+import winston, { format } from 'winston';
 import fs from 'fs';
 import path from 'path';
 import DailyRotateFile from 'winston-daily-rotate-file';
@@ -56,6 +56,7 @@ function configureTransports(options) {
   }
 
   logger.configure({
+    format: format.combine(format.timestamp(), format.json()),
     transports,
   });
 }


### PR DESCRIPTION
Fix for issue https://github.com/parse-community/parse-server/issues/5560

Basically Winston was updated to 3.x which changed timestamp is to be used. This PR adds the timestamp back to the logs.