### PR TITLE
Logger: Fix timestamp and format

### DIFF
--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -40,13 +40,33 @@ describe('WinstonLogger', () => {
   });
 
   it('should have a timestamp', done => {
-    logging.logger.query({}, (err, results) => {
+    logging.logger.info('hi');
+    logging.logger.query({ limit: 1 }, (err, results) => {
       if (err) {
         done.fail(err);
       }
       expect(results['parse-server'][0].timestamp).toBeDefined();
       done();
     });
+  });
+
+  it('console should not be json', done => {
+    // Force console transport
+    reconfigureServer({
+      logsFolder: null,
+      silent: false,
+    })
+      .then(() => {
+        spyOn(process.stdout, 'write');
+        logging.logger.info('hi', { key: 'value' });
+        expect(process.stdout.write).toHaveBeenCalled();
+        const firstLog = process.stdout.write.calls.first().args[0];
+        expect(firstLog).toEqual('info: hi {"key":"value"}' + '\n');
+        return reconfigureServer();
+      })
+      .then(() => {
+        done();
+      });
   });
 
   it('should enable JSON logs', done => {

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -39,6 +39,16 @@ describe('WinstonLogger', () => {
     });
   });
 
+  it('should have a timestamp', done => {
+    logging.logger.query({}, (err, results) => {
+      if (err) {
+        done.fail(err);
+      }
+      expect(results['parse-server'][0].timestamp).toBeDefined();
+      done();
+    });
+  });
+
   it('should enable JSON logs', done => {
     // Force console transport
     reconfigureServer({

--- a/spec/LoggerController.spec.js
+++ b/spec/LoggerController.spec.js
@@ -66,10 +66,7 @@ describe('LoggerController', () => {
   });
 
   it('can process an ascending query without throwing', done => {
-    // Make mock request
     const query = {
-      from: '2016-01-01Z00:00:00',
-      until: '2016-01-01Z00:00:00',
       size: 5,
       order: 'asc',
       level: 'error',
@@ -114,10 +111,7 @@ describe('LoggerController', () => {
   });
 
   it('can process a descending query without throwing', done => {
-    // Make mock request
     const query = {
-      from: '2016-01-01Z00:00:00',
-      until: '2016-01-01Z00:00:00',
       size: 5,
       order: 'desc',
       level: 'error',

--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -66,6 +66,22 @@ describe('error logs', () => {
       }
     );
   });
+
+  fit('Should filter on query', done => {
+    const winstonLoggerAdapter = new WinstonLoggerAdapter();
+    winstonLoggerAdapter.log('error', 'testing error logs');
+    winstonLoggerAdapter.query(
+      {
+        from: new Date(Date.now() - 500),
+        size: 100,
+        level: 'info',
+      },
+      results => {
+        expect(results.filter(e => e.level !== 'info').length).toBe(0);
+        done();
+      }
+    );
+  });
 });
 
 describe('verbose logs', () => {

--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -67,17 +67,17 @@ describe('error logs', () => {
     );
   });
 
-  fit('Should filter on query', done => {
+  it('Should filter on query', done => {
     const winstonLoggerAdapter = new WinstonLoggerAdapter();
     winstonLoggerAdapter.log('error', 'testing error logs');
     winstonLoggerAdapter.query(
       {
         from: new Date(Date.now() - 500),
         size: 100,
-        level: 'info',
+        level: 'error',
       },
       results => {
-        expect(results.filter(e => e.level !== 'info').length).toBe(0);
+        expect(results.filter(e => e.level !== 'error').length).toBe(0);
         done();
       }
     );

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -18,10 +18,8 @@ function configureTransports(options) {
         Object.assign(
           {
             filename: 'parse-server.info',
-            json: true,
           },
-          options,
-          { timestamp: true }
+          options
         )
       );
       parseServer.name = 'parse-server';
@@ -31,10 +29,9 @@ function configureTransports(options) {
         Object.assign(
           {
             filename: 'parse-server.err',
-            json: true,
           },
           options,
-          { level: 'error', timestamp: true }
+          { level: 'error' }
         )
       );
       parseServerError.name = 'parse-server-error';

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -1,4 +1,4 @@
-import winston from 'winston';
+import winston, { format } from 'winston';
 import fs from 'fs';
 import path from 'path';
 import DailyRotateFile from 'winston-daily-rotate-file';
@@ -18,6 +18,8 @@ function configureTransports(options) {
         Object.assign(
           {
             filename: 'parse-server.info',
+            json: true,
+            format: format.combine(format.timestamp(), format.json()),
           },
           options
         )
@@ -29,6 +31,8 @@ function configureTransports(options) {
         Object.assign(
           {
             filename: 'parse-server.err',
+            json: true,
+            format: format.combine(format.timestamp(), format.json()),
           },
           options,
           { level: 'error' }
@@ -38,18 +42,18 @@ function configureTransports(options) {
       transports.push(parseServerError);
     }
 
-    transports.push(
-      new winston.transports.Console(
-        Object.assign(
-          {
-            colorize: true,
-            name: 'console',
-            silent,
-          },
-          options
-        )
-      )
+    const consoleFormat = options.json ? format.json() : format.simple();
+    const consoleOptions = Object.assign(
+      {
+        colorize: true,
+        name: 'console',
+        silent,
+        format: consoleFormat,
+      },
+      options
     );
+
+    transports.push(new winston.transports.Console(consoleOptions));
   }
 
   logger.configure({


### PR DESCRIPTION
fixes: #5560

When digging into the failed tests on #5561 I realized that we want to configure each transport, rather than the whole logger.

I also think we have to handle json distinctly, so I started a new branch.

@mrowe009 did the hard work here....