### PR TITLE
Update Travis CI Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
   - /^greenkeeper/.*$/
 cache:
   directories:
-  - node_modules
+  - "$HOME/.npm"
   - "$HOME/.mongodb/versions"
 
 # Test stage


### PR DESCRIPTION
`prepare` causes `npm ci` to be used. `.npm` is the recommended cache directory for `npm ci`. Should speed up build times.

https://docs.npmjs.com/cli/ci