### PR TITLE
Changing __indexBuildCompletionCallbackForTests callback to serverSta…

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -540,7 +540,7 @@ describe('Cloud Code', () => {
           done();
         }
       );
-    }, 500);
+    }, 1000);
   });
 
   it('test cloud function return types', function(done) {

--- a/spec/EnableExpressErrorHandler.spec.js
+++ b/spec/EnableExpressErrorHandler.spec.js
@@ -17,7 +17,7 @@ describe('Enable express error handler', () => {
         masterKey: masterKey,
         serverURL: serverUrl,
         enableExpressErrorHandler: true,
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(Parse.applicationId).toEqual('anOtherTestApp');
             const app = express();

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -158,7 +158,7 @@ describe('ParseLiveQueryServer', function() {
           classNames: ['Yolo'],
         },
         startLiveQueryServer: true,
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(parseServer.liveQueryServer).not.toBeUndefined();
             expect(parseServer.liveQueryServer.server).toBe(parseServer.server);
@@ -181,7 +181,7 @@ describe('ParseLiveQueryServer', function() {
         liveQueryServerOptions: {
           port: 22347,
         },
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(parseServer.liveQueryServer).not.toBeUndefined();
             expect(parseServer.liveQueryServer.server).not.toBe(

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -62,7 +62,7 @@ describe('Server Url Checks', () => {
     }
     const newConfiguration = Object.assign({}, defaultConfiguration, {
       databaseAdapter,
-      __indexBuildCompletionCallbackForTests: promise => {
+      serverStartComplete: promise => {
         promise.then(() => {
           parseServer.handleShutdown();
           parseServer.server.close(err => {

--- a/spec/PostgresInitOptions.spec.js
+++ b/spec/PostgresInitOptions.spec.js
@@ -28,7 +28,7 @@ function createParseServer(options) {
     const parseServer = new ParseServer.default(
       Object.assign({}, defaultConfiguration, options, {
         serverURL: 'http://localhost:12666/parse',
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(Parse.applicationId).toEqual('test');
             const app = express();

--- a/spec/RedisCacheAdapter.spec.js
+++ b/spec/RedisCacheAdapter.spec.js
@@ -78,7 +78,7 @@ describe_only(() => {
           .put(KEY, VALUE, ttl)
           .then(() => cache.get(KEY))
           .then(value => expect(value).toEqual(VALUE))
-          .then(wait.bind(null, 2))
+          .then(wait.bind(null, 500))
           .then(() => cache.get(KEY))
           .then(value => expect(value).toEqual(null))
       );

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -150,7 +150,7 @@ const reconfigureServer = changedConfiguration => {
         defaultConfiguration,
         changedConfiguration,
         {
-          __indexBuildCompletionCallbackForTests: indexBuildPromise =>
+          serverStartComplete: indexBuildPromise =>
             indexBuildPromise.then(() => {
               resolve(parseServer);
             }, reject),

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -295,7 +295,7 @@ describe('server', () => {
         appId: 'aTestApp',
         masterKey: 'aTestMasterKey',
         serverURL: 'http://localhost:12666/parse',
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(Parse.applicationId).toEqual('aTestApp');
             const app = express();
@@ -332,7 +332,7 @@ describe('server', () => {
         appId: 'anOtherTestApp',
         masterKey: 'anOtherTestMasterKey',
         serverURL: 'http://localhost:12667/parse',
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise
             .then(() => {
               expect(Parse.applicationId).toEqual('anOtherTestApp');

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -173,7 +173,7 @@ export interface ParseServerOptions {
   /* Live query server configuration options (will start the liveQuery server) */
   liveQueryServerOptions: ?LiveQueryServerOptions;
 
-  __indexBuildCompletionCallbackForTests: ?() => void;
+  serverStartComplete: ?() => void;
 }
 
 export interface CustomPagesOptions {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -80,7 +80,7 @@ class ParseServer {
       cloud,
       javascriptKey,
       serverURL = requiredParameter('You must provide a serverURL!'),
-      __indexBuildCompletionCallbackForTests = () => {},
+      serverStartComplete = () => {},
     } = options;
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
@@ -101,9 +101,7 @@ class ParseServer {
 
     // Note: Tests will start to fail if any validation happens after this is called.
     if (process.env.TESTING) {
-      __indexBuildCompletionCallbackForTests(
-        Promise.all([dbInitPromise, hooksLoadPromise])
-      );
+      serverStartComplete(Promise.all([dbInitPromise, hooksLoadPromise]));
     }
 
     if (cloud) {


### PR DESCRIPTION
According to the discussion on https://github.com/parse-community/parse-server/pull/5573 this PR changes the name of "__indexBuildCompletionCallbackForTests" callback to "serverStartComplete".