### PR TITLE
Avoid unhandled promise rejection

### DIFF
--- a/spec/EnableExpressErrorHandler.spec.js
+++ b/spec/EnableExpressErrorHandler.spec.js
@@ -17,47 +17,45 @@ describe('Enable express error handler', () => {
         masterKey: masterKey,
         serverURL: serverUrl,
         enableExpressErrorHandler: true,
-        serverStartComplete: promise => {
-          promise.then(() => {
-            expect(Parse.applicationId).toEqual('anOtherTestApp');
-            const app = express();
-            app.use('/parse', parseServer);
+        serverStartComplete: () => {
+          expect(Parse.applicationId).toEqual('anOtherTestApp');
+          const app = express();
+          app.use('/parse', parseServer);
 
-            server = app.listen(12667);
+          server = app.listen(12667);
 
-            app.use(function(err, req, res, next) {
-              next;
-              lastError = err;
-            });
-
-            request({
-              method: 'PUT',
-              url: serverUrl + '/classes/AnyClass/nonExistingId',
-              headers: {
-                'X-Parse-Application-Id': appId,
-                'X-Parse-Master-Key': masterKey,
-                'Content-Type': 'application/json',
-              },
-              body: { someField: 'blablabla' },
-            })
-              .then(() => {
-                fail('Should throw error');
-              })
-              .catch(response => {
-                const reqError = response.data;
-                expect(reqError).toBeDefined();
-                expect(lastError).toBeDefined();
-
-                expect(lastError.code).toEqual(101);
-                expect(lastError.message).toEqual('Object not found.');
-
-                expect(lastError.code).toEqual(reqError.code);
-                expect(lastError.message).toEqual(reqError.error);
-              })
-              .then(() => {
-                server.close(done);
-              });
+          app.use(function(err, req, res, next) {
+            next;
+            lastError = err;
           });
+
+          request({
+            method: 'PUT',
+            url: serverUrl + '/classes/AnyClass/nonExistingId',
+            headers: {
+              'X-Parse-Application-Id': appId,
+              'X-Parse-Master-Key': masterKey,
+              'Content-Type': 'application/json',
+            },
+            body: { someField: 'blablabla' },
+          })
+            .then(() => {
+              fail('Should throw error');
+            })
+            .catch(response => {
+              const reqError = response.data;
+              expect(reqError).toBeDefined();
+              expect(lastError).toBeDefined();
+
+              expect(lastError.code).toEqual(101);
+              expect(lastError.message).toEqual('Object not found.');
+
+              expect(lastError.code).toEqual(reqError.code);
+              expect(lastError.message).toEqual(reqError.error);
+            })
+            .then(() => {
+              server.close(done);
+            });
         },
       })
     );

--- a/spec/EnableExpressErrorHandler.spec.js
+++ b/spec/EnableExpressErrorHandler.spec.js
@@ -17,7 +17,7 @@ describe('Enable express error handler', () => {
         masterKey: masterKey,
         serverURL: serverUrl,
         enableExpressErrorHandler: true,
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(Parse.applicationId).toEqual('anOtherTestApp');
             const app = express();

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -158,7 +158,7 @@ describe('ParseLiveQueryServer', function() {
           classNames: ['Yolo'],
         },
         startLiveQueryServer: true,
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(parseServer.liveQueryServer).not.toBeUndefined();
             expect(parseServer.liveQueryServer.server).toBe(parseServer.server);
@@ -181,7 +181,7 @@ describe('ParseLiveQueryServer', function() {
         liveQueryServerOptions: {
           port: 22347,
         },
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(parseServer.liveQueryServer).not.toBeUndefined();
             expect(parseServer.liveQueryServer.server).not.toBe(

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -158,12 +158,10 @@ describe('ParseLiveQueryServer', function() {
           classNames: ['Yolo'],
         },
         startLiveQueryServer: true,
-        serverStartComplete: promise => {
-          promise.then(() => {
-            expect(parseServer.liveQueryServer).not.toBeUndefined();
-            expect(parseServer.liveQueryServer.server).toBe(parseServer.server);
-            parseServer.server.close(() => done());
-          });
+        serverStartComplete: () => {
+          expect(parseServer.liveQueryServer).not.toBeUndefined();
+          expect(parseServer.liveQueryServer.server).toBe(parseServer.server);
+          parseServer.server.close(() => done());
         },
       });
     });
@@ -181,15 +179,13 @@ describe('ParseLiveQueryServer', function() {
         liveQueryServerOptions: {
           port: 22347,
         },
-        serverStartComplete: promise => {
-          promise.then(() => {
-            expect(parseServer.liveQueryServer).not.toBeUndefined();
-            expect(parseServer.liveQueryServer.server).not.toBe(
-              parseServer.server
-            );
-            parseServer.liveQueryServer.server.close(() => {
-              parseServer.server.close(() => done());
-            });
+        serverStartComplete: () => {
+          expect(parseServer.liveQueryServer).not.toBeUndefined();
+          expect(parseServer.liveQueryServer.server).not.toBe(
+            parseServer.server
+          );
+          parseServer.liveQueryServer.server.close(() => {
+            parseServer.server.close(() => done());
           });
         },
       });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -6,6 +6,8 @@ const MongoStorageAdapter = require('../lib/Adapters/Storage/Mongo/MongoStorageA
 const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/PostgresStorageAdapter')
   .default;
 const ParseServer = require('../lib/ParseServer').default;
+const path = require('path');
+const { spawn } = require('child_process');
 
 describe('Server Url Checks', () => {
   let server;
@@ -75,5 +77,25 @@ describe('Server Url Checks', () => {
       },
     });
     const parseServer = ParseServer.start(newConfiguration);
+  });
+
+  it('does not have unhandled promise rejection in the case of load error', done => {
+    const parseServerProcess = spawn(
+      path.resolve(__dirname, './support/FailingServer.js')
+    );
+    let stdout;
+    let stderr;
+    parseServerProcess.stdout.on('data', data => {
+      stdout = data.toString();
+    });
+    parseServerProcess.stderr.on('data', data => {
+      stderr = data.toString();
+    });
+    parseServerProcess.on('close', code => {
+      expect(code).toEqual(1);
+      expect(stdout).toBeUndefined();
+      expect(stderr).toContain('MongoNetworkError:');
+      done();
+    });
   });
 });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -62,7 +62,7 @@ describe('Server Url Checks', () => {
     }
     const newConfiguration = Object.assign({}, defaultConfiguration, {
       databaseAdapter,
-      __indexBuildCompletionCallbackForTests: promise => {
+      serverStartComplete: promise => {
         promise.then(() => {
           parseServer.handleShutdown();
           parseServer.server.close(err => {

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -62,16 +62,14 @@ describe('Server Url Checks', () => {
     }
     const newConfiguration = Object.assign({}, defaultConfiguration, {
       databaseAdapter,
-      serverStartComplete: promise => {
-        promise.then(() => {
-          parseServer.handleShutdown();
-          parseServer.server.close(err => {
-            if (err) {
-              done.fail('Close Server Error');
-            }
-            reconfigureServer({}).then(() => {
-              done();
-            });
+      serverStartComplete: () => {
+        parseServer.handleShutdown();
+        parseServer.server.close(err => {
+          if (err) {
+            done.fail('Close Server Error');
+          }
+          reconfigureServer({}).then(() => {
+            done();
           });
         });
       },

--- a/spec/PostgresInitOptions.spec.js
+++ b/spec/PostgresInitOptions.spec.js
@@ -28,8 +28,10 @@ function createParseServer(options) {
     const parseServer = new ParseServer.default(
       Object.assign({}, defaultConfiguration, options, {
         serverURL: 'http://localhost:12666/parse',
-        serverStartComplete: promise => {
-          promise.then(() => {
+        serverStartComplete: error => {
+          if (error) {
+            reject(error);
+          } else {
             expect(Parse.applicationId).toEqual('test');
             const app = express();
             app.use('/parse', parseServer.app);
@@ -37,7 +39,7 @@ function createParseServer(options) {
             const server = app.listen(12666);
             Parse.serverURL = 'http://localhost:12666/parse';
             resolve(server);
-          }, reject);
+          }
         },
       })
     );

--- a/spec/PostgresInitOptions.spec.js
+++ b/spec/PostgresInitOptions.spec.js
@@ -28,7 +28,7 @@ function createParseServer(options) {
     const parseServer = new ParseServer.default(
       Object.assign({}, defaultConfiguration, options, {
         serverURL: 'http://localhost:12666/parse',
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(Parse.applicationId).toEqual('test');
             const app = express();

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -150,7 +150,7 @@ const reconfigureServer = changedConfiguration => {
         defaultConfiguration,
         changedConfiguration,
         {
-          __indexBuildCompletionCallbackForTests: indexBuildPromise =>
+          serverStartComplete: indexBuildPromise =>
             indexBuildPromise.then(() => {
               resolve(parseServer);
             }, reject),

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -150,10 +150,13 @@ const reconfigureServer = changedConfiguration => {
         defaultConfiguration,
         changedConfiguration,
         {
-          serverStartComplete: indexBuildPromise =>
-            indexBuildPromise.then(() => {
+          serverStartComplete: error => {
+            if (error) {
+              reject(error);
+            } else {
               resolve(parseServer);
-            }, reject),
+            }
+          },
           mountPath: '/1',
           port,
         }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -295,30 +295,28 @@ describe('server', () => {
         appId: 'aTestApp',
         masterKey: 'aTestMasterKey',
         serverURL: 'http://localhost:12666/parse',
-        serverStartComplete: promise => {
-          promise.then(() => {
-            expect(Parse.applicationId).toEqual('aTestApp');
-            const app = express();
-            app.use('/parse', parseServer.app);
+        serverStartComplete: () => {
+          expect(Parse.applicationId).toEqual('aTestApp');
+          const app = express();
+          app.use('/parse', parseServer.app);
 
-            const server = app.listen(12666);
-            const obj = new Parse.Object('AnObject');
-            let objId;
-            obj
-              .save()
-              .then(obj => {
-                objId = obj.id;
-                const q = new Parse.Query('AnObject');
-                return q.first();
-              })
-              .then(obj => {
-                expect(obj.id).toEqual(objId);
-                server.close(done);
-              })
-              .catch(() => {
-                server.close(done);
-              });
-          });
+          const server = app.listen(12666);
+          const obj = new Parse.Object('AnObject');
+          let objId;
+          obj
+            .save()
+            .then(obj => {
+              objId = obj.id;
+              const q = new Parse.Query('AnObject');
+              return q.first();
+            })
+            .then(obj => {
+              expect(obj.id).toEqual(objId);
+              server.close(done);
+            })
+            .catch(() => {
+              server.close(done);
+            });
         },
       })
     );
@@ -332,7 +330,8 @@ describe('server', () => {
         appId: 'anOtherTestApp',
         masterKey: 'anOtherTestMasterKey',
         serverURL: 'http://localhost:12667/parse',
-        serverStartComplete: promise => {
+        serverStartComplete: error => {
+          const promise = error ? Promise.reject(error) : Promise.resolve();
           promise
             .then(() => {
               expect(Parse.applicationId).toEqual('anOtherTestApp');

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -295,7 +295,7 @@ describe('server', () => {
         appId: 'aTestApp',
         masterKey: 'aTestMasterKey',
         serverURL: 'http://localhost:12666/parse',
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise.then(() => {
             expect(Parse.applicationId).toEqual('aTestApp');
             const app = express();
@@ -332,7 +332,7 @@ describe('server', () => {
         appId: 'anOtherTestApp',
         masterKey: 'anOtherTestMasterKey',
         serverURL: 'http://localhost:12667/parse',
-        __indexBuildCompletionCallbackForTests: promise => {
+        serverStartComplete: promise => {
           promise
             .then(() => {
               expect(Parse.applicationId).toEqual('anOtherTestApp');

--- a/spec/support/FailingServer.js
+++ b/spec/support/FailingServer.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const ParseServer = require('../../lib/index').ParseServer;
+
+ParseServer.start({
+  appId: 'test',
+  masterKey: 'test',
+  databaseURI:
+    'mongodb://doesnotexist:27017/parseServerMongoAdapterTestDatabase',
+});

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -173,7 +173,7 @@ export interface ParseServerOptions {
   /* Live query server configuration options (will start the liveQuery server) */
   liveQueryServerOptions: ?LiveQueryServerOptions;
 
-  __indexBuildCompletionCallbackForTests: ?() => void;
+  serverStartComplete: ?() => void;
 }
 
 export interface CustomPagesOptions {

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -173,7 +173,7 @@ export interface ParseServerOptions {
   /* Live query server configuration options (will start the liveQuery server) */
   liveQueryServerOptions: ?LiveQueryServerOptions;
 
-  serverStartComplete: ?() => void;
+  serverStartComplete: ?(error: ?Error) => void;
 }
 
 export interface CustomPagesOptions {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -80,7 +80,7 @@ class ParseServer {
       cloud,
       javascriptKey,
       serverURL = requiredParameter('You must provide a serverURL!'),
-      __indexBuildCompletionCallbackForTests = () => {},
+      serverStartComplete = () => {},
     } = options;
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
@@ -101,9 +101,7 @@ class ParseServer {
 
     // Note: Tests will start to fail if any validation happens after this is called.
     if (process.env.TESTING) {
-      __indexBuildCompletionCallbackForTests(
-        Promise.all([dbInitPromise, hooksLoadPromise])
-      );
+      serverStartComplete(Promise.all([dbInitPromise, hooksLoadPromise]));
     }
 
     if (cloud) {


### PR DESCRIPTION
According to the discussion on https://github.com/parse-community/parse-server/pull/5573 this PR removes the unhandled promise rejections during server initialization on prod.