### PR TITLE
Fixing Redis adapter tests

### DIFF
--- a/spec/RedisCacheAdapter.spec.js
+++ b/spec/RedisCacheAdapter.spec.js
@@ -39,7 +39,7 @@ describe_only(() => {
       .put(KEY, VALUE)
       .then(() => cache.get(KEY))
       .then(value => expect(value).toEqual(VALUE))
-      .then(wait.bind(null, 2))
+      .then(wait.bind(null, 5))
       .then(() => cache.get(KEY))
       .then(value => expect(value).toEqual(null))
       .then(done);
@@ -62,7 +62,7 @@ describe_only(() => {
       .put(KEY, VALUE, Infinity)
       .then(() => cache.get(KEY))
       .then(value => expect(value).toEqual(VALUE))
-      .then(wait.bind(null, 1))
+      .then(wait.bind(null, 5))
       .then(() => cache.get(KEY))
       .then(value => expect(value).toEqual(VALUE))
       .then(done);
@@ -78,7 +78,7 @@ describe_only(() => {
           .put(KEY, VALUE, ttl)
           .then(() => cache.get(KEY))
           .then(value => expect(value).toEqual(VALUE))
-          .then(wait.bind(null, 2))
+          .then(wait.bind(null, 5))
           .then(() => cache.get(KEY))
           .then(value => expect(value).toEqual(null))
       );


### PR DESCRIPTION
It's weird, but I wrote the test below and it fails almost every time I run. 
```
fit('timeout should wait', done => {
    let promise = Promise.resolve();
    for (let i = 0; i < 1000; i ++) {
      promise = promise
        .then(() => new Date())
        .then(startDate => new Promise(resolve => setTimeout(() => resolve(startDate), 2)))
        .then(startDate => {
          if ((new Date()) - startDate < 2) {
            done.fail();
          }
        });
    }
    promise.then(done);
  });
```

There are some tests that set a 1ms ttl, wait 2ms and check if it is expired (it is supposed to be). But because of this strange behavior of setTimeout function, sometimes the time difference between the two operations is below 2ms and Redis understand that the key is not yet expired. So I suggest increasing some waiting times to avoid builds to fail. That's what this PR is about.