### PR TITLE
Database version in features

### DIFF
--- a/spec/features.spec.js
+++ b/spec/features.spec.js
@@ -3,8 +3,8 @@
 const request = require('../lib/request');
 
 describe('features', () => {
-  it('should return the serverInfo', done => {
-    request({
+  it('should return the serverInfo', async () => {
+    const response = await request({
       url: 'http://localhost:8378/1/serverInfo',
       json: true,
       headers: {
@@ -12,26 +12,33 @@ describe('features', () => {
         'X-Parse-REST-API-Key': 'rest',
         'X-Parse-Master-Key': 'test',
       },
-    }).then(response => {
-      console.log(response.data);
-      done();
     });
+    const data = response.data;
+    expect(data).toBeDefined();
+    expect(data.features).toBeDefined();
+    expect(data.parseServerVersion).toBeDefined();
+    expect(data.database).toBeDefined();
+    expect(['MongoDB', 'PostgreSQL']).toContain(data.database.engine);
   });
 
-  it('requires the master key to get features', done => {
-    request({
-      url: 'http://localhost:8378/1/serverInfo',
-      json: true,
-      headers: {
-        'X-Parse-Application-Id': 'test',
-        'X-Parse-REST-API-Key': 'rest',
-      },
-    }).then(response => {
-      expect(response.status).toEqual(403);
-      expect(response.data.error).toEqual(
-        'unauthorized: master key is required'
+  it('requires the master key to get features', async done => {
+    try {
+      console.log('==============');
+      await request({
+        url: 'http://localhost:8378/1/serverInfo',
+        json: true,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+      });
+      done.fail(
+        'The serverInfo request should be rejected without the master key'
       );
+    } catch (error) {
+      expect(error.status).toEqual(403);
+      expect(error.data.error).toEqual('unauthorized: master key is required');
       done();
-    });
+    }
   });
 });

--- a/spec/features.spec.js
+++ b/spec/features.spec.js
@@ -3,6 +3,21 @@
 const request = require('../lib/request');
 
 describe('features', () => {
+  it('should return the serverInfo', done => {
+    request({
+      url: 'http://localhost:8378/1/serverInfo',
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Master-Key': 'test',
+      },
+    }).then(response => {
+      console.log(response.data);
+      done();
+    });
+  });
+
   it('requires the master key to get features', done => {
     request({
       url: 'http://localhost:8378/1/serverInfo',
@@ -11,7 +26,7 @@ describe('features', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       },
-    }).then(fail, response => {
+    }).then(response => {
       expect(response.status).toEqual(403);
       expect(response.data.error).toEqual(
         'unauthorized: master key is required'

--- a/spec/features.spec.js
+++ b/spec/features.spec.js
@@ -23,7 +23,6 @@ describe('features', () => {
 
   it('requires the master key to get features', async done => {
     try {
-      console.log('==============');
       await request({
         url: 'http://localhost:8378/1/serverInfo',
         json: true,

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -127,6 +127,7 @@ export class MongoStorageAdapter implements StorageAdapter {
   _maxTimeMS: ?number;
   canSortOnJoinTables: boolean;
   databaseVersion: string;
+  engine: string;
 
   constructor({
     uri = defaults.DefaultMongoURI,
@@ -137,6 +138,7 @@ export class MongoStorageAdapter implements StorageAdapter {
     this._collectionPrefix = collectionPrefix;
     this._mongoOptions = mongoOptions;
     this._mongoOptions.useNewUrlParser = true;
+    this.engine = 'MongoDB';
 
     // MaxTimeMS is not a global MongoDB client option, it is applied per operation.
     this._maxTimeMS = mongoOptions.maxTimeMS;

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -126,6 +126,7 @@ export class MongoStorageAdapter implements StorageAdapter {
   client: MongoClient;
   _maxTimeMS: ?number;
   canSortOnJoinTables: boolean;
+  databaseVersion: string;
 
   constructor({
     uri = defaults.DefaultMongoURI,
@@ -171,6 +172,12 @@ export class MongoStorageAdapter implements StorageAdapter {
         });
         this.client = client;
         this.database = database;
+
+        // databaseVersion
+        const adminDb = database.admin();
+        adminDb.serverStatus().then(status => {
+          this.databaseVersion = status.version;
+        });
       })
       .catch(err => {
         delete this.connectionPromise;

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -174,12 +174,6 @@ export class MongoStorageAdapter implements StorageAdapter {
         });
         this.client = client;
         this.database = database;
-
-        // databaseVersion
-        const adminDb = database.admin();
-        adminDb.serverStatus().then(status => {
-          this.databaseVersion = status.version;
-        });
       })
       .catch(err => {
         delete this.connectionPromise;
@@ -968,7 +962,15 @@ export class MongoStorageAdapter implements StorageAdapter {
   }
 
   performInitialization(): Promise<void> {
-    return Promise.resolve();
+    // databaseVersion
+    this.connect()
+      .then(() => {
+        const adminDb = this.database.admin();
+        return adminDb.serverStatus();
+      })
+      .then(status => {
+        this.databaseVersion = status.version;
+      });
   }
 
   createIndex(className: string, index: any) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -963,7 +963,7 @@ export class MongoStorageAdapter implements StorageAdapter {
 
   performInitialization(): Promise<void> {
     // databaseVersion
-    this.connect()
+    return this.connect()
       .then(() => {
         const adminDb = this.database.admin();
         return adminDb.serverStatus();

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -778,6 +778,7 @@ const buildWhereClause = ({ schema, query, index }): WhereClause => {
 
 export class PostgresStorageAdapter implements StorageAdapter {
   canSortOnJoinTables: boolean;
+  databaseVersion: string;
 
   // Private
   _collectionPrefix: string;

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -2279,6 +2279,12 @@ export class PostgresStorageAdapter implements StorageAdapter {
       })
       .then(data => {
         debug(`initializationDone in ${data.duration}`);
+        // databaseVersion
+        return this._client.query('SHOW server_version');
+      })
+      .then(versionData => {
+        // versionData is like [ { server_version: '11.3' } ]
+        this.databaseVersion = versionData[0].server_version;
       })
       .catch(error => {
         /* eslint-disable no-console */

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -779,6 +779,7 @@ const buildWhereClause = ({ schema, query, index }): WhereClause => {
 export class PostgresStorageAdapter implements StorageAdapter {
   canSortOnJoinTables: boolean;
   databaseVersion: string;
+  engine: string;
 
   // Private
   _collectionPrefix: string;
@@ -791,6 +792,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
     this._client = client;
     this._pgp = pgp;
     this.canSortOnJoinTables = false;
+    this.engine = 'PostgreSQL';
   }
 
   handleShutdown() {

--- a/src/Adapters/Storage/StorageAdapter.js
+++ b/src/Adapters/Storage/StorageAdapter.js
@@ -26,6 +26,7 @@ export type FullQueryOptions = QueryOptions & UpdateQueryOptions;
 export interface StorageAdapter {
   canSortOnJoinTables: boolean;
   databaseVersion: string;
+  engine: string;
 
   classExists(className: string): Promise<boolean>;
   setClassLevelPermissions(className: string, clps: any): Promise<void>;

--- a/src/Adapters/Storage/StorageAdapter.js
+++ b/src/Adapters/Storage/StorageAdapter.js
@@ -25,6 +25,7 @@ export type FullQueryOptions = QueryOptions & UpdateQueryOptions;
 
 export interface StorageAdapter {
   canSortOnJoinTables: boolean;
+  databaseVersion: string;
 
   classExists(className: string): Promise<boolean>;
   setClassLevelPermissions(className: string, clps: any): Promise<void>;

--- a/src/Routers/FeaturesRouter.js
+++ b/src/Routers/FeaturesRouter.js
@@ -9,7 +9,7 @@ export class FeaturesRouter extends PromiseRouter {
       '/serverInfo',
       middleware.promiseEnforceMasterKeyAccess,
       req => {
-        const config = req.config;
+        const { config } = req;
         const features = {
           globalConfig: {
             create: true,

--- a/src/Routers/FeaturesRouter.js
+++ b/src/Routers/FeaturesRouter.js
@@ -9,6 +9,7 @@ export class FeaturesRouter extends PromiseRouter {
       '/serverInfo',
       middleware.promiseEnforceMasterKeyAccess,
       req => {
+        const config = req.config;
         const features = {
           globalConfig: {
             create: true,
@@ -33,9 +34,9 @@ export class FeaturesRouter extends PromiseRouter {
             from: true,
           },
           push: {
-            immediatePush: req.config.hasPushSupport,
-            scheduledPush: req.config.hasPushScheduledSupport,
-            storedPushData: req.config.hasPushSupport,
+            immediatePush: config.hasPushSupport,
+            scheduledPush: config.hasPushScheduledSupport,
+            storedPushData: config.hasPushSupport,
             pushAudiences: true,
             localization: true,
           },
@@ -51,12 +52,14 @@ export class FeaturesRouter extends PromiseRouter {
           },
         };
 
+        const dbAdapter = config.database.adapter;
         return {
           response: {
             features: features,
             parseServerVersion: version,
             database: {
-              version: req.config.database.adapter.databaseVersion,
+              engine: dbAdapter.engine,
+              version: dbAdapter.databaseVersion,
             },
           },
         };

--- a/src/Routers/FeaturesRouter.js
+++ b/src/Routers/FeaturesRouter.js
@@ -55,6 +55,9 @@ export class FeaturesRouter extends PromiseRouter {
           response: {
             features: features,
             parseServerVersion: version,
+            database: {
+              version: req.config.database.adapter.databaseVersion,
+            },
           },
         };
       }


### PR DESCRIPTION
I added databaseVersion and engine in serverInfo (and in StorageAdapter).
I also corrected the old test (it failed apparently).

Note that I installed a local MongoDB. The features.spec.js tests pass with no error, but I still get a "Top Level suite" error:
Could not find a MongoDB version matching `{"version":"${MONGODB_VERSION:=4.0.4}","arch":"x86_64","platform":"win32","branch":"master","bits":"64","de
bug":false,"ext":".zip","distro":"2008plus-ssl","filenamePlatform":"win32"}`

