### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ VOLUME /parse-server/cloud /parse-server/config
 WORKDIR /parse-server
 
 COPY package*.json ./
-COPY postinstall.js ./
 
-RUN npm ci --production
+RUN npm ci --production --ignore-scripts
 
 COPY bin bin
 COPY public_html public_html


### PR DESCRIPTION
Adds `--ignore-scripts` options to prevent node lifecycle scripts from running in the release build. i.e `prepare` and `postinstall`