### PR TITLE
Avoid calling `allowCrossDomain` twice per request

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -151,10 +151,10 @@ class ParseServer {
     // It's the equivalent of https://api.parse.com/1 in the hosted Parse API.
     var api = express();
     //api.use("/apps", express.static(__dirname + "/public"));
+    api.use(middlewares.allowCrossDomain);
     // File handling needs to be before default middlewares are applied
     api.use(
       '/',
-      middlewares.allowCrossDomain,
       new FilesRouter().expressRouter({
         maxUploadSize: maxUploadSize,
       })
@@ -173,7 +173,6 @@ class ParseServer {
     );
 
     api.use(bodyParser.json({ type: '*/*', limit: maxUploadSize }));
-    api.use(middlewares.allowCrossDomain);
     api.use(middlewares.allowMethodOverride);
     api.use(middlewares.handleParseHeaders);
 


### PR DESCRIPTION
`api.use('/', middleware, ...)` will end up calling `middleware` for _every_ request, even if no routers in the `...` part matches.

This is because passing a router to express is just like passing any other route handler. The only thing that happens when it doesn't match a route is that it calls `next`, but by that point, the middleware has already run. 

The changes in the PR avoids adding the middleware twice for every route except file upload routes. Which will make express not call `allowCrossDomain` twice for every incoming request.

-----

Happy to explain more if there's is something unclear, just happened to stumble upon this when debugging a CORS issue...