### PR TITLE
Added rest option: excludeKeys

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3266,8 +3266,8 @@ describe('Parse.Query testing', () => {
       );
   });
 
-  it('select keys query', function(done) {
-    const obj = new TestObject({ foo: 'baz', bar: 1 });
+  it('select/unselect keys query', function(done) {
+    const obj = new TestObject({ foo: 'baz', bar: 1, wooz: [1, 2, 3] });
 
     obj
       .save()
@@ -3288,11 +3288,17 @@ describe('Parse.Query testing', () => {
           undefined,
           "expected 'bar' field to be unset"
         );
+        strictEqual(
+          result.get('wooz'),
+          undefined,
+          "expected 'wooz' field to be unset"
+        );
         return result.fetch();
       })
       .then(function(result) {
         strictEqual(result.get('foo'), 'baz');
         strictEqual(result.get('bar'), 1);
+        strictEqual(result.get('wooz')[0], 1);
       })
       .then(function() {
         obj._clearServerData();
@@ -3313,6 +3319,11 @@ describe('Parse.Query testing', () => {
           undefined,
           "expected 'bar' field to be unset"
         );
+        strictEqual(
+          result.get('wooz'),
+          undefined,
+          "expected 'wooz' field to be unset"
+        );
       })
       .then(function() {
         obj._clearServerData();
@@ -3325,6 +3336,11 @@ describe('Parse.Query testing', () => {
         ok(!result.dirty(), 'expected result not to be dirty');
         strictEqual(result.get('foo'), 'baz');
         strictEqual(result.get('bar'), 1);
+        strictEqual(
+          result.get('wooz'),
+          undefined,
+          "expected 'wooz' field to be unset"
+        );
       })
       .then(function() {
         obj._clearServerData();
@@ -3337,6 +3353,60 @@ describe('Parse.Query testing', () => {
         ok(!result.dirty(), 'expected result not to be dirty');
         strictEqual(result.get('foo'), 'baz');
         strictEqual(result.get('bar'), 1);
+        strictEqual(
+          result.get('wooz'),
+          undefined,
+          "expected 'wooz' field to be unset"
+        );
+      })
+      .then(function() {
+        obj._clearServerData();
+        return request({
+          url: Parse.serverURL + '/classes/TestObject',
+          qs: {
+            excludeKeys: 'bar,wooz',
+          },
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
+          },
+        });
+      })
+      .then(function(result) {
+        result = result.data.results[0];
+        strictEqual(result.foo, 'baz');
+        strictEqual(result.bar, undefined, "expected 'bar' field to be unset");
+        strictEqual(
+          result.wooz,
+          undefined,
+          "expected 'wooz' field to be unset"
+        );
+      })
+      .then(function() {
+        obj._clearServerData();
+        return request({
+          url: Parse.serverURL + '/classes/TestObject',
+          qs: {
+            keys: 'foo',
+            excludeKeys: 'foo',
+          },
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-Javascript-Key': Parse.javaScriptKey,
+            'Content-Type': 'application/json',
+          },
+        });
+      })
+      .then(function(result) {
+        result = result.data.results[0];
+        strictEqual(result.foo, undefined, "expected 'foo' field to be unset");
+        strictEqual(result.bar, undefined, "expected 'bar' field to be unset");
+        strictEqual(
+          result.wooz,
+          undefined,
+          "expected 'wooz' field to be unset"
+        );
       })
       .then(
         function() {

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -711,24 +711,26 @@ RestQuery.prototype.handleIncludeAll = function() {
       this.include = [...new Set([...this.include, ...includeFields])];
       // if this.keys not set, then all keys are already included
       if (this.keys) {
-        this.keys = [...new Set([...this.keys, ...keyFields])]
-          // Ignore excluded keys
-          .filter(k => !this.excludeKeys || this.excludeKeys.indexOf(k) < 0);
+        this.keys = [...new Set([...this.keys, ...keyFields])];
       }
     });
 };
 
-// Upadates property `this.keys` to contain all keys but the ones unselected.
+// Updates property `this.keys` to contain all keys but the ones unselected.
 RestQuery.prototype.handleExcludeKeys = function() {
   if (!this.excludeKeys) {
+    return;
+  }
+  if (this.keys) {
+    this.keys = this.keys.filter(k => !this.excludeKeys.includes(k));
     return;
   }
   return this.config.database
     .loadSchema()
     .then(schemaController => schemaController.getOneSchema(this.className))
     .then(schema => {
-      const fields = this.keys ? this.keys : Object.keys(schema.fields);
-      this.keys = fields.filter(k => this.excludeKeys.indexOf(k) < 0);
+      const fields = Object.keys(schema.fields);
+      this.keys = fields.filter(k => !this.excludeKeys.includes(k));
     });
 };
 

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -165,6 +165,7 @@ export class ClassesRouter extends PromiseRouter {
       'order',
       'count',
       'keys',
+      'excludeKeys',
       'include',
       'includeAll',
       'redirectClassNameForKey',
@@ -199,6 +200,9 @@ export class ClassesRouter extends PromiseRouter {
     }
     if (typeof body.keys == 'string') {
       options.keys = body.keys;
+    }
+    if (typeof body.excludeKeys == 'string') {
+      options.excludeKeys = body.excludeKeys;
     }
     if (body.include) {
       options.include = String(body.include);


### PR DESCRIPTION
Added support for rest parameter `excludeKeys` in queries (similar to `keys`) in order to exclude the desired fields from retrieved objects.

Fixes #4948 