### PR TITLE
GraphQL: User sign up required fields

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -3110,7 +3110,7 @@ describe('ParseGraphQLServer', () => {
         it('should sign user up', async () => {
           const result = await apolloClient.mutate({
             mutation: gql`
-              mutation SignUp($fields: _UserFields) {
+              mutation SignUp($fields: _UserSignUpFields) {
                 users {
                   signUp(fields: $fields) {
                     sessionToken

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -551,6 +551,43 @@ const load = (parseGraphQLSchema, parseClass) => {
     });
     parseGraphQLSchema.meType = meType;
     parseGraphQLSchema.graphQLTypes.push(meType);
+
+    const userSignUpInputTypeName = `_UserSignUpFields`;
+    const userSignUpInputType = new GraphQLInputObjectType({
+      name: userSignUpInputTypeName,
+      description: `The ${userSignUpInputTypeName} input type is used in operations that involve inputting objects of ${className} class when signing up.`,
+      fields: () =>
+        classCustomFields.reduce(
+          (fields, field) => {
+            const type = mapInputType(
+              parseClass.fields[field].type,
+              parseClass.fields[field].targetClass,
+              parseGraphQLSchema.parseClassTypes
+            );
+            if (type) {
+              return {
+                ...fields,
+                [field]: {
+                  description: `This is the object ${field}.`,
+                  type:
+                    field === 'username' || field === 'password'
+                      ? new GraphQLNonNull(type)
+                      : type,
+                },
+              };
+            } else {
+              return fields;
+            }
+          },
+          {
+            ACL: defaultGraphQLTypes.ACL_ATT,
+          }
+        ),
+    });
+    parseGraphQLSchema.parseClassTypes[
+      '_User'
+    ].signUpInputType = userSignUpInputType;
+    parseGraphQLSchema.graphQLTypes.push(userSignUpInputType);
   }
 };
 

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -18,7 +18,7 @@ const load = parseGraphQLSchema => {
     args: {
       fields: {
         descriptions: 'These are the fields of the user.',
-        type: parseGraphQLSchema.parseClassTypes['_User'].classGraphQLInputType,
+        type: parseGraphQLSchema.parseClassTypes['_User'].signUpInputType,
       },
     },
     type: new GraphQLNonNull(defaultGraphQLTypes.SIGN_UP_RESULT),


### PR DESCRIPTION
When signing up, the `username` and `password` fields are required, but this rule was not described in the GraphQL schema as `UserFields`.