### PR TITLE
Fix: Linking with Apple Auth

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -17,7 +17,7 @@ const responses = {
 
 describe('AuthenticationProviders', function() {
   [
-    'apple-signin',
+    'apple',
     'facebook',
     'facebookaccountkit',
     'github',
@@ -51,7 +51,7 @@ describe('AuthenticationProviders', function() {
     });
 
     it(`should provide the right responses for adapter ${providerName}`, async () => {
-      if (providerName === 'twitter' || providerName === 'apple-signin') {
+      if (providerName === 'twitter' || providerName === 'apple') {
         return;
       }
       spyOn(require('../lib/Adapters/Auth/httpsRequest'), 'get').and.callFake(
@@ -1087,7 +1087,7 @@ describe('oauth2 auth adapter', () => {
 });
 
 describe('apple signin auth adapter', () => {
-  const apple = require('../lib/Adapters/Auth/apple-signin');
+  const apple = require('../lib/Adapters/Auth/apple');
   const jwt = require('jsonwebtoken');
 
   it('should throw error with missing id_token', async () => {
@@ -1095,14 +1095,14 @@ describe('apple signin auth adapter', () => {
       await apple.validateAuthData({}, { client_id: 'secret' });
       fail();
     } catch (e) {
-      expect(e.message).toBe('id_token is invalid for this user.');
+      expect(e.message).toBe('id token is invalid for this user.');
     }
   });
 
   it('should not verify invalid id_token', async () => {
     try {
       await apple.validateAuthData(
-        { id_token: 'the_token' },
+        { id: 'the_token' },
         { client_id: 'secret' }
       );
       fail();
@@ -1120,7 +1120,7 @@ describe('apple signin auth adapter', () => {
     spyOn(jwt, 'verify').and.callFake(() => fakeClaim);
 
     const result = await apple.validateAuthData(
-      { id_token: 'the_token' },
+      { id: 'the_token' },
       { client_id: 'secret' }
     );
     expect(result).toEqual(fakeClaim);
@@ -1134,13 +1134,13 @@ describe('apple signin auth adapter', () => {
 
     try {
       await apple.validateAuthData(
-        { id_token: 'the_token' },
+        { id: 'the_token' },
         { client_id: 'secret' }
       );
       fail();
     } catch (e) {
       expect(e.message).toBe(
-        'id_token not issued by correct OpenID provider - expected: https://appleid.apple.com | from: https://not.apple.com'
+        'id token not issued by correct OpenID provider - expected: https://appleid.apple.com | from: https://not.apple.com'
       );
     }
   });
@@ -1154,7 +1154,7 @@ describe('apple signin auth adapter', () => {
 
     try {
       await apple.validateAuthData(
-        { id_token: 'the_token' },
+        { id: 'the_token' },
         { client_id: 'secret' }
       );
       fail();

--- a/src/Adapters/Auth/apple.js
+++ b/src/Adapters/Auth/apple.js
@@ -21,7 +21,7 @@ const verifyIdToken = async (token, clientID) => {
   if (!token) {
     throw new Parse.Error(
       Parse.Error.OBJECT_NOT_FOUND,
-      'id_token is invalid for this user.'
+      'id token is invalid for this user.'
     );
   }
   const applePublicKey = await getApplePublicKey();
@@ -30,7 +30,7 @@ const verifyIdToken = async (token, clientID) => {
   if (jwtClaims.iss !== TOKEN_ISSUER) {
     throw new Parse.Error(
       Parse.Error.OBJECT_NOT_FOUND,
-      `id_token not issued by correct OpenID provider - expected: ${TOKEN_ISSUER} | from: ${jwtClaims.iss}`
+      `id token not issued by correct OpenID provider - expected: ${TOKEN_ISSUER} | from: ${jwtClaims.iss}`
     );
   }
   if (clientID !== undefined && jwtClaims.aud !== clientID) {
@@ -42,9 +42,9 @@ const verifyIdToken = async (token, clientID) => {
   return jwtClaims;
 };
 
-// Returns a promise that fulfills if this id_token is valid
+// Returns a promise that fulfills if this id token is valid
 function validateAuthData(authData, options = {}) {
-  return verifyIdToken(authData.id_token, options.client_id);
+  return verifyIdToken(authData.id, options.client_id);
 }
 
 // Returns a promise that fulfills if this app id is valid.
@@ -53,6 +53,6 @@ function validateAppId() {
 }
 
 module.exports = {
-  validateAppId: validateAppId,
-  validateAuthData: validateAuthData,
+  validateAppId,
+  validateAuthData,
 };

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -1,5 +1,6 @@
 import loadAdapter from '../AdapterLoader';
 
+const apple = require('./apple');
 const facebook = require('./facebook');
 const facebookaccountkit = require('./facebookaccountkit');
 const instagram = require('./instagram');
@@ -28,6 +29,7 @@ const anonymous = {
 };
 
 const providers = {
+  apple,
   facebook,
   facebookaccountkit,
   instagram,


### PR DESCRIPTION
Fixing https://github.com/parse-community/parse-server/pull/5694

*Properly loads the provider
*Rename from apple-signin to apple (key names can't have hyphens)
*Rename id_token to id (auth adapters require id)

```
{
  "apple": {
    "id": "jwt token for user", // required, used for validation
    "access_token": "an authorized access token for the user", // optional, currently does nothing but maybe in the future
  }
}
```

There is an optional `client_id` that you can pass in to Server Auth Configuration for extra validation.
```
{
  auth: {
   apple: {
     client_id: "", // optional, use the Service ID from apple.
  }
}
```