### PR TITLE
Curl installation in Docker container for container healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN npm run build
 
 # Release stage
 FROM node:lts-alpine as release
+
+RUN apk add --no-cache curl
+
 VOLUME /parse-server/cloud /parse-server/config
 
 WORKDIR /parse-server


### PR DESCRIPTION
Hello everyone!

I've been using parse-server for quite some time and recently I did the simplest setup which involved building the docker image and uploading it to AWS ECR. However there was a small problem related to healthchecks when running it.

#### Problem: 

Container healthchecks kept failing when using the following command inside the container:
```
curl -f http://localhost:1337/parse/health || exit 1
```

#### Cause:

Curl not being installed in the docker image

#### Solution:

Installing `curl` in the Dockerfile release stage.

PS: not sure if this pull request is needed since there might be alternative tools installed on the base image (node:lts-alpine) that surve the same purpose.

Thank you for considering it!
