### PR TITLE
Make possible to alter response using the after save trigger

### DIFF
--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -419,4 +419,28 @@ describe('RestQuery.each', () => {
     expect(resultsOne.length).toBe(1);
     expect(resultsTwo.length).toBe(1);
   });
+
+  it('test afterSave response object is return', done => {
+    Parse.Cloud.afterSave('TestObject2', function(req) {
+      const jsonObject = req.object.toJSON();
+      delete jsonObject.todelete;
+      jsonObject.toadd = true;
+
+      req.object = {
+        toJSON: () => jsonObject,
+        equals: () => false,
+      };
+
+      return req.object;
+    });
+
+    rest
+      .create(config, nobody, 'TestObject2', { todelete: true, tokeep: true })
+      .then(response => {
+        expect(response.response.toadd).toBeTruthy();
+        expect(response.response.tokeep).toBeTruthy();
+        expect(response.response.todelete).toBeUndefined();
+        done();
+      });
+  });
 });

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -421,17 +421,18 @@ describe('RestQuery.each', () => {
   });
 
   it('test afterSave response object is return', done => {
+    Parse.Cloud.beforeSave('TestObject2', function(req) {
+      req.object.set('tobeaddbefore', true);
+      req.object.set('tobeaddbeforeandremoveafter', true);
+    });
+
     Parse.Cloud.afterSave('TestObject2', function(req) {
       const jsonObject = req.object.toJSON();
       delete jsonObject.todelete;
+      delete jsonObject.tobeaddbeforeandremoveafter;
       jsonObject.toadd = true;
 
-      req.object = {
-        toJSON: () => jsonObject,
-        equals: () => false,
-      };
-
-      return req.object;
+      return jsonObject;
     });
 
     rest
@@ -439,6 +440,8 @@ describe('RestQuery.each', () => {
       .then(response => {
         expect(response.response.toadd).toBeTruthy();
         expect(response.response.tokeep).toBeTruthy();
+        expect(response.response.tobeaddbefore).toBeTruthy();
+        expect(response.response.tobeaddbeforeandremoveafter).toBeUndefined();
         expect(response.response.todelete).toBeUndefined();
         done();
       });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1578,6 +1578,15 @@ RestWrite.prototype.runAfterSaveTrigger = function() {
       this.config,
       this.context
     )
+    .then(result => {
+      if (
+        result &&
+        result.constructor === Object &&
+        Object.keys(result).length !== 0
+      ) {
+        this.response.response = result;
+      }
+    })
     .catch(function(err) {
       logger.warn('afterSave caught an error', err);
     });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1579,11 +1579,7 @@ RestWrite.prototype.runAfterSaveTrigger = function() {
       this.context
     )
     .then(result => {
-      if (
-        result &&
-        result.constructor === Object &&
-        Object.keys(result).length !== 0
-      ) {
+      if (result && typeof result === 'object') {
         this.response.response = result;
       }
     })

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -271,7 +271,6 @@ export function getResponseObject(request, resolve, reject) {
         typeof response === 'object' &&
         request.triggerName === Types.afterSave
       ) {
-        console.log('test');
         return resolve(response);
       }
       if (request.triggerName === Types.afterSave) {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -266,6 +266,16 @@ export function getResponseObject(request, resolve, reject) {
       ) {
         return resolve(response);
       }
+      if (
+        response &&
+        typeof response.toJSON === 'function' &&
+        request.triggerName === Types.afterSave
+      ) {
+        return resolve(response.toJSON());
+      }
+      if (request.triggerName === Types.afterSave) {
+        return resolve();
+      }
       response = {};
       if (request.triggerName === Types.beforeSave) {
         response['object'] = request.object._getSaveJSON();

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -268,10 +268,11 @@ export function getResponseObject(request, resolve, reject) {
       }
       if (
         response &&
-        typeof response.toJSON === 'function' &&
+        typeof response === 'object' &&
         request.triggerName === Types.afterSave
       ) {
-        return resolve(response.toJSON());
+        console.log('test');
+        return resolve(response);
       }
       if (request.triggerName === Types.afterSave) {
         return resolve();


### PR DESCRIPTION
The trigger response is only handle for beforeSave and afterFind event let handle it also for afterSave.

In my use case, I do some data manipulation/injection using the `beforeSave` trigger and I don't want to show them. Since it's not possible to define an hidden field (like the hard coded field password), It would be great to be able to alter the object using `after-save` like we can do it with `after-find`.

Let me know if you have some suggestion or question about the change :)