### PR TITLE
GraphQL @mock directive

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -5272,6 +5272,8 @@ describe('ParseGraphQLServer', () => {
             hello: String @resolve
             hello2: String @resolve(to: "hello")
             userEcho(user: _UserFields!): _UserClass! @resolve
+            hello3: String! @mock(with: "Hello world!")
+            hello4: _UserClass! @mock(with: { username: "somefolk" })
           }
         `,
       });
@@ -5356,6 +5358,36 @@ describe('ParseGraphQLServer', () => {
       });
 
       expect(result.data.custom.userEcho.username).toEqual('somefolk');
+    });
+
+    it('can mock a custom query with string', async () => {
+      const result = await apolloClient.query({
+        query: gql`
+          query Hello {
+            custom {
+              hello3
+            }
+          }
+        `,
+      });
+
+      expect(result.data.custom.hello3).toEqual('Hello world!');
+    });
+
+    it('can mock a custom query with auto type', async () => {
+      const result = await apolloClient.query({
+        query: gql`
+          query Hello {
+            custom {
+              hello4 {
+                username
+              }
+            }
+          }
+        `,
+      });
+
+      expect(result.data.custom.hello4.username).toEqual('somefolk');
     });
   });
 });

--- a/src/GraphQL/loaders/schemaDirectives.js
+++ b/src/GraphQL/loaders/schemaDirectives.js
@@ -5,6 +5,7 @@ import { FunctionsRouter } from '../../Routers/FunctionsRouter';
 export const definitions = gql`
   directive @namespace on FIELD_DEFINITION
   directive @resolve(to: String) on FIELD_DEFINITION
+  directive @mock(with: Any!) on FIELD_DEFINITION
 `;
 
 const load = parseGraphQLSchema => {
@@ -46,6 +47,16 @@ const load = parseGraphQLSchema => {
   }
 
   parseGraphQLSchema.graphQLSchemaDirectives.resolve = ResolveDirectiveVisitor;
+
+  class MockDirectiveVisitor extends SchemaDirectiveVisitor {
+    visitFieldDefinition(field) {
+      field.resolve = () => {
+        return this.args.with;
+      };
+    }
+  }
+
+  parseGraphQLSchema.graphQLSchemaDirectives.mock = MockDirectiveVisitor;
 };
 
 export { load };


### PR DESCRIPTION
This PR includes a new @mock directive to the GraphQL API. Using this directive, it is possible to return fake values for a custom query or mutation. Ex the following schema:

```
extend type Query {
  hello: String! @mock(with: "Hello world!")
}
```

If you run:

```
query Hello {
  hello
}
```

You will have:

```
{
  "data": {
    "hello": "Hello world!"
  }
}
```