### PR TITLE
Fix Bug in GraphQL  _or Operator

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -1523,6 +1523,44 @@ describe('ParseGraphQLServer', () => {
             ).toEqual(['someValue1', 'someValue3']);
           });
 
+          it('should support _or operation', async () => {
+            await prepareData();
+
+            await parseGraphQLServer.parseGraphQLSchema.databaseController.schemaCache.clear();
+
+            const result = await apolloClient.query({
+              query: gql`
+                query {
+                  objects {
+                    findGraphQLClass(
+                      where: {
+                        _or: [
+                          { someField: { _eq: "someValue1" } }
+                          { someField: { _eq: "someValue2" } }
+                        ]
+                      }
+                    ) {
+                      results {
+                        someField
+                      }
+                    }
+                  }
+                }
+              `,
+              context: {
+                headers: {
+                  'X-Parse-Master-Key': 'test',
+                },
+              },
+            });
+
+            expect(
+              result.data.objects.findGraphQLClass.results
+                .map(object => object.someField)
+                .sort()
+            ).toEqual(['someValue1', 'someValue2']);
+          });
+
           it('should support order, skip and limit arguments', async () => {
             const promises = [];
             for (let i = 0; i < 100; i++) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -119,7 +119,7 @@ const validateQuery = (
          */
         Object.keys(query).forEach(key => {
           const noCollisions = !query.$or.some(subq =>
-            subq.hasOwnProperty(key)
+            Object.hasOwnProperty.call(subq, key)
           );
           let hasNears = false;
           if (query[key] != null && typeof query[key] == 'object') {


### PR DESCRIPTION
It was caused by legacy code `subq.hasOwnProperty(key)`. I changed to `Object.hasOwnProperty.call(subq, key)` and fixed the problem. I see there are other codes that do the same. It would be probably good to add the prototype format in our lint and fix in all places (ref: https://eslint.org/docs/rules/no-prototype-builtins). @acinader @dplewis any thoughts?