### PR TITLE
feat: Add "count" to CLP initial value

### DIFF
--- a/spec/MongoSchemaCollectionAdapter.spec.js
+++ b/spec/MongoSchemaCollectionAdapter.spec.js
@@ -11,6 +11,7 @@ describe('MongoSchemaCollection', () => {
         _client_permissions: {
           get: true,
           find: true,
+          count: true,
           update: true,
           create: true,
           delete: true,
@@ -19,6 +20,7 @@ describe('MongoSchemaCollection', () => {
           class_permissions: {
             get: { '*': true },
             find: { '*': true },
+            count: { '*': true },
             update: { '*': true },
             create: { '*': true },
             delete: { '*': true },
@@ -69,6 +71,7 @@ describe('MongoSchemaCollection', () => {
       classLevelPermissions: {
         find: { '*': true },
         get: { '*': true },
+        count: { '*': true },
         create: { '*': true },
         update: { '*': true },
         delete: { '*': true },

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -257,6 +257,7 @@ describe('ParseLiveQueryServer', function() {
         expect(saveArgs[0]).toBe('Yolo');
         expect(saveArgs[3]).toEqual({
           get: {},
+          count: {},
           addField: {},
           create: { '*': true },
           find: {},
@@ -271,6 +272,7 @@ describe('ParseLiveQueryServer', function() {
         expect(deleteArgs[0]).toBe('Yolo');
         expect(deleteArgs[3]).toEqual({
           get: {},
+          count: {},
           addField: {},
           create: { '*': true },
           find: {},
@@ -1978,6 +1980,7 @@ describe('LiveQueryController', () => {
         expect(saveArgs[0]).toBe('Yolo');
         expect(saveArgs[3]).toEqual({
           get: {},
+          count: {},
           addField: {},
           create: { '*': true },
           find: {},
@@ -1992,6 +1995,7 @@ describe('LiveQueryController', () => {
         expect(deleteArgs[0]).toBe('Yolo');
         expect(deleteArgs[3]).toEqual({
           get: {},
+          count: {},
           addField: {},
           create: { '*': true },
           find: {},

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -322,6 +322,7 @@ describe('SchemaController', () => {
           classLevelPermissions: {
             find: { '*': true },
             get: { '*': true },
+            count: { '*': true },
             create: { '*': true },
             update: { '*': true },
             delete: { '*': true },
@@ -341,6 +342,7 @@ describe('SchemaController', () => {
     const levelPermissions = {
       find: { '*': true },
       get: { '*': true },
+      count: { '*': true },
       create: { '*': true },
       update: { '*': true },
       delete: { '*': true },
@@ -472,6 +474,7 @@ describe('SchemaController', () => {
           classLevelPermissions: {
             find: { '*': true },
             get: { '*': true },
+            count: { '*': true },
             create: { '*': true },
             update: { '*': true },
             delete: { '*': true },
@@ -787,6 +790,7 @@ describe('SchemaController', () => {
           classLevelPermissions: {
             find: { '*': true },
             get: { '*': true },
+            count: { '*': true },
             create: { '*': true },
             update: { '*': true },
             delete: { '*': true },
@@ -833,6 +837,7 @@ describe('SchemaController', () => {
           classLevelPermissions: {
             find: { '*': true },
             get: { '*': true },
+            count: { '*': true },
             create: { '*': true },
             update: { '*': true },
             delete: { '*': true },
@@ -865,6 +870,7 @@ describe('SchemaController', () => {
           classLevelPermissions: {
             find: { '*': true },
             get: { '*': true },
+            count: { '*': true },
             create: { '*': true },
             update: { '*': true },
             delete: { '*': true },
@@ -899,6 +905,7 @@ describe('SchemaController', () => {
           classLevelPermissions: {
             find: { '*': true },
             get: { '*': true },
+            count: { '*': true },
             create: { '*': true },
             update: { '*': true },
             delete: { '*': true },
@@ -1088,6 +1095,7 @@ describe('SchemaController', () => {
             classLevelPermissions: {
               find: { '*': true },
               get: { '*': true },
+              count: { '*': true },
               create: { '*': true },
               update: { '*': true },
               delete: { '*': true },

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -31,6 +31,9 @@ const defaultClassLevelPermissions = {
   find: {
     '*': true,
   },
+  count: {
+    '*': true,
+  },
   create: {
     '*': true,
   },
@@ -1160,6 +1163,7 @@ describe('schemas', () => {
             'role:admin': true,
           },
           get: {},
+          count: {},
           update: {},
           delete: {},
           addField: {},
@@ -2037,6 +2041,7 @@ describe('schemas', () => {
       {
         get: { '*': true },
         find: { '*': true },
+        count: { '*': true },
         create: { '*': true },
       },
       true
@@ -2056,6 +2061,7 @@ describe('schemas', () => {
         expect(res.data.classLevelPermissions).toEqual({
           get: { '*': true },
           find: { '*': true },
+          count: { '*': true },
           create: { '*': true },
           update: {},
           delete: {},

--- a/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
@@ -57,6 +57,7 @@ function mongoSchemaFieldsToParseSchemaFields(schema) {
 
 const emptyCLPS = Object.freeze({
   find: {},
+  count: {},
   get: {},
   create: {},
   update: {},
@@ -67,6 +68,7 @@ const emptyCLPS = Object.freeze({
 
 const defaultCLPS = Object.freeze({
   find: { '*': true },
+  count: { '*': true },
   get: { '*': true },
   create: { '*': true },
   update: { '*': true },

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -102,6 +102,7 @@ const transformValue = value => {
 const emptyCLPS = Object.freeze({
   find: {},
   get: {},
+  count: {},
   create: {},
   update: {},
   delete: {},
@@ -112,6 +113,7 @@ const emptyCLPS = Object.freeze({
 const defaultCLPS = Object.freeze({
   find: { '*': true },
   get: { '*': true },
+  count: { '*': true },
   create: { '*': true },
   update: { '*': true },
   delete: { '*': true },


### PR DESCRIPTION
In order to [#1165](https://github.com/parse-community/parse-dashboard/issues/1165) work properly, it is needed to include "count" to the initial CLP when a class is created.