### PR TITLE
support PhantAuth authentication

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -13,6 +13,7 @@ const responses = {
   wechat: { errcode: 0 },
   weibo: { uid: 'userId' },
   qq: 'callback( {"openid":"userId"} );', // yes it's like that, run eval in the client :P
+  phantauth: { sub: 'userId' },
 };
 
 describe('AuthenticationProviders', function() {
@@ -33,6 +34,7 @@ describe('AuthenticationProviders', function() {
     'spotify',
     'wechat',
     'weibo',
+    'phantauth',
   ].map(function(providerName) {
     it('Should validate structure of ' + providerName, done => {
       const provider = require('../lib/Adapters/Auth/' + providerName);

--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -1167,3 +1167,23 @@ describe('apple signin auth adapter', () => {
     }
   });
 });
+
+describe('phant auth adapter', () => {
+  const httpsRequest = require('../lib/Adapters/Auth/httpsRequest');
+
+  it('validateAuthData should throw for invalid auth', async () => {
+    const authData = {
+      id: 'fakeid',
+      access_token: 'sometoken',
+    };
+    const { adapter } = authenticationLoader.loadAuthAdapter('phantauth', {});
+
+    spyOn(httpsRequest, 'get').and.callFake(() => Promise.resolve({ sub: 'invalidID' }));
+    try {
+      await adapter.validateAuthData(authData);
+      fail();
+    } catch (e) {
+      expect(e.message).toBe('PhantAuth auth is invalid for this user.');
+    }
+  });
+});

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -18,6 +18,7 @@ const qq = require('./qq');
 const wechat = require('./wechat');
 const weibo = require('./weibo');
 const oauth2 = require('./oauth2');
+const phantauth = require('./phantauth');
 
 const anonymous = {
   validateAuthData: () => {
@@ -47,6 +48,7 @@ const providers = {
   qq,
   wechat,
   weibo,
+  phantauth,
 };
 
 function authDataValidator(adapter, appIds, options) {

--- a/src/Adapters/Auth/phantauth.js
+++ b/src/Adapters/Auth/phantauth.js
@@ -4,7 +4,7 @@
  * PhantAuth was designed to simplify testing for applications using OpenID Connect
  * authentication by making use of random generated users.
  *
- * To learn more, please go to: https://wwww.phantauth.net
+ * To learn more, please go to: https://www.phantauth.net
  */
 
 var Parse = require('parse/node').Parse;
@@ -23,7 +23,7 @@ function validateAuthData(authData) {
   });
 }
 
-// Returns a promise that fulfills iff this app id is valid.
+// Returns a promise that fulfills if this app id is valid.
 function validateAppId() {
   return Promise.resolve();
 }

--- a/src/Adapters/Auth/phantauth.js
+++ b/src/Adapters/Auth/phantauth.js
@@ -1,13 +1,11 @@
 /*
- * Helper functions for authenticating with PhantAuth.
- *
  * PhantAuth was designed to simplify testing for applications using OpenID Connect
  * authentication by making use of random generated users.
  *
  * To learn more, please go to: https://www.phantauth.net
  */
 
-var Parse = require('parse/node').Parse;
+const { Parse } = require('parse/node');
 const httpsRequest = require('./httpsRequest');
 
 // Returns a promise that fulfills if this user id is valid.

--- a/src/Adapters/Auth/phantauth.js
+++ b/src/Adapters/Auth/phantauth.js
@@ -1,0 +1,46 @@
+/*
+ * Helper functions for authenticating with PhantAuth.
+ *
+ * PhantAuth was designed to simplify testing for applications using OpenID Connect
+ * authentication by making use of random generated users.
+ *
+ * To learn more, please go to: https://wwww.phantauth.net
+ */
+
+var Parse = require('parse/node').Parse;
+const httpsRequest = require('./httpsRequest');
+
+// Returns a promise that fulfills if this user id is valid.
+function validateAuthData(authData) {
+  return request('auth/userinfo', authData.access_token).then(data => {
+    if (data && data.sub == authData.id) {
+      return;
+    }
+    throw new Parse.Error(
+      Parse.Error.OBJECT_NOT_FOUND,
+      'PhantAuth auth is invalid for this user.'
+    );
+  });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+// A promisey wrapper for api requests
+function request(path, access_token) {
+  return httpsRequest.get({
+    host: 'phantauth.net',
+    path: '/' + path,
+    headers: {
+      Authorization: 'bearer ' + access_token,
+      'User-Agent': 'parse-server',
+    },
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData,
+};


### PR DESCRIPTION
PhantAuth was designed to simplify testing of applications using OpenID Connect authentication by making use of randomly generated users.

By using PhantAuth, you can test applications built on Parse Server with an unlimited number of test users. It could bring the developers of applications using Parse Server considerable added value.

To learn more, please visit: https://www.phantauth.net
