### PR TITLE
Update ParseWebSocketServer.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11046,12 +11046,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
-    "uws": {
-      "version": "10.148.1",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-10.148.1.tgz",
-      "integrity": "sha1-/Rp5z2EYo4jgob7YoTlwMNLE/Sw=",
-      "optional": true
-    },
     "v8-compile-cache": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -108,8 +108,7 @@
     "parse-server": "./bin/parse-server"
   },
   "optionalDependencies": {
-    "bcrypt": "3.0.6",
-    "uws": "10.148.1"
+    "bcrypt": "3.0.6"
   },
   "collective": {
     "type": "opencollective",

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -1,7 +1,9 @@
 import logger from '../logger';
 
 const typeMap = new Map([['disconnect', 'close']]);
-const getWS = require('ws');
+const getWS = function(){
+  return require('ws');
+};
 
 export class ParseWebSocketServer {
   server: Object;

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -1,13 +1,7 @@
 import logger from '../logger';
 
 const typeMap = new Map([['disconnect', 'close']]);
-const getWS = function() {
-  try {
-    return require('uws');
-  } catch (e) {
-    return require('ws');
-  }
-};
+const getWS = require('ws');
 
 export class ParseWebSocketServer {
   server: Object;


### PR DESCRIPTION
fix wss:// error by requiring 'ws' module, remove uws as it has been deprecated and removed from npm

See: https://github.com/parse-community/parse-server/issues/5347