### PR TITLE
Add git to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN npm run build
 
 # Release stage
 FROM node:lts-alpine as release
+
+RUN apk update; \
+  apk add git;
+
 VOLUME /parse-server/cloud /parse-server/config
 
 WORKDIR /parse-server


### PR DESCRIPTION
The push adapter now uses a node-apn fork. This PR adds git to the build to pull the fork down.

I'm not a docker expert. Any feedback would be great.

<img width="689" alt="Screen Shot 2019-07-28 at 3 04 34 PM" src="https://user-images.githubusercontent.com/9830365/62012235-53e8b780-b149-11e9-95c9-5599b8605feb.png">