### PR TITLE
Fix month in aggregate tests

### DIFF
--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -237,7 +237,7 @@ describe('Parse.Query Aggregate testing', () => {
       .then(results => {
         const createdAt = new Date(obj1.createdAt);
         expect(results[0].objectId.day).toEqual(createdAt.getUTCDate());
-        expect(results[0].objectId.month).toEqual(createdAt.getMonth() + 1);
+        expect(results[0].objectId.month).toEqual(createdAt.getUTCMonth() + 1);
         expect(results[0].objectId.year).toEqual(createdAt.getUTCFullYear());
         done();
       });
@@ -267,7 +267,7 @@ describe('Parse.Query Aggregate testing', () => {
       .then(results => {
         const createdAt = new Date(obj1.createdAt);
         expect(results[0].objectId.day).toEqual(createdAt.getUTCDate());
-        expect(results[0].objectId.month).toEqual(createdAt.getMonth() + 1);
+        expect(results[0].objectId.month).toEqual(createdAt.getUTCMonth() + 1);
         expect(results[0].objectId.year).toEqual(createdAt.getUTCFullYear());
         done();
       });


### PR DESCRIPTION
These two tests only break in the last day of the month, depending on your timezone and the time of day you are running the tests. They just failed for me and I noticed.