### PR TITLE
Fix apple signin authAdapter

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -1104,7 +1104,7 @@ describe('apple signin auth adapter', () => {
   it('should not verify invalid id_token', async () => {
     try {
       await apple.validateAuthData(
-        { id: 'the_token' },
+        { id: 'the_user_id', token: 'the_token' },
         { client_id: 'secret' }
       );
       fail();
@@ -1118,11 +1118,12 @@ describe('apple signin auth adapter', () => {
       iss: 'https://appleid.apple.com',
       aud: 'secret',
       exp: Date.now(),
+      sub: 'the_user_id',
     };
     spyOn(jwt, 'verify').and.callFake(() => fakeClaim);
 
     const result = await apple.validateAuthData(
-      { id: 'the_token' },
+      { id: 'the_user_id', token: 'the_token' },
       { client_id: 'secret' }
     );
     expect(result).toEqual(fakeClaim);
@@ -1131,12 +1132,13 @@ describe('apple signin auth adapter', () => {
   it('should throw error with with invalid jwt issuer', async () => {
     const fakeClaim = {
       iss: 'https://not.apple.com',
+      sub: 'the_user_id',
     };
     spyOn(jwt, 'verify').and.callFake(() => fakeClaim);
 
     try {
       await apple.validateAuthData(
-        { id: 'the_token' },
+        { id: 'the_user_id', token: 'the_token' },
         { client_id: 'secret' }
       );
       fail();
@@ -1151,12 +1153,13 @@ describe('apple signin auth adapter', () => {
     const fakeClaim = {
       iss: 'https://appleid.apple.com',
       aud: 'invalid_client_id',
+      sub: 'the_user_id',
     };
     spyOn(jwt, 'verify').and.callFake(() => fakeClaim);
 
     try {
       await apple.validateAuthData(
-        { id: 'the_token' },
+        { id: 'the_user_id', token: 'the_token' },
         { client_id: 'secret' }
       );
       fail();

--- a/src/Adapters/Auth/apple.js
+++ b/src/Adapters/Auth/apple.js
@@ -29,7 +29,7 @@ const getApplePublicKey = async () => {
   return currentKey;
 };
 
-const verifyIdToken = async (token, clientID) => {
+const verifyIdToken = async ({ token, id }, clientID) => {
   if (!token) {
     throw new Parse.Error(
       Parse.Error.OBJECT_NOT_FOUND,
@@ -45,6 +45,12 @@ const verifyIdToken = async (token, clientID) => {
       `id token not issued by correct OpenID provider - expected: ${TOKEN_ISSUER} | from: ${jwtClaims.iss}`
     );
   }
+  if (jwtClaims.sub !== id) {
+    throw new Parse.Error(
+      Parse.Error.OBJECT_NOT_FOUND,
+      `auth data is invalid for this user.`
+    );
+  }
   if (clientID !== undefined && jwtClaims.aud !== clientID) {
     throw new Parse.Error(
       Parse.Error.OBJECT_NOT_FOUND,
@@ -56,7 +62,7 @@ const verifyIdToken = async (token, clientID) => {
 
 // Returns a promise that fulfills if this id token is valid
 function validateAuthData(authData, options = {}) {
-  return verifyIdToken(authData.id, options.client_id);
+  return verifyIdToken(authData, options.client_id);
 }
 
 // Returns a promise that fulfills if this app id is valid.


### PR DESCRIPTION
Fix #5890 

We use the apple user identifier instead of the JWT token as the id
```
{
  "apple": {
    "id": "user",
    "token": "the identity token for the user"
  }
}
```