### PR TITLE
Return specific Type on specific Mutation

### DIFF
--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -715,9 +715,28 @@ const load = (
           }
         }, {}),
     });
+
+    const userLogInInputTypeName = '_UserLoginFields';
+    const userLogInInputType = new GraphQLInputObjectType({
+      name: userLogInInputTypeName,
+      description: `The ${userLogInInputTypeName} input type is used to login.`,
+      fields: {
+        username: {
+          description: 'This is the username used to log the user in.',
+          type: new GraphQLNonNull(GraphQLString),
+        },
+        password: {
+          description: 'This is the password used to log the user in.',
+          type: new GraphQLNonNull(GraphQLString),
+        },
+      },
+    });
     parseGraphQLSchema.parseClassTypes[
       '_User'
     ].signUpInputType = userSignUpInputType;
+    parseGraphQLSchema.parseClassTypes[
+      '_User'
+    ].logInInputType = userLogInInputType;
     parseGraphQLSchema.graphQLTypes.push(userSignUpInputType);
   }
 };


### PR DESCRIPTION
## Return specific Type on specific Mutation

- [x] Return Type on Create
- [x] Return Type on Update
- [x] Return Type on Delete
- [x] Optimization
- [x] Return Me on SignUp

> Create

```graphql
mutation {
  objects {
    createExample(
      fields: {
        name: "Hello"
        price: 10
        tags: ["hello","world"]
        description: "A good hello world"
      }
    ) {
      objectId
      description
      tags
    }
  }
}
```

> Update

```graphql
mutation {
  objects {
    updateExample(
      objectId: "jsh7cs6j"
      fields: {
        description: "A good hello world modified"
      }
    ) {
      objectId
      description
      tags
      name
    }
  }
}
```

> Delete

```graphql
mutation {
  objects {
    deleteExample(
      objectId: "jsh7cs6j"
    ) {
      objectId
      description
      tags
      name
    }
  }
}
```

## Change login Args
Convert the `login` args into an `input`

## Return type `Me` on `Signup`
I made a shortcut, it probably needs to be improved.

#5863