### PR TITLE
Improve Live Query Monitoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 - greenkeeper-lockfile-update
 script:
 - npm run lint
-- npm run coverage
+- npm run pretest && npm run coverage
 after_script:
 - greenkeeper-lockfile-upload
 - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "testonly": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=4.0.4} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=mmapv1} TESTING=1 jasmine",
     "test": "npm run testonly",
     "posttest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=4.0.4} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=mmapv1} mongodb-runner stop",
-    "coverage": "npm run pretest && cross-env MONGODB_VERSION=${MONGODB_VERSION:=4.0.4} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=mmapv1} TESTING=1 nyc jasmine && npm run posttest",
+    "coverage": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=4.0.4} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=mmapv1} TESTING=1 nyc jasmine",
     "start": "node ./bin/parse-server",
     "prepare": "npm run build",
     "postinstall": "node -p 'require(\"./postinstall.js\")()'"

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -293,7 +293,9 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._validateKeys = jasmine
       .createSpy('validateKeys')
       .and.returnValue(true);
-    parseLiveQueryServer._handleConnect(parseWebSocket);
+    parseLiveQueryServer._handleConnect(parseWebSocket, {
+      sessionToken: 'token',
+    });
 
     const clientKeys = parseLiveQueryServer.clients.keys();
     expect(parseLiveQueryServer.clients.size).toBe(1);
@@ -335,6 +337,7 @@ describe('ParseLiveQueryServer', function() {
       query: query,
       requestId: requestId,
       sessionToken: 'sessionToken',
+      installationId: 'installationId',
     };
     parseLiveQueryServer._handleSubscribe(parseWebSocket, request);
 
@@ -357,6 +360,7 @@ describe('ParseLiveQueryServer', function() {
     expect(args[0]).toBe(requestId);
     expect(args[1].fields).toBe(query.fields);
     expect(args[1].sessionToken).toBe(request.sessionToken);
+    expect(args[1].installationId).toBe(request.installationId);
     // Make sure we send subscribe response to the client
     expect(client.pushSubscribe).toHaveBeenCalledWith(requestId);
   });

--- a/src/LiveQuery/Client.js
+++ b/src/LiveQuery/Client.js
@@ -15,6 +15,7 @@ class Client {
   id: number;
   parseWebSocket: any;
   hasMasterKey: boolean;
+  sessionToken: string;
   userId: string;
   roles: Array<string>;
   subscriptionInfos: Object;
@@ -27,10 +28,16 @@ class Client {
   pushDelete: Function;
   pushLeave: Function;
 
-  constructor(id: number, parseWebSocket: any, hasMasterKey: boolean) {
+  constructor(
+    id: number,
+    parseWebSocket: any,
+    hasMasterKey: boolean = false,
+    sessionToken: string
+  ) {
     this.id = id;
     this.parseWebSocket = parseWebSocket;
     this.hasMasterKey = hasMasterKey;
+    this.sessionToken = sessionToken;
     this.roles = [];
     this.subscriptionInfos = new Map();
     this.pushConnect = this._pushEvent('connected');

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -672,7 +672,7 @@ class ParseLiveQueryServer {
     const subscriptionInfo = {
       subscription: subscription,
     };
-    // Add selected fields, sessionToken, installationId for this subscription if necessary
+    // Add selected fields, sessionToken and installationId for this subscription if necessary
     if (request.query.fields) {
       subscriptionInfo.fields = request.query.fields;
     }


### PR DESCRIPTION
Adds support for installationId.

Fixes inconsistency with Wiki where connect should set session token to the client. This will have lower priority than a subscribe with sessionToken when verifying ACL.

Let me know if any other fields should be added.