### PR TITLE
Fix GraphQL max upload size

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -111,6 +111,20 @@ describe('ParseGraphQLServer', () => {
     });
   });
 
+  describe('_transformMaxUploadSizeToBytes', () => {
+    it('should transform to bytes', () => {
+      expect(parseGraphQLServer._transformMaxUploadSizeToBytes('20mb')).toBe(
+        20971520
+      );
+      expect(parseGraphQLServer._transformMaxUploadSizeToBytes('333Gb')).toBe(
+        357556027392
+      );
+      expect(
+        parseGraphQLServer._transformMaxUploadSizeToBytes('123456KB')
+      ).toBe(126418944);
+    });
+  });
+
   describe('applyGraphQL', () => {
     it('should require an Express.js app instance', () => {
       expect(() => parseGraphQLServer.applyGraphQL()).toThrow(

--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -54,21 +54,32 @@ class ParseGraphQLServer {
     }
   }
 
+  _transformMaxUploadSizeToBytes(maxUploadSize) {
+    const unitMap = {
+      kb: 1,
+      mb: 2,
+      gb: 3,
+    };
+
+    return (
+      Number(maxUploadSize.slice(0, -2)) *
+      Math.pow(1024, unitMap[maxUploadSize.slice(-2).toLowerCase()])
+    );
+  }
+
   applyGraphQL(app) {
     if (!app || !app.use) {
       requiredParameter('You must provide an Express.js app instance!');
     }
 
-    const maxUploadSize = this.parseServer.config.maxUploadSize || '20mb';
-    const maxFileSize =
-      (Number(maxUploadSize.slice(0, -2)) * 1024) ^
-      {
-        kb: 1,
-        mb: 2,
-        gb: 3,
-      }[maxUploadSize.slice(-2).toLowerCase()];
-
-    app.use(this.config.graphQLPath, graphqlUploadExpress({ maxFileSize }));
+    app.use(
+      this.config.graphQLPath,
+      graphqlUploadExpress({
+        maxFileSize: this._transformMaxUploadSizeToBytes(
+          this.parseServer.config.maxUploadSize || '20mb'
+        ),
+      })
+    );
     app.use(this.config.graphQLPath, corsMiddleware());
     app.use(this.config.graphQLPath, bodyParser.json());
     app.use(this.config.graphQLPath, handleParseHeaders);


### PR DESCRIPTION
This PR fixes one of the issues that is causing the bug of https://github.com/parse-community/parse-server/issues/5935

The max upload size was miscalculated and therefore only allowing the upload of small files.