### PR TITLE
Remove Mongo topology deprecation notice from the grid adapters

### DIFF
--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -20,7 +20,10 @@ export class GridFSBucketAdapter extends FilesAdapter {
     super();
     this._databaseURI = mongoDatabaseURI;
 
-    const defaultMongoOptions = { useNewUrlParser: true };
+    const defaultMongoOptions = {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    };
     this._mongoOptions = Object.assign(defaultMongoOptions, mongoOptions);
   }
 

--- a/src/Adapters/Files/GridStoreAdapter.js
+++ b/src/Adapters/Files/GridStoreAdapter.js
@@ -21,7 +21,10 @@ export class GridStoreAdapter extends FilesAdapter {
     super();
     this._databaseURI = mongoDatabaseURI;
 
-    const defaultMongoOptions = { useNewUrlParser: true };
+    const defaultMongoOptions = {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    };
     this._mongoOptions = Object.assign(defaultMongoOptions, mongoOptions);
   }
 


### PR DESCRIPTION
Remove MongoDB unified topology deprecation notice from the grid adapters