### PR TITLE
Handle shutdown on grid adapters

### DIFF
--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -60,4 +60,19 @@ describe('GridFSBucket and GridStore interop', () => {
     await gfsAdapter.deleteFile('myFileName');
     await expectMissingFile(gfsAdapter, 'myFileName');
   });
+
+  it('handleShutdown, close connection', done => {
+    const databaseURI = 'mongodb://localhost:27017/parse';
+    const gfsAdapter = new GridFSBucketAdapter(databaseURI);
+
+    gfsAdapter._connect().then(db => {
+      expect(db.serverConfig.connections().length > 0).toEqual(true);
+      expect(db.serverConfig.s.connected).toEqual(true);
+      gfsAdapter.handleShutdown().then(() => {
+        expect(db.serverConfig.connections().length > 0).toEqual(false);
+        expect(db.serverConfig.s.connected).toEqual(false);
+        done();
+      });
+    });
+  });
 });

--- a/spec/GridStoreAdapter.spec.js
+++ b/spec/GridStoreAdapter.spec.js
@@ -96,4 +96,19 @@ describe_only_db('mongo')('GridStoreAdapter', () => {
       })
       .catch(fail);
   });
+
+  it('handleShutdown, close connection', done => {
+    const databaseURI = 'mongodb://localhost:27017/parse';
+    const gridStoreAdapter = new GridStoreAdapter(databaseURI);
+
+    gridStoreAdapter._connect().then(db => {
+      expect(db.serverConfig.connections().length > 0).toEqual(true);
+      expect(db.serverConfig.s.connected).toEqual(true);
+      gridStoreAdapter.handleShutdown().then(() => {
+        expect(db.serverConfig.connections().length > 0).toEqual(false);
+        expect(db.serverConfig.s.connected).toEqual(false);
+        done();
+      });
+    });
+  });
 });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -66,7 +66,11 @@ describe('Server Url Checks', () => {
     const newConfiguration = Object.assign({}, defaultConfiguration, {
       databaseAdapter,
       serverStartComplete: () => {
-        parseServer.config.filesController.adapter._connect().then(() => {
+        let promise = Promise.resolve();
+        if (process.env.PARSE_SERVER_TEST_DB !== 'postgres') {
+          promise = parseServer.config.filesController.adapter._connect();
+        }
+        promise.then(() => {
           parseServer.handleShutdown();
           parseServer.server.close(err => {
             if (err) {

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -66,14 +66,16 @@ describe('Server Url Checks', () => {
     const newConfiguration = Object.assign({}, defaultConfiguration, {
       databaseAdapter,
       serverStartComplete: () => {
-        parseServer.handleShutdown();
-        parseServer.server.close(err => {
-          if (err) {
-            done.fail('Close Server Error');
-          }
-          reconfigureServer({}).then(() => {
-            expect(close).toBe(true);
-            done();
+        parseServer.config.filesController.adapter._connect().then(() => {
+          parseServer.handleShutdown();
+          parseServer.server.close(err => {
+            if (err) {
+              done.fail('Close Server Error');
+            }
+            reconfigureServer({}).then(() => {
+              expect(close).toBe(true);
+              done();
+            });
           });
         });
       },

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -32,7 +32,10 @@ export class GridFSBucketAdapter extends FilesAdapter {
       this._connectionPromise = MongoClient.connect(
         this._databaseURI,
         this._mongoOptions
-      ).then(client => client.db(client.s.options.dbName));
+      ).then(client => {
+        this._client = client;
+        return client.db(client.s.options.dbName);
+      });
     }
     return this._connectionPromise;
   }
@@ -97,6 +100,13 @@ export class GridFSBucketAdapter extends FilesAdapter {
   async getDownloadStream(filename: string) {
     const bucket = await this._getBucket();
     return bucket.openDownloadStreamByName(filename);
+  }
+
+  handleShutdown() {
+    if (!this._client) {
+      return Promise.resolve();
+    }
+    return this._client.close(false);
   }
 }
 

--- a/src/Adapters/Files/GridStoreAdapter.js
+++ b/src/Adapters/Files/GridStoreAdapter.js
@@ -33,7 +33,10 @@ export class GridStoreAdapter extends FilesAdapter {
       this._connectionPromise = MongoClient.connect(
         this._databaseURI,
         this._mongoOptions
-      ).then(client => client.db(client.s.options.dbName));
+      ).then(client => {
+        this._client = client;
+        return client.db(client.s.options.dbName);
+      });
     }
     return this._connectionPromise;
   }
@@ -98,6 +101,13 @@ export class GridStoreAdapter extends FilesAdapter {
         return gridStore.open();
       });
     });
+  }
+
+  handleShutdown() {
+    if (!this._client) {
+      return Promise.resolve();
+    }
+    return this._client.close(false);
   }
 }
 


### PR DESCRIPTION
The Grid Adapters are currently not handling the shutdown. It means that if someone start the Parse Server using the CLI, then create a file, then try to close the process, the process never finishes because the connections are not properly closed.