### PR TITLE
Protected fields pointer-permissions support

### DIFF
--- a/spec/ProtectedFields.spec.js
+++ b/spec/ProtectedFields.spec.js
@@ -256,7 +256,7 @@ describe('ProtectedFields', function() {
       let objectAgain = await obj.fetch();
       expect(objectAgain.get('owners')[0].id).toBe(user1.id);
       expect(objectAgain.get('test')).toBe('test');
-      await Parse.User.logIn('user1', 'password');
+      await Parse.User.logIn('user2', 'password');
       objectAgain = await obj.fetch();
       expect(objectAgain.get('owners')[1].id).toBe(user2.id);
       expect(objectAgain.get('test')).toBe('test');

--- a/spec/ProtectedFields.spec.js
+++ b/spec/ProtectedFields.spec.js
@@ -167,7 +167,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
@@ -194,7 +193,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
@@ -221,7 +219,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
@@ -247,7 +244,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners'],
             protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
@@ -278,7 +274,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners'],
             protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
@@ -305,7 +300,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners'],
             protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
@@ -332,7 +326,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners', 'owner'],
             protectedFields: {
               '*': [],
               'userField:owners': ['owners'],
@@ -350,7 +343,7 @@ describe('ProtectedFields', function() {
         done();
       });
 
-      it('should ignore pointer-permission fields not declared in the readUserFields', async done => {
+      it('should ignore pointer-permission fields not present in object', async done => {
         const config = Config.get(Parse.applicationId);
         const obj = new Parse.Object('AnObject');
 
@@ -366,11 +359,10 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: [],
             protectedFields: {
               '*': [],
-              'userField:owners': ['idontexist'],
-              'userField:owner': ['idontexist2'],
+              'userField:idontexist': ['owner'],
+              'userField:idontexist2': ['owners'],
             },
           }
         );
@@ -403,7 +395,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
@@ -441,7 +432,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
@@ -478,7 +468,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
@@ -514,7 +503,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners'],
             protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
@@ -564,7 +552,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners'],
             protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
@@ -601,7 +588,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners'],
             protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
@@ -639,7 +625,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owners', 'owner'],
             protectedFields: {
               '*': [],
               'userField:owners': ['owners'],
@@ -666,7 +651,7 @@ describe('ProtectedFields', function() {
         done();
       });
 
-      it('should ignore pointer-permission fields not declared in the readUserFields', async done => {
+      it('should ignore pointer-permission fields not present in object', async done => {
         const config = Config.get(Parse.applicationId);
         const obj = new Parse.Object('AnObject');
         const obj2 = new Parse.Object('AnObject');
@@ -686,11 +671,10 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: [],
             protectedFields: {
               '*': [],
-              'userField:owners': ['idontexist'],
-              'userField:owner': ['idontexist2'],
+              'userField:idontexist': ['owner'],
+              'userField:idontexist2': ['owners'],
             },
           }
         );
@@ -733,7 +717,6 @@ describe('ProtectedFields', function() {
           {
             get: { '*': true },
             find: { '*': true },
-            readUserFields: ['owner'],
             protectedFields: {
               '*': ['owner'],
               'userField:owner': [],

--- a/spec/ProtectedFields.spec.js
+++ b/spec/ProtectedFields.spec.js
@@ -168,7 +168,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owner'],
-            protectedFields: { '*': ['owner'], 'readUserFields:owner': [] },
+            protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
 
@@ -195,7 +195,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owner'],
-            protectedFields: { '*': ['owner'], 'readUserFields:owner': [] },
+            protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
 
@@ -222,7 +222,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owner'],
-            protectedFields: { '*': ['owner'], 'readUserFields:owner': [] },
+            protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
 
@@ -248,7 +248,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owners'],
-            protectedFields: { '*': ['owners'], 'readUserFields:owners': [] },
+            protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
 
@@ -279,7 +279,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owners'],
-            protectedFields: { '*': ['owners'], 'readUserFields:owners': [] },
+            protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
 
@@ -306,7 +306,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owners'],
-            protectedFields: { '*': ['owners'], 'readUserFields:owners': [] },
+            protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
 
@@ -335,8 +335,8 @@ describe('ProtectedFields', function() {
             readUserFields: ['owners', 'owner'],
             protectedFields: {
               '*': [],
-              'readUserFields:owners': ['owners'],
-              'readUserFields:owner': ['owner'],
+              'userField:owners': ['owners'],
+              'userField:owner': ['owner'],
             },
           }
         );
@@ -369,8 +369,8 @@ describe('ProtectedFields', function() {
             readUserFields: [],
             protectedFields: {
               '*': [],
-              'readUserFields:owners': ['idontexist'],
-              'readUserFields:owner': ['idontexist2'],
+              'userField:owners': ['idontexist'],
+              'userField:owner': ['idontexist2'],
             },
           }
         );
@@ -404,7 +404,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owner'],
-            protectedFields: { '*': ['owner'], 'readUserFields:owner': [] },
+            protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
 
@@ -442,7 +442,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owner'],
-            protectedFields: { '*': ['owner'], 'readUserFields:owner': [] },
+            protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
 
@@ -479,7 +479,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owner'],
-            protectedFields: { '*': ['owner'], 'readUserFields:owner': [] },
+            protectedFields: { '*': ['owner'], 'userField:owner': [] },
           }
         );
 
@@ -515,7 +515,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owners'],
-            protectedFields: { '*': ['owners'], 'readUserFields:owners': [] },
+            protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
 
@@ -565,7 +565,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owners'],
-            protectedFields: { '*': ['owners'], 'readUserFields:owners': [] },
+            protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
 
@@ -602,7 +602,7 @@ describe('ProtectedFields', function() {
             get: { '*': true },
             find: { '*': true },
             readUserFields: ['owners'],
-            protectedFields: { '*': ['owners'], 'readUserFields:owners': [] },
+            protectedFields: { '*': ['owners'], 'userField:owners': [] },
           }
         );
 
@@ -642,8 +642,8 @@ describe('ProtectedFields', function() {
             readUserFields: ['owners', 'owner'],
             protectedFields: {
               '*': [],
-              'readUserFields:owners': ['owners'],
-              'readUserFields:owner': ['owner'],
+              'userField:owners': ['owners'],
+              'userField:owner': ['owner'],
             },
           }
         );
@@ -689,8 +689,8 @@ describe('ProtectedFields', function() {
             readUserFields: [],
             protectedFields: {
               '*': [],
-              'readUserFields:owners': ['idontexist'],
-              'readUserFields:owner': ['idontexist2'],
+              'userField:owners': ['idontexist'],
+              'userField:owner': ['idontexist2'],
             },
           }
         );
@@ -736,7 +736,7 @@ describe('ProtectedFields', function() {
             readUserFields: ['owner'],
             protectedFields: {
               '*': ['owner'],
-              'readUserFields:owner': [],
+              'userField:owner': [],
             },
           }
         );

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -221,9 +221,9 @@ const filterSensitiveData = (
     ) {
       // extract protectedFields added with the pointer-permission prefix
       const protectedFieldsPointerPerm = Object.keys(perms.protectedFields)
-        .filter(key => key.startsWith('readUserFields:'))
+        .filter(key => key.startsWith('userField:'))
         .map(key => {
-          return { key: key.substring(15), value: perms.protectedFields[key] };
+          return { key: key.substring(10), value: perms.protectedFields[key] };
         });
 
       const newProtectedFields: Array<string> = [];

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -192,15 +192,18 @@ const validateQuery = (
 
 // Filters out any data that shouldn't be on this REST-formatted object.
 const filterSensitiveData = (
-  isMaster,
-  aclGroup,
-  className,
-  protectedFields,
-  object
+  isMaster: boolean,
+  aclGroup: any[],
+  auth: any,
+  className: string,
+  protectedFields: null | Array<any>,
+  object: any
 ) => {
-  protectedFields && protectedFields.forEach(k => delete object[k]);
+  const isUserClass = className === '_User';
+  if (!isUserClass || !auth || !auth.user || object.objectId !== auth.user.id)
+    protectedFields && protectedFields.forEach(k => delete object[k]);
 
-  if (className !== '_User') {
+  if (!isUserClass) {
     return object;
   }
 
@@ -1385,6 +1388,7 @@ class DatabaseController {
                         return filterSensitiveData(
                           isMaster,
                           aclGroup,
+                          auth,
                           className,
                           protectedFields,
                           object
@@ -1518,13 +1522,6 @@ class DatabaseController {
     if (!protectedFields) return null;
 
     if (aclGroup.indexOf(query.objectId) > -1) return null;
-    if (
-      Object.keys(query).length === 0 &&
-      auth &&
-      auth.user &&
-      aclGroup.indexOf(auth.user.id) > -1
-    )
-      return null;
 
     let protectedKeys = Object.values(protectedFields).reduce(
       (acc, val) => acc.concat(val),

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -176,7 +176,7 @@ const volatileClasses = Object.freeze([
 const userIdRegex = /^[a-zA-Z0-9]{10}$/;
 // Anything that start with role
 const roleRegex = /^role:.*/;
-// Anything that start with readUserFields
+// Anything that starts with readUserFields
 const pointerPermissionRegex = /^readUserFields:.*/;
 // * permission
 const publicRegex = /^\*$/;
@@ -908,10 +908,15 @@ export default class SchemaController {
           let defaultValueType = getType(fieldType.defaultValue);
           if (typeof defaultValueType === 'string') {
             defaultValueType = { type: defaultValueType };
-          } else if (typeof defaultValueType === 'object' && fieldType.type === 'Relation') {
+          } else if (
+            typeof defaultValueType === 'object' &&
+            fieldType.type === 'Relation'
+          ) {
             return {
               code: Parse.Error.INCORRECT_TYPE,
-              error: `The 'default value' option is not applicable for ${typeToString(fieldType)}`
+              error: `The 'default value' option is not applicable for ${typeToString(
+                fieldType
+              )}`,
             };
           }
           if (!dbTypeMatchesObjectType(fieldType, defaultValueType)) {
@@ -926,7 +931,9 @@ export default class SchemaController {
           if (typeof fieldType === 'object' && fieldType.type === 'Relation') {
             return {
               code: Parse.Error.INCORRECT_TYPE,
-              error: `The 'required' option is not applicable for ${typeToString(fieldType)}`
+              error: `The 'required' option is not applicable for ${typeToString(
+                fieldType
+              )}`,
             };
           }
         }

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -176,6 +176,8 @@ const volatileClasses = Object.freeze([
 const userIdRegex = /^[a-zA-Z0-9]{10}$/;
 // Anything that start with role
 const roleRegex = /^role:.*/;
+// Anything that start with readUserFields
+const pointerPermissionRegex = /^readUserFields:.*/;
 // * permission
 const publicRegex = /^\*$/;
 
@@ -184,6 +186,7 @@ const requireAuthenticationRegex = /^requiresAuthentication$/;
 const permissionKeyRegex = Object.freeze([
   userIdRegex,
   roleRegex,
+  pointerPermissionRegex,
   publicRegex,
   requireAuthenticationRegex,
 ]);

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -176,8 +176,8 @@ const volatileClasses = Object.freeze([
 const userIdRegex = /^[a-zA-Z0-9]{10}$/;
 // Anything that start with role
 const roleRegex = /^role:.*/;
-// Anything that starts with readUserFields
-const pointerPermissionRegex = /^readUserFields:.*/;
+// Anything that starts with userField
+const pointerPermissionRegex = /^userField:.*/;
 // * permission
 const publicRegex = /^\*$/;
 


### PR DESCRIPTION
This PR adds the ability to specify `readUserFields` columns to set different `protectedFields`when the current user is contained in such a field.

Fixes #5884 by using the approach discussed in [PR 5887](https://github.com/parse-community/parse-server/pull/5887#issuecomment-518748271).

The extended syntax can be seen in this example:
`protectedFields: {
    Book: { '*': ['profit', 'contract'], 'readUserFields:author': [] },
}`