### PR TITLE
fix(middlewares): handleParseErrors not logging ParseError message

### DIFF
--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -203,7 +203,7 @@ describe('Cloud Code Logger', () => {
       .catch(() => {})
       .then(() => {
         const logs = spy.calls.all().reverse();
-        expect(logs[0].args[1]).toBe('Parse error: ');
+        expect(logs[0].args[1]).toBe('ParseError: 141 it failed!');
         expect(logs[0].args[2].message).toBe('it failed!');
 
         const log = logs[1].args;
@@ -270,7 +270,7 @@ describe('Cloud Code Logger', () => {
     expect(spy).toHaveBeenCalled();
     expect(spy.calls.count()).toBe(1);
     const { args } = spy.calls.mostRecent();
-    expect(args[0]).toBe('Parse error: ');
+    expect(args[0]).toBe('ParseError: 101 Object not found.');
     expect(args[1].message).toBe('Object not found.');
   });
 });

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -325,7 +325,7 @@ export function handleParseErrors(err, req, res, next) {
 
     res.status(httpStatus);
     res.json({ code: err.code, error: err.message });
-    log.error('Parse error: ', err);
+    log.error(err.toString(), err);
     if (req.config && req.config.enableExpressErrorHandler) {
       next(err);
     }


### PR DESCRIPTION
On `handleParseErrors` middleware, if the error is an instance of `ParseError`, the logger logs just `Parse error:` and does not include the actual error message.
This is bad for adapters since we're forcing implementations to make use of `meta` data to gather useful information about the error thrown.
In this case, we could use `ParseError#toString` that would print something like `ParseError: 141 Invalid function: "hello"`.