### PR TITLE
refactor(GraphQL): Pointer constraint input type as ID

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -3416,11 +3416,7 @@ describe('ParseGraphQLServer', () => {
                   _or: [
                     {
                       pointerToUser: {
-                        _eq: {
-                          __type: 'Pointer',
-                          className: '_User',
-                          objectId: user5.id,
-                        },
+                        _eq: user5.id,
                       },
                     },
                     {
@@ -3443,6 +3439,40 @@ describe('ParseGraphQLServer', () => {
                 .map(object => object.someField)
                 .sort()
             ).toEqual(['someValue1', 'someValue3']);
+          });
+
+          it('should support _in pointer operator using class specific query', async () => {
+            await prepareData();
+
+            await parseGraphQLServer.parseGraphQLSchema.databaseController.schemaCache.clear();
+
+            const result = await apolloClient.query({
+              query: gql`
+                query FindSomeObjects($where: GraphQLClassWhereInput) {
+                  graphQLClasses(where: $where) {
+                    results {
+                      someField
+                    }
+                  }
+                }
+              `,
+              variables: {
+                where: {
+                  pointerToUser: {
+                    _in: [user5.id],
+                  },
+                },
+              },
+              context: {
+                headers: {
+                  'X-Parse-Master-Key': 'test',
+                },
+              },
+            });
+
+            const { results } = result.data.graphQLClasses;
+            expect(results.length).toBe(1);
+            expect(results[0].someField).toEqual('someValue3');
           });
 
           it('should support _or operation', async () => {
@@ -3543,11 +3573,7 @@ describe('ParseGraphQLServer', () => {
               _or: [
                 {
                   pointerToUser: {
-                    _eq: {
-                      __type: 'Pointer',
-                      className: '_User',
-                      objectId: user5.id,
-                    },
+                    _eq: user5.id,
                   },
                 },
                 {
@@ -3599,11 +3625,7 @@ describe('ParseGraphQLServer', () => {
               _or: [
                 {
                   pointerToUser: {
-                    _eq: {
-                      __type: 'Pointer',
-                      className: '_User',
-                      objectId: user5.id,
-                    },
+                    _eq: user5.id,
                   },
                 },
                 {

--- a/src/GraphQL/helpers/objectsQueries.js
+++ b/src/GraphQL/helpers/objectsQueries.js
@@ -62,12 +62,13 @@ const findObjects = async (
   config,
   auth,
   info,
-  selectedFields
+  selectedFields,
+  fields
 ) => {
   if (!where) {
     where = {};
   }
-  transformQueryInputToParse(where);
+  transformQueryInputToParse(where, fields);
 
   const options = {};
 

--- a/src/GraphQL/loaders/parseClassQueries.js
+++ b/src/GraphQL/loaders/parseClassQueries.js
@@ -120,7 +120,8 @@ const load = function(
             config,
             auth,
             info,
-            selectedFields.map(field => field.split('.', 1)[0])
+            selectedFields.map(field => field.split('.', 1)[0]),
+            parseClass.fields
           );
         } catch (e) {
           parseGraphQLSchema.handleError(e);

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -202,6 +202,30 @@ const load = (
     classGraphQLUpdateType
   );
 
+  const classGraphQLPointerTypeName = `${graphQLClassName}PointerInput`;
+  let classGraphQLPointerType = new GraphQLInputObjectType({
+    name: classGraphQLPointerTypeName,
+    description: `Allow to link OR add and link an object of the ${graphQLClassName} class.`,
+    fields: () => {
+      const fields = {
+        link: {
+          description: `Link an existing object from ${graphQLClassName} class.`,
+          type: GraphQLID,
+        },
+      };
+      if (isCreateEnabled) {
+        fields['createAndLink'] = {
+          description: `Create and link an object from ${graphQLClassName} class.`,
+          type: classGraphQLCreateType,
+        };
+      }
+      return fields;
+    },
+  });
+  classGraphQLPointerType =
+    parseGraphQLSchema.addGraphQLType(classGraphQLPointerType) ||
+    defaultGraphQLTypes.OBJECT;
+
   const classGraphQLRelationTypeName = `${graphQLClassName}RelationInput`;
   let classGraphQLRelationType = new GraphQLInputObjectType({
     name: classGraphQLRelationTypeName,
@@ -237,12 +261,8 @@ const load = (
     fields: {
       _eq: defaultGraphQLTypes._eq(GraphQLID),
       _ne: defaultGraphQLTypes._ne(GraphQLID),
-      _in: defaultGraphQLTypes._in(
-        new GraphQLList(defaultGraphQLTypes.OBJECT_ID)
-      ),
-      _nin: defaultGraphQLTypes._nin(
-        new GraphQLList(defaultGraphQLTypes.OBJECT_ID)
-      ),
+      _in: defaultGraphQLTypes._in(defaultGraphQLTypes.OBJECT_ID),
+      _nin: defaultGraphQLTypes._nin(defaultGraphQLTypes.OBJECT_ID),
       _exists: defaultGraphQLTypes._exists,
       _select: defaultGraphQLTypes._select,
       _dontSelect: defaultGraphQLTypes._dontSelect,
@@ -506,6 +526,7 @@ const load = (
   );
 
   parseGraphQLSchema.parseClassTypes[className] = {
+    classGraphQLPointerType,
     classGraphQLRelationType,
     classGraphQLCreateType,
     classGraphQLUpdateType,

--- a/src/GraphQL/transformers/query.js
+++ b/src/GraphQL/transformers/query.js
@@ -43,6 +43,7 @@ const parseMap = {
 
 const transformQueryInputToParse = (
   constraints,
+  fields,
   parentFieldName,
   parentConstraints
 ) => {
@@ -93,6 +94,21 @@ const transformQueryInputToParse = (
       delete constraints[fieldName];
       fieldName = parseMap[fieldName];
       constraints[fieldName] = fieldValue;
+
+      // If parent field type is Pointer, changes constraint value to format expected
+      // by Parse.
+      if (
+        fields[parentFieldName] &&
+        fields[parentFieldName].type === 'Pointer' &&
+        typeof fieldValue === 'string'
+      ) {
+        const { targetClass } = fields[parentFieldName];
+        constraints[fieldName] = {
+          __type: 'Pointer',
+          className: targetClass,
+          objectId: fieldValue,
+        };
+      }
     }
     switch (fieldName) {
       case '$point':
@@ -147,7 +163,7 @@ const transformQueryInputToParse = (
         break;
     }
     if (typeof fieldValue === 'object') {
-      transformQueryInputToParse(fieldValue, fieldName, constraints);
+      transformQueryInputToParse(fieldValue, fields, fieldName, constraints);
     }
   });
 };


### PR DESCRIPTION
Redefines the Pointer constraint input type from a custom scalar to
a simple ID.