### PR TITLE
Bootstreap script: use #!/bin/bash instead of #!/bin/sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'


### PR DESCRIPTION
The script uses double square brackets, which are a non-standard extension to `[]`. The shebang line should reflect that. Some shells (e.g. dash, the default shell under Debian) do not support double square brackets. This leads to the script not working under Debian.