### PR TITLE
Bootstrap-Script: Install parse-server 3.9.0 instead of 2.0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -163,7 +163,7 @@ cat > ./package.json << EOF
     "start": "parse-server config.json"
   },
   "dependencies": {
-    "parse-server": "^2.0.0"
+    "parse-server": "^3.9.0"
   }
 }
 EOF


### PR DESCRIPTION
The script currently writes a package.json with a dependency on parse-server version 2.0. This should probably always be automatically updated to the latest version using some CI magic.