### PR TITLE
Prevent afterFind with saving objects

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2450,4 +2450,58 @@ describe('beforeLogin hook', () => {
     await Parse.User.logIn('tupac', 'shakur');
     done();
   });
+
+  it('afterFind should not be triggered when saving an object', async () => {
+    let beforeSaves = 0;
+    Parse.Cloud.beforeSave('SavingTest', () => {
+      beforeSaves++;
+    });
+
+    let afterSaves = 0;
+    Parse.Cloud.afterSave('SavingTest', () => {
+      afterSaves++;
+    });
+
+    let beforeFinds = 0;
+    Parse.Cloud.beforeFind('SavingTest', () => {
+      beforeFinds++;
+    });
+
+    let afterFinds = 0;
+    Parse.Cloud.afterFind('SavingTest', () => {
+      afterFinds++;
+    });
+
+    const obj = new Parse.Object('SavingTest');
+    obj.set('someField', 'some value 1');
+    await obj.save();
+
+    expect(beforeSaves).toEqual(1);
+    expect(afterSaves).toEqual(1);
+    expect(beforeFinds).toEqual(0);
+    expect(afterFinds).toEqual(0);
+
+    obj.set('someField', 'some value 2');
+    await obj.save();
+
+    expect(beforeSaves).toEqual(2);
+    expect(afterSaves).toEqual(2);
+    expect(beforeFinds).toEqual(0);
+    expect(afterFinds).toEqual(0);
+
+    await obj.fetch();
+
+    expect(beforeSaves).toEqual(2);
+    expect(afterSaves).toEqual(2);
+    expect(beforeFinds).toEqual(1);
+    expect(afterFinds).toEqual(1);
+
+    obj.set('someField', 'some value 3');
+    await obj.save();
+
+    expect(beforeSaves).toEqual(3);
+    expect(afterSaves).toEqual(3);
+    expect(beforeFinds).toEqual(1);
+    expect(afterFinds).toEqual(1);
+  });
 });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -24,7 +24,8 @@ function RestQuery(
   className,
   restWhere = {},
   restOptions = {},
-  clientSDK
+  clientSDK,
+  runAfterFind = true
 ) {
   this.config = config;
   this.auth = auth;
@@ -32,6 +33,7 @@ function RestQuery(
   this.restWhere = restWhere;
   this.restOptions = restOptions;
   this.clientSDK = clientSDK;
+  this.runAfterFind = runAfterFind;
   this.response = null;
   this.findOptions = {};
 
@@ -772,6 +774,9 @@ RestQuery.prototype.handleInclude = function() {
 //Returns a promise of a processed set of results
 RestQuery.prototype.runAfterFindTrigger = function() {
   if (!this.response) {
+    return;
+  }
+  if (!this.runAfterFind) {
     return;
   }
   // Avoid doing any setup for triggers if there is no 'afterFind' trigger for this class.

--- a/src/rest.js
+++ b/src/rest.js
@@ -225,7 +225,15 @@ function update(config, auth, className, restWhere, restObject, clientSDK) {
       const hasLiveQuery = checkLiveQuery(className, config);
       if (hasTriggers || hasLiveQuery) {
         // Do not use find, as it runs the before finds
-        return new RestQuery(config, auth, className, restWhere).execute({
+        return new RestQuery(
+          config,
+          auth,
+          className,
+          restWhere,
+          undefined,
+          undefined,
+          false
+        ).execute({
           op: 'update',
         });
       }


### PR DESCRIPTION
Fixes: https://github.com/parse-community/parse-server/issues/6088