### PR TITLE
fix(GraphQL): fix graphql mutations not returning updated information

### DIFF
--- a/src/GraphQL/loaders/parseClassMutations.js
+++ b/src/GraphQL/loaders/parseClassMutations.js
@@ -22,7 +22,7 @@ const getOnlyRequiredFields = (
   const missingFields = selectedFields
     .filter(
       field =>
-        (!updatedFields[field] && !nativeObjectFields.includes(field)) ||
+        !nativeObjectFields.includes(field) ||
         includedFields.includes(field)
     )
     .join(',');


### PR DESCRIPTION
This issue occurs when an updated field is modified in beforeSave, but the unmodified version is returned if requested by the resolver.

For example
```gql
mutation UpdateTitle($id: ID!, $title: String!) {
  updateSomeObject(id: $id, fields: { title: $title }) {
      id
      title
      slug
  }
}
```

In the above, if we modify the `title` by let's say, trimming it - the resolved `title` will not reflect this change, and instead just return the input variable. Other resolved fields that are not sent within the `fields` input are returned properly using the latest data.