### PR TITLE
Throw error when setting authData to null

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -479,19 +479,6 @@ describe('parseObjectToMongoObjectForCreate', () => {
     }).toThrow();
     done();
   });
-
-  it('ignores authData field in DB so it can be synthesized in code', done => {
-    const input = {
-      _id: '123',
-      _auth_data_acme: { id: 'abc' },
-      authData: null,
-    };
-    const output = transform.mongoObjectToParseObject(null, input, {
-      fields: {},
-    });
-    expect(output.authData.acme.id).toBe('abc');
-    done();
-  });
 });
 
 describe('transformUpdate', () => {

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -506,6 +506,21 @@ describe('parseObjectToMongoObjectForCreate', () => {
   });
 });
 
+it('cannot have a custom field name beginning with underscore', done => {
+  const input = {
+    _id: '123',
+    _thisFieldNameIs: 'invalid',
+  };
+  try {
+    transform.mongoObjectToParseObject('TestObject', input, {
+      fields: {},
+    });
+  } catch (e) {
+    expect(e).toBeDefined();
+  }
+  done();
+});
+
 describe('transformUpdate', () => {
   it('removes Relation types', done => {
     const input = {

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -479,6 +479,19 @@ describe('parseObjectToMongoObjectForCreate', () => {
     }).toThrow();
     done();
   });
+
+  it('ignores authData field in DB so it can be synthesized in code', done => {
+    const input = {
+      _id: '123',
+      _auth_data_acme: { id: 'abc' },
+      authData: null,
+    };
+    const output = transform.mongoObjectToParseObject(null, input, {
+      fields: {},
+    });
+    expect(output.authData.acme.id).toBe('abc');
+    done();
+  });
 });
 
 describe('transformUpdate', () => {

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -496,14 +496,12 @@ describe('parseObjectToMongoObjectForCreate', () => {
   it('can set authData when not User class', done => {
     const input = {
       _id: '123',
-      _auth_data_acme: { id: 'abc' },
       authData: 'random',
     };
     const output = transform.mongoObjectToParseObject('TestObject', input, {
       fields: {},
     });
     expect(output.authData).toBe('random');
-    expect(output._auth_data_acme).toBeUndefined();
     done();
   });
 });

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -486,7 +486,7 @@ describe('parseObjectToMongoObjectForCreate', () => {
       _auth_data_acme: { id: 'abc' },
       authData: null,
     };
-    const output = transform.mongoObjectToParseObject(null, input, {
+    const output = transform.mongoObjectToParseObject('_User', input, {
       fields: {},
     });
     expect(output.authData.acme.id).toBe('abc');

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -480,7 +480,7 @@ describe('parseObjectToMongoObjectForCreate', () => {
     done();
   });
 
-  it('ignores authData field in DB so it can be synthesized in code', done => {
+  it('ignores User authData field in DB so it can be synthesized in code', done => {
     const input = {
       _id: '123',
       _auth_data_acme: { id: 'abc' },
@@ -490,6 +490,20 @@ describe('parseObjectToMongoObjectForCreate', () => {
       fields: {},
     });
     expect(output.authData.acme.id).toBe('abc');
+    done();
+  });
+
+  it('can set authData when not User class', done => {
+    const input = {
+      _id: '123',
+      _auth_data_acme: { id: 'abc' },
+      authData: 'random',
+    };
+    const output = transform.mongoObjectToParseObject('TestObject', input, {
+      fields: {},
+    });
+    expect(output.authData).toBe('random');
+    expect(output._auth_data_acme).toBeUndefined();
     done();
   });
 });

--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -276,6 +276,16 @@ describe('Parse.Object testing', () => {
     done();
   });
 
+  it('can set authData when not user class', async () => {
+    const obj = new Parse.Object('TestObject');
+    obj.set('authData', 'random');
+    await obj.save();
+    expect(obj.get('authData')).toBe('random');
+    const query = new Parse.Query('TestObject');
+    const object = await query.get(obj.id, { useMasterKey: true });
+    expect(object.get('authData')).toBe('random');
+  });
+
   it('invalid class name', function(done) {
     const item = new Parse.Object('Foo^bar');
     item.save().then(

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1246,18 +1246,28 @@ describe('Parse.User testing', () => {
     done();
   });
 
-  it('log in with provider despite invalid authData field in DB', async done => {
-    const provider = getMockFacebookProvider();
-    Parse.User._registerAuthenticationProvider(provider);
-    const user = await Parse.User._logInWith('facebook');
-    user.set('authData', null);
-    await user.save();
-    let authData = user.get('authData');
-    expect(authData).toBe(null);
-    await user.fetch();
-    authData = user.get('authData');
-    expect(authData.facebook.id).toBeDefined();
-    done();
+  it('can not set authdata to null', async () => {
+    try {
+      const provider = getMockFacebookProvider();
+      Parse.User._registerAuthenticationProvider(provider);
+      const user = await Parse.User._logInWith('facebook');
+      user.set('authData', null);
+      await user.save();
+    } catch (e) {
+      expect(e.message).toBe('This authentication method is unsupported.');
+    }
+  });
+
+  it('can not set authdata to undefined', async () => {
+    try {
+      const provider = getMockFacebookProvider();
+      Parse.User._registerAuthenticationProvider(provider);
+      const user = await Parse.User._logInWith('facebook');
+      user.set('authData', undefined);
+      await user.save();
+    } catch (e) {
+      expect(e.message).toBe('This authentication method is unsupported.');
+    }
   });
 
   it('user authData should be available in cloudcode (#2342)', async done => {

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1246,7 +1246,7 @@ describe('Parse.User testing', () => {
     done();
   });
 
-  fit('log in with provider despite invalid authData field in DB', async done => {
+  it('log in with provider despite invalid authData field in DB', async done => {
     const provider = getMockFacebookProvider();
     Parse.User._registerAuthenticationProvider(provider);
     const user = await Parse.User._logInWith('facebook');

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1246,6 +1246,20 @@ describe('Parse.User testing', () => {
     done();
   });
 
+  fit('log in with provider despite invalid authData field in DB', async done => {
+    const provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    const user = await Parse.User._logInWith('facebook');
+    user.set('authData', null);
+    await user.save();
+    let authData = user.get('authData');
+    expect(authData).toBe(null);
+    await user.fetch();
+    authData = user.get('authData');
+    expect(authData.facebook.id).toBeDefined();
+    done();
+  });
+
   it('user authData should be available in cloudcode (#2342)', async done => {
     Parse.Cloud.define('checkLogin', req => {
       expect(req.user).not.toBeUndefined();

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1253,21 +1253,23 @@ describe('Parse.User testing', () => {
       const user = await Parse.User._logInWith('facebook');
       user.set('authData', null);
       await user.save();
+      fail();
     } catch (e) {
       expect(e.message).toBe('This authentication method is unsupported.');
     }
   });
 
-  it('can not set authdata to undefined', async () => {
-    try {
-      const provider = getMockFacebookProvider();
-      Parse.User._registerAuthenticationProvider(provider);
-      const user = await Parse.User._logInWith('facebook');
-      user.set('authData', undefined);
-      await user.save();
-    } catch (e) {
-      expect(e.message).toBe('This authentication method is unsupported.');
-    }
+  it('ignore setting authdata to undefined', async () => {
+    const provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    const user = await Parse.User._logInWith('facebook');
+    user.set('authData', undefined);
+    await user.save();
+    let authData = user.get('authData');
+    expect(authData).toBe(undefined);
+    await user.fetch();
+    authData = user.get('authData');
+    expect(authData.facebook.id).toBeDefined();
   });
 
   it('user authData should be available in cloudcode (#2342)', async done => {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1404,8 +1404,11 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
             restObject['timesUsed'] = mongoObject[key];
             break;
           case 'authData':
-            // Ignore `authData` in _User as this key is reserved to be synthesized of `_auth_data_*` keys
-            if (className !== '_User') {
+            if (className === '_User') {
+              log.warn(
+                'ignoring authData in _User as this key is reserved to be synthesized of `_auth_data_*` keys'
+              );
+            } else {
               restObject['authData'] = mongoObject[key];
             }
             break;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1412,7 +1412,7 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
           default:
             // Check other auth data keys
             var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
-            if (authDataMatch) {
+            if (authDataMatch && className === '_User') {
               var provider = authDataMatch[1];
               restObject['authData'] = restObject['authData'] || {};
               restObject['authData'][provider] = mongoObject[key];

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1404,7 +1404,10 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
             restObject['timesUsed'] = mongoObject[key];
             break;
           case 'authData':
-            // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
+            // Ignore `authData` in _User as this key is reserved to be synthesized of `_auth_data_*` keys
+            if (className !== '_User') {
+              restObject['authData'] = mongoObject[key];
+            }
             break;
           default:
             // Check other auth data keys

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1403,9 +1403,6 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
           case 'times_used':
             restObject['timesUsed'] = mongoObject[key];
             break;
-          case 'authData':
-            // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
-            break;
           default:
             // Check other auth data keys
             var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1403,6 +1403,9 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
           case 'times_used':
             restObject['timesUsed'] = mongoObject[key];
             break;
+          case 'authData':
+            // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
+            break;
           default:
             // Check other auth data keys
             var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1281,6 +1281,10 @@ export class PostgresStorageAdapter implements StorageAdapter {
       if (object[fieldName] === null) {
         return;
       }
+      if (fieldName === 'authData') {
+        // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
+        return;
+      }
       var authDataMatch = fieldName.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
       if (authDataMatch) {
         var provider = authDataMatch[1];

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1281,10 +1281,6 @@ export class PostgresStorageAdapter implements StorageAdapter {
       if (object[fieldName] === null) {
         return;
       }
-      if (fieldName === 'authData') {
-        // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
-        return;
-      }
       var authDataMatch = fieldName.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
       if (authDataMatch) {
         var provider = authDataMatch[1];
@@ -1885,6 +1881,10 @@ export class PostgresStorageAdapter implements StorageAdapter {
   // Does not strip out anything based on a lack of authentication.
   postgresObjectToParseObject(className: string, object: any, schema: any) {
     Object.keys(schema.fields).forEach(fieldName => {
+      if (fieldName === 'authData' && className === '_User') {
+        // Ignore `authData` in `_User` as this key is reserved to be synthesized of `_auth_data_*` keys
+        return;
+      }
       if (schema.fields[fieldName].type === 'Pointer' && object[fieldName]) {
         object[fieldName] = {
           objectId: object[fieldName],

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1529,8 +1529,10 @@ export class PostgresStorageAdapter implements StorageAdapter {
 
     for (const fieldName in update) {
       const fieldValue = update[fieldName];
-      // Drop any undefined values.
-      if (typeof fieldValue === 'undefined') {
+      if (fieldName === 'authData' && fieldValue === null) {
+        // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
+      } else if (typeof fieldValue === 'undefined') {
+        // Drop any undefined values.
         delete update[fieldName];
       } else if (fieldValue === null) {
         updatePatterns.push(`$${index}:name = NULL`);
@@ -1881,10 +1883,6 @@ export class PostgresStorageAdapter implements StorageAdapter {
   // Does not strip out anything based on a lack of authentication.
   postgresObjectToParseObject(className: string, object: any, schema: any) {
     Object.keys(schema.fields).forEach(fieldName => {
-      if (fieldName === 'authData' && className === '_User') {
-        // Ignore `authData` in `_User` as this key is reserved to be synthesized of `_auth_data_*` keys
-        return;
-      }
       if (schema.fields[fieldName].type === 'Pointer' && object[fieldName]) {
         object[fieldName] = {
           objectId: object[fieldName],

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1529,10 +1529,8 @@ export class PostgresStorageAdapter implements StorageAdapter {
 
     for (const fieldName in update) {
       const fieldValue = update[fieldName];
-      if (fieldName === 'authData' && fieldValue === null) {
-        // Ignore `authData` as this key is reserved to be synthesized of `_auth_data_*` keys
-      } else if (typeof fieldValue === 'undefined') {
-        // Drop any undefined values.
+      // Drop any undefined values.
+      if (typeof fieldValue === 'undefined') {
         delete update[fieldName];
       } else if (fieldValue === null) {
         updatePatterns.push(`$${index}:name = NULL`);

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -417,8 +417,21 @@ RestWrite.prototype.validateAuthData = function() {
     }
   }
 
-  if (!this.data.authData || !Object.keys(this.data.authData).length) {
+  if (
+    (this.data.authData && !Object.keys(this.data.authData).length) ||
+    !Object.prototype.hasOwnProperty.call(this.data, 'authData')
+  ) {
+    // Handle saving authData to {} or if authData doesn't exist
     return;
+  } else if (
+    Object.prototype.hasOwnProperty.call(this.data, 'authData') &&
+    !this.data.authData
+  ) {
+    // Handle saving authData to null
+    throw new Parse.Error(
+      Parse.Error.UNSUPPORTED_SERVICE,
+      'This authentication method is unsupported.'
+    );
   }
 
   var authData = this.data.authData;


### PR DESCRIPTION
Fixed `authData` field in DB overwriting synthesized `authData` field that contains values of `_auth_data_*` fields.

Fixed only for mongoDB & Postgres.