### PR TITLE
Move filename validation out of the Router and into the FilesAdaptor

### DIFF
--- a/spec/AdaptableController.spec.js
+++ b/spec/AdaptableController.spec.js
@@ -64,6 +64,7 @@ describe('AdaptableController', () => {
       deleteFile: function() {},
       getFileData: function() {},
       getFileLocation: function() {},
+      validateFilename: function() {},
     };
     expect(() => {
       new FilesController(adapter);
@@ -77,6 +78,7 @@ describe('AdaptableController', () => {
     AGoodAdapter.prototype.deleteFile = function() {};
     AGoodAdapter.prototype.getFileData = function() {};
     AGoodAdapter.prototype.getFileLocation = function() {};
+    AGoodAdapter.prototype.validateFilename = function() {};
 
     const adapter = new AGoodAdapter();
     expect(() => {

--- a/spec/AdapterLoader.spec.js
+++ b/spec/AdapterLoader.spec.js
@@ -43,6 +43,7 @@ describe('AdapterLoader', () => {
     expect(typeof adapter.deleteFile).toBe('function');
     expect(typeof adapter.getFileData).toBe('function');
     expect(typeof adapter.getFileLocation).toBe('function');
+    expect(typeof adapter.validateFilename).toBe('function');
     done();
   });
 
@@ -56,6 +57,8 @@ describe('AdapterLoader', () => {
     expect(typeof adapter.deleteFile).toBe('function');
     expect(typeof adapter.getFileData).toBe('function');
     expect(typeof adapter.getFileLocation).toBe('function');
+    // Older adapters won't implement this
+    // expect(typeof adapter.validateFilename).toBe('function');
     done();
   });
 

--- a/spec/AdapterLoader.spec.js
+++ b/spec/AdapterLoader.spec.js
@@ -43,7 +43,6 @@ describe('AdapterLoader', () => {
     expect(typeof adapter.deleteFile).toBe('function');
     expect(typeof adapter.getFileData).toBe('function');
     expect(typeof adapter.getFileLocation).toBe('function');
-    expect(typeof adapter.validateFilename).toBe('function');
     done();
   });
 
@@ -57,8 +56,6 @@ describe('AdapterLoader', () => {
     expect(typeof adapter.deleteFile).toBe('function');
     expect(typeof adapter.getFileData).toBe('function');
     expect(typeof adapter.getFileLocation).toBe('function');
-    // Older adapters won't implement this
-    // expect(typeof adapter.validateFilename).toBe('function');
     done();
   });
 

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -14,6 +14,7 @@ const mockAdapter = {
   deleteFile: () => {},
   getFileData: () => {},
   getFileLocation: () => 'xyz',
+  validateFilename: () => {},
 };
 
 // Small additional tests to improve overall coverage
@@ -116,6 +117,15 @@ describe('FilesController', () => {
       fileName
     );
 
+    done();
+  });
+
+  it('should reject slashes in file names', done => {
+    const gridStoreAdapter = new GridFSBucketAdapter(
+      'mongodb://localhost:27017/parse'
+    );
+    const fileName = 'foo/randomFileName.pdf';
+    expect(gridStoreAdapter.validateFilename(fileName)).not.toBe(null);
     done();
   });
 });

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -4,6 +4,8 @@ const WinstonLoggerAdapter = require('../lib/Adapters/Logger/WinstonLoggerAdapte
   .WinstonLoggerAdapter;
 const GridFSBucketAdapter = require('../lib/Adapters/Files/GridFSBucketAdapter')
   .GridFSBucketAdapter;
+const GridStoreAdapter = require('../lib/Adapters/Files/GridStoreAdapter')
+  .GridStoreAdapter;
 const Config = require('../lib/Config');
 const FilesController = require('../lib/Controllers/FilesController').default;
 
@@ -122,6 +124,15 @@ describe('FilesController', () => {
 
   it('should reject slashes in file names', done => {
     const gridStoreAdapter = new GridFSBucketAdapter(
+      'mongodb://localhost:27017/parse'
+    );
+    const fileName = 'foo/randomFileName.pdf';
+    expect(gridStoreAdapter.validateFilename(fileName)).not.toBe(null);
+    done();
+  });
+
+  it('should also reject slashes in file names', done => {
+    const gridStoreAdapter = new GridStoreAdapter(
       'mongodb://localhost:27017/parse'
     );
     const fileName = 'foo/randomFileName.pdf';

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -16,7 +16,7 @@
 // database adapter.
 
 import type { Config } from '../../Config';
-import Parse from 'parse/lib/node/Parse';
+import Parse from 'parse/node';
 /**
  * @module Adapters
  */
@@ -60,28 +60,26 @@ export class FilesAdapter {
    */
   getFileLocation(config: Config, filename: string): string {}
 
-  /** Validate a filename for this adaptor type (optional)1G
+  /** Validate a filename for this adapter type
    *
    * @param {string} filename
    *
-   * @returns {null|*|Parse.Error} null if there are no errors
+   * @returns {null|Parse.Error} null if there are no errors
    */
-  // TODO: Make this required once enough people have updated their adaptors
-  // validateFilename(filename): ?Parse.Error {}
+  validateFilename(filename: string): ?Parse.Error {}
 }
 
 /**
- * Default filename validate pulled out of FilesRouter.  Mostly used for Mongo storage
+ * Simple filename validation
  *
  * @param filename
- * @returns {null|*|Parse.Error|Parse.ParseError|ParseError|ParseError|Parse.ParseError}
+ * @returns {null|Parse.Error}
  */
 export function validateFilename(filename): ?Parse.Error {
   if (filename.length > 128) {
     return new Parse.Error(Parse.Error.INVALID_FILE_NAME, 'Filename too long.');
   }
 
-  // US/ASCII centric default
   const regx = /^[_a-zA-Z0-9][a-zA-Z0-9@. ~_-]*$/;
   if (!filename.match(regx)) {
     return new Parse.Error(
@@ -89,7 +87,7 @@ export function validateFilename(filename): ?Parse.Error {
       'Filename contains invalid characters.'
     );
   }
-  return null; // No errors
+  return null;
 }
 
 export default FilesAdapter;

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -10,6 +10,7 @@
 // * getFileLocation(config, filename)
 // Adapter classes should implement the following functions:
 // * validateFilename(filename)
+// * handleFileStream(filename, req, res, contentType)
 //
 // Default is GridFSBucketAdapter, which requires mongo
 // and for the API server to be using the DatabaseController with Mongo
@@ -66,7 +67,18 @@ export class FilesAdapter {
    *
    * @returns {null|Parse.Error} null if there are no errors
    */
-  validateFilename(filename: string): ?Parse.Error {}
+  // validateFilename(filename: string): ?Parse.Error {}
+
+  /** Handles Byte-Range Requests for Streaming
+   *
+   * @param {string} filename
+   * @param {object} req
+   * @param {object} res
+   * @param {string} contentType
+   *
+   * @returns {Promise} Data for byte range
+   */
+  // handleFileStream(filename: string, res: any, req: any, contentType: string): Promise
 }
 
 /**

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -8,12 +8,15 @@
 // * deleteFile(filename)
 // * getFileData(filename)
 // * getFileLocation(config, filename)
+// Adapter classes should implement the following functions:
+// * validateFilename(filename)
 //
 // Default is GridFSBucketAdapter, which requires mongo
 // and for the API server to be using the DatabaseController with Mongo
 // database adapter.
 
 import type { Config } from '../../Config';
+import Parse from 'parse/lib/node/Parse';
 /**
  * @module Adapters
  */
@@ -56,6 +59,37 @@ export class FilesAdapter {
    * @return {string} Absolute URL
    */
   getFileLocation(config: Config, filename: string): string {}
+
+  /** Validate a filename for this adaptor type (optional)1G
+   *
+   * @param {string} filename
+   *
+   * @returns {null|*|Parse.Error} null if there are no errors
+   */
+  // TODO: Make this required once enough people have updated their adaptors
+  // validateFilename(filename): ?Parse.Error {}
+}
+
+/**
+ * Default filename validate pulled out of FilesRouter.  Mostly used for Mongo storage
+ *
+ * @param filename
+ * @returns {null|*|Parse.Error|Parse.ParseError|ParseError|ParseError|Parse.ParseError}
+ */
+export function validateFilename(filename): ?Parse.Error {
+  if (filename.length > 128) {
+    return new Parse.Error(Parse.Error.INVALID_FILE_NAME, 'Filename too long.');
+  }
+
+  // US/ASCII centric default
+  const regx = /^[_a-zA-Z0-9][a-zA-Z0-9@. ~_-]*$/;
+  if (!filename.match(regx)) {
+    return new Parse.Error(
+      Parse.Error.INVALID_FILE_NAME,
+      'Filename contains invalid characters.'
+    );
+  }
+  return null; // No errors
 }
 
 export default FilesAdapter;

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -8,7 +8,7 @@
 
 // @flow-disable-next
 import { MongoClient, GridFSBucket, Db } from 'mongodb';
-import { FilesAdapter } from './FilesAdapter';
+import { FilesAdapter, validateFilename } from './FilesAdapter';
 import defaults from '../../defaults';
 
 export class GridFSBucketAdapter extends FilesAdapter {
@@ -138,6 +138,10 @@ export class GridFSBucketAdapter extends FilesAdapter {
       return Promise.resolve();
     }
     return this._client.close(false);
+  }
+
+  validateFilename(filename) {
+    return validateFilename(filename);
   }
 }
 

--- a/src/Adapters/Files/GridStoreAdapter.js
+++ b/src/Adapters/Files/GridStoreAdapter.js
@@ -9,7 +9,7 @@
 
 // @flow-disable-next
 import { MongoClient, GridStore, Db } from 'mongodb';
-import { FilesAdapter } from './FilesAdapter';
+import { FilesAdapter, validateFilename } from './FilesAdapter';
 import defaults from '../../defaults';
 
 export class GridStoreAdapter extends FilesAdapter {
@@ -109,6 +109,10 @@ export class GridStoreAdapter extends FilesAdapter {
       return Promise.resolve();
     }
     return this._client.close(false);
+  }
+
+  validateFilename(filename) {
+    return validateFilename(filename);
   }
 }
 

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -1,7 +1,7 @@
 // FilesController.js
 import { randomHexString } from '../cryptoUtils';
 import AdaptableController from './AdaptableController';
-import { FilesAdapter } from '../Adapters/Files/FilesAdapter';
+import { validateFilename, FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path from 'path';
 import mime from 'mime';
 
@@ -94,6 +94,13 @@ export class FilesController extends AdaptableController {
 
   handleFileStream(config, filename, req, res, contentType) {
     return this.adapter.handleFileStream(filename, req, res, contentType);
+  }
+
+  validateFilename(filename) {
+    if (typeof this.adapter.validateFilename === 'function') {
+      return this.adapter.validateFilename(filename);
+    }
+    return validateFilename(filename);
   }
 }
 

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -69,6 +69,11 @@ export class FilesRouter {
   }
 
   createHandler(req, res, next) {
+    const config = req.config;
+    const filesController = config.filesController;
+    const filename = req.params.filename;
+    const contentType = req.get('Content-type');
+
     if (!req.body || !req.body.length) {
       next(
         new Parse.Error(Parse.Error.FILE_SAVE_ERROR, 'Invalid file upload.')
@@ -76,27 +81,11 @@ export class FilesRouter {
       return;
     }
 
-    if (req.params.filename.length > 128) {
-      next(
-        new Parse.Error(Parse.Error.INVALID_FILE_NAME, 'Filename too long.')
-      );
+    const error = filesController.validateFilename(filename);
+    if (error) {
+      next(error);
       return;
     }
-
-    if (!req.params.filename.match(/^[_a-zA-Z0-9][a-zA-Z0-9@\.\ ~_-]*$/)) {
-      next(
-        new Parse.Error(
-          Parse.Error.INVALID_FILE_NAME,
-          'Filename contains invalid characters.'
-        )
-      );
-      return;
-    }
-
-    const filename = req.params.filename;
-    const contentType = req.get('Content-type');
-    const config = req.config;
-    const filesController = config.filesController;
 
     filesController
       .createFile(config, filename, req.body, contentType)


### PR DESCRIPTION
Didn't seem to make sense to me that the router would be deciding the syntax of my filenames.   Specifically, I wanted to be able to create "directories" in AWS, and the router was rejecting the '/' character.    Note, there is no behavior change in this code WRT how / is treated in a filename, because there is no AWS code here.   That's a decision for the FilesAdaptor