### PR TITLE
Added warning for special URL sensitive characters for appId

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -26,6 +26,14 @@ describe('server', () => {
       });
   });
 
+  it('show warning if any reserved characters in appId', done => {
+    spyOn(console, 'warn').and.callThrough();
+    reconfigureServer({ appId: 'test!-^' }).then(() => {
+      expect(console.warn).toHaveBeenCalled();
+      return done();
+    });
+  });
+
   it('support http basic authentication with masterkey', done => {
     reconfigureServer({ appId: 'test' }).then(() => {
       request({

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -376,34 +376,12 @@ function injectDefaults(options: ParseServerOptions) {
     options.serverURL = `http://localhost:${options.port}${options.mountPath}`;
   }
 
+  // Reserved Characters
   if (options.appId) {
-    const reservedCharacters = [
-      '!',
-      '#',
-      '$',
-      '%',
-      '&',
-      "'",
-      '(',
-      ')',
-      '*',
-      '+',
-      '/',
-      ':',
-      ';',
-      '=',
-      '?',
-      '@',
-      '[',
-      ']',
-    ];
-    if (
-      reservedCharacters.some(function(v) {
-        return options.appId.indexOf(v) >= 0;
-      })
-    ) {
+    const regex = /[!#$%'()*+&/:;=?@[\]{}^,|<>]/g;
+    if (options.appId.match(regex)) {
       console.warn(
-        `\nappId is containing some special characters that can cause issues while using with urls.\n`
+        `\nWARNING, appId that contains special characters can cause issues while using with urls.\n`
       );
     }
   }

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -376,6 +376,38 @@ function injectDefaults(options: ParseServerOptions) {
     options.serverURL = `http://localhost:${options.port}${options.mountPath}`;
   }
 
+  if (options.appId) {
+    const reservedCharacters = [
+      '!',
+      '#',
+      '$',
+      '%',
+      '&',
+      "'",
+      '(',
+      ')',
+      '*',
+      '+',
+      '/',
+      ':',
+      ';',
+      '=',
+      '?',
+      '@',
+      '[',
+      ']',
+    ];
+    if (
+      reservedCharacters.some(function(v) {
+        return options.appId.indexOf(v) >= 0;
+      })
+    ) {
+      console.warn(
+        `\nappId is containing some special characters that can cause issues while using with urls.\n`
+      );
+    }
+  }
+
   // Backwards compatibility
   if (options.userSensitiveFields) {
     /* eslint-disable no-console */


### PR DESCRIPTION
If we use reserved and unwise character in context of a URI/URL inside an Application ID, it can create issues in many cases such as:

1. The rendered URL for a password reset, email verification won't work as it fails to be rendered in the actual application id resulted in unauthorized. 
2. The file download will be an issue as parse uses application id in the URL too. 

So I included a warning message for some reserved character in the context of URL which can cause problems where application id is included in a URL.