### PR TITLE
Remove Parse.Error dependency from FileAdapters.  Bump version number for fileNameValidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "An express module providing a Parse-compatible API server",
   "main": "lib/index.js",
   "repository": {

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -65,9 +65,9 @@ export class FilesAdapter {
    *
    * @param {string} filename
    *
-   * @returns {null|Parse.Error} null if there are no errors
+   * @returns {null|string} error message or null if there are no errors
    */
-  // validateFilename(filename: string): ?Parse.Error {}
+  // validateFilename(filename: string): ?string {}
 
   /** Handles Byte-Range Requests for Streaming
    *
@@ -89,15 +89,12 @@ export class FilesAdapter {
  */
 export function validateFilename(filename): ?Parse.Error {
   if (filename.length > 128) {
-    return new Parse.Error(Parse.Error.INVALID_FILE_NAME, 'Filename too long.');
+    return 'Filename too long.';
   }
 
   const regx = /^[_a-zA-Z0-9][a-zA-Z0-9@. ~_-]*$/;
   if (!filename.match(regx)) {
-    return new Parse.Error(
-      Parse.Error.INVALID_FILE_NAME,
-      'Filename contains invalid characters.'
-    );
+    return 'Filename contains invalid characters.';
   }
   return null;
 }

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -4,6 +4,7 @@ import AdaptableController from './AdaptableController';
 import { validateFilename, FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path from 'path';
 import mime from 'mime';
+import Parse from 'parse/node';
 
 const legacyFilesRegex = new RegExp(
   '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-.*'
@@ -97,10 +98,17 @@ export class FilesController extends AdaptableController {
   }
 
   validateFilename(filename) {
+    var errormsg;
     if (typeof this.adapter.validateFilename === 'function') {
-      return this.adapter.validateFilename(filename);
+      errormsg = this.adapter.validateFilename(filename);
+    } else {
+      errormsg = validateFilename(filename);
     }
-    return validateFilename(filename);
+
+    if (errormsg) {
+      return new Parse.Error(Parse.Error.INVALID_FILE_NAME, errormsg);
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
FileAdapters are no longer required to create Parse.Error object.
Minor version?  #flameon