### PR TITLE
Fix installationId on LiveQuery connect

### DIFF
--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -337,7 +337,6 @@ describe('ParseLiveQueryServer', function() {
       query: query,
       requestId: requestId,
       sessionToken: 'sessionToken',
-      installationId: 'installationId',
     };
     parseLiveQueryServer._handleSubscribe(parseWebSocket, request);
 
@@ -360,7 +359,6 @@ describe('ParseLiveQueryServer', function() {
     expect(args[0]).toBe(requestId);
     expect(args[1].fields).toBe(query.fields);
     expect(args[1].sessionToken).toBe(request.sessionToken);
-    expect(args[1].installationId).toBe(request.installationId);
     // Make sure we send subscribe response to the client
     expect(client.pushSubscribe).toHaveBeenCalledWith(requestId);
   });
@@ -518,6 +516,7 @@ describe('ParseLiveQueryServer', function() {
     const connectRequest = {
       op: 'connect',
       applicationId: '1',
+      installationId: '1234',
     };
     // Trigger message event
     parseWebSocket.emit('message', connectRequest);

--- a/src/LiveQuery/Client.js
+++ b/src/LiveQuery/Client.js
@@ -16,6 +16,7 @@ class Client {
   parseWebSocket: any;
   hasMasterKey: boolean;
   sessionToken: string;
+  installationId: string;
   userId: string;
   roles: Array<string>;
   subscriptionInfos: Object;
@@ -32,12 +33,14 @@ class Client {
     id: number,
     parseWebSocket: any,
     hasMasterKey: boolean = false,
-    sessionToken: string
+    sessionToken: string,
+    installationId: string
   ) {
     this.id = id;
     this.parseWebSocket = parseWebSocket;
     this.hasMasterKey = hasMasterKey;
     this.sessionToken = sessionToken;
+    this.installationId = installationId;
     this.roles = [];
     this.subscriptionInfos = new Map();
     this.pushConnect = this._pushEvent('connected');
@@ -93,6 +96,7 @@ class Client {
       const response: Message = {
         op: type,
         clientId: this.id,
+        installationId: this.installationId,
       };
       if (typeof subscriptionId !== 'undefined') {
         response['requestId'] = subscriptionId;

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -584,7 +584,8 @@ class ParseLiveQueryServer {
       clientId,
       parseWebsocket,
       hasMasterKey,
-      request.sessionToken
+      request.sessionToken,
+      request.installationId
     );
     parseWebsocket.clientId = clientId;
     this.clients.set(parseWebsocket.clientId, client);
@@ -679,9 +680,6 @@ class ParseLiveQueryServer {
     if (request.sessionToken) {
       subscriptionInfo.sessionToken = request.sessionToken;
     }
-    if (request.installationId) {
-      subscriptionInfo.installationId = request.installationId;
-    }
     client.addSubscriptionInfo(request.requestId, subscriptionInfo);
 
     // Add clientId to subscription
@@ -703,7 +701,7 @@ class ParseLiveQueryServer {
       subscriptions: this.subscriptions.size,
       sessionToken: request.sessionToken,
       useMasterKey: client.hasMasterKey,
-      installationId: request.installationId,
+      installationId: client.installationId,
     });
   }
 
@@ -785,7 +783,7 @@ class ParseLiveQueryServer {
       subscriptions: this.subscriptions.size,
       sessionToken: subscriptionInfo.sessionToken,
       useMasterKey: client.hasMasterKey,
-      installationId: subscriptionInfo.installationId,
+      installationId: client.installationId,
     });
 
     if (!notifyClient) {

--- a/src/LiveQuery/RequestSchema.js
+++ b/src/LiveQuery/RequestSchema.js
@@ -36,6 +36,9 @@ const connect = {
     sessionToken: {
       type: 'string',
     },
+    installationId: {
+      type: 'string',
+    },
   },
   required: ['op', 'applicationId'],
   additionalProperties: false,


### PR DESCRIPTION
Throws an error and prevents LiveQuery from reconnecting.

Fixes Monitoring installationId.
Allow installationId to be sent to and from client.

To be used with: https://github.com/parse-community/Parse-SDK-JS/pull/977