### PR TITLE
Add funding link

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
     "url": "https://opencollective.com/parse-server",
     "logo": "https://opencollective.com/parse-server/logo.txt?reverse=true&variant=binary"
   },
+  “funding”: {
+    “type”: “opencollective”,
+    “url”: “https://opencollective.com/parse-server”
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/package.json
+++ b/package.json
@@ -119,9 +119,9 @@
     "url": "https://opencollective.com/parse-server",
     "logo": "https://opencollective.com/parse-server/logo.txt?reverse=true&variant=binary"
   },
-  “funding”: {
-    “type”: “opencollective”,
-    “url”: “https://opencollective.com/parse-server”
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parse-server"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
I got an email from open collective saying that npm added a new funding property to v6.13; allowing people to use `npm fund` to find out funding info about all of the packages they have installed.

Seems like a no brainier.