### PR TITLE
added afterLogout trigger

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2457,17 +2457,18 @@ describe('beforeLogin hook', () => {
   });
 
   it('should trigger afterLogout hook on logout', async done => {
-    let hit = 0;
+    let userId;
     Parse.Cloud.afterLogout(req => {
-      hit++;
       expect(req.object.className).toEqual('_Session');
       expect(req.object.id).toBeDefined();
+      const user = req.object.get('user');
+      expect(user).toBeDefined();
+      userId = user.id;
     });
 
     const user = await Parse.User.signUp('user', 'pass');
-    await user.save();
     await Parse.User.logOut();
-    expect(hit).toBe(1);
+    expect(user.id).toBe(userId);
     done();
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2219,10 +2219,14 @@ describe('afterFind hooks', () => {
   it('should validate triggers correctly', () => {
     expect(() => {
       Parse.Cloud.beforeSave('_Session', () => {});
-    }).toThrow('Triggers are not supported for _Session class.');
+    }).toThrow(
+      'Only the afterLogout trigger is allowed for the _Session class.'
+    );
     expect(() => {
       Parse.Cloud.afterSave('_Session', () => {});
-    }).toThrow('Triggers are not supported for _Session class.');
+    }).toThrow(
+      'Only the afterLogout trigger is allowed for the _Session class.'
+    );
     expect(() => {
       Parse.Cloud.beforeSave('_PushStatus', () => {});
     }).toThrow('Only afterSave is allowed on _PushStatus');
@@ -2247,6 +2251,22 @@ describe('afterFind hooks', () => {
     expect(() => {
       Parse.Cloud.beforeLogin('SomeClass', () => {});
     }).toThrow('Only the _User class is allowed for the beforeLogin trigger');
+    expect(() => {
+      Parse.Cloud.afterLogout(() => {});
+    }).not.toThrow();
+    expect(() => {
+      Parse.Cloud.afterLogout('_Session', () => {});
+    }).not.toThrow();
+    expect(() => {
+      Parse.Cloud.afterLogout('_User', () => {});
+    }).toThrow(
+      'Only the _Session class is allowed for the afterLogout trigger.'
+    );
+    expect(() => {
+      Parse.Cloud.afterLogout('SomeClass', () => {});
+    }).toThrow(
+      'Only the _Session class is allowed for the afterLogout trigger.'
+    );
   });
 
   it('should skip afterFind hooks for aggregate', done => {
@@ -2433,6 +2453,19 @@ describe('beforeLogin hook', () => {
     const user = await Parse.User.signUp('tupac', 'shakur');
     expect(user).toBeDefined();
     expect(hit).toBe(0);
+    done();
+  });
+
+  it('should trigger afterLogout hook on logout', async done => {
+    let hit = 0;
+    Parse.Cloud.afterLogout(() => {
+      hit++;
+    });
+
+    const user = await Parse.User.signUp('user', 'pass');
+    await user.save();
+    await Parse.User.logOut();
+    expect(hit).toBe(1);
     done();
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2458,8 +2458,10 @@ describe('beforeLogin hook', () => {
 
   it('should trigger afterLogout hook on logout', async done => {
     let hit = 0;
-    Parse.Cloud.afterLogout(() => {
+    Parse.Cloud.afterLogout(req => {
       hit++;
+      expect(req.object.className).toEqual('_Session');
+      expect(req.object.id).toBeDefined();
     });
 
     const user = await Parse.User.signUp('user', 'pass');

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1523,6 +1523,21 @@ describe('Parse.User testing', () => {
     done();
   });
 
+  it('logout with provider should call afterLogout trigger', async done => {
+    const provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+
+    let hit = 0;
+    Parse.Cloud.afterLogout(() => {
+      hit++;
+    });
+    await Parse.User._logInWith('facebook');
+    await Parse.User.current().save({ name: 'user' });
+    await Parse.User.logOut();
+    expect(hit).toBe(1);
+    done();
+  });
+
   it('link with provider', async done => {
     const provider = getMockFacebookProvider();
     Parse.User._registerAuthenticationProvider(provider);

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1527,16 +1527,17 @@ describe('Parse.User testing', () => {
     const provider = getMockFacebookProvider();
     Parse.User._registerAuthenticationProvider(provider);
 
-    let hit = 0;
+    let userId;
     Parse.Cloud.afterLogout(req => {
-      hit++;
       expect(req.object.className).toEqual('_Session');
       expect(req.object.id).toBeDefined();
+      const user = req.object.get('user');
+      expect(user).toBeDefined();
+      userId = user.id;
     });
-    await Parse.User._logInWith('facebook');
-    await Parse.User.current().save({ name: 'user' });
+    const user = await Parse.User._logInWith('facebook');
     await Parse.User.logOut();
-    expect(hit).toBe(1);
+    expect(user.id).toBe(userId);
     done();
   });
 

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1528,8 +1528,10 @@ describe('Parse.User testing', () => {
     Parse.User._registerAuthenticationProvider(provider);
 
     let hit = 0;
-    Parse.Cloud.afterLogout(() => {
+    Parse.Cloud.afterLogout(req => {
       hit++;
+      expect(req.object.className).toEqual('_Session');
+      expect(req.object.id).toBeDefined();
     });
     await Parse.User._logInWith('facebook');
     await Parse.User.current().save({ name: 'user' });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -321,6 +321,33 @@ RestWrite.prototype.runBeforeLoginTrigger = async function(userData) {
   );
 };
 
+RestWrite.prototype.runAfterLogoutTrigger = async function(sessionData) {
+  // Avoid doing any setup for triggers if there is no 'afterLogout' trigger
+  if (
+    !triggers.triggerExists(
+      this.className,
+      triggers.Types.afterLogout,
+      this.config.applicationId
+    )
+  ) {
+    return;
+  }
+
+  // Cloud code gets a bit of extra data for its objects
+  const extraData = { className: this.className };
+  const session = triggers.inflate(extraData, sessionData);
+
+  // no need to return a response
+  await triggers.maybeRunTrigger(
+    triggers.Types.afterLogout,
+    this.auth,
+    session,
+    null,
+    this.config,
+    this.context
+  );
+};
+
 RestWrite.prototype.setRequiredFieldsIfNeeded = function() {
   if (this.data) {
     return this.validSchemaController.getAllClasses().then(allClasses => {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -321,33 +321,6 @@ RestWrite.prototype.runBeforeLoginTrigger = async function(userData) {
   );
 };
 
-RestWrite.prototype.runAfterLogoutTrigger = async function(sessionData) {
-  // Avoid doing any setup for triggers if there is no 'afterLogout' trigger
-  if (
-    !triggers.triggerExists(
-      this.className,
-      triggers.Types.afterLogout,
-      this.config.applicationId
-    )
-  ) {
-    return;
-  }
-
-  // Cloud code gets a bit of extra data for its objects
-  const extraData = { className: this.className };
-  const session = triggers.inflate(extraData, sessionData);
-
-  // no need to return a response
-  await triggers.maybeRunTrigger(
-    triggers.Types.afterLogout,
-    this.auth,
-    session,
-    null,
-    this.config,
-    this.context
-  );
-};
-
 RestWrite.prototype.setRequiredFieldsIfNeeded = function() {
   if (this.data) {
     return this.validSchemaController.getAllClasses().then(allClasses => {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -302,6 +302,7 @@ export class UsersRouter extends ClassesRouter {
                 records.results[0].objectId
               )
               .then(() => {
+                this._runAfterLogoutTrigger(req, records.results[0]);
                 return Promise.resolve(success);
               });
           }
@@ -309,6 +310,17 @@ export class UsersRouter extends ClassesRouter {
         });
     }
     return Promise.resolve(success);
+  }
+
+  _runAfterLogoutTrigger(req, session) {
+    // After logout trigger
+    maybeRunTrigger(
+      TriggerTypes.afterLogout,
+      req.auth,
+      Parse.Session.fromJSON(Object.assign({ className: '_Session' }, session)),
+      null,
+      req.config
+    );
   }
 
   _throwOnBadEmailConfig(req) {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -166,6 +166,41 @@ ParseCloud.beforeLogin = function(handler) {
 };
 
 /**
+ *
+ * Registers the after logout function.
+ *
+ * **Available in Cloud Code only.**
+ *
+ * This function is triggered after a user logs out.
+ *
+ * ```
+ * Parse.Cloud.afterLogout((request) => {
+ *   // code here
+ * })
+ *
+ * ```
+ *
+ * @method afterLogout
+ * @name Parse.Cloud.afterLogout
+ * @param {Function} func The function to run after a logout. This function can be async and should take one parameter a {@link Parse.Cloud.TriggerRequest};
+ */
+ParseCloud.afterLogout = function(handler) {
+  let className = '_Session';
+  if (typeof handler === 'string' || isParseObjectConstructor(handler)) {
+    // validation will occur downstream, this is to maintain internal
+    // code consistency with the other hook types.
+    className = getClassName(handler);
+    handler = arguments[1];
+  }
+  triggers.addTrigger(
+    triggers.Types.afterLogout,
+    className,
+    handler,
+    Parse.applicationId
+  );
+};
+
+/**
  * Registers an after save function.
  *
  * **Available in Cloud Code only.**

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -33,11 +33,6 @@ const baseStore = function() {
 };
 
 function validateClassNameForTriggers(className, type) {
-  // Contains classes which do not allow triggers of any kind
-  const restrictedClassNames = [];
-  if (restrictedClassNames.indexOf(className) != -1) {
-    throw `Triggers are not supported for ${className} class.`;
-  }
   if (type == Types.beforeSave && className === '_PushStatus') {
     // _PushStatus uses undocumented nested key increment ops
     // allowing beforeSave would mess up the objects big time

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -4,6 +4,7 @@ import { logger } from './logger';
 
 export const Types = {
   beforeLogin: 'beforeLogin',
+  afterLogout: 'afterLogout',
   beforeSave: 'beforeSave',
   afterSave: 'afterSave',
   beforeDelete: 'beforeDelete',
@@ -32,7 +33,8 @@ const baseStore = function() {
 };
 
 function validateClassNameForTriggers(className, type) {
-  const restrictedClassNames = ['_Session'];
+  // Contains classes which do not allow triggers of any kind
+  const restrictedClassNames = [];
   if (restrictedClassNames.indexOf(className) != -1) {
     throw `Triggers are not supported for ${className} class.`;
   }
@@ -46,6 +48,16 @@ function validateClassNameForTriggers(className, type) {
     // TODO: check if upstream code will handle `Error` instance rather
     // than this anti-pattern of throwing strings
     throw 'Only the _User class is allowed for the beforeLogin trigger';
+  }
+  if (type === Types.afterLogout && className !== '_Session') {
+    // TODO: check if upstream code will handle `Error` instance rather
+    // than this anti-pattern of throwing strings
+    throw 'Only the _Session class is allowed for the afterLogout trigger.';
+  }
+  if (className === '_Session' && type !== Types.afterLogout) {
+    // TODO: check if upstream code will handle `Error` instance rather
+    // than this anti-pattern of throwing strings
+    throw 'Only the afterLogout trigger is allowed for the _Session class.';
   }
   return className;
 }


### PR DESCRIPTION
Analogous to the existing `beforeLogin` trigger, this `afterLogout` trigger can be used to perform certain clean-up actions upon user logout.

The `afterLogout` trigger contains the `_Session` object that was deleted. Usually, a session object contains a pointer to a `_User` object with which the session is associated. With that, actions can be taken for the specific user that logged out.

Caveat:
The `afterLogout` is only triggered when a session object was deleted upon logout. If a user logs out but there is not session object to be deleted, the `afterLogout` trigger is not called. This is by design, because without a session object to determine _who_ logged out, the `afterLogout` trigger does not seem useful.