### PR TITLE
Add LDAP auth module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "graphql-upload": "8.1.0",
     "intersect": "1.0.1",
     "jsonwebtoken": "8.5.1",
+    "ldapjs": "^1.0.2",
     "lodash": "4.17.15",
     "lru-cache": "5.1.1",
     "mime": "2.4.4",

--- a/spec/LdapAuth.spec.js
+++ b/spec/LdapAuth.spec.js
@@ -1,0 +1,85 @@
+const ldap = require('../lib/Adapters/Auth/ldap');
+const mockLdapServer = require('./MockLdapServer');
+
+it('Should fail with missing options', done => {
+  try {
+    ldap.validateAuthData({ id: 'testuser', password: 'testpw' });
+  } catch (error) {
+    jequal(error.message, 'LDAP auth configuration missing');
+    done();
+  }
+});
+
+it('Should succeed with right credentials', done => {
+  mockLdapServer(1010, 'uid=testuser, o=example').then(server => {
+    const options = {
+      suffix: 'o=example',
+      url: 'ldap://localhost:1010',
+      dn: 'uid={{id}}, o=example',
+    };
+    ldap
+      .validateAuthData({ id: 'testuser', password: 'secret' }, options)
+      .then(done)
+      .catch(done.fail)
+      .finally(() => server.close());
+  });
+});
+
+it('Should fail with wrong credentials', done => {
+  mockLdapServer(1010, 'uid=testuser, o=example').then(server => {
+    const options = {
+      suffix: 'o=example',
+      url: 'ldap://localhost:1010',
+      dn: 'uid={{id}}, o=example',
+    };
+    ldap
+      .validateAuthData({ id: 'testuser', password: 'wrong!' }, options)
+      .then(done.fail)
+      .catch(err => {
+        jequal(err.message, 'LDAP: Wrong username or password');
+        done();
+      })
+      .finally(() => server.close());
+  });
+});
+
+it('Should succeed if user is in given group', done => {
+  mockLdapServer(1010, 'uid=testuser, o=example').then(server => {
+    const options = {
+      suffix: 'o=example',
+      url: 'ldap://localhost:1010',
+      dn: 'uid={{id}}, o=example',
+      groupCn: 'powerusers',
+      groupFilter:
+        '(&(uniqueMember=uid={{id}}, o=example)(objectClass=groupOfUniqueNames))',
+    };
+
+    ldap
+      .validateAuthData({ id: 'testuser', password: 'secret' }, options)
+      .then(done)
+      .catch(done.fail)
+      .finally(() => server.close());
+  });
+});
+
+it('Should fail if user is not in given group', done => {
+  mockLdapServer(1010, 'uid=testuser, o=example').then(server => {
+    const options = {
+      suffix: 'o=example',
+      url: 'ldap://localhost:1010',
+      dn: 'uid={{id}}, o=example',
+      groupDn: 'ou=somegroup, o=example',
+      groupFilter:
+        '(&(uniqueMember=uid={{id}}, o=example)(objectClass=groupOfUniqueNames))',
+    };
+
+    ldap
+      .validateAuthData({ id: 'testuser', password: 'secret' }, options)
+      .then(done.fail)
+      .catch(err => {
+        jequal(err.message, 'LDAP: User not in group');
+        done();
+      })
+      .finally(() => server.close());
+  });
+});

--- a/spec/MockLdapServer.js
+++ b/spec/MockLdapServer.js
@@ -1,0 +1,44 @@
+const ldapjs = require('ldapjs');
+
+function newServer(port, dn) {
+  const server = ldapjs.createServer();
+
+  server.bind('o=example', function(req, res, next) {
+    if (req.dn.toString() !== dn || req.credentials !== 'secret')
+      return next(new ldapjs.InvalidCredentialsError());
+    res.end();
+    return next();
+  });
+
+  server.search('o=example', function(req, res) {
+    const obj = {
+      dn: req.dn.toString(),
+      attributes: {
+        objectclass: ['organization', 'top'],
+        o: 'example',
+      },
+    };
+
+    const group = {
+      dn: req.dn.toString(),
+      attributes: {
+        objectClass: ['groupOfUniqueNames', 'top'],
+        uniqueMember: ['uid=testuser, o=example'],
+        cn: 'powerusers',
+        ou: 'powerusers',
+      },
+    };
+
+    if (req.filter.matches(obj.attributes)) {
+      res.send(obj);
+    }
+
+    if (req.filter.matches(group.attributes)) {
+      res.send(group);
+    }
+    res.end();
+  });
+  return new Promise(resolve => server.listen(port, () => resolve(server)));
+}
+
+module.exports = newServer;

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -23,6 +23,7 @@ const weibo = require('./weibo');
 const oauth2 = require('./oauth2');
 const phantauth = require('./phantauth');
 const microsoft = require('./microsoft');
+const ldap = require('./ldap');
 
 const anonymous = {
   validateAuthData: () => {
@@ -57,6 +58,7 @@ const providers = {
   weibo,
   phantauth,
   microsoft,
+  ldap,
 };
 
 function authDataValidator(adapter, appIds, options) {

--- a/src/Adapters/Auth/ldap.js
+++ b/src/Adapters/Auth/ldap.js
@@ -1,0 +1,93 @@
+const ldapjs = require('ldapjs');
+const Parse = require('parse/node').Parse;
+
+function validateAuthData(authData, options) {
+  if (!optionsAreValid(options)) {
+    throw new Parse.Error(
+      Parse.Error.INTERNAL_SERVER_ERROR,
+      'LDAP auth configuration missing'
+    );
+  }
+
+  const client = ldapjs.createClient({ url: options.url });
+  const userCn =
+    typeof options.dn === 'string'
+      ? options.dn.replace('{{id}}', authData.id)
+      : `uid=${authData.id},${options.suffix}`;
+
+  return new Promise((resolve, reject) => {
+    client.bind(userCn, authData.password, err => {
+      if (err) {
+        client.destroy(err);
+        return reject(
+          new Parse.Error(
+            Parse.Error.OBJECT_NOT_FOUND,
+            'LDAP: Wrong username or password'
+          )
+        );
+      }
+
+      if (
+        typeof options.groupCn === 'string' &&
+        typeof options.groupFilter === 'string'
+      ) {
+        const filter = options.groupFilter.replace(/{{id}}/gi, authData.id);
+        const opts = {
+          scope: 'sub',
+          filter: filter,
+        };
+        let found = false;
+        client.search(options.suffix, opts, (searchError, res) => {
+          if (searchError) {
+            throw new Parse.Error(
+              Parse.Error.INTERNAL_SERVER_ERROR,
+              'LDAP group search failed'
+            );
+          }
+          res.on('searchEntry', function(entry) {
+            if (entry.object.cn === options.groupCn) {
+              found = true;
+              client.unbind();
+              client.destroy();
+              return resolve();
+            }
+          });
+          res.on('end', function() {
+            if (!found) {
+              client.unbind();
+              client.destroy();
+              reject(
+                new Parse.Error(
+                  Parse.Error.INTERNAL_SERVER_ERROR,
+                  'LDAP: User not in group'
+                )
+              );
+            }
+          });
+        });
+      } else {
+        client.unbind();
+        client.destroy();
+        resolve();
+      }
+    });
+  });
+}
+
+function optionsAreValid(options) {
+  return (
+    typeof options === 'object' &&
+    typeof options.suffix === 'string' &&
+    typeof options.url === 'string' &&
+    options.url.startsWith('ldap://')
+  );
+}
+
+function validateAppId() {
+  return Promise.resolve();
+}
+
+module.exports = {
+  validateAppId,
+  validateAuthData,
+};


### PR DESCRIPTION
This PR adds a auth module for [LDAP](https://ldap.com/) servers. There are some people who have rolled their own implementations of this (you can find them by searching for 'ldap' in the issues) so there is definitely a need for it. The PR adds a dependency on the [ldapjs](http://ldapjs.org/) package. 

I tried to make it as generic as possible, so it *should* work with all kinds of LDAP servers and configurations. This means that it takes a lot of config options, but I'll open a PR in the `docs` repo shortly where I describe how to set it up.