### PR TITLE
Improve WebSocketServer Error Handling

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+describe('ParseLiveQuery', function() {
+  it('can subscribe to query', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['TestObject'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+    subscription.on('update', async object => {
+      expect(object.get('foo')).toBe('bar');
+      done();
+    });
+    object.set({ foo: 'bar' });
+    await object.save();
+  });
+
+  afterEach(async function(done) {
+    const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
+    client.close();
+    // Wait for live query client to disconnect
+    setTimeout(() => {
+      done();
+    }, 1000);
+  });
+});

--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -49,14 +49,15 @@ describe('ParseWebSocketServer', function() {
       }
       onListen() {}
       onConnection() {}
-      onError(error) {
-        wssError = error;
-      }
+      onError() {}
       start() {
         const wss = new WebSocketServer({ server: this.options.server });
         wss.on('listening', this.onListen);
         wss.on('connection', this.onConnection);
-        wss.on('error', this.onError);
+        wss.on('error', error => {
+          wssError = error;
+          this.onError(error);
+        });
         this.wss = wss;
       }
     }

--- a/src/Adapters/WebSocketServer/WSAdapter.js
+++ b/src/Adapters/WebSocketServer/WSAdapter.js
@@ -13,10 +13,12 @@ export class WSAdapter extends WSSAdapter {
 
   onListen() {}
   onConnection(ws) {}
+  onError(error) {}
   start() {
     const wss = new WebSocketServer({ server: this.options.server });
     wss.on('listening', this.onListen);
     wss.on('connection', this.onConnection);
+    wss.on('error', this.onError);
   }
   close() {}
 }

--- a/src/Adapters/WebSocketServer/WSSAdapter.js
+++ b/src/Adapters/WebSocketServer/WSSAdapter.js
@@ -4,6 +4,7 @@
 // Adapter classes must implement the following functions:
 // * onListen()
 // * onConnection(ws)
+// * onError(error)
 // * start()
 // * close()
 //
@@ -22,6 +23,7 @@ export class WSSAdapter {
   constructor(options) {
     this.onListen = () => {};
     this.onConnection = () => {};
+    this.onError = () => {};
   }
 
   // /**
@@ -35,6 +37,13 @@ export class WSSAdapter {
   //  * @param {WebSocket} ws - RFC 6455 WebSocket.
   //  */
   // onConnection(ws) {}
+
+  // /**
+  //  * Emitted when error event is called.
+  //  *
+  //  * @param {Error} error - WebSocketServer error
+  //  */
+  // onError(error) {}
 
   /**
    * Initialize Connection.

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -392,6 +392,8 @@ class ParseLiveQueryServer {
         event: 'ws_disconnect',
         clients: this.clients.size,
         subscriptions: this.subscriptions.size,
+        useMasterKey: client.hasMasterKey,
+        installationId: client.installationId,
       });
     });
 

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -23,6 +23,9 @@ export class ParseWebSocketServer {
         }
       }, config.websocketTimeout || 10 * 1000);
     };
+    wss.onError = error => {
+      logger.error(error);
+    };
     wss.start();
     this.server = wss;
   }


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/6173

Prevents an unhandled promise rejection and crashing.

Includes an example for LiveQuery test and closing the proper connections. Since they didn’t exist.

Improve live query monitoring