### PR TITLE
Allow validateFilename to return a string or Parse Error

### DIFF
--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -16,7 +16,9 @@ const mockAdapter = {
   deleteFile: () => {},
   getFileData: () => {},
   getFileLocation: () => 'xyz',
-  validateFilename: () => {},
+  validateFilename: () => {
+    return null;
+  },
 };
 
 // Small additional tests to improve overall coverage
@@ -75,6 +77,19 @@ describe('FilesController', () => {
 
         done();
       });
+  });
+
+  it('should create a parse error when a string is returned', done => {
+    const mock2 = mockAdapter;
+    mock2.validateFilename = () => {
+      return 'Bad file! No biscuit!';
+    };
+    const filesController = new FilesController(mockAdapter);
+    const error = filesController.validateFilename();
+    expect(typeof error).toBe('object');
+    expect(error.message.indexOf('biscuit')).toBe(13);
+    expect(error.code).toBe(Parse.Error.INVALID_FILE_NAME);
+    done();
   });
 
   it('should add a unique hash to the file name when the preserveFileName option is false', done => {

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -4,6 +4,7 @@ import AdaptableController from './AdaptableController';
 import { validateFilename, FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path from 'path';
 import mime from 'mime';
+const Parse = require('parse').Parse;
 
 const legacyFilesRegex = new RegExp(
   '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-.*'
@@ -98,7 +99,11 @@ export class FilesController extends AdaptableController {
 
   validateFilename(filename) {
     if (typeof this.adapter.validateFilename === 'function') {
-      return this.adapter.validateFilename(filename);
+      const error = this.adapter.validateFilename(filename);
+      if (typeof error !== 'string') {
+        return error;
+      }
+      return new Parse.Error(Parse.Error.INVALID_FILE_NAME, error);
     }
     return validateFilename(filename);
   }


### PR DESCRIPTION
This follows from https://github.com/parse-community/parse-server-s3-adapter/pull/76