### PR TITLE
Add maxLogFiles option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,11 +3041,6 @@
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
       "dev": true
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-    },
     "d": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
@@ -4567,9 +4562,9 @@
       }
     },
     "file-stream-rotator": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.4.1.tgz",
-      "integrity": "sha512-W3aa3QJEc8BS2MmdVpQiYLKHj3ijpto1gMDlsgCRSKfIUe6MwkcpODGPQ3vZfb0XvCeCqlu9CBQTN7oQri2TZQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.5.5.tgz",
+      "integrity": "sha512-XzvE1ogpxUbARtZPZLICaDRAeWxoQLFMKS3ZwADoCQmurKEwuDD2jEfDVPm/R1HeKYsRYEl9PzVIezjQ3VTTPQ==",
       "requires": {
         "moment": "^2.11.2"
       }
@@ -5433,7 +5428,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6391,7 +6386,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -7193,7 +7188,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7870,7 +7865,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -8056,7 +8051,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -8068,7 +8063,7 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -8083,7 +8078,7 @@
         },
         "rimraf": {
           "version": "2.2.6",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
           "integrity": "sha1-xZWXVpsU2VatKcrMQr3d9fDqT0w=",
           "dev": true
         }
@@ -8125,7 +8120,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -8634,9 +8629,9 @@
       }
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -8924,6 +8919,7 @@
         "@babel/runtime": "7.7.4",
         "@babel/runtime-corejs3": "7.7.4",
         "uuid": "3.3.3",
+        "ws": "7.2.0",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
@@ -8942,6 +8938,14 @@
           "requires": {
             "core-js-pure": "^3.0.0",
             "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "ws": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
+          "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
+          "requires": {
+            "async-limiter": "^1.0.0"
           }
         }
       }
@@ -9396,7 +9400,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -9774,7 +9778,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -10605,7 +10609,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -10626,7 +10630,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -11186,39 +11190,14 @@
         }
       }
     },
-    "winston-compat": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/winston-compat/-/winston-compat-0.1.4.tgz",
-      "integrity": "sha512-mMEfFsSm6GmkFF+f4/0UJtG4N1vSaczGmXLVJYmS/+u2zUaIPcw2ZRuwUg2TvVBjswgiraN+vNnAG8z4fRUZ4w==",
-      "requires": {
-        "cycle": "~1.0.3",
-        "logform": "^1.6.0",
-        "triple-beam": "^1.2.0"
-      },
-      "dependencies": {
-        "logform": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
-          "integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
-          "requires": {
-            "colors": "^1.2.1",
-            "fast-safe-stringify": "^2.0.4",
-            "fecha": "^2.3.3",
-            "ms": "^2.1.1",
-            "triple-beam": "^1.2.0"
-          }
-        }
-      }
-    },
     "winston-daily-rotate-file": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-3.10.0.tgz",
-      "integrity": "sha512-KO8CfbI2CvdR3PaFApEH02GPXiwJ+vbkF1mCkTlvRIoXFI8EFlf1ACcuaahXTEiDEKCii6cNe95gsL4ZkbnphA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.4.0.tgz",
+      "integrity": "sha512-1JHFqpqkZphLZPUDQBoJpcBj2cy/aZkOXlcHcZa3oVcNXxuenptGGXztI07jqTJ/FJdUPm1MOLwrp09zPFIUew==",
       "requires": {
-        "file-stream-rotator": "^0.4.1",
-        "object-hash": "^1.3.0",
+        "file-stream-rotator": "^0.5.5",
+        "object-hash": "^2.0.1",
         "triple-beam": "^1.3.0",
-        "winston-compat": "^0.1.4",
         "winston-transport": "^4.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tv4": "1.3.0",
     "uuid": "3.3.3",
     "winston": "3.2.1",
-    "winston-daily-rotate-file": "3.10.0",
+    "winston-daily-rotate-file": "4.4.0",
     "ws": "7.2.1"
   },
   "devDependencies": {

--- a/resources/buildConfigDefinitions.js
+++ b/resources/buildConfigDefinitions.js
@@ -218,6 +218,9 @@ function inject(t, list) {
     if (type === 'NumberOrBoolean') {
       type = 'Number|Boolean';
     }
+    if (type === 'NumberOrString') {
+      type = 'Number|String';
+    }
     if (type === 'Adapter') {
       const adapterType = elt.typeAnnotation.typeParameters.params[0].id.name;
       type = `Adapter<${adapterType}>`;

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -79,6 +79,7 @@ export function configureLogger({
   logLevel = winston.level,
   verbose = defaults.verbose,
   silent = defaults.silent,
+  maxLogFiles,
 } = {}) {
   if (verbose) {
     logLevel = 'verbose';
@@ -100,6 +101,7 @@ export function configureLogger({
   options.dirname = logsFolder;
   options.level = logLevel;
   options.silent = silent;
+  options.maxFiles = maxLogFiles;
 
   if (jsonLogs) {
     options.json = true;

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -76,10 +76,18 @@ export function getLoggerController(
     logsFolder,
     verbose,
     logLevel,
+    maxLogFiles,
     silent,
     loggerAdapter,
   } = options;
-  const loggerOptions = { jsonLogs, logsFolder, verbose, logLevel, silent };
+  const loggerOptions = {
+    jsonLogs,
+    logsFolder,
+    verbose,
+    logLevel,
+    silent,
+    maxLogFiles,
+  };
   const loggerControllerAdapter = loadAdapter(
     loggerAdapter,
     WinstonLoggerAdapter,

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -19,7 +19,7 @@ module.exports.ParseServerOptions = {
   },
   allowCustomObjectId: {
     env: 'PARSE_SERVER_ALLOW_CUSTOM_OBJECT_ID',
-    help: 'Enable (or disable) custom objectId, defaults to false',
+    help: 'Enable (or disable) custom objectId',
     action: parsers.booleanParser,
     default: false,
   },
@@ -229,6 +229,12 @@ module.exports.ParseServerOptions = {
     env: 'PARSE_SERVER_MAX_LIMIT',
     help: 'Max value for limit option on queries, defaults to unlimited',
     action: parsers.numberParser('maxLimit'),
+  },
+  maxLogFiles: {
+    env: 'PARSE_SERVER_MAX_LOG_FILES',
+    help:
+      "Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null)",
+    action: parsers.objectParser,
   },
   maxUploadSize: {
     env: 'PARSE_SERVER_MAX_UPLOAD_SIZE',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -2,7 +2,7 @@
  * @interface ParseServerOptions
  * @property {Any} accountLockout account lockout policy for failed login attempts
  * @property {Boolean} allowClientClassCreation Enable (or disable) client class creation, defaults to true
- * @property {Boolean} allowCustomObjectId Enable (or disable) custom objectId, defaults to false
+ * @property {Boolean} allowCustomObjectId Enable (or disable) custom objectId
  * @property {String[]} allowHeaders Add headers to Access-Control-Allow-Headers
  * @property {Adapter<AnalyticsAdapter>} analyticsAdapter Adapter module for the analytics
  * @property {String} appId Your Parse Application ID
@@ -42,6 +42,7 @@
  * @property {String} masterKey Your Parse Master Key
  * @property {String[]} masterKeyIps Restrict masterKey to be used by only these ips, defaults to [] (allow all ips)
  * @property {Number} maxLimit Max value for limit option on queries, defaults to unlimited
+ * @property {Number|String} maxLogFiles Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null)
  * @property {String} maxUploadSize Max file size for uploads, defaults to 20mb
  * @property {Union} middleware middleware for express server, can be string or function
  * @property {Boolean} mountGraphQL Mounts the GraphQL endpoint

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -10,6 +10,7 @@ import { WSSAdapter } from '../Adapters/WebSocketServer/WSSAdapter';
 // @flow
 type Adapter<T> = string | any | T;
 type NumberOrBoolean = number | boolean;
+type NumberOrString = number | string;
 type ProtectedFields = any;
 
 export interface ParseServerOptions {
@@ -51,6 +52,8 @@ export interface ParseServerOptions {
   verbose: ?boolean;
   /* Sets the level for logs */
   logLevel: ?string;
+  /* Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null) */
+  maxLogFiles: ?NumberOrString;
   /* Disables console output
   :ENV: SILENT */
   silent: ?boolean;


### PR DESCRIPTION
Addresses https://community.parseplatform.org/t/server-log-retention/867/2.

https://github.com/winstonjs/winston-daily-rotate-file#options

Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null).

I'll run this in production for a few days. I assume it works.

Useful for saving disk space.

Update winston-daily-rotate-file package to 4.4.0.