### PR TITLE
Fix postgres build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ stage: test
 env:
   global:
   - COVERAGE_OPTION='./node_modules/.bin/nyc'
-  - PGPORT=5432
   matrix:
   - MONGODB_VERSION=4.0.4 MONGODB_TOPOLOGY=replicaset MONGODB_STORAGE_ENGINE=wiredTiger
   - MONGODB_VERSION=3.6.9
@@ -45,8 +44,8 @@ before_install:
 before_script:
 - node -e 'require("./lib/index.js")'
 - psql -c 'create database parse_server_postgres_adapter_test_database;' -U postgres
-- psql -c 'CREATE EXTENSION postgis WITH VERSION "2.5";' -U postgres -d parse_server_postgres_adapter_test_database
-- psql -c 'CREATE EXTENSION postgis_topology WITH VERSION "2.5";' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis;' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d parse_server_postgres_adapter_test_database
 - greenkeeper-lockfile-update
 script:
 - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_install:
 before_script:
 - node -e 'require("./lib/index.js")'
 - psql -c 'create database parse_server_postgres_adapter_test_database;' -U postgres
-- psql -c 'CREATE EXTENSION postgis;' -U postgres -d parse_server_postgres_adapter_test_database
-- psql -c 'CREATE EXTENSION postgis_topology;' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis WITH VERSION 2.5.2;' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis_topology WITH VERSION 2.5.2;' -U postgres -d parse_server_postgres_adapter_test_database
 - greenkeeper-lockfile-update
 script:
 - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
 dist: xenial
 services:
+- postgresql
 - redis-server
 - docker
+addons:
+  postgresql: '11'
+  apt:
+    packages:
+    - postgresql-11
+    - postgresql-11-postgis-2.5
+    - postgresql-11-postgis-2.5-scripts
 branches:
   only:
   - master
@@ -32,15 +40,13 @@ before_install:
 - nvm use $NODE_VERSION
 - npm install -g greenkeeper-lockfile@1
 - sudo service postgresql stop
-- sudo apt install -yq --no-install-suggests --no-install-recommends postgresql-11-postgis-2.5-scripts postgresql-11 postgresql-client-11 postgresql-11-postgis-2.5
 - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/11/main/postgresql.conf
-- sudo cp /etc/postgresql/{10,11}/main/pg_hba.conf
 - sudo service postgresql restart 11
 before_script:
 - node -e 'require("./lib/index.js")'
 - psql -c 'create database parse_server_postgres_adapter_test_database;' -U postgres
-- psql -c 'CREATE EXTENSION postgis WITH VERSION "2.5.2";' -U postgres -d parse_server_postgres_adapter_test_database
-- psql -c 'CREATE EXTENSION postgis_topology WITH VERSION "2.5.2";' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis WITH VERSION "2.5";' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis_topology WITH VERSION "2.5";' -U postgres -d parse_server_postgres_adapter_test_database
 - greenkeeper-lockfile-update
 script:
 - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: node_js
 dist: xenial
 services:
-- postgresql
 - redis-server
 - docker
-addons:
-  postgresql: '11'
-  apt:
-    packages:
-    - postgresql-11
-    - postgresql-11-postgis-2.5
 branches:
   only:
   - master
@@ -38,10 +31,11 @@ before_install:
 - nvm install $NODE_VERSION
 - nvm use $NODE_VERSION
 - npm install -g greenkeeper-lockfile@1
+- sudo service postgresql stop
+- sudo apt install -yq --no-install-suggests --no-install-recommends postgresql-11-postgis-2.5-scripts postgresql-11 postgresql-client-11 postgresql-11-postgis-2.5
 - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/11/main/postgresql.conf
 - sudo cp /etc/postgresql/{10,11}/main/pg_hba.conf
-- sudo service postgresql stop
-- sudo service postgresql start 11
+- sudo service postgresql restart 11
 before_script:
 - node -e 'require("./lib/index.js")'
 - psql -c 'create database parse_server_postgres_adapter_test_database;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_install:
 before_script:
 - node -e 'require("./lib/index.js")'
 - psql -c 'create database parse_server_postgres_adapter_test_database;' -U postgres
-- psql -c 'CREATE EXTENSION postgis WITH VERSION 2.5.2;' -U postgres -d parse_server_postgres_adapter_test_database
-- psql -c 'CREATE EXTENSION postgis_topology WITH VERSION 2.5.2;' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis WITH VERSION "2.5.2";' -U postgres -d parse_server_postgres_adapter_test_database
+- psql -c 'CREATE EXTENSION postgis_topology WITH VERSION "2.5.2";' -U postgres -d parse_server_postgres_adapter_test_database
 - greenkeeper-lockfile-update
 script:
 - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
     packages:
     - postgresql-11
     - postgresql-11-postgis-2.5
-    - postgresql-11-postgis-2.5-scripts
 branches:
   only:
   - master


### PR DESCRIPTION
For some reason postgis 2.4 (doesn't exist) tries to get used instead of 2.5.

```
ERROR:  could not access file "$libdir/postgis-2.4": No such file or directory
The command "psql -c 'CREATE EXTENSION postgis;' -U postgres -d 
```