### PR TITLE
GraphQL: Reset Password & Verification Email

### DIFF
--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -1,4 +1,4 @@
-import { GraphQLNonNull, GraphQLString } from 'graphql';
+import { GraphQLNonNull, GraphQLString, GraphQLBoolean } from 'graphql';
 import { mutationWithClientMutationId } from 'graphql-relay';
 import UsersRouter from '../../Routers/UsersRouter';
 import * as objectsMutations from '../helpers/objectsMutations';
@@ -93,16 +93,18 @@ const load = parseGraphQLSchema => {
         const { username, password } = args;
         const { config, auth, info } = context;
 
-        const { sessionToken } = (await usersRouter.handleLogIn({
-          body: {
-            username,
-            password,
-          },
-          query: {},
-          config,
-          auth,
-          info,
-        })).response;
+        const { sessionToken } = (
+          await usersRouter.handleLogIn({
+            body: {
+              username,
+              password,
+            },
+            query: {},
+            config,
+            auth,
+            info,
+          })
+        ).response;
 
         info.sessionToken = sessionToken;
 
@@ -171,6 +173,105 @@ const load = parseGraphQLSchema => {
   );
   parseGraphQLSchema.addGraphQLType(logOutMutation.type, true, true);
   parseGraphQLSchema.addGraphQLMutation('logOut', logOutMutation, true, true);
+
+  const resetPasswordMutation = mutationWithClientMutationId({
+    name: 'ResetPassword',
+    description:
+      'The resetPassword mutation can be used to reset the password of an existing user.',
+    inputFields: {
+      email: {
+        descriptions: 'Email of the user that should receive the reset email',
+        type: new GraphQLNonNull(GraphQLString),
+      },
+    },
+    outputFields: {
+      ok: {
+        description: "It's always true.",
+        type: new GraphQLNonNull(GraphQLBoolean),
+      },
+    },
+    mutateAndGetPayload: async ({ email }, context) => {
+      const { config, auth, info } = context;
+
+      await usersRouter.handleResetRequest({
+        body: {
+          email,
+        },
+        config,
+        auth,
+        info,
+      });
+
+      return { ok: true };
+    },
+  });
+
+  parseGraphQLSchema.addGraphQLType(
+    resetPasswordMutation.args.input.type.ofType,
+    true,
+    true
+  );
+  parseGraphQLSchema.addGraphQLType(resetPasswordMutation.type, true, true);
+  parseGraphQLSchema.addGraphQLMutation(
+    'resetPassword',
+    resetPasswordMutation,
+    true,
+    true
+  );
+
+  const sendVerificationEmailMutation = mutationWithClientMutationId({
+    name: 'SendVerificationEmail',
+    description:
+      'The sendVerificationEmail mutation can be used to send the verification email again.',
+    inputFields: {
+      email: {
+        descriptions:
+          'Email of the user that should receive the verification email',
+        type: new GraphQLNonNull(GraphQLString),
+      },
+    },
+    outputFields: {
+      ok: {
+        description: "It's always true.",
+        type: new GraphQLNonNull(GraphQLBoolean),
+      },
+    },
+    mutateAndGetPayload: async ({ email }, context) => {
+      try {
+        const { config, auth, info } = context;
+
+        await usersRouter.handleVerificationEmailRequest({
+          body: {
+            email,
+          },
+          config,
+          auth,
+          info,
+        });
+
+        return { ok: true };
+      } catch (e) {
+        parseGraphQLSchema.handleError(e);
+      }
+    },
+  });
+
+  parseGraphQLSchema.addGraphQLType(
+    sendVerificationEmailMutation.args.input.type.ofType,
+    true,
+    true
+  );
+  parseGraphQLSchema.addGraphQLType(
+    sendVerificationEmailMutation.type,
+    true,
+    true
+  );
+  parseGraphQLSchema.addGraphQLMutation(
+    'sendVerificationEmail',
+    sendVerificationEmailMutation,
+    true,
+    true
+  );
 };
 
 export { load };


### PR DESCRIPTION
Allow to reset password and send (again) verification email with GraphQL API