### PR TITLE
fix(GraphQL): Timeout when fetching huge collections

### DIFF
--- a/src/GraphQL/helpers/objectsQueries.js
+++ b/src/GraphQL/helpers/objectsQueries.js
@@ -119,6 +119,8 @@ const findObjects = async (
   ) {
     if (limit || limit === 0) {
       options.limit = limit;
+    } else {
+      options.limit = 100;
     }
     if (options.limit !== 0) {
       if (order) {
@@ -127,10 +129,7 @@ const findObjects = async (
       if (skip) {
         options.skip = skip;
       }
-      if (
-        config.maxLimit &&
-        (options.limit === undefined || options.limit > config.maxLimit)
-      ) {
+      if (config.maxLimit && options.limit > config.maxLimit) {
         // Silently replace the limit on the query with the max configured
         options.limit = config.maxLimit;
       }

--- a/src/GraphQL/helpers/objectsQueries.js
+++ b/src/GraphQL/helpers/objectsQueries.js
@@ -127,7 +127,10 @@ const findObjects = async (
       if (skip) {
         options.skip = skip;
       }
-      if (config.maxLimit && options.limit > config.maxLimit) {
+      if (
+        config.maxLimit &&
+        (options.limit === undefined || options.limit > config.maxLimit)
+      ) {
         // Silently replace the limit on the query with the max configured
         options.limit = config.maxLimit;
       }


### PR DESCRIPTION
Currently, when not specifying a `limit` to the GraphQL find-like query, it tries to fetch the entire collection of objects from a class. However, if the class contains a huge set of objects, it is never resolved and results in timeout.

In order to solve this kind of problem, `parse-server` allows us to define a `maxLimit` parameter when initialized, which limits the maximum number of objects fetched per query; but it is not properly considered when the `limit` is undefined.