### PR TITLE
GraphQL: Fix Geo Queries

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -9922,6 +9922,87 @@ describe('ParseGraphQLServer', () => {
             expect(typeof getResult.data.someClass.someField).toEqual('object');
             expect(getResult.data.someClass.someField).toEqual(someFieldValue);
             expect(getResult.data.someClasses.edges.length).toEqual(1);
+
+            const getGeoWhere = await apolloClient.query({
+              query: gql`
+                query GeoQuery($latitude: Float!, $longitude: Float!) {
+                  nearSphere: someClasses(
+                    where: {
+                      someField: {
+                        nearSphere: {
+                          latitude: $latitude
+                          longitude: $longitude
+                        }
+                      }
+                    }
+                  ) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                  geoWithin: someClasses(
+                    where: {
+                      someField: {
+                        geoWithin: {
+                          centerSphere: {
+                            distance: 10
+                            center: {
+                              latitude: $latitude
+                              longitude: $longitude
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                  within: someClasses(
+                    where: {
+                      someField: {
+                        within: {
+                          box: {
+                            bottomLeft: {
+                              latitude: $latitude
+                              longitude: $longitude
+                            }
+                            upperRight: {
+                              latitude: $latitude
+                              longitude: $longitude
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              `,
+              variables: {
+                latitude: 45,
+                longitude: 45,
+              },
+            });
+            expect(getGeoWhere.data.nearSphere.edges[0].node.id).toEqual(
+              createResult.data.createSomeClass.someClass.id
+            );
+            expect(getGeoWhere.data.geoWithin.edges[0].node.id).toEqual(
+              createResult.data.createSomeClass.someClass.id
+            );
+            expect(getGeoWhere.data.within.edges[0].node.id).toEqual(
+              createResult.data.createSomeClass.someClass.id
+            );
           } catch (e) {
             handleError(e);
           }
@@ -10020,6 +10101,34 @@ describe('ParseGraphQLServer', () => {
               }))
             );
             expect(getResult.data.someClasses.edges.length).toEqual(1);
+            const getIntersect = await apolloClient.query({
+              query: gql`
+                query IntersectQuery($point: GeoPointInput!) {
+                  someClasses(
+                    where: {
+                      somePolygonField: { geoIntersects: { point: $point } }
+                    }
+                  ) {
+                    edges {
+                      node {
+                        id
+                        somePolygonField {
+                          latitude
+                          longitude
+                        }
+                      }
+                    }
+                  }
+                }
+              `,
+              variables: {
+                point: { latitude: 44, longitude: 45 },
+              },
+            });
+            expect(getIntersect.data.someClasses.edges.length).toEqual(1);
+            expect(getIntersect.data.someClasses.edges[0].node.id).toEqual(
+              createResult.data.createSomeClass.someClass.id
+            );
           } catch (e) {
             handleError(e);
           }

--- a/src/GraphQL/transformers/query.js
+++ b/src/GraphQL/transformers/query.js
@@ -182,13 +182,17 @@ const transformQueryConstraintInputToParse = (
       return;
     }
     switch (fieldName) {
-      case '$point':
-      case '$nearSphere':
+      case 'point':
         if (typeof fieldValue === 'object' && !fieldValue.__type) {
           fieldValue.__type = 'GeoPoint';
         }
         break;
-      case '$box':
+      case 'nearSphere':
+        if (typeof fieldValue === 'object' && !fieldValue.__type) {
+          fieldValue.__type = 'GeoPoint';
+        }
+        break;
+      case 'box':
         if (
           typeof fieldValue === 'object' &&
           fieldValue.bottomLeft &&
@@ -204,10 +208,10 @@ const transformQueryConstraintInputToParse = (
               ...fieldValue.upperRight,
             },
           ];
-          constraints[fieldName] = fieldValue;
+          constraints[parseConstraintMap[fieldName]] = fieldValue;
         }
         break;
-      case '$polygon':
+      case 'polygon':
         if (fieldValue instanceof Array) {
           fieldValue.forEach(geoPoint => {
             if (typeof geoPoint === 'object' && !geoPoint.__type) {
@@ -216,7 +220,7 @@ const transformQueryConstraintInputToParse = (
           });
         }
         break;
-      case '$centerSphere':
+      case 'centerSphere':
         if (
           typeof fieldValue === 'object' &&
           fieldValue.center &&
@@ -229,7 +233,7 @@ const transformQueryConstraintInputToParse = (
             },
             fieldValue.distance,
           ];
-          constraints[fieldName] = fieldValue;
+          constraints[parseConstraintMap[fieldName]] = fieldValue;
         }
         break;
     }


### PR DESCRIPTION
Due to a lack of tests on geo queries, when we removed the `$` from constraints we broke some of geo queries.