### PR TITLE
WIP: Locked Pre defined Schemas  / auto migration

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1693,7 +1693,7 @@ class DatabaseController {
 
   // TODO: create indexes on first creation of a _User object. Otherwise it's impossible to
   // have a Parse app without it having a _User collection.
-  performInitialization() {
+  async performInitialization(options) {
     const requiredUserFields = {
       fields: {
         ...SchemaController.defaultColumns._Default,
@@ -1750,13 +1750,17 @@ class DatabaseController {
     const adapterInit = this.adapter.performInitialization({
       VolatileClassesSchemas: SchemaController.VolatileClassesSchemas,
     });
-    return Promise.all([
+    const promises = await Promise.all([
       usernameUniqueness,
       emailUniqueness,
       roleUniqueness,
       adapterInit,
       indexPromise,
     ]);
+    if (options.schemas) {
+      await (await this.loadSchema()).loadSchemas(options.schemas);
+    }
+    return promises;
   }
 
   static _validateQuery: (any, boolean) => void;

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -528,4 +528,10 @@ module.exports.LiveQueryServerOptions = {
     help: 'Adapter module for the WebSocketServer',
     action: parsers.moduleOrObjectParser,
   },
+  schemas: {
+    env: 'PARSE_SERVER_SCHEMAS',
+    help:
+      'Schemas options allow to lock and pre define schemas of the parse server.',
+    action: parsers.objectParser,
+  },
 };

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -73,6 +73,7 @@
  * @property {Boolean} verbose Set the logging to verbose
  * @property {Boolean} verifyUserEmails Enable (or disable) user email validation, defaults to false
  * @property {String} webhookKey Key sent with outgoing webhook calls
+ * @property {Parse.Schema[]} schemas lock and pre define schemas of the parse server.
  */
 
 /**

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -75,7 +75,7 @@ class ParseServer {
     this.config = Config.put(Object.assign({}, options, allControllers));
 
     logging.setLogger(loggerController);
-    const dbInitPromise = databaseController.performInitialization();
+    const dbInitPromise = databaseController.performInitialization(options);
     const hooksLoadPromise = hooksController.load();
 
     // Note: Tests will start to fail if any validation happens after this is called.

--- a/src/ParseServerSchemas.js
+++ b/src/ParseServerSchemas.js
@@ -1,0 +1,197 @@
+import Parse from '../utils/Parse';
+
+// add class await schema.addClassIfNotExists(name,schema)
+// update class await schema.updateClass(name,transformToParse(schemaFields, existingParseClass.fields),undefined,undefined,config.database);
+
+export const buildSchemas = async (localSchemas, config) => {
+  const schema = await config.database.loadSchema({ clearCache: true });
+  const allCloudSchema = await schema
+    .getAllClasses(true)
+    .filter(s => !lib.isDefaultSchema(s.className));
+  await Promise.all(
+    localSchemas.map(async localSchema =>
+      lib.saveOrUpdate(allCloudSchema, localSchema)
+    )
+  );
+};
+
+export const lib = {
+  saveOrUpdate: async (allCloudSchema, localSchema) => {
+    const cloudSchema = allCloudSchema.find(
+      sc => sc.className === localSchema.className
+    );
+    if (cloudSchema) {
+      await lib.updateSchema(localSchema, cloudSchema);
+    } else {
+      await lib.saveSchema(localSchema);
+    }
+  },
+  saveSchema: async localSchema => {
+    const newLocalSchema = new Parse.Schema(localSchema.className);
+    // Handle fields
+    Object.keys(localSchema.fields)
+      .filter(
+        fieldName => !lib.isDefaultFields(localSchema.className, fieldName)
+      )
+      .forEach(fieldName => {
+        const { type, ...others } = localSchema.fields[fieldName];
+        lib.handleFields(newLocalSchema, fieldName, type, others);
+      });
+    // Handle indexes
+    if (localSchema.indexes) {
+      Object.keys(localSchema.indexes).forEach(indexName =>
+        newLocalSchema.addIndex(indexName, localSchema.indexes[indexName])
+      );
+    }
+
+    newLocalSchema.setCLP(localSchema.classLevelPermissions);
+    return newLocalSchema.save();
+  },
+  updateSchema: async (localSchema, cloudSchema) => {
+    const newLocalSchema = new Parse.Schema(localSchema.className);
+
+    // Handle fields
+    // Check addition
+    Object.keys(localSchema.fields)
+      .filter(
+        fieldName => !lib.isDefaultFields(localSchema.className, fieldName)
+      )
+      .forEach(fieldName => {
+        const { type, ...others } = localSchema.fields[fieldName];
+        if (!cloudSchema.fields[fieldName])
+          lib.handleFields(newLocalSchema, fieldName, type, others);
+      });
+
+    // Check deletion
+    await Promise.all(
+      Object.keys(cloudSchema.fields)
+        .filter(
+          fieldName => !lib.isDefaultFields(localSchema.className, fieldName)
+        )
+        .map(async fieldName => {
+          const field = cloudSchema.fields[fieldName];
+          if (!localSchema.fields[fieldName]) {
+            newLocalSchema.deleteField(fieldName);
+            await newLocalSchema.update();
+            return;
+          }
+          const localField = localSchema.fields[fieldName];
+          if (!lib.paramsAreEquals(field, localField)) {
+            newLocalSchema.deleteField(fieldName);
+            await newLocalSchema.update();
+            const { type, ...others } = localField;
+            lib.handleFields(newLocalSchema, fieldName, type, others);
+          }
+        })
+    );
+
+    // Handle Indexes
+    // Check addition
+    const cloudIndexes = lib.fixCloudIndexes(cloudSchema.indexes);
+
+    if (localSchema.indexes) {
+      Object.keys(localSchema.indexes).forEach(indexName => {
+        if (
+          !cloudIndexes[indexName] &&
+          !lib.isNativeIndex(localSchema.className, indexName)
+        )
+          newLocalSchema.addIndex(indexName, localSchema.indexes[indexName]);
+      });
+    }
+
+    const indexesToAdd = [];
+
+    // Check deletion
+    Object.keys(cloudIndexes).forEach(async indexName => {
+      if (!lib.isNativeIndex(localSchema.className, indexName)) {
+        if (!localSchema.indexes[indexName]) {
+          newLocalSchema.deleteIndex(indexName);
+        } else if (
+          !lib.paramsAreEquals(
+            localSchema.indexes[indexName],
+            cloudIndexes[indexName]
+          )
+        ) {
+          newLocalSchema.deleteIndex(indexName);
+          indexesToAdd.push({
+            indexName,
+            index: localSchema.indexes[indexName],
+          });
+        }
+      }
+    });
+    newLocalSchema.setCLP(localSchema.classLevelPermissions);
+    await newLocalSchema.update();
+    indexesToAdd.forEach(o => newLocalSchema.addIndex(o.indexName, o.index));
+    return newLocalSchema.update();
+  },
+
+  isDefaultSchema: className =>
+    ['_Session', '_Role', '_PushStatus', '_Installation'].indexOf(className) !==
+    -1,
+
+  isDefaultFields: (className, fieldName) =>
+    [
+      'objectId',
+      'createdAt',
+      'updatedAt',
+      'ACL',
+      'emailVerified',
+      'authData',
+      'username',
+      'password',
+      'email',
+    ]
+      .filter(
+        value =>
+          (className !== '_User' && value !== 'email') || className === '_User'
+      )
+      .indexOf(fieldName) !== -1,
+
+  fixCloudIndexes: cloudSchemaIndexes => {
+    if (!cloudSchemaIndexes) return {};
+    // eslint-disable-next-line
+    const { _id_, ...others } = cloudSchemaIndexes;
+
+    return {
+      objectId: { objectId: 1 },
+      ...others,
+    };
+  },
+
+  isNativeIndex: (className, indexName) => {
+    if (className === '_User') {
+      switch (indexName) {
+        case 'username_1':
+          return true;
+        case 'objectId':
+          return true;
+        case 'email_1':
+          return true;
+        default:
+          break;
+      }
+    }
+    return false;
+  },
+
+  paramsAreEquals: (indexA, indexB) => {
+    const keysIndexA = Object.keys(indexA);
+    const keysIndexB = Object.keys(indexB);
+
+    // Check key name
+    if (keysIndexA.length !== keysIndexB.length) return false;
+    return keysIndexA.every(k => indexA[k] === indexB[k]);
+  },
+
+  handleFields: (newLocalSchema, fieldName, type, others) => {
+    if (type === 'Relation') {
+      newLocalSchema.addRelation(fieldName, others.targetClass);
+    } else if (type === 'Pointer') {
+      const { targetClass, ...others2 } = others;
+      newLocalSchema.addPointer(fieldName, targetClass, others2);
+    } else {
+      newLocalSchema.addField(fieldName, type, others);
+    }
+  },
+};

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -6,6 +6,15 @@ var Parse = require('parse/node').Parse,
 import PromiseRouter from '../PromiseRouter';
 import * as middleware from '../middlewares';
 
+const checkSchemasOption = req => {
+  if (req.config.schemas) {
+    throw new Parse.Error(
+      Parse.Error.OPERATION_FORBIDDEN,
+      'This server use schemas option, schemas creation/modification operations are blocked. You can still delete a class.'
+    );
+  }
+};
+
 function classNameMismatchResponse(bodyClass, pathClass) {
   throw new Parse.Error(
     Parse.Error.INVALID_CLASS_NAME,
@@ -42,6 +51,7 @@ function getOneSchema(req) {
 }
 
 function createSchema(req) {
+  checkSchemasOption(req);
   if (req.auth.isReadOnly) {
     throw new Parse.Error(
       Parse.Error.OPERATION_FORBIDDEN,
@@ -76,6 +86,7 @@ function createSchema(req) {
 }
 
 function modifySchema(req) {
+  checkSchemasOption(req);
   if (req.auth.isReadOnly) {
     throw new Parse.Error(
       Parse.Error.OPERATION_FORBIDDEN,
@@ -104,6 +115,8 @@ function modifySchema(req) {
 }
 
 const deleteSchema = req => {
+  // Here we do not check schemas options, developer need to delete manually classes
+  // to avoid data loss during auto migration
   if (req.auth.isReadOnly) {
     throw new Parse.Error(
       Parse.Error.OPERATION_FORBIDDEN,


### PR DESCRIPTION
With the recent add of GraphQL, schema less behavior of Parse could be a problem to use the GraphQL API correctly (due to the auto generation based on existing schemas). So from my own experience with a script that i use on my parse servers, i suggest to add an option `schemas` to Parse Server that allow to:
* Define Schema (Rest Interface Like)
* Auto management feature for fields, indexes, CLPS at start time
* Lock schema operations on public api to avoid unwanted results in case of parse server restart/deployment

**Note: Missing tests, it's just a first architectural push**

Tell me what you think about this ?