### PR TITLE
Add new afterLogin cloud code hook

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2647,10 +2647,10 @@ describe('afterLogin hook', () => {
   it('should have expected data in request', async done => {
     Parse.Cloud.afterLogin(req => {
       expect(req.object).toBeDefined();
-      expect(req.user).toBeUndefined();
+      expect(req.user).toBeDefined();
       expect(req.headers).toBeDefined();
       expect(req.ip).toBeDefined();
-      expect(req.installationId).toBeUndefined();
+      expect(req.installationId).toBeDefined();
       expect(req.context).toBeUndefined();
     });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2269,21 +2269,43 @@ describe('afterFind hooks', () => {
     expect(() => {
       Parse.Cloud.beforeLogin(() => {});
     }).not.toThrow(
-      'Only the _User class is allowed for the beforeLogin trigger'
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
     );
     expect(() => {
       Parse.Cloud.beforeLogin('_User', () => {});
     }).not.toThrow(
-      'Only the _User class is allowed for the beforeLogin trigger'
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
     );
     expect(() => {
       Parse.Cloud.beforeLogin(Parse.User, () => {});
     }).not.toThrow(
-      'Only the _User class is allowed for the beforeLogin trigger'
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
     );
     expect(() => {
       Parse.Cloud.beforeLogin('SomeClass', () => {});
-    }).toThrow('Only the _User class is allowed for the beforeLogin trigger');
+    }).toThrow(
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
+    );
+    expect(() => {
+      Parse.Cloud.afterLogin(() => {});
+    }).not.toThrow(
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
+    );
+    expect(() => {
+      Parse.Cloud.afterLogin('_User', () => {});
+    }).not.toThrow(
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
+    );
+    expect(() => {
+      Parse.Cloud.afterLogin(Parse.User, () => {});
+    }).not.toThrow(
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
+    );
+    expect(() => {
+      Parse.Cloud.afterLogin('SomeClass', () => {});
+    }).toThrow(
+      'Only the _User class is allowed for the beforeLogin and afterLogin triggers'
+    );
     expect(() => {
       Parse.Cloud.afterLogout(() => {});
     }).not.toThrow();
@@ -2572,5 +2594,68 @@ describe('beforeLogin hook', () => {
     expect(afterSaves).toEqual(3);
     expect(beforeFinds).toEqual(1);
     expect(afterFinds).toEqual(1);
+  });
+});
+
+describe('afterLogin hook', () => {
+  it('should run afterLogin after successful login', async done => {
+    let hit = 0;
+    Parse.Cloud.afterLogin(req => {
+      hit++;
+      expect(req.object.get('username')).toEqual('testuser');
+    });
+
+    await Parse.User.signUp('testuser', 'p@ssword');
+    const user = await Parse.User.logIn('testuser', 'p@ssword');
+    expect(hit).toBe(1);
+    expect(user).toBeDefined();
+    expect(user.getUsername()).toBe('testuser');
+    expect(user.getSessionToken()).toBeDefined();
+    done();
+  });
+
+  it('should not run afterLogin after unsuccessful login', async done => {
+    let hit = 0;
+    Parse.Cloud.afterLogin(req => {
+      hit++;
+      expect(req.object.get('username')).toEqual('testuser');
+    });
+
+    await Parse.User.signUp('testuser', 'p@ssword');
+    try {
+      await Parse.User.logIn('testuser', 'badpassword');
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
+    }
+    expect(hit).toBe(0);
+    done();
+  });
+
+  it('should not run afterLogin on sign up', async done => {
+    let hit = 0;
+    Parse.Cloud.afterLogin(req => {
+      hit++;
+      expect(req.object.get('username')).toEqual('testuser');
+    });
+
+    const user = await Parse.User.signUp('testuser', 'p@ssword');
+    expect(user).toBeDefined();
+    expect(hit).toBe(0);
+    done();
+  });
+
+  it('should have expected data in request', async done => {
+    Parse.Cloud.afterLogin(req => {
+      expect(req.object).toBeDefined();
+      expect(req.user).toBeUndefined();
+      expect(req.headers).toBeDefined();
+      expect(req.ip).toBeDefined();
+      expect(req.installationId).toBeUndefined();
+      expect(req.context).toBeUndefined();
+    });
+
+    await Parse.User.signUp('testuser', 'p@ssword');
+    await Parse.User.logIn('testuser', 'p@ssword');
+    done();
   });
 });

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -264,6 +264,15 @@ export class UsersRouter extends ClassesRouter {
     user.sessionToken = sessionData.sessionToken;
 
     await createSession();
+
+    maybeRunTrigger(
+      TriggerTypes.afterLogin,
+      null,
+      Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
+      null,
+      req.config
+    );
+
     return { response: user };
   }
 

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -265,10 +265,13 @@ export class UsersRouter extends ClassesRouter {
 
     await createSession();
 
+    const afterLoginUser = Parse.User.fromJSON(
+      Object.assign({ className: '_User' }, user)
+    );
     maybeRunTrigger(
       TriggerTypes.afterLogin,
-      null,
-      Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
+      { ...req.auth, user: afterLoginUser },
+      afterLoginUser,
       null,
       req.config
     );

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -167,6 +167,42 @@ ParseCloud.beforeLogin = function(handler) {
 
 /**
  *
+ * Registers the after login function.
+ *
+ * **Available in Cloud Code only.**
+ *
+ * This function is triggered after a user logs in successfully,
+ * and after a _Session object has been created.
+ *
+ * ```
+ * Parse.Cloud.afterLogin((request) => {
+ *   // code here
+ * })
+ *
+ * ```
+ *
+ * @method afterLogin
+ * @name Parse.Cloud.afterLogin
+ * @param {Function} func The function to run after a login. This function can be async and should take one parameter a {@link Parse.Cloud.TriggerRequest};
+ */
+ParseCloud.afterLogin = function(handler) {
+  let className = '_User';
+  if (typeof handler === 'string' || isParseObjectConstructor(handler)) {
+    // validation will occur downstream, this is to maintain internal
+    // code consistency with the other hook types.
+    className = getClassName(handler);
+    handler = arguments[1];
+  }
+  triggers.addTrigger(
+    triggers.Types.afterLogin,
+    className,
+    handler,
+    Parse.applicationId
+  );
+};
+
+/**
+ *
  * Registers the after logout function.
  *
  * **Available in Cloud Code only.**

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -4,6 +4,7 @@ import { logger } from './logger';
 
 export const Types = {
   beforeLogin: 'beforeLogin',
+  afterLogin: 'afterLogin',
   afterLogout: 'afterLogout',
   beforeSave: 'beforeSave',
   afterSave: 'afterSave',
@@ -39,10 +40,13 @@ function validateClassNameForTriggers(className, type) {
     // TODO: Allow proper documented way of using nested increment ops
     throw 'Only afterSave is allowed on _PushStatus';
   }
-  if (type === Types.beforeLogin && className !== '_User') {
+  if (
+    (type === Types.beforeLogin || type === Types.afterLogin) &&
+    className !== '_User'
+  ) {
     // TODO: check if upstream code will handle `Error` instance rather
     // than this anti-pattern of throwing strings
-    throw 'Only the _User class is allowed for the beforeLogin trigger';
+    throw 'Only the _User class is allowed for the beforeLogin and afterLogin triggers';
   }
   if (type === Types.afterLogout && className !== '_Session') {
     // TODO: check if upstream code will handle `Error` instance rather
@@ -615,7 +619,8 @@ export function maybeRunTrigger(
         const promise = trigger(request);
         if (
           triggerType === Types.afterSave ||
-          triggerType === Types.afterDelete
+          triggerType === Types.afterDelete ||
+          triggerType === Types.afterLogin
         ) {
           logTriggerAfterHook(
             triggerType,


### PR DESCRIPTION
This PR adds a new `afterLogin` cloud code hook. I referenced the pull request adding the `beforeLogin` hook done by @omairvaiyani quite heavily for this PR, so it was implemented in a very similar manner.

Currently there is no method to do any work after a user has successfully logged in, and Parse Server does not allow hooks on `_Session` objects. 

**Use cases:**

- Sending events to other parts of a system when a user logs in.
- Recording a successful login event for analytics.
- Performing any other necessary post login actions like sending emails, etc.

**Motivation:**

In my specific case, we have an API gateway and authentication service in other areas of our system. This uses Parse authentication and user sessions when necessary for Parse users. We have a need to keep track of Parse Sessions in other areas of our system, so with this new hook we are able to send events when a new session is created on login that can be consumed by our other services. We also use the `afterLogout` hook when sessions are deleted as well.

**Example usage:**

```
// In cloud code
Parse.Cloud.afterLogin(request => { 
  const { object: user } = request;
  // do stuff with user or session here.
});
```