### PR TITLE
Remove unuseful promise resolve.

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -66,15 +66,13 @@ const getAuthForSessionToken = async function({
     const userJSON = await cacheController.user.get(sessionToken);
     if (userJSON) {
       const cachedUser = Parse.Object.fromJSON(userJSON);
-      return Promise.resolve(
-        new Auth({
-          config,
-          cacheController,
-          isMaster: false,
-          installationId,
-          user: cachedUser,
-        })
-      );
+      new Auth({
+        config,
+        cacheController,
+        isMaster: false,
+        installationId,
+        user: cachedUser,
+      })
     }
   }
 


### PR DESCRIPTION
There is no need to make an extra Promise.resolve into an async function. This only downgrade event loop performance. Mix callback promises and async/await is not a good pattern.