### PR TITLE
Fix Unknow type merge bug on overloaded types

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -10821,11 +10821,11 @@ describe('ParseGraphQLServer', () => {
         expect(result2.data.someClass.name).toEqual('aname');
         expect(result.data.someClass.language).toEqual('fr');
         const result3 = await apolloClient.mutate({
-          variables: { id: obj.id, name: 'anewname' },
+          variables: { id: obj.id, name: 'anewname', type: 'human' },
           mutation: gql`
-            mutation someClass($id: ID!, $name: String!) {
+            mutation someClass($id: ID!, $name: String!, $type: TypeEnum!) {
               updateSomeClass(
-                input: { id: $id, fields: { name: $name, type: human } }
+                input: { id: $id, fields: { name: $name, type: $type } }
               ) {
                 someClass {
                   nameUpperCase

--- a/src/GraphQL/ParseGraphQLSchema.js
+++ b/src/GraphQL/ParseGraphQLSchema.js
@@ -215,22 +215,26 @@ class ParseGraphQLSchema {
               autoGraphQLSchemaType &&
               typeof customGraphQLSchemaType.getFields === 'function'
             ) {
-              const findLastType = type => {
+              const findAndAddLastType = type => {
                 if (type.name) {
-                  return type;
+                  if (!this.graphQLAutoSchema.getType(type)) {
+                    // To avoid schema stitching (Unknow type) bug on variables
+                    // transfer the final type to the Auto Schema
+                    this.graphQLAutoSchema._typeMap[type.name] = type;
+                  }
                 } else {
                   if (type.ofType) {
-                    return findLastType(type.ofType);
+                    findAndAddLastType(type.ofType);
                   }
                 }
               };
               Object.values(customGraphQLSchemaType.getFields()).forEach(
                 field => {
-                  const type = findLastType(field.type);
-                  if (!this.graphQLAutoSchema.getType(type.name)) {
-                    // To avoid schema stitching (Unknow type) bug on variables
-                    // transfer the final type to the Auto Schema
-                    this.graphQLAutoSchema._typeMap[type.name] = type;
+                  findAndAddLastType(field.type);
+                  if (field.args) {
+                    field.args.forEach(arg => {
+                      findAndAddLastType(arg.type);
+                    });
                   }
                 }
               );


### PR DESCRIPTION
We got a subtile bug on named mutation with variables that contains type from custom schema overloaded on an auto schema field (see fixed test use case).