### PR TITLE
GraphQL: Change Order Enum Strategy

### DIFF
--- a/src/GraphQL/helpers/objectsQueries.js
+++ b/src/GraphQL/helpers/objectsQueries.js
@@ -3,6 +3,20 @@ import { offsetToCursor, cursorToOffset } from 'graphql-relay';
 import rest from '../../rest';
 import { transformQueryInputToParse } from '../transformers/query';
 
+const transformOrder = order =>
+  order
+    .map(o => {
+      const direction = o.indexOf('_ASC') > 0 ? '_ASC' : '_DESC';
+      let field = o.replace(direction, '');
+      field = field === 'id' ? 'objectId' : field;
+      if (direction === '_ASC') {
+        return `${field}`;
+      } else {
+        return `-${field}`;
+      }
+    })
+    .join(',');
+
 const needToGetAllKeys = (fields, keys) =>
   keys
     ? !!keys.split(',').find(keyName => !fields[keyName.split('.')[0]])
@@ -130,7 +144,7 @@ const findObjects = async (
     }
     if (options.limit !== 0) {
       if (order) {
-        options.order = order;
+        options.order = transformOrder(order);
       }
       if (skip) {
         options.skip = skip;

--- a/src/GraphQL/helpers/objectsQueries.js
+++ b/src/GraphQL/helpers/objectsQueries.js
@@ -3,6 +3,11 @@ import { offsetToCursor, cursorToOffset } from 'graphql-relay';
 import rest from '../../rest';
 import { transformQueryInputToParse } from '../transformers/query';
 
+const needToGetAllKeys = (fields, keys) =>
+  keys
+    ? !!keys.split(',').find(keyName => !fields[keyName.split('.')[0]])
+    : true;
+
 const transformOrder = order =>
   order
     .map(o => {
@@ -16,11 +21,6 @@ const transformOrder = order =>
       }
     })
     .join(',');
-
-const needToGetAllKeys = (fields, keys) =>
-  keys
-    ? !!keys.split(',').find(keyName => !fields[keyName.split('.')[0]])
-    : true;
 
 const getObject = async (
   className,

--- a/src/GraphQL/loaders/parseClassQueries.js
+++ b/src/GraphQL/loaders/parseClassQueries.js
@@ -125,12 +125,11 @@ const load = function(
               .filter(field => field.startsWith('edges.node.'))
               .map(field => field.replace('edges.node.', ''))
           );
-          const parseOrder = order && order.join(',');
 
           return await objectsQueries.findObjects(
             className,
             where,
-            parseOrder,
+            order,
             skip,
             first,
             after,

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -347,12 +347,11 @@ const load = (
       const updatedSortFields = {
         ...sortFields,
       };
-      const value = field === 'id' ? 'objectId' : field;
       if (asc) {
-        updatedSortFields[`${field}_ASC`] = { value };
+        updatedSortFields[`${field}_ASC`] = {};
       }
       if (desc) {
-        updatedSortFields[`${field}_DESC`] = { value: `-${value}` };
+        updatedSortFields[`${field}_DESC`] = {};
       }
       return updatedSortFields;
     }, {}),
@@ -434,7 +433,6 @@ const load = (
                     .filter(field => field.startsWith('edges.node.'))
                     .map(field => field.replace('edges.node.', ''))
                 );
-                const parseOrder = order && order.join(',');
 
                 return objectsQueries.findObjects(
                   source[field].className,
@@ -449,7 +447,7 @@ const load = (
                     },
                     ...(where || {}),
                   },
-                  parseOrder,
+                  order,
                   skip,
                   first,
                   after,


### PR DESCRIPTION
Due to https://github.com/apollographql/graphql-tools/pull/1206, enums with custom value are not correctly merged and lead to bugs and validation error.

We need to transform GraphQL Order to Parse Order later before sending request to Parse Server.

This bug only occur on merged schemas.