### PR TITLE
Apply `npm install` to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       "dev": true,
       "requires": {
         "chokidar": "^2.1.8",
+        "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
@@ -60,6 +61,12 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8229,6 +8236,7 @@
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
+        "commander": "^4.0.1",
         "cosmiconfig": "^6.0.0",
         "debug": "^4.1.1",
         "dedent": "^0.7.0",
@@ -8284,6 +8292,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
         },
         "debug": {
@@ -10134,6 +10148,7 @@
         "@babel/runtime-corejs3": "7.7.7",
         "crypto-js": "3.1.9-1",
         "uuid": "3.3.3",
+        "ws": "7.2.1",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
@@ -10158,6 +10173,11 @@
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
           "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+        },
+        "ws": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+          "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
         }
       }
     },


### PR DESCRIPTION
It's not clear what happened in #6478, but it appears that it dropped
the `ws` dependency of the `parse` package when it was updating the
local version of the dependency. This means that running `npm install`
dirties the working tree, which is surprising!

A similar problem seems to have occurred in #6504, that time related to
the `commander` package.

I've filed an issue for the surprising behavior from greenkeeper:
https://github.com/greenkeeperio/greenkeeper-lockfile/issues/250