### PR TITLE
feat(performance): use $graphLookup for auth

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -29,7 +29,7 @@ function Auth({
 
 // Whether this auth could possibly modify the given user id.
 // It still could be forbidden via ACLs even if this returns true.
-Auth.prototype.isUnauthenticated = function() {
+Auth.prototype.isUnauthenticated = function () {
   if (this.isMaster) {
     return false;
   }
@@ -55,7 +55,7 @@ function nobody(config) {
 }
 
 // Returns a promise that resolves to an Auth object
-const getAuthForSessionToken = async function({
+const getAuthForSessionToken = async function ({
   config,
   cacheController,
   sessionToken,
@@ -94,11 +94,13 @@ const getAuthForSessionToken = async function({
     );
     results = (await query.execute()).results;
   } else {
-    results = (await new Parse.Query(Parse.Session)
-      .limit(1)
-      .include('user')
-      .equalTo('sessionToken', sessionToken)
-      .find({ useMasterKey: true })).map(obj => obj.toJSON());
+    results = (
+      await new Parse.Query(Parse.Session)
+        .limit(1)
+        .include('user')
+        .equalTo('sessionToken', sessionToken)
+        .find({ useMasterKey: true })
+    ).map((obj) => obj.toJSON());
   }
 
   if (results.length !== 1 || !results[0]['user']) {
@@ -134,7 +136,7 @@ const getAuthForSessionToken = async function({
   });
 };
 
-var getAuthForLegacySessionToken = function({
+var getAuthForLegacySessionToken = function ({
   config,
   sessionToken,
   installationId,
@@ -149,7 +151,7 @@ var getAuthForLegacySessionToken = function({
     { sessionToken },
     restOptions
   );
-  return query.execute().then(response => {
+  return query.execute().then((response) => {
     var results = response.results;
     if (results.length !== 1) {
       throw new Parse.Error(
@@ -169,8 +171,7 @@ var getAuthForLegacySessionToken = function({
   });
 };
 
-// Returns a promise that resolves to an array of role names
-Auth.prototype.getUserRoles = function() {
+Auth.prototype.getUserRoles = function () {
   if (this.isMaster || !this.user) {
     return Promise.resolve([]);
   }
@@ -180,11 +181,117 @@ Auth.prototype.getUserRoles = function() {
   if (this.rolePromise) {
     return this.rolePromise;
   }
-  this.rolePromise = this._loadRoles();
+  this.rolePromise = this._loadUserRolesForAccess();
   return this.rolePromise;
 };
 
-Auth.prototype.getRolesForUser = async function() {
+Auth.prototype._loadUserRolesForAccess = async function () {
+  if (this.cacheController) {
+    const cachedRoles = await this.cacheController.role.get(this.user.id);
+    if (cachedRoles != null) {
+      this.fetchedRoles = true;
+      this.userRoles = cachedRoles;
+      return cachedRoles;
+    }
+  }
+
+  const { results } = await new RestQuery(
+    this.config,
+    master(this.config),
+    '_Join:users:_Role',
+    {},
+    {
+      pipeline: this._generateRoleGraphPipeline(),
+    }
+  ).execute();
+
+  const { directRoles, childRoles } = results[0];
+  const roles = [...directRoles, ...childRoles];
+  this.userRoles = roles.map((role) => `role:${role.name}`);
+  this.fetchedRoles = true;
+  this.rolePromise = null;
+  this.cacheRoles();
+  return this.userRoles;
+};
+
+Auth.prototype._generateRoleGraphPipeline = function () {
+  return [
+    {
+      $match: {
+        relatedId: this.user.id,
+      },
+    },
+    {
+      $graphLookup: {
+        from: '_Join:roles:_Role',
+        startWith: '$owningId',
+        connectFromField: 'owningId',
+        connectToField: 'relatedId',
+        as: 'childRolePath',
+      },
+    },
+    {
+      $facet: {
+        directRoles: [
+          {
+            $lookup: {
+              from: '_Role',
+              localField: 'owningId',
+              foreignField: '_id',
+              as: 'Roles',
+            },
+          },
+          {
+            $unwind: {
+              path: '$Roles',
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                $ifNull: ['$Roles', { $literal: {} }],
+              },
+            },
+          },
+          {
+            $project: {
+              name: 1,
+            },
+          },
+        ],
+        childRoles: [
+          {
+            $lookup: {
+              from: '_Role',
+              localField: 'childRolePath.owningId',
+              foreignField: '_id',
+              as: 'Roles',
+            },
+          },
+          {
+            $unwind: {
+              path: '$Roles',
+            },
+          },
+          {
+            $replaceRoot: {
+              newRoot: {
+                $ifNull: ['$Roles', { $literal: {} }],
+              },
+            },
+          },
+          {
+            $project: {
+              name: 1,
+            },
+          },
+        ],
+      },
+    },
+  ];
+};
+
+Auth.prototype.getRolesForUser = async function () {
   //Stack all Parse.Role
   const results = [];
   if (this.config) {
@@ -201,17 +308,17 @@ Auth.prototype.getRolesForUser = async function() {
       '_Role',
       restWhere,
       {}
-    ).each(result => results.push(result));
+    ).each((result) => results.push(result));
   } else {
     await new Parse.Query(Parse.Role)
       .equalTo('users', this.user)
-      .each(result => results.push(result.toJSON()), { useMasterKey: true });
+      .each((result) => results.push(result.toJSON()), { useMasterKey: true });
   }
   return results;
 };
 
 // Iterates through the role tree and compiles a user's roles
-Auth.prototype._loadRoles = async function() {
+Auth.prototype._loadRoles = async function () {
   if (this.cacheController) {
     const cachedRoles = await this.cacheController.role.get(this.user.id);
     if (cachedRoles != null) {
@@ -246,7 +353,7 @@ Auth.prototype._loadRoles = async function() {
     rolesMap.ids,
     rolesMap.names
   );
-  this.userRoles = roleNames.map(r => {
+  this.userRoles = roleNames.map((r) => {
     return 'role:' + r;
   });
   this.fetchedRoles = true;
@@ -255,7 +362,7 @@ Auth.prototype._loadRoles = async function() {
   return this.userRoles;
 };
 
-Auth.prototype.cacheRoles = function() {
+Auth.prototype.cacheRoles = function () {
   if (!this.cacheController) {
     return false;
   }
@@ -263,22 +370,22 @@ Auth.prototype.cacheRoles = function() {
   return true;
 };
 
-Auth.prototype.getRolesByIds = async function(ins) {
+Auth.prototype.getRolesByIds = async function (ins) {
   const results = [];
   // Build an OR query across all parentRoles
   if (!this.config) {
     await new Parse.Query(Parse.Role)
       .containedIn(
         'roles',
-        ins.map(id => {
+        ins.map((id) => {
           const role = new Parse.Object(Parse.Role);
           role.id = id;
           return role;
         })
       )
-      .each(result => results.push(result.toJSON()), { useMasterKey: true });
+      .each((result) => results.push(result.toJSON()), { useMasterKey: true });
   } else {
-    const roles = ins.map(id => {
+    const roles = ins.map((id) => {
       return {
         __type: 'Pointer',
         className: '_Role',
@@ -292,18 +399,18 @@ Auth.prototype.getRolesByIds = async function(ins) {
       '_Role',
       restWhere,
       {}
-    ).each(result => results.push(result));
+    ).each((result) => results.push(result));
   }
   return results;
 };
 
 // Given a list of roleIds, find all the parent roles, returns a promise with all names
-Auth.prototype._getAllRolesNamesForRoleIds = function(
+Auth.prototype._getAllRolesNamesForRoleIds = function (
   roleIDs,
   names = [],
   queriedRoles = {}
 ) {
-  const ins = roleIDs.filter(roleID => {
+  const ins = roleIDs.filter((roleID) => {
     const wasQueried = queriedRoles[roleID] !== true;
     queriedRoles[roleID] = true;
     return wasQueried;
@@ -315,7 +422,7 @@ Auth.prototype._getAllRolesNamesForRoleIds = function(
   }
 
   return this.getRolesByIds(ins)
-    .then(results => {
+    .then((results) => {
       // Nothing found
       if (!results.length) {
         return Promise.resolve(names);
@@ -338,12 +445,12 @@ Auth.prototype._getAllRolesNamesForRoleIds = function(
         queriedRoles
       );
     })
-    .then(names => {
+    .then((names) => {
       return Promise.resolve([...new Set(names)]);
     });
 };
 
-const createSession = function(
+const createSession = function (
   config,
   { userId, createdWith, installationId, additionalSessionData }
 ) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -65,7 +65,7 @@ const specialQuerykeys = [
   '_failed_login_count',
 ];
 
-const isSpecialQueryKey = key => {
+const isSpecialQueryKey = (key) => {
   return specialQuerykeys.indexOf(key) >= 0;
 };
 
@@ -107,7 +107,7 @@ const validateQuery = (query: any): void => {
     }
   }
 
-  Object.keys(query).forEach(key => {
+  Object.keys(query).forEach((key) => {
     if (query && query[key] && query[key].$regex) {
       if (typeof query[key].$options === 'string') {
         if (!query[key].$options.match(/^[imxs]+$/)) {
@@ -149,8 +149,8 @@ const filterSensitiveData = (
     if (isReadOperation && perms.protectedFields) {
       // extract protectedFields added with the pointer-permission prefix
       const protectedFieldsPointerPerm = Object.keys(perms.protectedFields)
-        .filter(key => key.startsWith('userField:'))
-        .map(key => {
+        .filter((key) => key.startsWith('userField:'))
+        .map((key) => {
           return { key: key.substring(10), value: perms.protectedFields[key] };
         });
 
@@ -158,13 +158,13 @@ const filterSensitiveData = (
       let overrideProtectedFields = false;
 
       // check if the object grants the current user access based on the extracted fields
-      protectedFieldsPointerPerm.forEach(pointerPerm => {
+      protectedFieldsPointerPerm.forEach((pointerPerm) => {
         let pointerPermIncludesUser = false;
         const readUserFieldValue = object[pointerPerm.key];
         if (readUserFieldValue) {
           if (Array.isArray(readUserFieldValue)) {
             pointerPermIncludesUser = readUserFieldValue.some(
-              user => user.objectId && user.objectId === userId
+              (user) => user.objectId && user.objectId === userId
             );
           } else {
             pointerPermIncludesUser =
@@ -186,14 +186,14 @@ const filterSensitiveData = (
         newProtectedFields.push(protectedFields);
       }
       // intersect all sets of protectedFields
-      newProtectedFields.forEach(fields => {
+      newProtectedFields.forEach((fields) => {
         if (fields) {
           // if there're no protctedFields by other criteria ( id / role / auth)
           // then we must intersect each set (per userField)
           if (!protectedFields) {
             protectedFields = fields;
           } else {
-            protectedFields = protectedFields.filter(v => fields.includes(v));
+            protectedFields = protectedFields.filter((v) => fields.includes(v));
           }
         }
       });
@@ -205,13 +205,13 @@ const filterSensitiveData = (
   /* special treat for the user class: don't filter protectedFields if currently loggedin user is
   the retrieved user */
   if (!(isUserClass && userId && object.objectId === userId)) {
-    protectedFields && protectedFields.forEach(k => delete object[k]);
+    protectedFields && protectedFields.forEach((k) => delete object[k]);
 
     // fields not requested by client (excluded),
     //but were needed to apply protecttedFields
     perms.protectedFields &&
       perms.protectedFields.temporaryKeys &&
-      perms.protectedFields.temporaryKeys.forEach(k => delete object[k]);
+      perms.protectedFields.temporaryKeys.forEach((k) => delete object[k]);
   }
 
   if (!isUserClass) {
@@ -265,7 +265,7 @@ const specialKeysForUpdate = [
   '_password_history',
 ];
 
-const isSpecialUpdateKey = key => {
+const isSpecialUpdateKey = (key) => {
   return specialKeysForUpdate.indexOf(key) >= 0;
 };
 
@@ -291,7 +291,7 @@ function sanitizeDatabaseResult(originalObject, result): Promise<any> {
   if (!result) {
     return Promise.resolve(response);
   }
-  Object.keys(originalObject).forEach(key => {
+  Object.keys(originalObject).forEach((key) => {
     const keyUpdate = originalObject[key];
     // determine if that was an op
     if (
@@ -312,7 +312,7 @@ function joinTableName(className, key) {
   return `_Join:${key}:${className}`;
 }
 
-const flattenUpdateOperatorsForCreate = object => {
+const flattenUpdateOperatorsForCreate = (object) => {
   for (const key in object) {
     if (object[key] && object[key].__op) {
       switch (object[key].__op) {
@@ -367,7 +367,7 @@ const flattenUpdateOperatorsForCreate = object => {
 
 const transformAuthData = (className, object, schema) => {
   if (object.authData && className === '_User') {
-    Object.keys(object.authData).forEach(provider => {
+    Object.keys(object.authData).forEach((provider) => {
       const providerData = object.authData[provider];
       const fieldName = `_auth_data_${provider}`;
       if (providerData == null) {
@@ -387,7 +387,7 @@ const untransformObjectACL = ({ _rperm, _wperm, ...output }) => {
   if (_rperm || _wperm) {
     output.ACL = {};
 
-    (_rperm || []).forEach(entry => {
+    (_rperm || []).forEach((entry) => {
       if (!output.ACL[entry]) {
         output.ACL[entry] = { read: true };
       } else {
@@ -395,7 +395,7 @@ const untransformObjectACL = ({ _rperm, _wperm, ...output }) => {
       }
     });
 
-    (_wperm || []).forEach(entry => {
+    (_wperm || []).forEach((entry) => {
       if (!output.ACL[entry]) {
         output.ACL[entry] = { write: true };
       } else {
@@ -442,8 +442,10 @@ class DatabaseController {
 
   purgeCollection(className: string): Promise<void> {
     return this.loadSchema()
-      .then(schemaController => schemaController.getOneSchema(className))
-      .then(schema => this.adapter.deleteObjectsByQuery(className, schema, {}));
+      .then((schemaController) => schemaController.getOneSchema(className))
+      .then((schema) =>
+        this.adapter.deleteObjectsByQuery(className, schema, {})
+      );
   }
 
   validateClassName(className: string): Promise<void> {
@@ -490,7 +492,7 @@ class DatabaseController {
   // classname through the key.
   // TODO: make this not in the DatabaseController interface
   redirectClassNameForKey(className: string, key: string): Promise<?string> {
-    return this.loadSchema().then(schema => {
+    return this.loadSchema().then((schema) => {
       var t = schema.getExpectedType(className, key);
       if (t != null && typeof t !== 'string' && t.type === 'Relation') {
         return t.targetClass;
@@ -514,7 +516,7 @@ class DatabaseController {
     const isMaster = acl === undefined;
     var aclGroup: string[] = acl || [];
     return this.loadSchema()
-      .then(s => {
+      .then((s) => {
         schema = s;
         if (isMaster) {
           return Promise.resolve();
@@ -550,7 +552,7 @@ class DatabaseController {
     var aclGroup = acl || [];
 
     return this.loadSchemaIfNeeded(validSchemaController).then(
-      schemaController => {
+      (schemaController) => {
         return (isMaster
           ? Promise.resolve()
           : schemaController.validatePermission(className, aclGroup, 'update')
@@ -594,7 +596,7 @@ class DatabaseController {
             validateQuery(query);
             return schemaController
               .getOneSchema(className, true)
-              .catch(error => {
+              .catch((error) => {
                 // If the schema doesn't exist, pretend it exists with no fields. This behavior
                 // will likely need revisiting.
                 if (error === undefined) {
@@ -602,8 +604,8 @@ class DatabaseController {
                 }
                 throw error;
               })
-              .then(schema => {
-                Object.keys(update).forEach(fieldName => {
+              .then((schema) => {
+                Object.keys(update).forEach((fieldName) => {
                   if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
                     throw new Parse.Error(
                       Parse.Error.INVALID_KEY_NAME,
@@ -626,7 +628,7 @@ class DatabaseController {
                     update[updateOperation] &&
                     typeof update[updateOperation] === 'object' &&
                     Object.keys(update[updateOperation]).some(
-                      innerKey =>
+                      (innerKey) =>
                         innerKey.includes('$') || innerKey.includes('.')
                     )
                   ) {
@@ -641,7 +643,7 @@ class DatabaseController {
                 if (validateOnly) {
                   return this.adapter
                     .find(className, schema, query, {})
-                    .then(result => {
+                    .then((result) => {
                       if (!result || !result.length) {
                         throw new Parse.Error(
                           Parse.Error.OBJECT_NOT_FOUND,
@@ -697,7 +699,7 @@ class DatabaseController {
               return result;
             });
           })
-          .then(result => {
+          .then((result) => {
             if (skipSanitization) {
               return Promise.resolve(result);
             }
@@ -820,7 +822,7 @@ class DatabaseController {
         doc,
         this._transactionalSession
       )
-      .catch(error => {
+      .catch((error) => {
         // We don't care if they try to delete a non-existent relation.
         if (error.code == Parse.Error.OBJECT_NOT_FOUND) {
           return;
@@ -846,7 +848,7 @@ class DatabaseController {
     const aclGroup = acl || [];
 
     return this.loadSchemaIfNeeded(validSchemaController).then(
-      schemaController => {
+      (schemaController) => {
         return (isMaster
           ? Promise.resolve()
           : schemaController.validatePermission(className, aclGroup, 'delete')
@@ -873,7 +875,7 @@ class DatabaseController {
           validateQuery(query);
           return schemaController
             .getOneSchema(className)
-            .catch(error => {
+            .catch((error) => {
               // If the schema doesn't exist, pretend it exists with no fields. This behavior
               // will likely need revisiting.
               if (error === undefined) {
@@ -881,7 +883,7 @@ class DatabaseController {
               }
               throw error;
             })
-            .then(parseFormatSchema =>
+            .then((parseFormatSchema) =>
               this.adapter.deleteObjectsByQuery(
                 className,
                 parseFormatSchema,
@@ -889,7 +891,7 @@ class DatabaseController {
                 this._transactionalSession
               )
             )
-            .catch(error => {
+            .catch((error) => {
               // When deleting sessions while changing passwords, don't throw an error if they don't have any sessions.
               if (
                 className === '_Session' &&
@@ -930,14 +932,14 @@ class DatabaseController {
 
     return this.validateClassName(className)
       .then(() => this.loadSchemaIfNeeded(validSchemaController))
-      .then(schemaController => {
+      .then((schemaController) => {
         return (isMaster
           ? Promise.resolve()
           : schemaController.validatePermission(className, aclGroup, 'create')
         )
           .then(() => schemaController.enforceClassExists(className))
           .then(() => schemaController.getOneSchema(className, true))
-          .then(schema => {
+          .then((schema) => {
             transformAuthData(className, object, schema);
             flattenUpdateOperatorsForCreate(object);
             if (validateOnly) {
@@ -950,7 +952,7 @@ class DatabaseController {
               this._transactionalSession
             );
           })
-          .then(result => {
+          .then((result) => {
             if (validateOnly) {
               return originalObject;
             }
@@ -979,7 +981,7 @@ class DatabaseController {
     }
     const fields = Object.keys(object);
     const schemaFields = Object.keys(classSchema.fields);
-    const newKeys = fields.filter(field => {
+    const newKeys = fields.filter((field) => {
       // Skip fields that are unset
       if (
         object[field] &&
@@ -1038,7 +1040,7 @@ class DatabaseController {
         { owningId },
         findOptions
       )
-      .then(results => results.map(result => result.relatedId));
+      .then((results) => results.map((result) => result.relatedId));
   }
 
   // Returns a promise for a list of owning ids given some related ids.
@@ -1055,7 +1057,7 @@ class DatabaseController {
         { relatedId: { $in: relatedIds } },
         {}
       )
-      .then(results => results.map(result => result.owningId));
+      .then((results) => results.map((result) => result.owningId));
   }
 
   // Modifies query so that it no longer has $in on relation fields, or
@@ -1069,7 +1071,7 @@ class DatabaseController {
       return Promise.all(
         ors.map((aQuery, index) => {
           return this.reduceInRelation(className, aQuery, schema).then(
-            aQuery => {
+            (aQuery) => {
               query['$or'][index] = aQuery;
             }
           );
@@ -1079,7 +1081,7 @@ class DatabaseController {
       });
     }
 
-    const promises = Object.keys(query).map(key => {
+    const promises = Object.keys(query).map((key) => {
       const t = schema.getExpectedType(className, key);
       if (!t || t.type !== 'Relation') {
         return Promise.resolve(query);
@@ -1093,16 +1095,16 @@ class DatabaseController {
           query[key].__type == 'Pointer')
       ) {
         // Build the list of queries
-        queries = Object.keys(query[key]).map(constraintKey => {
+        queries = Object.keys(query[key]).map((constraintKey) => {
           let relatedIds;
           let isNegation = false;
           if (constraintKey === 'objectId') {
             relatedIds = [query[key].objectId];
           } else if (constraintKey == '$in') {
-            relatedIds = query[key]['$in'].map(r => r.objectId);
+            relatedIds = query[key]['$in'].map((r) => r.objectId);
           } else if (constraintKey == '$nin') {
             isNegation = true;
-            relatedIds = query[key]['$nin'].map(r => r.objectId);
+            relatedIds = query[key]['$nin'].map((r) => r.objectId);
           } else if (constraintKey == '$ne') {
             isNegation = true;
             relatedIds = [query[key]['$ne'].objectId];
@@ -1122,11 +1124,11 @@ class DatabaseController {
       delete query[key];
       // execute each query independently to build the list of
       // $in / $nin
-      const promises = queries.map(q => {
+      const promises = queries.map((q) => {
         if (!q) {
           return Promise.resolve();
         }
-        return this.owningIds(className, key, q.relatedIds).then(ids => {
+        return this.owningIds(className, key, q.relatedIds).then((ids) => {
           if (q.isNegation) {
             this.addNotInObjectIdsIds(ids, query);
           } else {
@@ -1155,7 +1157,7 @@ class DatabaseController {
   ): ?Promise<void> {
     if (query['$or']) {
       return Promise.all(
-        query['$or'].map(aQuery => {
+        query['$or'].map((aQuery) => {
           return this.reduceRelationKeys(className, aQuery, queryOptions);
         })
       );
@@ -1169,7 +1171,7 @@ class DatabaseController {
         relatedTo.object.objectId,
         queryOptions
       )
-        .then(ids => {
+        .then((ids) => {
           delete query['$relatedTo'];
           this.addInObjectIdsIds(ids, query);
           return this.reduceRelationKeys(className, query, queryOptions);
@@ -1192,7 +1194,7 @@ class DatabaseController {
       idsFromEq,
       idsFromIn,
       ids,
-    ].filter(list => list !== null);
+    ].filter((list) => list !== null);
     const totalLength = allIds.reduce((memo, list) => memo + list.length, 0);
 
     let idsIntersection = [];
@@ -1221,7 +1223,7 @@ class DatabaseController {
   addNotInObjectIdsIds(ids: string[] = [], query: any) {
     const idsFromNin =
       query.objectId && query.objectId['$nin'] ? query.objectId['$nin'] : [];
-    let allIds = [...idsFromNin, ...ids].filter(list => list !== null);
+    let allIds = [...idsFromNin, ...ids].filter((list) => list !== null);
 
     // make a set and spread to remove duplicates
     allIds = [...new Set(allIds)];
@@ -1290,13 +1292,13 @@ class DatabaseController {
 
     let classExists = true;
     return this.loadSchemaIfNeeded(validSchemaController).then(
-      schemaController => {
+      (schemaController) => {
         //Allow volatile classes if querying with Master (for _PushStatus)
         //TODO: Move volatile classes concept into mongo adapter, postgres adapter shouldn't care
         //that api.parse.com breaks when _PushStatus exists in mongo.
         return schemaController
           .getOneSchema(className, isMaster)
-          .catch(error => {
+          .catch((error) => {
             // Behavior for non-existent classes is kinda weird on Parse.com. Probably doesn't matter too much.
             // For now, pretend the class exists but has no objects,
             if (error === undefined) {
@@ -1305,7 +1307,7 @@ class DatabaseController {
             }
             throw error;
           })
-          .then(schema => {
+          .then((schema) => {
             // Parse.com treats queries on _created_at and _updated_at as if they were queries on createdAt and updatedAt,
             // so duplicate that behavior here. If both are specified, the correct behavior to match Parse.com is to
             // use the one that appears first in the sort list.
@@ -1327,7 +1329,7 @@ class DatabaseController {
               caseInsensitive,
               explain,
             };
-            Object.keys(sort).forEach(fieldName => {
+            Object.keys(sort).forEach((fieldName) => {
               if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
                 throw new Parse.Error(
                   Parse.Error.INVALID_KEY_NAME,
@@ -1417,7 +1419,7 @@ class DatabaseController {
                     );
                   }
                 } else if (pipeline) {
-                  if (!classExists) {
+                  if (!classExists && className !== '_Join:users:_Role') {
                     return [];
                   } else {
                     return this.adapter.aggregate(
@@ -1439,8 +1441,8 @@ class DatabaseController {
                 } else {
                   return this.adapter
                     .find(className, schema, query, queryOptions)
-                    .then(objects =>
-                      objects.map(object => {
+                    .then((objects) =>
+                      objects.map((object) => {
                         object = untransformObjectACL(object);
                         return filterSensitiveData(
                           isMaster,
@@ -1454,7 +1456,7 @@ class DatabaseController {
                         );
                       })
                     )
-                    .catch(error => {
+                    .catch((error) => {
                       throw new Parse.Error(
                         Parse.Error.INTERNAL_SERVER_ERROR,
                         error
@@ -1469,8 +1471,10 @@ class DatabaseController {
 
   deleteSchema(className: string): Promise<void> {
     return this.loadSchema({ clearCache: true })
-      .then(schemaController => schemaController.getOneSchema(className, true))
-      .catch(error => {
+      .then((schemaController) =>
+        schemaController.getOneSchema(className, true)
+      )
+      .catch((error) => {
         if (error === undefined) {
           return { fields: {} };
         } else {
@@ -1482,7 +1486,7 @@ class DatabaseController {
           .then(() =>
             this.adapter.count(className, { fields: {} }, null, '', false)
           )
-          .then(count => {
+          .then((count) => {
             if (count > 0) {
               throw new Parse.Error(
                 255,
@@ -1491,13 +1495,13 @@ class DatabaseController {
             }
             return this.adapter.deleteClass(className);
           })
-          .then(wasParseCollection => {
+          .then((wasParseCollection) => {
             if (wasParseCollection) {
               const relationFieldNames = Object.keys(schema.fields).filter(
-                fieldName => schema.fields[fieldName].type === 'Relation'
+                (fieldName) => schema.fields[fieldName].type === 'Relation'
               );
               return Promise.all(
-                relationFieldNames.map(name =>
+                relationFieldNames.map((name) =>
                   this.adapter.deleteClass(joinTableName(className, name))
                 )
               ).then(() => {
@@ -1529,7 +1533,7 @@ class DatabaseController {
     }
     const perms = schema.getClassLevelPermissions(className);
 
-    const userACL = aclGroup.filter(acl => {
+    const userACL = aclGroup.filter((acl) => {
       return acl.indexOf('role:') != 0 && acl != '*';
     });
 
@@ -1566,7 +1570,7 @@ class DatabaseController {
         objectId: userId,
       };
 
-      const ors = permFields.flatMap(key => {
+      const ors = permFields.flatMap((key) => {
         // constraint for single pointer setup
         const q = {
           [key]: userPointer,
@@ -1682,9 +1686,9 @@ class DatabaseController {
     }, []);
 
     // intersect all sets of protectedFields
-    protectedKeysSets.forEach(fields => {
+    protectedKeysSets.forEach((fields) => {
       if (fields) {
-        protectedKeys = protectedKeys.filter(v => fields.includes(v));
+        protectedKeys = protectedKeys.filter((v) => fields.includes(v));
       }
     });
 
@@ -1694,7 +1698,7 @@ class DatabaseController {
   createTransactionalSession() {
     return this.adapter
       .createTransactionalSession()
-      .then(transactionalSession => {
+      .then((transactionalSession) => {
         this._transactionalSession = transactionalSession;
       });
   }
@@ -1737,10 +1741,10 @@ class DatabaseController {
       },
     };
 
-    const userClassPromise = this.loadSchema().then(schema =>
+    const userClassPromise = this.loadSchema().then((schema) =>
       schema.enforceClassExists('_User')
     );
-    const roleClassPromise = this.loadSchema().then(schema =>
+    const roleClassPromise = this.loadSchema().then((schema) =>
       schema.enforceClassExists('_Role')
     );
 
@@ -1748,7 +1752,7 @@ class DatabaseController {
       .then(() =>
         this.adapter.ensureUniqueness('_User', requiredUserFields, ['username'])
       )
-      .catch(error => {
+      .catch((error) => {
         logger.warn('Unable to ensure uniqueness for usernames: ', error);
         throw error;
       });
@@ -1763,7 +1767,7 @@ class DatabaseController {
           true
         )
       )
-      .catch(error => {
+      .catch((error) => {
         logger.warn(
           'Unable to create case insensitive username index: ',
           error
@@ -1775,7 +1779,7 @@ class DatabaseController {
       .then(() =>
         this.adapter.ensureUniqueness('_User', requiredUserFields, ['email'])
       )
-      .catch(error => {
+      .catch((error) => {
         logger.warn(
           'Unable to ensure uniqueness for user email addresses: ',
           error
@@ -1793,7 +1797,7 @@ class DatabaseController {
           true
         )
       )
-      .catch(error => {
+      .catch((error) => {
         logger.warn('Unable to create case insensitive email index: ', error);
         throw error;
       });
@@ -1802,7 +1806,7 @@ class DatabaseController {
       .then(() =>
         this.adapter.ensureUniqueness('_Role', requiredRoleFields, ['name'])
       )
-      .catch(error => {
+      .catch((error) => {
         logger.warn('Unable to ensure uniqueness for role name: ', error);
         throw error;
       });
@@ -1824,7 +1828,7 @@ class DatabaseController {
     ]);
   }
 
-  static _validateQuery: any => void;
+  static _validateQuery: (any) => void;
 }
 
 module.exports = DatabaseController;


### PR DESCRIPTION
At a high-level, this PR (work in progress) replaces the current recursive roles/auth query with a single aggregation pipeline to list all roles within the user's graph in one request. For applications at scale, this (at first set of benchmarks) appears to suggest a >10x reduction in request times before the cache kicks in.

After this [discussion](https://github.com/parse-community/parse-server/issues/6513) I have managed to land a big performance improvement. Each request by an authenticated user that results in a database query must be authorised, which currently means loading all the roles that the user is in, and loading the roles that yield to these, one level at a time.

Currently, for every new layer of roles added to an application, the request grows by 1. Depending on your setup, this can be quite a slow process. We've seen this take upwards of 5s on some of our heavy users with a significant amount of roles. There are certainly some application and schema design improvements that developers could make to reduce the total number or indeed levels of roles, however, we have a clear vector to optimise a very central part of this codebase. 

**Rough benchmarks:**
I ran these against my own application about 10 times for each of the following cases

Num roles: 5
Current: ~100-160ms
New: ~25-30ms

Num roles: 50
Current: ~200-500ms
New: ~40-60ms

Num roles: 1000
Current: ~900-4400ms
New: ~65-120ms

**Help needed**
The test suite uses `mongo-runner` which appears to have some shortcomings when dealing with `$graphLookup`, hence the anaemic test suite in this PR. Any suggestions here would be helpful. The current test-suite (`Auth.spec.js`) does not fully cover the role look up anyways. 

Work in progress:
- [x] Proof of concept
- [ ] Remove legacy functions 
- [ ] Test-cases
- [ ] Postgres support or backwards compatibility 
- [ ] Proper solution for `DatabaseController...classExists` problem