### PR TITLE
Add `bson-ext` as optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,7 +3604,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
@@ -3753,6 +3752,25 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
       "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+    },
+    "bson-ext": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bson-ext/-/bson-ext-2.0.3.tgz",
+      "integrity": "sha512-/QnZ5wr46L53ai5NdkNZKsvRGvlqGjSblbA61goiCx0UUIKpzF9uCodeola92pIBBfB9nbJ3XTn8HKX2ecthBg==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "bson": "^2.0.2",
+        "nan": "^2.14.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.8.tgz",
+          "integrity": "sha512-0F0T3gHeOwJzHWcN60BZomqj5hCBDRk4b3fANuruvDTnyJJ8sggABKSaePM2F34THNZZSIlB2P1mk2nQWgBr9w==",
+          "optional": true
+        }
+      }
     },
     "buffer": {
       "version": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "parse-server": "./bin/parse-server"
   },
   "optionalDependencies": {
-    "bcrypt": "4.0.1"
+    "bcrypt": "4.0.1",
+    "bson-ext": "^2.0.3"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
The `bson-ext` package builds a C++ addon that the Mongo driver can use to more efficiently serialize/deserialize when talking to Mongo. When this isn't loaded Mongo uses the `bson` package, which implements the same functionality in JS, so we can classify this as an "optional" dependency and not block a build if it is unavailable.