### PR TITLE
Adding ssl config params to Postgres URI

### DIFF
--- a/spec/PostgresConfigParser.spec.js
+++ b/spec/PostgresConfigParser.spec.js
@@ -35,8 +35,37 @@ dbOptionsTest[
   poolSize: 10,
 };
 dbOptionsTest[`${baseURI}?ssl=&binary=aa`] = {
-  ssl: false,
   binary: false,
+};
+dbOptionsTest[
+  `${baseURI}?ssl=true&ca=/path&pfx=/path&cert=/path&key=/path&binary=aa&passphrase=word&secureOptions=20`
+] = {
+  ssl: {
+    ca: '/path',
+    pfx: '/path',
+    cert: '/path',
+    key: '/path',
+    passphrase: 'word',
+    secureOptions: 20,
+  },
+  binary: false,
+};
+dbOptionsTest[
+  `${baseURI}?ssl=false&ca=/path&pfx=/path&cert=/path&key=/path&binary=aa`
+] = {
+  ssl: { ca: '/path', pfx: '/path', cert: '/path', key: '/path' },
+  binary: false,
+};
+dbOptionsTest[`${baseURI}?rejectUnauthorized=true`] = {
+  ssl: { rejectUnauthorized: true },
+};
+dbOptionsTest[
+  `${baseURI}?max=5&query_timeout=100&idleTimeoutMillis=1000&keepAlive=true`
+] = {
+  max: 5,
+  query_timeout: 100,
+  idleTimeoutMillis: 1000,
+  keepAlive: true,
 };
 
 describe('PostgresConfigParser.getDatabaseOptionsFromURI', () => {

--- a/spec/PostgresConfigParser.spec.js
+++ b/spec/PostgresConfigParser.spec.js
@@ -24,7 +24,7 @@ describe('PostgresConfigParser.parseQueryParams', () => {
 });
 
 const baseURI = 'postgres://username:password@localhost:5432/db-name';
-const testfile = fs.readFileSync('./Dockerfile');
+const testfile = fs.readFileSync('./Dockerfile').toString();
 const dbOptionsTest = {};
 dbOptionsTest[
   `${baseURI}?ssl=true&binary=true&application_name=app_name&fallback_application_name=f_app_name&poolSize=10`

--- a/spec/PostgresConfigParser.spec.js
+++ b/spec/PostgresConfigParser.spec.js
@@ -1,4 +1,5 @@
 const parser = require('../lib/Adapters/Storage/Postgres/PostgresConfigParser');
+const fs = require('fs');
 
 const queryParamTests = {
   'a=1&b=2': { a: '1', b: '2' },
@@ -23,7 +24,7 @@ describe('PostgresConfigParser.parseQueryParams', () => {
 });
 
 const baseURI = 'postgres://username:password@localhost:5432/db-name';
-
+const testfile = fs.readFileSync('./Dockerfile');
 const dbOptionsTest = {};
 dbOptionsTest[
   `${baseURI}?ssl=true&binary=true&application_name=app_name&fallback_application_name=f_app_name&poolSize=10`
@@ -38,22 +39,22 @@ dbOptionsTest[`${baseURI}?ssl=&binary=aa`] = {
   binary: false,
 };
 dbOptionsTest[
-  `${baseURI}?ssl=true&ca=/path&pfx=/path&cert=/path&key=/path&binary=aa&passphrase=word&secureOptions=20`
+  `${baseURI}?ssl=true&ca=./Dockerfile&pfx=./Dockerfile&cert=./Dockerfile&key=./Dockerfile&binary=aa&passphrase=word&secureOptions=20`
 ] = {
   ssl: {
-    ca: '/path',
-    pfx: '/path',
-    cert: '/path',
-    key: '/path',
+    ca: testfile,
+    pfx: testfile,
+    cert: testfile,
+    key: testfile,
     passphrase: 'word',
     secureOptions: 20,
   },
   binary: false,
 };
 dbOptionsTest[
-  `${baseURI}?ssl=false&ca=/path&pfx=/path&cert=/path&key=/path&binary=aa`
+  `${baseURI}?ssl=false&ca=./Dockerfile&pfx=./Dockerfile&cert=./Dockerfile&key=./Dockerfile&binary=aa`
 ] = {
-  ssl: { ca: '/path', pfx: '/path', cert: '/path', key: '/path' },
+  ssl: { ca: testfile, pfx: testfile, cert: testfile, key: testfile },
   binary: false,
 };
 dbOptionsTest[`${baseURI}?rejectUnauthorized=true`] = {

--- a/src/Adapters/Storage/Postgres/PostgresClient.js
+++ b/src/Adapters/Storage/Postgres/PostgresClient.js
@@ -1,9 +1,11 @@
+const parser = require('./PostgresConfigParser');
+
 export function createClient(uri, databaseOptions) {
-  const dbOptions = {};
+  let dbOptions = {};
   databaseOptions = databaseOptions || {};
 
   if (uri) {
-    dbOptions.connectionString = uri;
+    dbOptions = parser.getDatabaseOptionsFromURI(uri);
   }
 
   for (const key in databaseOptions) {

--- a/src/Adapters/Storage/Postgres/PostgresClient.js
+++ b/src/Adapters/Storage/Postgres/PostgresClient.js
@@ -1,11 +1,9 @@
-const parser = require('./PostgresConfigParser');
-
 export function createClient(uri, databaseOptions) {
-  let dbOptions = {};
+  const dbOptions = {};
   databaseOptions = databaseOptions || {};
 
   if (uri) {
-    dbOptions = parser.getDatabaseOptionsFromURI(uri);
+    dbOptions.connectionString = uri;
   }
 
   for (const key in databaseOptions) {

--- a/src/Adapters/Storage/Postgres/PostgresConfigParser.js
+++ b/src/Adapters/Storage/Postgres/PostgresConfigParser.js
@@ -1,5 +1,5 @@
 const url = require('url');
-
+const fs = require('fs');
 function getDatabaseOptionsFromURI(uri) {
   const databaseOptions = {};
 
@@ -31,16 +31,16 @@ function getDatabaseOptionsFromURI(uri) {
   ) {
     databaseOptions.ssl = {};
     if (queryParams.ca) {
-      databaseOptions.ssl.ca = queryParams.ca;
+      databaseOptions.ssl.ca = fs.readFileSync(queryParams.ca);
     }
     if (queryParams.pfx) {
-      databaseOptions.ssl.pfx = queryParams.pfx;
+      databaseOptions.ssl.pfx = fs.readFileSync(queryParams.pfx);
     }
     if (queryParams.cert) {
-      databaseOptions.ssl.cert = queryParams.cert;
+      databaseOptions.ssl.cert = fs.readFileSync(queryParams.cert);
     }
     if (queryParams.key) {
-      databaseOptions.ssl.key = queryParams.key;
+      databaseOptions.ssl.key = fs.readFileSync(queryParams.key);
     }
     if (queryParams.passphrase) {
       databaseOptions.ssl.passphrase = queryParams.passphrase;

--- a/src/Adapters/Storage/Postgres/PostgresConfigParser.js
+++ b/src/Adapters/Storage/Postgres/PostgresConfigParser.js
@@ -16,8 +16,44 @@ function getDatabaseOptionsFromURI(uri) {
   databaseOptions.user = authParts.length > 0 ? authParts[0] : '';
   databaseOptions.password = authParts.length > 1 ? authParts[1] : '';
 
-  databaseOptions.ssl =
-    queryParams.ssl && queryParams.ssl.toLowerCase() === 'true' ? true : false;
+  if (queryParams.ssl && queryParams.ssl.toLowerCase() === 'true') {
+    databaseOptions.ssl = true;
+  }
+
+  if (
+    queryParams.ca ||
+    queryParams.pfx ||
+    queryParams.cert ||
+    queryParams.key ||
+    queryParams.passphrase ||
+    queryParams.rejectUnauthorized ||
+    queryParams.secureOptions
+  ) {
+    databaseOptions.ssl = {};
+    if (queryParams.ca) {
+      databaseOptions.ssl.ca = queryParams.ca;
+    }
+    if (queryParams.pfx) {
+      databaseOptions.ssl.pfx = queryParams.pfx;
+    }
+    if (queryParams.cert) {
+      databaseOptions.ssl.cert = queryParams.cert;
+    }
+    if (queryParams.key) {
+      databaseOptions.ssl.key = queryParams.key;
+    }
+    if (queryParams.passphrase) {
+      databaseOptions.ssl.passphrase = queryParams.passphrase;
+    }
+    if (queryParams.rejectUnauthorized) {
+      databaseOptions.ssl.rejectUnauthorized =
+        queryParams.rejectUnauthorized.toLowerCase() === 'true' ? true : false;
+    }
+    if (queryParams.secureOptions) {
+      databaseOptions.ssl.secureOptions = parseInt(queryParams.secureOptions);
+    }
+  }
+
   databaseOptions.binary =
     queryParams.binary && queryParams.binary.toLowerCase() === 'true'
       ? true
@@ -30,6 +66,19 @@ function getDatabaseOptionsFromURI(uri) {
 
   if (queryParams.poolSize) {
     databaseOptions.poolSize = parseInt(queryParams.poolSize) || 10;
+  }
+  if (queryParams.max) {
+    databaseOptions.max = parseInt(queryParams.max) || 10;
+  }
+  if (queryParams.query_timeout) {
+    databaseOptions.query_timeout = parseInt(queryParams.query_timeout);
+  }
+  if (queryParams.idleTimeoutMillis) {
+    databaseOptions.idleTimeoutMillis = parseInt(queryParams.idleTimeoutMillis);
+  }
+  if (queryParams.keepAlive) {
+    databaseOptions.keepAlive =
+      queryParams.keepAlive.toLowerCase() === 'true' ? true : false;
   }
 
   return databaseOptions;

--- a/src/Adapters/Storage/Postgres/PostgresConfigParser.js
+++ b/src/Adapters/Storage/Postgres/PostgresConfigParser.js
@@ -31,16 +31,16 @@ function getDatabaseOptionsFromURI(uri) {
   ) {
     databaseOptions.ssl = {};
     if (queryParams.ca) {
-      databaseOptions.ssl.ca = fs.readFileSync(queryParams.ca);
+      databaseOptions.ssl.ca = fs.readFileSync(queryParams.ca).toString();
     }
     if (queryParams.pfx) {
-      databaseOptions.ssl.pfx = fs.readFileSync(queryParams.pfx);
+      databaseOptions.ssl.pfx = fs.readFileSync(queryParams.pfx).toString();
     }
     if (queryParams.cert) {
-      databaseOptions.ssl.cert = fs.readFileSync(queryParams.cert);
+      databaseOptions.ssl.cert = fs.readFileSync(queryParams.cert).toString();
     }
     if (queryParams.key) {
-      databaseOptions.ssl.key = fs.readFileSync(queryParams.key);
+      databaseOptions.ssl.key = fs.readFileSync(queryParams.key).toString();
     }
     if (queryParams.passphrase) {
       databaseOptions.ssl.passphrase = queryParams.passphrase;


### PR DESCRIPTION
~Use [pg-promise](https://github.com/vitaly-t/pg-promise/wiki/Connection-Syntax) native pg-connection-string to parse uri instead of [PostgresConfigParser.js](https://github.com/parse-community/parse-server/blob/master/src/Adapters/Storage/Postgres/PostgresConfigParser.js). The change allows for a more felxible uri for ssl along with the ability to supply additional parameters for establishing a connection with pg-promise.~

Update: Adding parameter parsing to PostgresConfigParser.js instead...

For example, the current PostgresConfigParser can only take a boolean ssl value and PostgresConfigParser limits the variables that can passed to pg-promise through an URI. This is important because #6555 upgraded pg-promise and added [changes](https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md) in [node-postgres](https://node-postgres.com/features/connecting) 8 below:
```Change default behavior when not specifying rejectUnauthorized with the SSL connection parameters. Previously we defaulted to rejectUnauthorized: false when it was not specifically included. We now default to rejectUnauthorized: true. Manually specify { ssl: { rejectUnauthorized: false } } for old behavior.```

In previous versions of pg-promise, this gave a warning. Currently you can't pass `rejectUnauthorized` through a URI string as an object to ssl. **This means that postgres users who use ssl not known to node-posgres are automatically rejected (which is basically any cert because you can't pass in `ca`  with the current PostgresConfigParser.js)**. Switching to the [pg-connection-string](https://github.com/iceddev/pg-connection-string) (which is part of the node-postures driver) allows for:

```
The resulting config contains a subset of the following properties:

- host - Postgres server hostname or, for UNIX domain sockets, the socket filename
- port - port on which to connect
- user - User with which to authenticate to the server
- password - Corresponding password
- database - Database name within the server
- client_encoding - string encoding the client will use
- ssl, either a boolean or an object with properties
-- cert
-- key
-- ca
any other query parameters (for example, application_name) are preserved intact.
```

Allowing you to pass parameters like:

```
Query parameters follow a ? character, including the following special query parameters:

- host=<host> - sets host property, overriding the URL's host
- encoding=<encoding> - sets the client_encoding property
- ssl=1, ssl=true, ssl=0, ssl=false - sets ssl to true or false, accordingly
- sslcert=<filename> - reads data from the given file and includes the result as ssl.cert
- sslkey=<filename> - reads data from the given file and includes the result as ssl.key
- sslrootcert=<filename> - reads data from the given file and includes the result as ssl.ca
```

PostgresConfigParser is left intact for legacy purposes as well is it can possibly be used to parse other custom items out of the uri string in the future.