### PR TITLE
Prevent regex queries from using case insensitive index and fix explain bug

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 semi: true
 trailingComma: "es5"
 singleQuote: true
+arrowParens: "avoid"

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -13,7 +13,6 @@
       "Item": true,
       "Container": true,
       "equal": true,
-      "expectAsync": true,
       "notEqual": true,
       "it_only_db": true,
       "it_exclude_dbs": true,

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -112,7 +112,7 @@ export default class MongoCollection {
       findOperation = findOperation.project(keys);
     }
 
-    if ((query.username?.$regex || query.email?.$regex) && !hint) {
+    if ((query?.username?.$regex || query?.email?.$regex) && !hint) {
       const indexName = query.username?.$regex ? 'username' : 'email';
       const caseInsensitiveIndexExists = await this._mongoCollection.indexExists(
         `case_insensitive_${indexName}`

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -112,7 +112,7 @@ export default class MongoCollection {
       findOperation = findOperation.project(keys);
     }
 
-    if (query.username?.$regex || query.email?.$regex) {
+    if ((query.username?.$regex || query.email?.$regex) && !hint) {
       const indexName = query.username?.$regex ? 'username' : 'email';
       const caseInsensitiveIndexExists = await this._mongoCollection.indexExists(
         `case_insensitive_${indexName}`

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -188,7 +188,7 @@ function RestQuery(
 // Returns a promise for the response - an object with optional keys
 // 'results' and 'count'.
 // TODO: consolidate the replaceX functions
-RestQuery.prototype.execute = function(executeOptions) {
+RestQuery.prototype.execute = function (executeOptions) {
   return Promise.resolve()
     .then(() => {
       return this.buildRestWhere();
@@ -216,7 +216,7 @@ RestQuery.prototype.execute = function(executeOptions) {
     });
 };
 
-RestQuery.prototype.each = function(callback) {
+RestQuery.prototype.each = function (callback) {
   const { config, auth, className, restWhere, restOptions, clientSDK } = this;
   // if the limit is set, use it
   restOptions.limit = restOptions.limit || 100;
@@ -248,7 +248,7 @@ RestQuery.prototype.each = function(callback) {
   );
 };
 
-RestQuery.prototype.buildRestWhere = function() {
+RestQuery.prototype.buildRestWhere = function () {
   return Promise.resolve()
     .then(() => {
       return this.getUserAndRoleACL();
@@ -277,7 +277,7 @@ RestQuery.prototype.buildRestWhere = function() {
 };
 
 // Uses the Auth object to get the list of roles, adds the user id
-RestQuery.prototype.getUserAndRoleACL = function() {
+RestQuery.prototype.getUserAndRoleACL = function () {
   if (this.auth.isMaster) {
     return Promise.resolve();
   }
@@ -298,7 +298,7 @@ RestQuery.prototype.getUserAndRoleACL = function() {
 
 // Changes the className if redirectClassNameForKey is set.
 // Returns a promise.
-RestQuery.prototype.redirectClassNameForKey = function() {
+RestQuery.prototype.redirectClassNameForKey = function () {
   if (!this.redirectKey) {
     return Promise.resolve();
   }
@@ -313,7 +313,7 @@ RestQuery.prototype.redirectClassNameForKey = function() {
 };
 
 // Validates this operation against the allowClientClassCreation config.
-RestQuery.prototype.validateClientClassCreation = function() {
+RestQuery.prototype.validateClientClassCreation = function () {
   if (
     this.config.allowClientClassCreation === false &&
     !this.auth.isMaster &&
@@ -358,7 +358,7 @@ function transformInQuery(inQueryObject, className, results) {
 // $inQuery clause.
 // The $inQuery clause turns into an $in with values that are just
 // pointers to the objects returned in the subquery.
-RestQuery.prototype.replaceInQuery = function() {
+RestQuery.prototype.replaceInQuery = function () {
   var inQueryObject = findObjectWithKey(this.restWhere, '$inQuery');
   if (!inQueryObject) {
     return;
@@ -419,7 +419,7 @@ function transformNotInQuery(notInQueryObject, className, results) {
 // $notInQuery clause.
 // The $notInQuery clause turns into a $nin with values that are just
 // pointers to the objects returned in the subquery.
-RestQuery.prototype.replaceNotInQuery = function() {
+RestQuery.prototype.replaceNotInQuery = function () {
   var notInQueryObject = findObjectWithKey(this.restWhere, '$notInQuery');
   if (!notInQueryObject) {
     return;
@@ -485,7 +485,7 @@ const transformSelect = (selectObject, key, objects) => {
 // The $select clause turns into an $in with values selected out of
 // the subquery.
 // Returns a possible-promise.
-RestQuery.prototype.replaceSelect = function() {
+RestQuery.prototype.replaceSelect = function () {
   var selectObject = findObjectWithKey(this.restWhere, '$select');
   if (!selectObject) {
     return;
@@ -550,7 +550,7 @@ const transformDontSelect = (dontSelectObject, key, objects) => {
 // The $dontSelect clause turns into an $nin with values selected out of
 // the subquery.
 // Returns a possible-promise.
-RestQuery.prototype.replaceDontSelect = function() {
+RestQuery.prototype.replaceDontSelect = function () {
   var dontSelectObject = findObjectWithKey(this.restWhere, '$dontSelect');
   if (!dontSelectObject) {
     return;
@@ -599,7 +599,7 @@ RestQuery.prototype.replaceDontSelect = function() {
   });
 };
 
-const cleanResultAuthData = function(result) {
+const cleanResultAuthData = function (result) {
   delete result.password;
   if (result.authData) {
     Object.keys(result.authData).forEach(provider => {
@@ -638,7 +638,7 @@ const replaceEqualityConstraint = constraint => {
   return constraint;
 };
 
-RestQuery.prototype.replaceEquality = function() {
+RestQuery.prototype.replaceEquality = function () {
   if (typeof this.restWhere !== 'object') {
     return;
   }
@@ -649,7 +649,7 @@ RestQuery.prototype.replaceEquality = function() {
 
 // Returns a promise for whether it was successful.
 // Populates this.response with an object that only has 'results'.
-RestQuery.prototype.runFind = function(options = {}) {
+RestQuery.prototype.runFind = function (options = {}) {
   if (this.findOptions.limit === 0) {
     this.response = { results: [] };
     return Promise.resolve();
@@ -666,17 +666,19 @@ RestQuery.prototype.runFind = function(options = {}) {
   return this.config.database
     .find(this.className, this.restWhere, findOptions, this.auth)
     .then(results => {
-      if (this.className === '_User') {
-        for (var result of results) {
-          cleanResultAuthData(result);
+      if (!findOptions.explain) {
+        if (this.className === '_User') {
+          for (var result of results) {
+            cleanResultAuthData(result);
+          }
         }
-      }
 
-      this.config.filesController.expandFilesInObject(this.config, results);
+        this.config.filesController.expandFilesInObject(this.config, results);
 
-      if (this.redirectClassName) {
-        for (var r of results) {
-          r.className = this.redirectClassName;
+        if (this.redirectClassName && !findOptions.explain) {
+          for (var r of results) {
+            r.className = this.redirectClassName;
+          }
         }
       }
       this.response = { results: results };
@@ -685,7 +687,7 @@ RestQuery.prototype.runFind = function(options = {}) {
 
 // Returns a promise for whether it was successful.
 // Populates this.response.count with the count
-RestQuery.prototype.runCount = function() {
+RestQuery.prototype.runCount = function () {
   if (!this.doCount) {
     return;
   }
@@ -700,7 +702,7 @@ RestQuery.prototype.runCount = function() {
 };
 
 // Augments this.response with all pointers on an object
-RestQuery.prototype.handleIncludeAll = function() {
+RestQuery.prototype.handleIncludeAll = function () {
   if (!this.includeAll) {
     return;
   }
@@ -729,7 +731,7 @@ RestQuery.prototype.handleIncludeAll = function() {
 };
 
 // Updates property `this.keys` to contain all keys but the ones unselected.
-RestQuery.prototype.handleExcludeKeys = function() {
+RestQuery.prototype.handleExcludeKeys = function () {
   if (!this.excludeKeys) {
     return;
   }
@@ -747,7 +749,7 @@ RestQuery.prototype.handleExcludeKeys = function() {
 };
 
 // Augments this.response with data at the paths provided in this.include.
-RestQuery.prototype.handleInclude = function() {
+RestQuery.prototype.handleInclude = function () {
   if (this.include.length == 0) {
     return;
   }
@@ -774,7 +776,7 @@ RestQuery.prototype.handleInclude = function() {
 };
 
 //Returns a promise of a processed set of results
-RestQuery.prototype.runAfterFindTrigger = function() {
+RestQuery.prototype.runAfterFindTrigger = function () {
   if (!this.response) {
     return;
   }


### PR DESCRIPTION
### Issue
After the release of Parse Server 4.0.0, we noticed a significant performance decrease when running regex queries against `Username` or `Email` on the `_User` class. After much research and conversation with the Mongo community, we determined that the issue was related to how Mongo determines which index to use and it was sometimes picking the new case insensitive index (released in Parse Server 4.0). As that new index is a collation and regex queries are not able to utilize collation indexes, this caused performance issues in large collections.

Our initial report and further discussion can be found here: https://github.com/parse-community/parse-server/issues/6559

### Solution
I've updated the `_rawFind()` method to use the appropriate case sensitive (i.e., non-collation) index only if the following are true:
1. The query includes a regex operator on either of the `username` or `email` fields AND a custom index hint was not passed.
2. Both of the automatically generated indexes (`case_insensitive_{fieldName}` and `{fieldName}_1`) exist.

This solution will prevent the case insensitive index from being used for regex queries on username or email fields in the `_User` class while still allowing users to bypass this system if they want.

### Explain fix
While working on this fix, I also noticed that the newly implemented `.explain()` method throws an error if you try to run it on a `_User` query due to the fact that the result parser expects an array of results, but Mongo returns an object when the explain is passed. This PR also includes a fix for that issue.