### PR TITLE
Create beforeConnect and beforeSubscribe Cloud Triggers

### DIFF
--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -285,7 +285,7 @@ describe('ParseLiveQueryServer', function() {
       .catch(done.fail);
   });
 
-  it('can handle connect command', function() {
+  it('can handle connect command', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     const parseWebSocket = {
       clientId: -1,
@@ -293,7 +293,7 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._validateKeys = jasmine
       .createSpy('validateKeys')
       .and.returnValue(true);
-    parseLiveQueryServer._handleConnect(parseWebSocket, {
+    await parseLiveQueryServer._handleConnect(parseWebSocket, {
       sessionToken: 'token',
     });
 
@@ -316,7 +316,7 @@ describe('ParseLiveQueryServer', function() {
     expect(Client.pushError).toHaveBeenCalled();
   });
 
-  it('can handle subscribe command with new query', function() {
+  it('can handle subscribe command with new query', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Add mock client
     const clientId = 1;
@@ -338,7 +338,7 @@ describe('ParseLiveQueryServer', function() {
       requestId: requestId,
       sessionToken: 'sessionToken',
     };
-    parseLiveQueryServer._handleSubscribe(parseWebSocket, request);
+    await parseLiveQueryServer._handleSubscribe(parseWebSocket, request);
 
     // Make sure we add the subscription to the server
     const subscriptions = parseLiveQueryServer.subscriptions;
@@ -363,7 +363,7 @@ describe('ParseLiveQueryServer', function() {
     expect(client.pushSubscribe).toHaveBeenCalledWith(requestId);
   });
 
-  it('can handle subscribe command with existing query', function() {
+  it('can handle subscribe command with existing query', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Add two mock clients
     const clientId = 1;
@@ -382,7 +382,7 @@ describe('ParseLiveQueryServer', function() {
       },
       fields: ['test'],
     };
-    addMockSubscription(
+    await addMockSubscription(
       parseLiveQueryServer,
       clientId,
       requestId,
@@ -401,7 +401,7 @@ describe('ParseLiveQueryServer', function() {
       fields: ['testAgain'],
     };
     const requestIdAgain = 1;
-    addMockSubscription(
+    await addMockSubscription(
       parseLiveQueryServer,
       clientIdAgain,
       requestIdAgain,
@@ -447,7 +447,7 @@ describe('ParseLiveQueryServer', function() {
     expect(Client.pushError).toHaveBeenCalled();
   });
 
-  it('can handle unsubscribe command without not existed query', function() {
+  it('can handle unsubscribe command without not existed query', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Add mock client
     const clientId = 1;
@@ -462,7 +462,7 @@ describe('ParseLiveQueryServer', function() {
     expect(Client.pushError).toHaveBeenCalled();
   });
 
-  it('can handle unsubscribe command', function() {
+  it('can handle unsubscribe command', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Add mock client
     const clientId = 1;
@@ -472,7 +472,7 @@ describe('ParseLiveQueryServer', function() {
       clientId: 1,
     };
     const requestId = 2;
-    const subscription = addMockSubscription(
+    const subscription = await addMockSubscription(
       parseLiveQueryServer,
       clientId,
       requestId,
@@ -696,7 +696,7 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._onAfterDelete(message, {});
   });
 
-  it('can handle object delete command which does not match any subscription', function() {
+  it('can handle object delete command which does not match any subscription', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make deletedParseObject
     const parseObject = new Parse.Object(testClassName);
@@ -714,7 +714,7 @@ describe('ParseLiveQueryServer', function() {
     addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     const client = parseLiveQueryServer.clients.get(clientId);
     // Mock _matchesSubscription to return not matching
     parseLiveQueryServer._matchesSubscription = function() {
@@ -729,7 +729,7 @@ describe('ParseLiveQueryServer', function() {
     expect(client.pushDelete).not.toHaveBeenCalled();
   });
 
-  it('can handle object delete command which matches some subscriptions', function(done) {
+  it('can handle object delete command which matches some subscriptions', async (done) => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make deletedParseObject
     const parseObject = new Parse.Object(testClassName);
@@ -746,7 +746,7 @@ describe('ParseLiveQueryServer', function() {
     addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     const client = parseLiveQueryServer.clients.get(clientId);
     // Mock _matchesSubscription to return matching
     parseLiveQueryServer._matchesSubscription = function() {
@@ -765,7 +765,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('has no subscription and can handle object save command', function() {
+  it('has no subscription and can handle object save command', async () => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make mock request message
     const message = generateMockMessage();
@@ -773,7 +773,7 @@ describe('ParseLiveQueryServer', function() {
     parseLiveQueryServer._onAfterSave(message);
   });
 
-  it('can handle object save command which does not match any subscription', function(done) {
+  it('can handle object save command which does not match any subscription', async (done) => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make mock request message
     const message = generateMockMessage();
@@ -782,7 +782,7 @@ describe('ParseLiveQueryServer', function() {
     const client = addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     // Mock _matchesSubscription to return not matching
     parseLiveQueryServer._matchesSubscription = function() {
       return false;
@@ -804,7 +804,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('can handle object enter command which matches some subscriptions', function(done) {
+  it('can handle object enter command which matches some subscriptions', async (done) => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make mock request message
     const message = generateMockMessage(true);
@@ -813,7 +813,7 @@ describe('ParseLiveQueryServer', function() {
     const client = addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     // Mock _matchesSubscription to return matching
     // In order to mimic a enter, we need original match return false
     // and the current match return true
@@ -841,7 +841,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('can handle object update command which matches some subscriptions', function(done) {
+  it('can handle object update command which matches some subscriptions', async (done) => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make mock request message
     const message = generateMockMessage(true);
@@ -850,7 +850,7 @@ describe('ParseLiveQueryServer', function() {
     const client = addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     // Mock _matchesSubscription to return matching
     parseLiveQueryServer._matchesSubscription = function(parseObject) {
       if (!parseObject) {
@@ -874,7 +874,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('can handle object leave command which matches some subscriptions', function(done) {
+  it('can handle object leave command which matches some subscriptions', async (done) => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make mock request message
     const message = generateMockMessage(true);
@@ -883,7 +883,7 @@ describe('ParseLiveQueryServer', function() {
     const client = addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     // Mock _matchesSubscription to return matching
     // In order to mimic a leave, we need original match return true
     // and the current match return false
@@ -911,7 +911,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('can handle update command with original object', function(done) {
+  it('can handle update command with original object', async (done) => {
     jasmine.restoreLibrary('../lib/LiveQuery/Client', 'Client');
     const Client = require('../lib/LiveQuery/Client').Client;
     const parseLiveQueryServer = new ParseLiveQueryServer({});
@@ -930,7 +930,7 @@ describe('ParseLiveQueryServer', function() {
     // Add mock subscription
     const requestId = 2;
 
-    addMockSubscription(
+    await addMockSubscription(
       parseLiveQueryServer,
       clientId,
       requestId,
@@ -961,7 +961,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('can handle object create command which matches some subscriptions', function(done) {
+  it('can handle object create command which matches some subscriptions', async (done) => {
     const parseLiveQueryServer = new ParseLiveQueryServer({});
     // Make mock request message
     const message = generateMockMessage();
@@ -970,7 +970,7 @@ describe('ParseLiveQueryServer', function() {
     const client = addMockClient(parseLiveQueryServer, clientId);
     // Add mock subscription
     const requestId = 2;
-    addMockSubscription(parseLiveQueryServer, clientId, requestId);
+    await addMockSubscription(parseLiveQueryServer, clientId, requestId);
     // Mock _matchesSubscription to return matching
     parseLiveQueryServer._matchesSubscription = function(parseObject) {
       if (!parseObject) {
@@ -994,7 +994,7 @@ describe('ParseLiveQueryServer', function() {
     }, jasmine.ASYNC_TEST_WAIT_TIME);
   });
 
-  it('can handle create command with fields', function(done) {
+  it('can handle create command with fields', async (done) => {
     jasmine.restoreLibrary('../lib/LiveQuery/Client', 'Client');
     const Client = require('../lib/LiveQuery/Client').Client;
     const parseLiveQueryServer = new ParseLiveQueryServer({});
@@ -1019,7 +1019,7 @@ describe('ParseLiveQueryServer', function() {
       },
       fields: ['test'],
     };
-    addMockSubscription(
+    await addMockSubscription(
       parseLiveQueryServer,
       clientId,
       requestId,
@@ -1842,7 +1842,7 @@ describe('ParseLiveQueryServer', function() {
     return client;
   }
 
-  function addMockSubscription(
+  async function addMockSubscription(
     parseLiveQueryServer,
     clientId,
     requestId,
@@ -1870,7 +1870,7 @@ describe('ParseLiveQueryServer', function() {
       requestId: requestId,
       sessionToken: 'sessionToken',
     };
-    parseLiveQueryServer._handleSubscribe(parseWebSocket, request);
+    await parseLiveQueryServer._handleSubscribe(parseWebSocket, request);
 
     // Make mock subscription
     const subscription = parseLiveQueryServer.subscriptions

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -608,7 +608,7 @@ class ParseLiveQueryServer {
       client.pushConnect();
       runLiveQueryEventHandlers(req);
     } catch(e) {
-       Client.pushError(parseWebsocket, e.code || 101, e.message || e);
+       Client.pushError(parseWebsocket, e.code || 101, e.message || e, false);
         logger.error(e);
     }
   }
@@ -645,7 +645,7 @@ class ParseLiveQueryServer {
     return isValid;
   }
 
-  _handleSubscribe(parseWebsocket: any, request: any): any {
+  async _handleSubscribe(parseWebsocket: any, request: any): any {
     // If we can not find this client, return error to client
     if (!Object.prototype.hasOwnProperty.call(parseWebsocket, 'clientId')) {
       Client.pushError(
@@ -660,8 +660,8 @@ class ParseLiveQueryServer {
     }
     const client = this.clients.get(parseWebsocket.clientId);
     const className = request.query.className;
-    maybeRunSubscribeTrigger('beforeSubscribe', className, request).then((result) => {
-     request.query = result;
+    try {
+      request.query = await maybeRunSubscribeTrigger('beforeSubscribe', className, request)
     // Get subscription from subscriptions, create one if necessary
      const subscriptionHash = queryHash(request.query);
     // Add className to subscriptions if necessary
@@ -715,10 +715,10 @@ class ParseLiveQueryServer {
         useMasterKey: client.hasMasterKey,
         installationId: client.installationId,
       });
-    }).catch(function(e){
-       Client.pushError(parseWebsocket, e.code || 101, e.message || e);
+    } catch(e) {
+       Client.pushError(parseWebsocket, e.code || 101, e.message || e, false);
       logger.error(e);
-    });
+    }
   }
 
   _handleUpdateSubscription(parseWebsocket: any, request: any): any {

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -576,7 +576,7 @@ class ParseLiveQueryServer {
     return false;
   }
 
-  _handleConnect(parseWebsocket: any, request: any): any {
+  async _handleConnect(parseWebsocket: any, request: any): any {
     if (!this._validateKeys(request, this.keyPairs)) {
       Client.pushError(parseWebsocket, 4, 'Key in request is not valid');
       logger.error('Key in request is not valid');
@@ -600,16 +600,17 @@ class ParseLiveQueryServer {
        useMasterKey: client.hasMasterKey,
        installationId: request.installationId,
       }
-    maybeRunConnectTrigger('beforeConnect',req).then(function(){
+    try {
+      await maybeRunConnectTrigger('beforeConnect',req)
       parseWebsocket.clientId = clientId;
       this.clients.set(parseWebsocket.clientId, client);
       logger.info(`Create new client: ${parseWebsocket.clientId}`);
       client.pushConnect();
       runLiveQueryEventHandlers(req);
-    }).catch(function(e){
+    } catch(e) {
        Client.pushError(parseWebsocket, e.code || 101, e.message || e);
         logger.error(e);
-    });
+    }
   }
 
   _hasMasterKey(request: any, validKeyPairs: any): boolean {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -453,6 +453,24 @@ ParseCloud.afterDeleteFile = function(handler) {
   );
 };
 
+ParseCloud.beforeConnect = function(handler) {
+  triggers.addFileTrigger(
+    triggers.Types.beforeConnect,
+    handler,
+    Parse.applicationId,
+  );
+};
+
+ParseCloud.beforeSubscribe = function(parseClass, handler) {
+  var className = getClassName(parseClass);
+  triggers.addTrigger(
+    triggers.Types.beforeSubscribe,
+    className,
+    handler,
+    Parse.applicationId
+  );
+};
+
 ParseCloud.onLiveQueryEvent = function(handler) {
   triggers.addLiveQueryEventHandler(handler, Parse.applicationId);
 };

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -454,7 +454,7 @@ ParseCloud.afterDeleteFile = function(handler) {
 };
 
 ParseCloud.beforeConnect = function(handler) {
-  triggers.addFileTrigger(
+  triggers.addConnectTrigger(
     triggers.Types.beforeConnect,
     handler,
     Parse.applicationId,

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -756,17 +756,17 @@ export async function maybeRunConnectTrigger(triggerType, client) {
   }
   await trigger(client) 
 }
-export async function maybeRunSubscribeTrigger(triggerType, className, client) {
+export async function maybeRunSubscribeTrigger(triggerType, className, request) {
   const trigger = getTrigger(className, triggerType, Parse.applicationId);
   if (!trigger) {
-    return client.query;
+    return request.query;
   }
   const parseQuery = new Parse.Query(className);
-  parseQuery.withJSON(client.query);
-  client.query = parseQuery;
-  const result = await trigger(client);
+  parseQuery.withJSON(request.query);
+  request.query = parseQuery;
+  const result = await trigger(request);
   if (result) {
     return result.toJSON();
   }
-  return client.query;
+  return request.query;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -793,6 +793,10 @@ async function userForSessionToken(sessionToken) {
   if (!session) {
      return Promise.reject('No session found for session token');
   }
-  const user = await session.get('user').fetch({useMasterKey:true});
+  const user = session.get('user');
+  if (!user) {
+     return Promise.reject('No session found for session token');
+  } 
+  await user.fetch({useMasterKey:true});
   return user;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -784,7 +784,7 @@ export async function maybeRunSubscribeTrigger(triggerType, className, request) 
   if (result) {
     return result.toJSON();
   }
-  return request.query;
+  return request.query.toJSON();
 }
 async function userForSessionToken(sessionToken) {
   var q = new Parse.Query('_Session');

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -786,13 +786,13 @@ export async function maybeRunSubscribeTrigger(triggerType, className, request) 
   }
   return request.query;
 }
-function userForSessionToken(sessionToken) {
+async function userForSessionToken(sessionToken) {
   var q = new Parse.Query('_Session');
   q.equalTo('sessionToken', sessionToken);
-  return q.first({ useMasterKey: true }).then(function(session) {
-    if (!session) {
-      return Promise.reject('No session found for session token');
-    }
-    return session.get('user');
-  });
+  const session = await q.first({ useMasterKey: true })
+  if (!session) {
+     return Promise.reject('No session found for session token');
+  }
+  const user = await session.get('user').fetch({useMasterKey:true});
+  return user;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -21,6 +21,7 @@ export const Types = {
 };
 
 const FileClassName = '@File';
+const ConnectClassName = '@Connect';
 
 const baseStore = function() {
   const Validators = {};
@@ -133,7 +134,9 @@ export function addTrigger(type, className, handler, applicationId) {
 export function addFileTrigger(type, handler, applicationId) {
   add(Category.Triggers, `${type}.${FileClassName}`, handler, applicationId);
 }
-
+export function addConnectTrigger(type, handler, applicationId) {
+  add(Category.Triggers, `${type}.${ConnectClassName}`, handler, applicationId);
+}
 export function addLiveQueryEventHandler(handler, applicationId) {
   applicationId = applicationId || Parse.applicationId;
   _triggerStore[applicationId] = _triggerStore[applicationId] || baseStore();
@@ -745,4 +748,12 @@ export async function maybeRunFileTrigger(triggerType, fileObject, config, auth)
     }
   }
   return fileObject;
+}
+export async function maybeRunConnectTrigger(triggerType, client) {
+  const trigger = getTrigger(ConnectClassName, triggerType, config.applicationId);
+  if (!trigger) {
+    return client;
+  }
+  await trigger() 
+  return client;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -752,10 +752,9 @@ export async function maybeRunFileTrigger(triggerType, fileObject, config, auth)
 export async function maybeRunConnectTrigger(triggerType, client) {
   const trigger = getTrigger(ConnectClassName, triggerType, Parse.applicationId);
   if (!trigger) {
-    return client;
+    return;
   }
   await trigger(client) 
-  return client;
 }
 export async function maybeRunSubscribeTrigger(triggerType, className, client) {
   const trigger = getTrigger(className, triggerType, Parse.applicationId);

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -751,7 +751,7 @@ export async function maybeRunFileTrigger(triggerType, fileObject, config, auth)
 }
 export async function maybeRunConnectTrigger(triggerType, request) {
   const trigger = getTrigger(ConnectClassName, triggerType, Parse.applicationId);
-  if (!trigger || trigger == null) {
+  if (!trigger) {
     return;
   }
   if (request.sessionToken) {
@@ -766,7 +766,7 @@ export async function maybeRunConnectTrigger(triggerType, request) {
 }
 export async function maybeRunSubscribeTrigger(triggerType, className, request) {
   const trigger = getTrigger(className, triggerType, Parse.applicationId);
-  if (!trigger || trigger == null) {
+  if (!trigger) {
     return request.query;
   }
   const parseQuery = new Parse.Query(className);
@@ -787,7 +787,7 @@ export async function maybeRunSubscribeTrigger(triggerType, className, request) 
   return request.query.toJSON();
 }
 async function userForSessionToken(sessionToken) {
-  var q = new Parse.Query('_Session');
+  const q = new Parse.Query('_Session');
   q.equalTo('sessionToken', sessionToken);
   const session = await q.first({ useMasterKey: true })
   if (!session) {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -754,6 +754,14 @@ export async function maybeRunConnectTrigger(triggerType, client) {
   if (!trigger) {
     return client;
   }
-  await trigger() 
+  await trigger(client) 
   return client;
+}
+export async function maybeRunSubscribeTrigger(triggerType, className, client) {
+  const trigger = getTrigger(className, triggerType, config.applicationId);
+  if (!trigger) {
+    return client.query;
+  }
+  const result = await trigger(client) || client.query;
+  return result;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -751,22 +751,22 @@ export async function maybeRunFileTrigger(triggerType, fileObject, config, auth)
 }
 export async function maybeRunConnectTrigger(triggerType, request) {
   const trigger = getTrigger(ConnectClassName, triggerType, Parse.applicationId);
-  if (!trigger) {
+  if (!trigger || trigger == null) {
     return;
   }
   if (request.sessionToken) {
     try {
-     const user = await userForSessionToken(request.sessionToken);
+      const user = await userForSessionToken(request.sessionToken);
       request.user = user;
     } catch(e) {
-     delete request.sessionToken; 
+      delete request.sessionToken;
     }
   }
-  await trigger(request) 
+  await trigger(request)
 }
 export async function maybeRunSubscribeTrigger(triggerType, className, request) {
   const trigger = getTrigger(className, triggerType, Parse.applicationId);
-  if (!trigger) {
+  if (!trigger || trigger == null) {
     return request.query;
   }
   const parseQuery = new Parse.Query(className);
@@ -774,10 +774,10 @@ export async function maybeRunSubscribeTrigger(triggerType, className, request) 
   request.query = parseQuery;
   if (request.sessionToken) {
     try {
-     const user = await userForSessionToken(request.sessionToken);
+      const user = await userForSessionToken(request.sessionToken);
       request.user = user;
     } catch(e) {
-     delete request.sessionToken; 
+      delete request.sessionToken;
     }
   }
   const result = await trigger(request);
@@ -791,12 +791,12 @@ async function userForSessionToken(sessionToken) {
   q.equalTo('sessionToken', sessionToken);
   const session = await q.first({ useMasterKey: true })
   if (!session) {
-     return Promise.reject('No session found for session token');
+    throw 'No session found for session token';
   }
   const user = session.get('user');
   if (!user) {
-     return Promise.reject('No session found for session token');
-  } 
+    throw 'No session found for session token';
+  }
   await user.fetch({useMasterKey:true});
   return user;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -16,6 +16,8 @@ export const Types = {
   afterSaveFile: 'afterSaveFile',
   beforeDeleteFile: 'beforeDeleteFile',
   afterDeleteFile: 'afterDeleteFile',
+  beforeConnect:'beforeConnect',
+  beforeSubscribe:'beforeSubscribe'
 };
 
 const FileClassName = '@File';

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -750,7 +750,7 @@ export async function maybeRunFileTrigger(triggerType, fileObject, config, auth)
   return fileObject;
 }
 export async function maybeRunConnectTrigger(triggerType, client) {
-  const trigger = getTrigger(ConnectClassName, triggerType, config.applicationId);
+  const trigger = getTrigger(ConnectClassName, triggerType, Parse.applicationId);
   if (!trigger) {
     return client;
   }
@@ -758,7 +758,7 @@ export async function maybeRunConnectTrigger(triggerType, client) {
   return client;
 }
 export async function maybeRunSubscribeTrigger(triggerType, className, client) {
-  const trigger = getTrigger(className, triggerType, config.applicationId);
+  const trigger = getTrigger(className, triggerType, Parse.applicationId);
   if (!trigger) {
     return client.query;
   }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -754,7 +754,6 @@ export async function maybeRunConnectTrigger(triggerType, request) {
   if (!trigger) {
     return;
   }
-  console.log(trigger);
   if (request.sessionToken) {
     try {
      const user = await userForSessionToken(request.sessionToken);

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -754,6 +754,7 @@ export async function maybeRunConnectTrigger(triggerType, request) {
   if (!trigger) {
     return;
   }
+  console.log(trigger);
   if (request.sessionToken) {
     try {
      const user = await userForSessionToken(request.sessionToken);

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -782,7 +782,7 @@ export async function maybeRunSubscribeTrigger(triggerType, className, request) 
   }
   const result = await trigger(request);
   if (result) {
-    return result.toJSON();
+    request.query = result;
   }
   return request.query.toJSON();
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -761,6 +761,12 @@ export async function maybeRunSubscribeTrigger(triggerType, className, client) {
   if (!trigger) {
     return client.query;
   }
-  const result = await trigger(client) || client.query;
-  return result;
+  const parseQuery = new Parse.Query(className);
+  parseQuery.withJSON(client.query);
+  client.query = parseQuery;
+  const result = await trigger(client);
+  if (result) {
+    return result.toJSON();
+  }
+  return client.query;
 }


### PR DESCRIPTION
My first PR so feel free to make suggestions of course.

Creates two new cloud code triggers which affect LiveQuery: beforeConnect and beforeSubscribe.

**beforeConnect** allows validation prior to a LiveQuery opening connection. This is not class specific.

```
Parse.Cloud.beforeConnect(async request => {
      if (!request.user) {
          throw "Please login before you attempt to connect."
      }
  });
```

**beforeSubscribe** handles the .subscribe methods from LiveQuery. Can be used to validate users, or to mutate the request.query, enforcing fields, equalTo, or whatever required.

```
  Parse.Cloud.beforeSubscribe(Parse.User, async request => {
      if (!request.user) {
          throw "Please login before you attempt to connect."
      }
      let query = request.query; // the Parse.Query
      query.select("name","year")
      return query;
  });
```

I also created `userForSessionToken` on triggers.js, so that the sessionToken from LQ is only looked up if the trigger exists.

In relation to #6642.