### PR TITLE
Remove hostnameMaxLen for Mongo URL

### DIFF
--- a/src/vendor/mongodbUrl.js
+++ b/src/vendor/mongodbUrl.js
@@ -40,7 +40,7 @@ const portPattern = /:[0-9]*$/;
 // Special case for a simple path URL
 const simplePathPattern = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/;
 
-const hostnameMaxLen = 255;
+const hostnameMaxLen = process.env.MONGODB_HOSTNAME_MAXLENGTH ? Number(process.env.MONGODB_HOSTNAME_MAXLENGTH) : null || 255;
 // protocols that can allow "unsafe" and "unwise" chars.
 const unsafeProtocol = {
   javascript: true,

--- a/src/vendor/mongodbUrl.js
+++ b/src/vendor/mongodbUrl.js
@@ -40,7 +40,6 @@ const portPattern = /:[0-9]*$/;
 // Special case for a simple path URL
 const simplePathPattern = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/;
 
-const hostnameMaxLen = process.env.MONGODB_HOSTNAME_MAXLENGTH ? Number(process.env.MONGODB_HOSTNAME_MAXLENGTH) : null || 255;
 // protocols that can allow "unsafe" and "unwise" chars.
 const unsafeProtocol = {
   javascript: true,
@@ -293,12 +292,8 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
       if (result !== undefined) rest = result;
     }
 
-    if (this.hostname.length > hostnameMaxLen) {
-      this.hostname = '';
-    } else {
-      // hostnames are always lower case.
-      this.hostname = this.hostname.toLowerCase();
-    }
+    // hostnames are always lower case.
+    this.hostname = this.hostname.toLowerCase();
 
     if (!ipv6Hostname) {
       // IDNA Support: Returns a punycoded representation of "domain".


### PR DESCRIPTION
In our Mongo cluster, we have 2 shards equalling 7 hosts that come in as a long comma-delimited list of host names.  This hostNameMaxLen of 255 should not apply to a mongo connection string like that:
mongodb://<USER>:<PASSWORD>@MYCLUSTER-shard-00-00.luszb.azure.mongodb.net:27016,MYCLUSTER-shard-00-01.luszb.azure.mongodb.net:27016,MYCLUSTER-shard-00-02.luszb.azure.mongodb.net:27016,MYCLUSTER-shard-00-03.luszb.azure.mongodb.net:27016,MYCLUSTER-shard-02-00.luszb.azure.mongodb.net:27016,MYCLUSTER-shard-02-01.luszb.azure.mongodb.net:27016,MYCLUSTER-shard-02-02.luszb.azure.mongodb.net:27016/dev?ssl=true&authSource=admin

We was using the SRV mongo connection string type which is much shorter:
mongodb+srv://<USER>:<PASSWORD>@MYCLUSTER-luszb.azure.mongodb.net/dev

But we were finding it to be unreliable with Azure's DNS.  We rarely change our cluster configuration, so having the long connection string would be more reliable

If these changes should be approached in some other manner, I'd be happy to do that.