### PR TITLE
removed gaze from dev dependencies and removed not working dev script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6422,15 +6422,6 @@
         "wide-align": "^1.1.0"
       }
     },
-    "gaze": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-      "dev": true,
-      "requires": {
-        "globule": "^1.0.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -6574,17 +6565,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
-    },
-    "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-      "dev": true,
-      "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.10",
-        "minimatch": "~3.0.2"
-      }
     },
     "got": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "eslint-plugin-flowtype": "5.0.3",
     "flow-bin": "0.119.1",
     "form-data": "3.0.0",
-    "gaze": "1.1.3",
     "graphql-tag": "^2.10.1",
     "husky": "4.2.5",
     "jasmine": "3.5.0",
@@ -95,7 +94,6 @@
   "scripts": {
     "definitions": "node ./resources/buildConfigDefinitions.js",
     "docs": "jsdoc -c ./jsdoc-conf.json",
-    "dev": "npm run build && node bin/dev",
     "lint": "flow && eslint --cache ./",
     "lint-fix": "eslint --fix --cache ./",
     "build": "babel src/ -d lib/ --copy-files",


### PR DESCRIPTION
There was a dev script added in [18f9e5340563833cebab333ee6205d5c8ac6413a](https://github.com/parse-community/parse-server/commit/18f9e5340563833cebab333ee6205d5c8ac6413a) where `gaze` was added to the dev dependencies and a script named `dev` was created in the package.json.

The dev script was removed in [021a12f648d53b30392f4ca3d4e3a78bebab1f54](https://github.com/parse-community/parse-server/commit/021a12f648d53b30392f4ca3d4e3a78bebab1f54) but the package.json wasn't cleaned up. Instead `gaze` was updated several times. 🤔

This PR removes the `gaze` package from the dev deps and removes the dev script from the package.json.