### PR TITLE
Allow passing custom gql schema function to ParseServer#start options

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -270,7 +270,7 @@ class ParseServer {
         graphQLCustomTypeDefs = parse(
           fs.readFileSync(options.graphQLSchema, 'utf8')
         );
-      } else if (typeof options.graphQLSchema === 'object') {
+      } else if (typeof options.graphQLSchema === 'object' || typeof options.graphQLSchema === 'function') {
         graphQLCustomTypeDefs = options.graphQLSchema;
       }
 


### PR DESCRIPTION
This simple typecheck seems to be missing, which results in not being able to pass a custom "merging" function to the ParseGraphQLServer instance through ParseServer#start.
[This section](https://github.com/parse-community/parse-server/blob/d5ac0f7748be370928f5c7a3418083c315b9356a/src/GraphQL/ParseGraphQLSchema.js#L262-L267) requires the passed custom graphql schema to be a function, however the line this PR alters prevents the usage of that section in its current revision.