### PR TITLE
Add file bucket encryption using fileKey

### DIFF
--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -35,6 +35,22 @@ describe_only_db('mongo')('GridFSBucket and GridStore interop', () => {
     expect(gfsResult.toString('utf8')).toBe(originalString);
   });
 
+  it('an encypted file created in GridStore should be available in GridFS', async () => {
+    const gsAdapter = new GridStoreAdapter(databaseURI);
+    const gfsAdapter = new GridFSBucketAdapter(
+      databaseURI,
+      { useNewUrlParser: true, useUnifiedTopology: true },
+      '89E4AFF1-DFE4-4603-9574-BFA16BB446FD'
+    );
+    await expectMissingFile(gfsAdapter, 'myFileName');
+    const originalString = 'abcdefghi';
+    await gfsAdapter.createFile('myFileName', originalString);
+    const gsResult = await gsAdapter.getFileData('myFileName');
+    expect(gsResult.toString('utf8')).not.toBe(originalString);
+    const gfsResult = await gfsAdapter.getFileData('myFileName');
+    expect(gfsResult.toString('utf8')).toBe(originalString);
+  });
+
   it('should save metadata', async () => {
     const gfsAdapter = new GridFSBucketAdapter(databaseURI);
     const originalString = 'abcdefghi';

--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -39,7 +39,7 @@ describe_only_db('mongo')('GridFSBucket and GridStore interop', () => {
     const gsAdapter = new GridStoreAdapter(databaseURI);
     const gfsAdapter = new GridFSBucketAdapter(
       databaseURI,
-      { useNewUrlParser: true, useUnifiedTopology: true },
+      {},
       '89E4AFF1-DFE4-4603-9574-BFA16BB446FD'
     );
     await expectMissingFile(gfsAdapter, 'myFileName');

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -125,7 +125,7 @@ export class GridFSBucketAdapter extends FilesAdapter {
             iv
           );
           decipher.setAuthTag(authTag);
-          resolve(
+          return resolve(
             Buffer.concat([decipher.update(encrypted), decipher.final()])
           );
         }

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -10,16 +10,30 @@
 import { MongoClient, GridFSBucket, Db } from 'mongodb';
 import { FilesAdapter, validateFilename } from './FilesAdapter';
 import defaults from '../../defaults';
+const crypto = require('crypto');
 
 export class GridFSBucketAdapter extends FilesAdapter {
   _databaseURI: string;
   _connectionPromise: Promise<Db>;
   _mongoOptions: Object;
+  _algorithm: string;
 
-  constructor(mongoDatabaseURI = defaults.DefaultMongoURI, mongoOptions = {}) {
+  constructor(
+    mongoDatabaseURI = defaults.DefaultMongoURI,
+    mongoOptions = {},
+    secretKey = undefined
+  ) {
     super();
     this._databaseURI = mongoDatabaseURI;
-
+    this._algorithm = 'aes-256-gcm';
+    this._secretKey =
+      secretKey !== undefined
+        ? crypto
+          .createHash('sha256')
+          .update(String(secretKey))
+          .digest('base64')
+          .substr(0, 32)
+        : null;
     const defaultMongoOptions = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
@@ -51,7 +65,23 @@ export class GridFSBucketAdapter extends FilesAdapter {
     const stream = await bucket.openUploadStream(filename, {
       metadata: options.metadata,
     });
-    await stream.write(data);
+    if (this._secretKey !== null) {
+      const iv = crypto.randomBytes(16);
+      const cipher = crypto.createCipheriv(
+        this._algorithm,
+        this._secretKey,
+        iv
+      );
+      const encryptedResult = Buffer.concat([
+        cipher.update(data),
+        cipher.final(),
+        iv,
+        cipher.getAuthTag(),
+      ]);
+      await stream.write(encryptedResult);
+    } else {
+      await stream.write(data);
+    }
     stream.end();
     return new Promise((resolve, reject) => {
       stream.on('finish', resolve);
@@ -82,7 +112,24 @@ export class GridFSBucketAdapter extends FilesAdapter {
         chunks.push(data);
       });
       stream.on('end', () => {
-        resolve(Buffer.concat(chunks));
+        const data = Buffer.concat(chunks);
+        if (this._secretKey !== null) {
+          const authTagLocation = data.length - 16;
+          const ivLocation = data.length - 32;
+          const authTag = data.slice(authTagLocation);
+          const iv = data.slice(ivLocation, authTagLocation);
+          const encrypted = data.slice(0, ivLocation);
+          const decipher = crypto.createDecipheriv(
+            this._algorithm,
+            this._secretKey,
+            iv
+          );
+          decipher.setAuthTag(authTag);
+          resolve(
+            Buffer.concat([decipher.update(encrypted), decipher.final()])
+          );
+        }
+        resolve(data);
       });
       stream.on('error', (err) => {
         reject(err);

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -105,12 +105,13 @@ export function getFilesController(
     filesAdapter,
     databaseAdapter,
     preserveFileName,
+    fileKey,
   } = options;
   if (!filesAdapter && databaseAdapter) {
     throw 'When using an explicit database adapter, you must also use an explicit filesAdapter.';
   }
   const filesControllerAdapter = loadAdapter(filesAdapter, () => {
-    return new GridFSBucketAdapter(databaseURI);
+    return new GridFSBucketAdapter(databaseURI, {}, fileKey);
   });
   return new FilesController(filesControllerAdapter, appId, {
     preserveFileName,


### PR DESCRIPTION
Adds fileKey encryption similar to original Parse. This is implemented for `GridFSBucketAdapter` and the [FileSystemAdapter](https://github.com/parse-community/parse-server-fs-adapter/pull/15). This uses AES256-GCM so it can detect if files are tampered with.

To use, simply use the env var `PARSE_SERVER_FILE_KEY`, pass in --fileKey in the CL, or initialize ParseServer with `fileKey="Your file encryptionKey"`. An example using `GridFSBucketAdapter `:

```javascript
const api = new ParseServer({
  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
  cloud: process.env.PARSE_SERVER_CLOUD || __dirname + '/cloud/main.js',
  appId: process.env.PARSE_SERVER_APPLICATION_ID || 'myAppId',
  masterKey: process.env.PARSE_SERVER_MASTER_KEY || '', 
  fileKey: process.env.PARSE_SERVER_FILE_KEY, //Add your file key here. Keep it secret
  ...
});
```

An example using `FileSystemAdapter`:
```javascript
const api = new ParseServer({
  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
  cloud: process.env.PARSE_SERVER_CLOUD || __dirname + '/cloud/main.js',
  appId: process.env.PARSE_SERVER_APPLICATION_ID || 'myAppId',
  masterKey: process.env.PARSE_SERVER_MASTER_KEY || '', 
  filesAdapter: new FSFilesAdapter({fileKey: process.env.PARSE_SERVER_FILE_KEY}), //Add your file key here. Keep it secret. Note that this is needed for Postgres or anyone using FSFilesAdapter. 
  ...
});
```

Be sure not to lose your key or change it after encrypting files. If you want to change your fileKey after encrypting, you will need the old fileKey and create CloudCode similar to what's mentioned below.

Note to people who already have unencrypted files any of these adapters. You will probably need to write some Cloud code to leverage the adapter to grab and encrypt all of your current ParseFiles with fileKey before you can use this.

Besides the CloudCode piece, this should introduce no breaking changes