### PR TITLE
feat: allow custom cors origin header

### DIFF
--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -357,6 +357,42 @@ describe('middlewares', () => {
     );
   });
 
+  it('should set default Access-Control-Allow-Origin if allowOrigin is empty', () => {
+    AppCache.put(fakeReq.body._ApplicationId, {
+      allowOrigin: undefined,
+    });
+    const headers = {};
+    const res = {
+      header: (key, value) => {
+        headers[key] = value;
+      },
+    };
+    const allowCrossDomain = middlewares.allowCrossDomain(
+      fakeReq.body._ApplicationId
+    );
+    allowCrossDomain(fakeReq, res, () => {});
+    expect(headers['Access-Control-Allow-Origin']).toEqual('*');
+  });
+
+  it('should set custom origin to Access-Control-Allow-Origin if allowOrigin is provided', () => {
+    AppCache.put(fakeReq.body._ApplicationId, {
+      allowOrigin: 'https://parseplatform.org/',
+    });
+    const headers = {};
+    const res = {
+      header: (key, value) => {
+        headers[key] = value;
+      },
+    };
+    const allowCrossDomain = middlewares.allowCrossDomain(
+      fakeReq.body._ApplicationId
+    );
+    allowCrossDomain(fakeReq, res, () => {});
+    expect(headers['Access-Control-Allow-Origin']).toEqual(
+      'https://parseplatform.org/'
+    );
+  });
+
   it('should use user provided on field userFromJWT', (done) => {
     AppCache.put(fakeReq.body._ApplicationId, {
       masterKey: 'masterKey',

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -28,6 +28,10 @@ module.exports.ParseServerOptions = {
     help: 'Add headers to Access-Control-Allow-Headers',
     action: parsers.arrayParser,
   },
+  allowOrigin: {
+    env: 'PARSE_SERVER_ALLOW_ORIGIN',
+    help: 'Sets the origin to Access-Control-Allow-Origin',
+  },
   analyticsAdapter: {
     env: 'PARSE_SERVER_ANALYTICS_ADAPTER',
     help: 'Adapter module for the analytics',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -4,6 +4,7 @@
  * @property {Boolean} allowClientClassCreation Enable (or disable) client class creation, defaults to true
  * @property {Boolean} allowCustomObjectId Enable (or disable) custom objectId
  * @property {String[]} allowHeaders Add headers to Access-Control-Allow-Headers
+ * @property {String} allowOrigin Sets the origin to Access-Control-Allow-Origin
  * @property {Adapter<AnalyticsAdapter>} analyticsAdapter Adapter module for the analytics
  * @property {String} appId Your Parse Application ID
  * @property {String} appName Sets the app name

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -29,6 +29,8 @@ export interface ParseServerOptions {
   appName: ?string;
   /* Add headers to Access-Control-Allow-Headers */
   allowHeaders: ?(string[]);
+  /* Sets the origin to Access-Control-Allow-Origin */
+  allowOrigin: ?string;
   /* Adapter module for the analytics */
   analyticsAdapter: ?Adapter<AnalyticsAdapter>;
   /* Adapter module for the files sub-system */

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -316,7 +316,8 @@ export function allowCrossDomain(appId) {
     if (config && config.allowHeaders) {
       allowHeaders += `, ${config.allowHeaders.join(', ')}`;
     }
-    res.header('Access-Control-Allow-Origin', '*');
+    const allowOrigin = (config && config.allowOrigin) || '*';
+    res.header('Access-Control-Allow-Origin', allowOrigin);
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
     res.header('Access-Control-Allow-Headers', allowHeaders);
     res.header(


### PR DESCRIPTION
Currently, the server sends CORS header with `Access-Control-Allow-Origin: *`. We should allow users to customize this value to allow tighter security configurations on their end.