### PR TITLE
Add version to playground to fix CDN

### DIFF
--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -109,6 +109,7 @@ class ParseGraphQLServer {
         res.write(
           renderPlaygroundPage({
             endpoint: this.config.graphQLPath,
+            version: '1.7.25',
             subscriptionEndpoint: this.config.subscriptionsPath,
             headers: {
               'X-Parse-Application-Id': this.parseServer.config.appId,


### PR DESCRIPTION
With automated updated currently playground won't load due to Apollo CDN 404 error
Linked to: https://github.com/apollographql/apollo-server/issues/2676