### PR TITLE
Remove wontfix label from stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,7 +17,7 @@ exemptLabels:
   - security
   - up-for-grabs
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Limit to only `issues` not `pulls`
 only: issues
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Replacing the `wontfix` label with `stale` label. `wontfix` looks like we would never fix them.