### PR TITLE
Fix NPM publish process

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,9 +122,6 @@
     "url": "https://opencollective.com/parse-server",
     "logo": "https://opencollective.com/parse-server/logo.txt?reverse=true&variant=binary"
   },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/parse-server"


### PR DESCRIPTION
I believe [this line](https://github.com/parse-community/parse-server/commit/f2f772084f6a05ec8b302f02ac0ecb220fbcf228#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) was added by mistake a while ago and it was making the npm publish process to fail.