### PR TITLE
improve field deletion in collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.3.0...master)
+- IMPROVE: Optimized deletion of class field from schema by using an index if available to do an index scan instead of a collection scan. [#6815](https://github.com/parse-community/parse-server/issues/6815). Thanks to [Manuel Trezza](https://github.com/mtrezza).
 
 ### 4.3.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.2.0...4.3.0)

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -433,6 +433,11 @@ export class MongoStorageAdapter implements StorageAdapter {
       collectionUpdate['$unset'][name] = null;
     });
 
+    const collectionFilter = { $or: [] };
+    mongoFormatNames.forEach(name => {
+      collectionFilter['$or'].push({ [name]: { $exists: true } });
+    });
+
     const schemaUpdate = { $unset: {} };
     fieldNames.forEach((name) => {
       schemaUpdate['$unset'][name] = null;
@@ -440,7 +445,7 @@ export class MongoStorageAdapter implements StorageAdapter {
     });
 
     return this._adaptiveCollection(className)
-      .then((collection) => collection.updateMany({}, collectionUpdate))
+      .then((collection) => collection.updateMany(collectionFilter, collectionUpdate))
       .then(() => this._schemaCollection())
       .then((schemaCollection) =>
         schemaCollection.updateSchema(className, schemaUpdate)


### PR DESCRIPTION
Simply adds a filter to `updateMany` when deleting the field from the collection. That means that only documents will be updated that contain the field.

In the status quo (without index), this added filter has no effect. But it gives the devop the ability to manually add the required index for the field to be deleted. The index has to be` { <fieldNameToDelete>: { $exists: true }}`.

Also added an additional test case for field deletion without index, which was missing before, hence increase in coverage.

closes https://github.com/parse-community/parse-server/issues/6815