### PR TITLE
Use an empty object as default value of options for Google Sign in

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -536,7 +536,7 @@ describe('server', () => {
     const jwt = require('jsonwebtoken');
 
     reconfigureServer({
-      auth: {}
+      auth: { google: {} }
     })
       .then(() => {
         const fakeClaim = {
@@ -548,9 +548,9 @@ describe('server', () => {
         const fakeDecodedToken = { header: { kid: '123', alg: 'RS256' } };
         spyOn(jwt, 'decode').and.callFake(() => fakeDecodedToken);
         spyOn(jwt, 'verify').and.callFake(() => fakeClaim);
-        const user = new Parse.User()
+        const user = new Parse.User();
         user.linkWith('google', { authData: { id: 'the_user_id', id_token: 'the_token' }})
-          .then(done)
+          .then(done);
       })
       .catch(done.fail);
   });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -531,4 +531,27 @@ describe('server', () => {
       })
       .catch(done.fail);
   });
+
+  it('should not fail when Google signin is introduced without the optional clientId', done => {
+    const jwt = require('jsonwebtoken');
+
+    reconfigureServer({
+      auth: {}
+    })
+      .then(() => {
+        const fakeClaim = {
+          iss: 'https://accounts.google.com',
+          aud: 'secret',
+          exp: Date.now(),
+          sub: 'the_user_id',
+        };
+        const fakeDecodedToken = { header: { kid: '123', alg: 'RS256' } };
+        spyOn(jwt, 'decode').and.callFake(() => fakeDecodedToken);
+        spyOn(jwt, 'verify').and.callFake(() => fakeClaim);
+        const user = new Parse.User()
+        user.linkWith('google', { authData: { id: 'the_user_id', id_token: 'the_token' }})
+          .then(done)
+      })
+      .catch(done.fail);
+  });
 });

--- a/src/Adapters/Auth/google.js
+++ b/src/Adapters/Auth/google.js
@@ -84,7 +84,7 @@ async function verifyIdToken({id_token: token, id}, {clientId}) {
 }
 
 // Returns a promise that fulfills if this user id is valid.
-function validateAuthData(authData, options) {
+function validateAuthData(authData, options = {}) {
   return verifyIdToken(authData, options);
 }
 


### PR DESCRIPTION
This pull request is to address the issue parse-community/docs#754.

Without a default value of options, we will have to explicitly define (at least) an empty object at initialization so that Google sign in function won't crash.