### PR TITLE
Fix mutating beforeSubscribe Query

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -155,10 +155,10 @@ describe('ParseLiveQuery', function () {
       verbose: false,
       silent: true,
     });
-    Parse.Cloud.beforeSubscribe(TestObject, () => {
+    Parse.Cloud.beforeSubscribe(TestObject, request => {
       const query = new Parse.Query(TestObject);
       query.equalTo('foo', 'yolo');
-      return query;
+      request.query = query;
     });
 
     const query = new Parse.Query(TestObject);

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -115,6 +115,95 @@ describe('ParseLiveQuery', function () {
     });
   });
 
+  it('can handle mutate beforeSubscribe query', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['TestObject'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+    Parse.Cloud.beforeSubscribe(TestObject, request => {
+      const query = request.query;
+      query.equalTo('yolo', 'abc');
+    });
+
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+
+    subscription.on('update', () => {
+      fail();
+    });
+    object.set({ foo: 'bar' });
+    await object.save();
+    setTimeout(async () => {
+      done();
+    }, 1000);
+  });
+
+  it('can return a new beforeSubscribe query', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['TestObject'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+    Parse.Cloud.beforeSubscribe(TestObject, () => {
+      const query = new Parse.Query(TestObject);
+      query.equalTo('foo', 'yolo');
+      return query;
+    });
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('foo', 'bar');
+    const subscription = await query.subscribe();
+
+    subscription.on('create', object => {
+      expect(object.get('foo')).toBe('yolo');
+      done();
+    });
+    const object = new TestObject();
+    object.set({ foo: 'yolo' });
+    await object.save();
+  });
+
+  it('can handle select beforeSubscribe query', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['TestObject'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+    Parse.Cloud.beforeSubscribe(TestObject, request => {
+      const query = request.query;
+      query.select('yolo');
+    });
+
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+
+    subscription.on('update', object => {
+      expect(object.get('foo')).toBeUndefined();
+      expect(object.get('yolo')).toBe('abc');
+      done();
+    });
+    object.set({ foo: 'bar', yolo: 'abc' });
+    await object.save();
+  });
+
   it('handle invalid websocket payload length', async done => {
     await reconfigureServer({
       liveQuery: {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -794,8 +794,8 @@ export async function maybeRunSubscribeTrigger(
   parseQuery.withJSON(request.query);
   request.query = parseQuery;
   request.user = await userForSessionToken(request.sessionToken);
-  const result = (await trigger(request)) || request.query;
-  const query = result.toJSON();
+  await trigger(request);
+  const query = request.query.toJSON();
   if (query.keys) {
     query.fields = query.keys.split(',');
   }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -794,7 +794,12 @@ export async function maybeRunSubscribeTrigger(
   parseQuery.withJSON(request.query);
   request.query = parseQuery;
   request.user = await userForSessionToken(request.sessionToken);
-  return trigger(request);
+  const result = (await trigger(request)) || request.query;
+  const query = result.toJSON();
+  if (query.keys) {
+    query.fields = query.keys.split(',');
+  }
+  request.query = query;
 }
 
 async function userForSessionToken(sessionToken) {


### PR DESCRIPTION
Fixes #6866, and now allows returning a new query.

Also adds additional test cases for `beforeSubscribe`. Failing tests are not related to this PR.

@mtrezza, any other tests required to make sure it's 100%?