### PR TITLE
Added request query as an argument to FileController instance in the …

### DIFF
--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -59,7 +59,7 @@ export class FilesAdapter {
    *
    * @return {Promise} a promise that should pass with the file data or fail on error
    */
-  getFileData(filename: string): Promise<any> {}
+  getFileData(filename: string, query: object | null): Promise<any> {}
 
   /** Returns an absolute URL where the file can be accessed
    *

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -11,8 +11,8 @@ const legacyFilesRegex = new RegExp(
 );
 
 export class FilesController extends AdaptableController {
-  getFileData(config, filename) {
-    return this.adapter.getFileData(filename);
+  getFileData(config, filename, query) {
+    return this.adapter.getFileData(filename, query);
   }
 
   createFile(config, filename, data, contentType, options) {

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -90,7 +90,7 @@ export class FilesRouter {
         });
     } else {
       filesController
-        .getFileData(config, filename)
+        .getFileData(config, filename, req.query)
         .then(data => {
           res.status(200);
           res.set('Content-Type', contentType);


### PR DESCRIPTION
Passed req.query(the request object query property) as a third argument to the instance of FileController's getFileData method called from the FileRouter's getHandler method for files not streamed.

A third and second parameter named query, which is an object that represent the node request object's query property is then added to getFileData method of FileController and FileAdapter classes respectively.

Purpose of Changes:

Some websites perform file manipulation on the fly by adding query string to request URIs(https://example.com/parse/file/X.png?thumbanail=100), such as image resize, converting an image to another format, blur, the list are endless. But parse-server FileAdapter class which is the base class for the beautiful parse-server custom file adapter functionality does not expose the node request query to the children classes(custom file adapters) to be used for manipulating files on the fly.

Exposing the query in the FileAdapter for its children to have access to in the getFileData and passing the query to the getFileData method of the fileController which is called in the getHandler method in the FileRouter is the essence of this pull request.

Thanks.