### PR TITLE
fix(directAccess/cloud-code): Pass installationId with LogIn

### DIFF
--- a/src/ParseServerRESTController.js
+++ b/src/ParseServerRESTController.js
@@ -107,6 +107,7 @@ function ParseServerRESTController(applicationId, router) {
           info: {
             applicationId: applicationId,
             sessionToken: options.sessionToken,
+            installationId: options.installationId,
             context: options.context || {}, // Add context
           },
           query,

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -41,8 +41,8 @@ export class UsersRouter extends ClassesRouter {
       // Use query parameters instead if provided in url
       let payload = req.body;
       if (
-        (!payload.username && req.query.username) ||
-        (!payload.email && req.query.email)
+        (!payload.username && req.query && req.query.username) ||
+        (!payload.email && req.query && req.query.email)
       ) {
         payload = req.query;
       }


### PR DESCRIPTION
InstallationId didn't get passed correctly. Resulting in _Session without installationId

https://github.com/parse-community/parse-server/blob/master/src/Routers/UsersRouter.js#L263

* Fixed error with POST /login and req.query is undefined

Let me know if more tests are needed.