### PR TITLE
Set objectId into query for Email Validation

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -1,5 +1,7 @@
 'use strict';
-
+const UserController = require('../lib/Controllers/UserController')
+  .UserController;
+const Config = require('../lib/Config');
 describe('ParseLiveQuery', function () {
   it('can subscribe to query', async done => {
     await reconfigureServer({
@@ -239,6 +241,62 @@ describe('ParseLiveQuery', function () {
       object.set({ foo: 'bar' });
       await object.save();
     }, 1000);
+  });
+
+  it('should execute live query update on email validation', async done => {
+    const emailAdapter = {
+      sendVerificationEmail: () => {},
+      sendPasswordResetEmail: () => Promise.resolve(),
+      sendMail: () => {},
+    };
+
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['_User'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+      websocketTimeout: 100,
+      appName: 'liveQueryEmailValidation',
+      verifyUserEmails: true,
+      emailAdapter: emailAdapter,
+      emailVerifyTokenValidityDuration: 20, // 0.5 second
+      publicServerURL: 'http://localhost:8378/1',
+    }).then(() => {
+      const user = new Parse.User();
+      user.set('password', 'asdf');
+      user.set('email', 'asdf@example.com');
+      user.set('username', 'zxcv');
+      user
+        .signUp()
+        .then(() => {
+          const config = Config.get('test');
+          return config.database.find('_User', {
+            username: 'zxcv',
+          });
+        })
+        .then(async results => {
+          const foundUser = results[0];
+          const query = new Parse.Query('_User');
+          query.equalTo('objectId', foundUser.objectId);
+          const subscription = await query.subscribe();
+
+          subscription.on('update', async object => {
+            expect(object).toBeDefined();
+            expect(object.get('emailVerified')).toBe(true);
+            done();
+          });
+
+          const userController = new UserController(emailAdapter, 'test', {
+            verifyUserEmails: true,
+          });
+          userController.verifyEmail(
+            foundUser.username,
+            foundUser._email_verify_token
+          );
+        });
+    });
   });
 
   afterEach(async function (done) {

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -68,13 +68,12 @@ export class UserController extends AdaptableController {
       this.config,
       Auth.master(this.config),
       '_User',
-      { username: username}
+      { username: username }
     );
     return findUserForEmailVerification.execute().then(result => {
       if (result.results.length && result.results[0].emailVerified) {
         return Promise.resolve(result.results.length[0]);
       }
-      
       query.objectId = result.results[0].objectId;
       return rest.update(this.config, masterAuth, '_User', query, updateFields);
     });

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -64,16 +64,18 @@ export class UserController extends AdaptableController {
       updateFields._email_verify_token_expires_at = { __op: 'Delete' };
     }
     const masterAuth = Auth.master(this.config);
-    var checkIfAlreadyVerified = new RestQuery(
+    var findUserForEmailVerification = new RestQuery(
       this.config,
       Auth.master(this.config),
       '_User',
-      { username: username, emailVerified: true }
+      { username: username}
     );
-    return checkIfAlreadyVerified.execute().then(result => {
-      if (result.results.length) {
+    return findUserForEmailVerification.execute().then(result => {
+      if (result.results.length && result.results[0].emailVerified) {
         return Promise.resolve(result.results.length[0]);
       }
+      
+      query.objectId = result.results[0].objectId;
       return rest.update(this.config, masterAuth, '_User', query, updateFields);
     });
   }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -73,10 +73,9 @@ export class UserController extends AdaptableController {
     return findUserForEmailVerification.execute().then(result => {
       if (result.results.length && result.results[0].emailVerified) {
         return Promise.resolve(result.results.length[0]);
-      } else if(result.results.length){
+      } else if (result.results.length) {
         query.objectId = result.results[0].objectId;
       }
-      
       return rest.update(this.config, masterAuth, '_User', query, updateFields);
     });
   }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -73,8 +73,10 @@ export class UserController extends AdaptableController {
     return findUserForEmailVerification.execute().then(result => {
       if (result.results.length && result.results[0].emailVerified) {
         return Promise.resolve(result.results.length[0]);
+      } else if(result.results.length){
+        query.objectId = result.results[0].objectId;
       }
-      query.objectId = result.results[0].objectId;
+      
       return rest.update(this.config, masterAuth, '_User', query, updateFields);
     });
   }


### PR DESCRIPTION
Fixes #6921

It seems that LiveQueryController need original object id to send event.
But, email validation was not retrieving the user validating email address.