### PR TITLE
LiveQueryEvent Error Logging Improvements

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -245,10 +245,7 @@ describe('ParseLiveQuery', function () {
     await object.save();
 
     Parse.Cloud.afterLiveQueryEvent('TestObject', () => {
-      setTimeout(() => {
-        done();
-      }, 2000);
-      throw 'Error.';
+      throw 'Throw error from LQ afterEvent.';
     });
 
     const query = new Parse.Query(TestObject);
@@ -257,8 +254,9 @@ describe('ParseLiveQuery', function () {
     subscription.on('update', () => {
       fail('update should not have been called.');
     });
-    subscription.on('error', () => {
-      fail('error should not have been called.');
+    subscription.on('error', e => {
+      expect(e).toBe('Throw error from LQ afterEvent.');
+      done();
     });
     object.set({ foo: 'bar' });
     await object.save();

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -232,7 +232,7 @@ describe('ParseLiveQuery', function () {
     await object.save();
   });
 
-  it('can handle afterEvent throw', async done => {
+  it('can handle afterEvent sendEvent to false', async done => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['TestObject'],
@@ -246,16 +246,10 @@ describe('ParseLiveQuery', function () {
     await object.save();
 
     Parse.Cloud.afterLiveQueryEvent('TestObject', req => {
-      const current = req.object;
-      const original = req.original;
-
       setTimeout(() => {
         done();
       }, 2000);
-
-      if (current.get('foo') != original.get('foo')) {
-        throw "Don't pass an update trigger, or message";
-      }
+      req.sendEvent = false;
     });
 
     const query = new Parse.Query(TestObject);

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -211,7 +211,7 @@ class ParseLiveQueryServer {
                   requestId
                 );
                 logger.error(
-                  `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
+                  `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                     JSON.stringify(error)
                 );
               }
@@ -385,7 +385,7 @@ class ParseLiveQueryServer {
                     requestId
                   );
                   logger.error(
-                    `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
+                    `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                       JSON.stringify(error)
                   );
                 }

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -203,6 +203,13 @@ class ParseLiveQueryServer {
               if (aclError) {
                 logger.error('Matching ACL error : ', error);
               } else {
+                Client.pushError(
+                  client.parseWebSocket,
+                  error.code || 101,
+                  error.message || error,
+                  false,
+                  requestId
+                );
                 logger.error(
                   `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                     JSON.stringify(error)
@@ -370,6 +377,13 @@ class ParseLiveQueryServer {
                 if (aclError) {
                   logger.error('Matching ACL error : ', error);
                 } else {
+                  Client.pushError(
+                    client.parseWebSocket,
+                    error.code || 101,
+                    error.message || error,
+                    false,
+                    requestId
+                  );
                   logger.error(
                     `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                       JSON.stringify(error)

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -185,7 +185,7 @@ class ParseLiveQueryServer {
                 subscriptions: this.subscriptions.size,
                 useMasterKey: client.hasMasterKey,
                 installationId: client.installationId,
-                sendEvent: false,
+                sendEvent: true,
               };
               return maybeRunAfterEventTrigger('afterEvent', className, res);
             })

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -204,7 +204,7 @@ class ParseLiveQueryServer {
                 logger.error('Matching ACL error : ', error);
               } else {
                 logger.error(
-                  `Failed running afterLiveQueryEvent for event ${res.event} session ${res.sessionToken} with:\n Error: ` +
+                  `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                     JSON.stringify(error)
                 );
               }
@@ -370,8 +370,8 @@ class ParseLiveQueryServer {
                 if (aclError) {
                   logger.error('Matching ACL error : ', error);
                 } else {
-                  logger.error(
-                    `Failed running afterLiveQueryEvent for event ${res.event} session ${res.sessionToken} with:\n Error: ` +
+                  logger.log(
+                    `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                       JSON.stringify(error)
                   );
                 }

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -370,7 +370,7 @@ class ParseLiveQueryServer {
                 if (aclError) {
                   logger.error('Matching ACL error : ', error);
                 } else {
-                  logger.log(
+                  logger.error(
                     `Failed running afterLiveQueryEvent for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
                       JSON.stringify(error)
                   );

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -198,24 +198,17 @@ class ParseLiveQueryServer {
               client.pushDelete(requestId, deletedParseObject);
             })
             .catch(error => {
-              if (
-                error.code == Parse.Error.OBJECT_NOT_FOUND ||
-                error.code == Parse.Error.OPERATION_FORBIDDEN
-              ) {
-                logger.error('Matching ACL error : ', error);
-              } else {
-                Client.pushError(
-                  client.parseWebSocket,
-                  error.code || 141,
-                  error.message || error,
-                  false,
-                  requestId
-                );
-                logger.error(
-                  `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
-                    JSON.stringify(error)
-                );
-              }
+              Client.pushError(
+                client.parseWebSocket,
+                error.code || 141,
+                error.message || error,
+                false,
+                requestId
+              );
+              logger.error(
+                `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
+                  JSON.stringify(error)
+              );
             });
         }
       }
@@ -373,24 +366,17 @@ class ParseLiveQueryServer {
                 }
               },
               error => {
-                if (
-                  error.code == Parse.Error.OBJECT_NOT_FOUND ||
-                  error.code == Parse.Error.OPERATION_FORBIDDEN
-                ) {
-                  logger.error('Matching ACL error : ', error);
-                } else {
-                  Client.pushError(
-                    client.parseWebSocket,
-                    error.code || 141,
-                    error.message || error,
-                    false,
-                    requestId
-                  );
-                  logger.error(
-                    `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
-                      JSON.stringify(error)
-                  );
-                }
+                Client.pushError(
+                  client.parseWebSocket,
+                  error.code || 141,
+                  error.message || error,
+                  false,
+                  requestId
+                );
+                logger.error(
+                  `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
+                    JSON.stringify(error)
+                );
               }
             );
         }

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -600,6 +600,7 @@ module.exports = ParseCloud;
  * @property {Parse.Object} original If set, the object, as currently stored.
  * @property {Integer} clients The number of clients connected.
  * @property {Integer} subscriptions The number of subscriptions connected.
+ * @property {Boolean} sendEvent If the LiveQuery event should be sent to the client. Set to false to prevent LiveQuery from pushing to the client.
  */
 
 /**


### PR DESCRIPTION
Minor changes to #6859 that I've realised should've been added.

-Throwing in an afterLiveQueryEvent trigger logs properly, instead of "Matching ACL error".
-New sendEvent parameter to afterLiveQueryEvent request payload.

I've been thinking about how the afterLiveQueryEvent should handle not firing events. In the specs, I previously did it by throwing an error in the afterLiveQueryEvent, but I don't think that makes much sense, and also will fill up the logs. Hence, I've added a property "sendEvent" to the afterLiveQueryEvent request payload. If the afterLiveQueryEvent trigger sets that to false, the LiveQuery won't push to the client.

That's all the changes in this PR. I was also thinking about what happens when afterLiveQueryEvent throws an error. Should this be sent to the client as a "error" event, or should it just log on the server (as current behaviour), and no LQ event triggered?

Thank you!