### PR TITLE
fix(jobs): Add Error Message to JobStatus Failure

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1652,6 +1652,16 @@ describe('Cloud Code', () => {
       );
     });
 
+    it('should set the failure message on the job error', async () => {
+      Parse.Cloud.job('myJobError', () => {
+        throw new Parse.Error(101, 'Something went wrong');
+      });
+      const job = await Parse.Cloud.startJob('myJobError');
+      const jobStatus = await Parse.Cloud.getJobStatus(job);
+      expect(jobStatus.get('message')).toEqual('Something went wrong');
+      expect(jobStatus.get('status')).toEqual('failed');
+    });
+
     function getJobStatus(jobId) {
       const q = new Parse.Query('_JobStatus');
       return q.get(jobId, { useMasterKey: true });

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -6,7 +6,7 @@ import Auth from './Auth';
 const PUSH_STATUS_COLLECTION = '_PushStatus';
 const JOB_STATUS_COLLECTION = '_JobStatus';
 
-const incrementOp = function(object = {}, key, amount = 1) {
+const incrementOp = function (object = {}, key, amount = 1) {
   if (!object[key]) {
     object[key] = { __op: 'Increment', amount: amount };
   } else {
@@ -91,7 +91,7 @@ export function jobStatusHandler(config) {
   const objectId = newObjectId(config.objectIdSize);
   const database = config.database;
   const handler = statusHandler(JOB_STATUS_COLLECTION, database);
-  const setRunning = function(jobName, params) {
+  const setRunning = function (jobName, params) {
     const now = new Date();
     jobStatus = {
       objectId,
@@ -107,26 +107,29 @@ export function jobStatusHandler(config) {
     return handler.create(jobStatus);
   };
 
-  const setMessage = function(message) {
+  const setMessage = function (message) {
     if (!message || typeof message !== 'string') {
       return Promise.resolve();
     }
     return handler.update({ objectId }, { message });
   };
 
-  const setSucceeded = function(message) {
+  const setSucceeded = function (message) {
     return setFinalStatus('succeeded', message);
   };
 
-  const setFailed = function(message) {
+  const setFailed = function (message) {
     return setFinalStatus('failed', message);
   };
 
-  const setFinalStatus = function(status, message = undefined) {
+  const setFinalStatus = function (status, message = undefined) {
     const finishedAt = new Date();
     const update = { status, finishedAt };
     if (message && typeof message === 'string') {
       update.message = message;
+    }
+    if (message instanceof Error && typeof message.message === 'string') {
+      update.message = message.message;
     }
     return handler.update({ objectId }, update);
   };
@@ -144,7 +147,7 @@ export function pushStatusHandler(config, existingObjectId) {
   const database = config.database;
   const handler = restStatusHandler(PUSH_STATUS_COLLECTION, config);
   let objectId = existingObjectId;
-  const setInitial = function(body = {}, where, options = { source: 'rest' }) {
+  const setInitial = function (body = {}, where, options = { source: 'rest' }) {
     const now = new Date();
     let pushTime = now.toISOString();
     let status = 'pending';
@@ -193,7 +196,7 @@ export function pushStatusHandler(config, existingObjectId) {
     });
   };
 
-  const setRunning = function(batches) {
+  const setRunning = function (batches) {
     logger.verbose(
       `_PushStatus ${objectId}: sending push to installations with %d batches`,
       batches
@@ -210,7 +213,7 @@ export function pushStatusHandler(config, existingObjectId) {
     );
   };
 
-  const trackSent = function(
+  const trackSent = function (
     results,
     UTCOffset,
     cleanupInstallations = process.env
@@ -310,7 +313,7 @@ export function pushStatusHandler(config, existingObjectId) {
     });
   };
 
-  const complete = function() {
+  const complete = function () {
     return handler.update(
       { objectId },
       {
@@ -320,7 +323,7 @@ export function pushStatusHandler(config, existingObjectId) {
     );
   };
 
-  const fail = function(err) {
+  const fail = function (err) {
     if (typeof err === 'string') {
       err = { message: err };
     }


### PR DESCRIPTION
Previously only supported promise rejections. This will support Error and Parse.Errors.
Useful for debugging why jobs failed.

<img width="723" alt="Screen Shot 2020-10-20 at 3 54 07 PM" src="https://user-images.githubusercontent.com/9830365/96646000-0f6aae00-12f1-11eb-90c4-f8876c9c02ad.png">


https://github.com/parse-community/parse-server/compare/job-error-fix?expand=1#diff-4b307fc6c944735404b819d07f4d514564d5f624f0f190df784c63067c483ab9R131
