### PR TITLE
Include stack in Cloud Code

### DIFF
--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -119,10 +119,11 @@ export class FunctionsRouter extends PromiseRouter {
         if (typeof message === 'string') {
           return reject(new Parse.Error(code, message));
         }
+        const error = new Parse.Error(code, message.message || message);
         if (message instanceof Error) {
-          message = message.message;
+          error.stack = message.stack;
         }
-        reject(new Parse.Error(code, message));
+        reject(error);
       },
       message: message,
     };

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -119,7 +119,10 @@ export class FunctionsRouter extends PromiseRouter {
         if (typeof message === 'string') {
           return reject(new Parse.Error(code, message));
         }
-        const error = new Parse.Error(code, message.message || message);
+        const error = new Parse.Error(
+          code,
+          (message && message.message) || message
+        );
         if (message instanceof Error) {
           error.stack = message.stack;
         }


### PR DESCRIPTION
At the moment in Cloud Code, if an error is thrown from a syntax / JS error, such as:

```
Parse.Cloud.define("testFunction", async (request) => {
    yolo
});
```
The following error is shown:
```
error: Parse error:  yolo is not defined {"code":141,"stack":"Error: yolo is not defined
    at error (/node_modules/parse-server/lib/Routers/FunctionsRouter.js:121:16)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)}"
```

Which can make it a bit difficult sometimes to trace when your main.js is long.

This PR passes stack through if the error thrown is an `Error`, meaning that the following is logged, making it a bit easier to identify where the syntax error was.

```
error: Parse error:  yolo is not defined {"code":141,"stack":"ReferenceError: yolo is not defined
    at  /cloud/main.js:3:5
    at /node_modules/parse-server/lib/Routers/FunctionsRouter.js:199:16
    at processTicksAndRejections (internal/process/task_queues.js:93:5)"}
```

Sorry for submitting so many PRs!

