### PR TITLE
Allow cloud code file to be an array of files or a folder

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -45,6 +45,46 @@ describe('Cloud Code', () => {
     );
   });
 
+  it('can load array of code files', async done => {
+    await reconfigureServer({
+      cloud: [
+        `${__dirname}/cloud/cloudCodeArray.js`,
+        `${__dirname}/cloud/cloudCodeArray2.js`,
+      ],
+    });
+    const promises = [
+      Parse.Cloud.run('cloudCodeArray', {}),
+      Parse.Cloud.run('cloudCodeArray2', {}),
+    ];
+    const result = await Promise.all(promises);
+    expect(result[0]).toEqual(
+      'It is possible to define cloud code as an array of files.'
+    );
+    expect(result[1]).toEqual(
+      'It is possible to define cloud code as an array of files two.'
+    );
+    done();
+  });
+
+  it('can load folder of code files', async done => {
+    await reconfigureServer({
+      cloud: `${__dirname}/cloud/functions`,
+    });
+
+    const promises = [
+      Parse.Cloud.run('cloudCodeSubfolder', {}),
+      Parse.Cloud.run('cloudCodeSubfolder2', {}),
+    ];
+    const result = await Promise.all(promises);
+    expect(result[0]).toEqual(
+      'It is possible to define cloud code as a folder of files.'
+    );
+    expect(result[1]).toEqual(
+      'It is possible to define cloud code as a folder of files two.'
+    );
+    done();
+  });
+
   it('can create functions', done => {
     Parse.Cloud.define('hello', () => {
       return 'Hello world!';

--- a/spec/cloud/cloudCodeArray.js
+++ b/spec/cloud/cloudCodeArray.js
@@ -1,0 +1,3 @@
+Parse.Cloud.define('cloudCodeArray', () => {
+  return 'It is possible to define cloud code as an array of files.';
+});

--- a/spec/cloud/cloudCodeArray2.js
+++ b/spec/cloud/cloudCodeArray2.js
@@ -1,0 +1,3 @@
+Parse.Cloud.define('cloudCodeArray2', () => {
+  return 'It is possible to define cloud code as an array of files two.';
+});

--- a/spec/cloud/functions/cloudCodeSubfolderFile.js
+++ b/spec/cloud/functions/cloudCodeSubfolderFile.js
@@ -1,0 +1,3 @@
+Parse.Cloud.define('cloudCodeSubfolder', () => {
+  return 'It is possible to define cloud code as a folder of files.';
+});

--- a/spec/cloud/functions/cloudCodeSubfolderFile2.js
+++ b/spec/cloud/functions/cloudCodeSubfolderFile2.js
@@ -1,0 +1,3 @@
+Parse.Cloud.define('cloudCodeSubfolder2', () => {
+  return 'It is possible to define cloud code as a folder of files two.';
+});

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -109,25 +109,15 @@ class ParseServer {
         throw "argument 'cloud' must either be a string, array, or function";
       }
       for (const cloudFileName of cloudFiles) {
-        const cloudDir = fs.lstatSync(cloudFileName);
         const filePath = path.resolve(process.cwd(), cloudFileName);
-        const requireFiles = files => {
-          const ext = path.extname(files) || '';
-          if (ext != '.js') {
-            console.log(
-              `Could not import cloud file ${files}. Error: Invalid format.`
-            );
-          } else {
-            require(files);
-          }
-        };
+        const cloudDir = fs.lstatSync(filePath);
         if (cloudDir.isDirectory()) {
           const files = fs.readdirSync(filePath);
           for (const file of files) {
-            requireFiles(path.join(filePath, file));
+            require(path.join(filePath, file));
           }
         } else {
-          requireFiles(filePath);
+          require(filePath);
         }
       }
     }


### PR DESCRIPTION
Sorry again for submitting so many PRs, I've had a few ideas of how to improve my Parse Server I thought I'd share with the community.

For my backend, I like to break down my functions by class name, and then import the files in main.js (e.g /cloud/functions contains "_User.js", which has all user `beforeSave` and `afterSave` functions, and any `Parse.Cloud.define` functions relevant to `Parse.User`).

This PR allows the cloud parameter to be a folder, where all .js files will be imported, or an array of files. This allows users to have more, smaller, organised cloud files, which in my experience, makes it easier to navigate.