### PR TITLE
Show a message if cloud functions are duplicated

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -57,14 +57,15 @@ describe('Cloud Code', () => {
   });
 
   it('show warning on duplicate cloud functions', done => {
-    spyOn(console, 'log').and.callFake(() => {});
+    const logger = require('../lib/logger').logger;
+    spyOn(logger, 'warn').and.callFake(() => {});
     Parse.Cloud.define('hello', () => {
       return 'Hello world!';
     });
     Parse.Cloud.define('hello', () => {
       return 'Hello world!';
     });
-    expect(console.log).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
     done();
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -56,6 +56,18 @@ describe('Cloud Code', () => {
     });
   });
 
+  it('show warning on duplicate cloud functions', done => {
+    spyOn(console, 'log').and.callFake(() => {});
+    Parse.Cloud.define('hello', () => {
+      return 'Hello world!';
+    });
+    Parse.Cloud.define('hello', () => {
+      return 'Hello world!';
+    });
+    expect(console.log).toHaveBeenCalled();
+    done();
+  });
+
   it('is cleared cleared after the previous test', done => {
     Parse.Cloud.run('hello', {}).catch(error => {
       expect(error.code).toEqual(141);

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -65,7 +65,9 @@ describe('Cloud Code', () => {
     Parse.Cloud.define('hello', () => {
       return 'Hello world!';
     });
-    expect(logger.warn).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Warning: Duplicate cloud functions exist for hello. Only the last one will be used and the others will be ignored.'
+    );
     done();
   });
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -98,6 +98,27 @@ function getStore(category, name, applicationId) {
 function add(category, name, handler, applicationId) {
   const lastComponent = name.split('.').splice(-1);
   const store = getStore(category, name, applicationId);
+  if (store[lastComponent]) {
+    const type = name.split('.')[0];
+    let warningMsg =
+      type == lastComponent ? `${lastComponent}` : `trigger ${type}`;
+    const classSpecific = [
+      'beforeSave',
+      'afterSave',
+      'beforeDelete',
+      'afterDelete',
+      'beforeFind',
+      'afterFind',
+      'beforeSubscribe',
+      'afterEvent',
+    ];
+    if (classSpecific.includes(type)) {
+      warningMsg += ` on class ${lastComponent}`;
+    }
+    console.log(
+      `Warning: Duplicate cloud functions exist for ${warningMsg}. The first will be ignored.`
+    );
+  }
   store[lastComponent] = handler;
 }
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -99,24 +99,8 @@ function add(category, name, handler, applicationId) {
   const lastComponent = name.split('.').splice(-1);
   const store = getStore(category, name, applicationId);
   if (store[lastComponent]) {
-    const type = name.split('.')[0];
-    let warningMsg =
-      type == lastComponent ? `${lastComponent}` : `trigger ${type}`;
-    const classSpecific = [
-      'beforeSave',
-      'afterSave',
-      'beforeDelete',
-      'afterDelete',
-      'beforeFind',
-      'afterFind',
-      'beforeSubscribe',
-      'afterEvent',
-    ];
-    if (classSpecific.includes(type)) {
-      warningMsg += ` on class ${lastComponent}`;
-    }
-    console.log(
-      `Warning: Duplicate cloud functions exist for ${warningMsg}. The first will be ignored.`
+    logger.warn(
+      `Warning: Duplicate cloud functions exist for ${lastComponent}. Only the last one will be used and the others will be ignored.`
     );
   }
   store[lastComponent] = handler;


### PR DESCRIPTION
My last PR, this is a little QOL improvement.

Basically, if you create two cloud functions with the same name, the first will be ignored, which is expected behaviour, but can lead to headaches if your main.js is large and you accidentally name a function the same, or you redefine a cloud trigger.

E.g, you create an important validation trigger

```
Parse.Cloud.beforeSave('TestObject', function (req) {
// important validation
});
```

And then further on, you think of adding another feature, but forget that you've already written a before save block,

```
Parse.Cloud.beforeSave('TestObject', function (req) {
// feature two
});
```

All the validation from the first trigger won't run (which is fine), but it'll be hard to initially know why the code broke.

This just adds a simple `console.log` on server start, if there are duplicate cloud functions, so developers can understand more what's happening:

`Warning: Duplicate cloud functions exist for trigger beforeSave on class TestObject. The first will be ignored.`