### PR TITLE
fix(directAccess): Properly handle response status

### DIFF
--- a/spec/ParseServerRESTController.spec.js
+++ b/spec/ParseServerRESTController.spec.js
@@ -127,6 +127,7 @@ describe('ParseServerRESTController', () => {
       expect(obj.existed()).toBe(false);
       await obj.save();
       expect(obj.existed()).toBe(false);
+
       const query = new Parse.Query('TestObject');
       const result = await query.get(obj.id);
       expect(result.existed()).toBe(true);

--- a/spec/ParseServerRESTController.spec.js
+++ b/spec/ParseServerRESTController.spec.js
@@ -101,7 +101,7 @@ describe('ParseServerRESTController', () => {
     );
   });
 
-  it('should handle response', async () => {
+  it('should handle response status', async () => {
     const router = ParseServer.promiseRouter({ appId: Parse.applicationId });
     spyOn(router, 'tryRouteRequest').and.callThrough();
     RESTController = ParseServerRESTController(Parse.applicationId, router);
@@ -117,6 +117,37 @@ describe('ParseServerRESTController', () => {
     expect(location).toBe(
       `http://localhost:8378/1/classes/MyObject/${resp.objectId}`
     );
+  });
+
+  it('should handle response status in batch', async () => {
+    const router = ParseServer.promiseRouter({ appId: Parse.applicationId });
+    spyOn(router, 'tryRouteRequest').and.callThrough();
+    RESTController = ParseServerRESTController(Parse.applicationId, router);
+    const resp = await RESTController.request(
+      'POST',
+      'batch',
+      {
+        requests: [
+          {
+            method: 'POST',
+            path: '/classes/MyObject',
+          },
+          {
+            method: 'POST',
+            path: '/classes/MyObject',
+          },
+        ],
+      },
+      {
+        returnStatus: true,
+      }
+    );
+    expect(resp.length).toBe(2);
+    expect(resp[0]._status).toBe(201);
+    expect(resp[1]._status).toBe(201);
+    expect(resp[0].success).toBeDefined();
+    expect(resp[1].success).toBeDefined();
+    expect(router.tryRouteRequest.calls.all().length).toBe(2);
   });
 
   it('properly handle existed', async done => {

--- a/src/ParseServerRESTController.js
+++ b/src/ParseServerRESTController.js
@@ -64,6 +64,11 @@ function ParseServerRESTController(applicationId, router) {
             config
           ).then(
             response => {
+              if (options.returnStatus) {
+                const status = response._status;
+                delete response._status;
+                return { success: response, _status: status };
+              }
               return { success: response };
             },
             error => {

--- a/src/ParseServerRESTController.js
+++ b/src/ParseServerRESTController.js
@@ -117,8 +117,13 @@ function ParseServerRESTController(applicationId, router) {
             return router.tryRouteRequest(method, path, request);
           })
           .then(
-            response => {
-              resolve(response.response, response.status, response);
+            resp => {
+              const { response, status } = resp;
+              if (options.returnStatus) {
+                resolve({ ...response, _status: status });
+              } else {
+                resolve(response);
+              }
             },
             err => {
               if (

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1704,7 +1704,8 @@ RestWrite.prototype.runAfterSaveTrigger = function () {
 RestWrite.prototype.location = function () {
   var middle =
     this.className === '_User' ? '/users/' : '/classes/' + this.className + '/';
-  return this.config.mount + middle + this.data.objectId;
+  const mount = this.config.mount || this.config.serverURL;
+  return mount + middle + this.data.objectId;
 };
 
 // A helper to get the object id for this operation.


### PR DESCRIPTION
Should handle response the same way [JS SDK RESTController](https://github.com/parse-community/Parse-SDK-JS/blob/e19da0e252b6c48d81976797244fb73d0c8872a9/src/RESTController.js#L260), [Single Save](https://github.com/parse-community/Parse-SDK-JS/blob/e19da0e252b6c48d81976797244fb73d0c8872a9/src/ParseObject.js#L2265) and [Batch Save](https://github.com/parse-community/Parse-SDK-JS/blob/e19da0e252b6c48d81976797244fb73d0c8872a9/src/ParseObject.js#L2206) does.

* Fix RestWrite location helper
* Properly return status code
* Ensure `object.existed()` works
* Ensure `batch` endpoint returns proper response