### PR TITLE
Remove unused parameter in Cloud Function

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1324,7 +1324,7 @@ describe('Cloud Code', () => {
       object.set('before', 'save');
     });
 
-    Parse.Cloud.define('removeme', (req, res) => {
+    Parse.Cloud.define('removeme', () => {
       const testObject = new TestObject();
       return testObject
         .save()
@@ -1335,11 +1335,10 @@ describe('Cloud Code', () => {
         .then(object => {
           object.unset('remove');
           return object.save();
-        })
-        .catch(res.error);
+        });
     });
 
-    Parse.Cloud.define('removeme2', (req, res) => {
+    Parse.Cloud.define('removeme2', () => {
       const testObject = new TestObject();
       return testObject
         .save()
@@ -1350,8 +1349,7 @@ describe('Cloud Code', () => {
         .then(object => {
           object.unset('remove');
           return object.save();
-        })
-        .catch(res.error);
+        });
     });
 
     Parse.Cloud.run('removeme')

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -99,7 +99,7 @@ export class FunctionsRouter extends PromiseRouter {
     });
   }
 
-  static createResponseObject(resolve, reject, message) {
+  static createResponseObject(resolve, reject) {
     return {
       success: function (result) {
         resolve({
@@ -128,7 +128,6 @@ export class FunctionsRouter extends PromiseRouter {
         }
         reject(error);
       },
-      message: message,
     };
   }
 
@@ -174,7 +173,7 @@ export class FunctionsRouter extends PromiseRouter {
       const userString =
         req.auth && req.auth.user ? req.auth.user.id : undefined;
       const cleanInput = logger.truncateLogMessage(JSON.stringify(params));
-      const { success, error, message } = FunctionsRouter.createResponseObject(
+      const { success, error } = FunctionsRouter.createResponseObject(
         result => {
           try {
             const cleanResult = logger.truncateLogMessage(
@@ -213,7 +212,7 @@ export class FunctionsRouter extends PromiseRouter {
       );
       return Promise.resolve()
         .then(() => {
-          return theFunction(request, { message });
+          return theFunction(request);
         })
         .then(success, error);
     });


### PR DESCRIPTION
`Parse.Cloud.define('MyClass', (request, message) => {})`

Useful for users who haven't migrated and still use response parameter.

Looks like it mixed up with the Jobs implementation. job has `request.message()`