### PR TITLE
ACL Options to Cloud Validator

### DIFF
--- a/spec/CloudCode.Validator.spec.js
+++ b/spec/CloudCode.Validator.spec.js
@@ -556,7 +556,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave request.user ACL', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: 'request.user',
+      setACL: 'request.user',
     });
     const user = await Parse.User.signUp('testuser', 'p@ssword');
     const obj = new Parse.Object('BeforeSave');
@@ -572,7 +572,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL publicRead', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: 'publicRead',
+      setACL: 'publicRead',
     });
     const obj = new Parse.Object('BeforeSave');
     obj.set('foo', 'bar');
@@ -586,7 +586,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL publicWrite', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: 'publicWrite',
+      setACL: 'publicWrite',
     });
     const obj = new Parse.Object('BeforeSave');
     obj.set('foo', 'bar');
@@ -600,7 +600,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL roleRead', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: 'roleRead:Administrator',
+      setACL: 'roleRead:Administrator',
     });
     const obj = new Parse.Object('BeforeSave');
     obj.set('foo', 'bar');
@@ -615,7 +615,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL roleWrite', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: 'roleWrite:Administrator',
+      setACL: 'roleWrite:Administrator',
     });
     const obj = new Parse.Object('BeforeSave');
     obj.set('foo', 'bar');
@@ -630,7 +630,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL roleReadWrite', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: 'roleReadWrite:Administrator',
+      setACL: 'roleReadWrite:Administrator',
     });
     const obj = new Parse.Object('BeforeSave');
     obj.set('foo', 'bar');
@@ -645,7 +645,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL object readWrite', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: {
+      setACL: {
         public: 'readWrite',
         'request.user': 'readWrite',
         'role:Administrator': 'readWrite',
@@ -677,7 +677,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL object readWrite override', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: {
+      setACL: {
         override: true,
         public: 'readWrite',
         'request.user': 'readWrite',
@@ -709,7 +709,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL object read', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: {
+      setACL: {
         public: 'read',
         'request.user': 'read',
         'role:Administrator': 'read',
@@ -735,7 +735,7 @@ describe('cloud validator', () => {
 
   it('basic beforeSave ACL object write', async function (done) {
     Parse.Cloud.beforeSave('BeforeSave', () => {}, {
-      ACL: {
+      setACL: {
         public: 'write',
         'request.user': 'write',
         'role:Administrator': 'write',

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -733,7 +733,7 @@ function builtInTriggerValidator(options, request, functionName) {
       }
     }
   }
-  const aclOptions = options.ACL;
+  const aclOptions = options.setACL;
   if (aclOptions && request.object && functionName === 'beforeSave.BeforeSave') {
     const getRoleName = roleStr => {
       return aclOptions.split(`${roleStr}:`)[1];


### PR DESCRIPTION
Extending on the ['how to improve default security'](https://community.parseplatform.org/t/parse-security-how-to-improve-default-security/924/23) discussion in the community forum, I thought it could be handy for the built-in cloud validator to have some ACL enforcement.

With this PR, you can add the following validation:

```
Parse.Cloud.beforeSave('BeforeSave', () => {}, {
      setACL: 'request.user',
});
```
or
```
Parse.Cloud.beforeSave('BeforeSave', () => {}, {
      setACL: {
        'request.user': 'readWrite',
        'role:Administrator': 'read',
      },
});
```

**Options:**
As a string:

- `request.user`: request.user can read + write. No public access
- `publicRead`: public read + no public write
- `publicWrite`: no public read + public write
- `roleRead:roleID`: role read for roleID  + no write for roleID
- `roleWrite:roleID`: no role read for roleID  + write for roleID
- `roleReadWrite:roleID`:role read for roleID  + write for roleID

As an object:
- `override`: whether the ACL should override the request.object ACL
- `public`: public ACL options. Either `read`,`write`, or `readWrite`
- `request.user`: request.user ACL options. Either `read`,`write`, or `readWrite`
- `role:***`: role ACL options. Either `read`,`write`, or `readWrite`
- `userID`: userID ACL options. Either `read`,`write`, or `readWrite`

Also, could it be worth allowing setting the validation object in schema, or another method (maybe the first parameter can be a validation object? If you want the validator on a class but don't care for the beforeSave logic, you'll just get:

```
Parse.Cloud.beforeSave('myClass', () => {}, {
      //validation    
});
```

This is another quick project for Hacktober by me, no stress if it's not appropriate for Parse!