### PR TITLE
fix(connection): MongoDB not able to connect to secondary member

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9414,9 +9414,9 @@
       "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "mongodb": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
-      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "4.17.20",
     "lru-cache": "5.1.1",
     "mime": "2.4.6",
-    "mongodb": "3.6.2",
+    "mongodb": "3.6.3",
     "parse": "2.17.0",
     "pg-promise": "10.7.0",
     "pluralize": "8.0.0",


### PR DESCRIPTION
fix for :  https://jira.mongodb.org/browse/NODE-2868
We had a issue with not being able to connect to secondary member of replica set so raised a bug with MongoDb and they released a update to the driver which fixed the bug. This PR updates the MongoDb driver in parse-server to v3.6.3 from v3.6.2 to fix the connection string issue.