### PR TITLE
Add encryptionKey to src/options/index.js

### DIFF
--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -27,6 +27,7 @@
  * @property {Boolean} enableAnonymousUsers Enable (or disable) anonymous users, defaults to true
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
  * @property {Boolean} enableSingleSchemaCache Use a single schema cache shared across requests. Reduces number of queries made to _SCHEMA, defaults to false, i.e. unique schema cache per request.
+ * @property {String} encryptionKey Key for encrypting your files
  * @property {Boolean} expireInactiveSessions Sets wether we should expire the inactive sessions, defaults to true
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -77,6 +77,9 @@ export interface ParseServerOptions {
   javascriptKey: ?string;
   /* Key for Unity and .Net SDK */
   dotNetKey: ?string;
+  /* Key for encrypting your files
+  :ENV: PARSE_SERVER_ENCRYPTION_KEY */
+  encryptionKey: ?string;
   /* Key for REST calls
   :ENV: PARSE_SERVER_REST_API_KEY */
   restAPIKey: ?string;


### PR DESCRIPTION
encryptionKey is defined manually in `src/Options/Definitions.js`, but not in `src/options/index.js`. This PR fixes that.