### PR TITLE
fix(beforeSave): Skip Sanitizing Database results

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1479,6 +1479,23 @@ describe('Cloud Code', () => {
     });
   });
 
+  it('beforeSave should not sanitize database', async done => {
+    let count = 0;
+    Parse.Cloud.beforeSave('CloudIncrementNested', () => {
+      count += 1;
+      if (count === 2) {
+        done();
+      }
+    });
+
+    const obj = new Parse.Object('CloudIncrementNested');
+    obj.set('objectField', { number: 5 });
+    await obj.save();
+
+    obj.increment('objectField.number', 10);
+    await obj.save();
+  });
+
   /**
    * Verifies that an afterSave hook throwing an exception
    * will not prevent a successful save response from being returned

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1483,9 +1483,6 @@ describe('Cloud Code', () => {
     let count = 0;
     Parse.Cloud.beforeSave('CloudIncrementNested', () => {
       count += 1;
-      if (count === 2) {
-        done();
-      }
     });
 
     const obj = new Parse.Object('CloudIncrementNested');
@@ -1494,6 +1491,7 @@ describe('Cloud Code', () => {
 
     obj.increment('objectField.number', 10);
     await obj.save();
+    count === 2 ? done() : fail();
   });
 
   /**

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -235,7 +235,7 @@ RestWrite.prototype.runBeforeSaveTrigger = function () {
           this.query,
           this.data,
           this.runOptions,
-          false,
+          true,
           true
         );
       } else {


### PR DESCRIPTION
I've been running into Internal Server Error when using beforeSave and nested objects.

`Uncaught exception: TypeError: Cannot read property 'split' of undefined`

`error: Uncaught internal server error. Cannot read property 'number' of undefined`

When using beforeSave there is a validation permission check. If an object exists it returns `{}` and does additional checks on an empty object. [ValidateOnly](https://github.com/parse-community/parse-server/blob/bfdc87803003e97e15063a27606d6c35b89133be/src/Controllers/DatabaseController.js#L498). I believe we can ignore those checks as they don’t have anything to do with beforeSave.

Let me know if additional tests are needed.

