### PR TITLE
feat: include sessionToken in onLiveQueryEvent

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -19,11 +19,8 @@ describe('ParseLiveQuery', function () {
     requestedUser.setUsername('username');
     requestedUser.setPassword('password');
     Parse.Cloud.onLiveQueryEvent(req => {
-      const { event, sessionToken, user } = req;
+      const { event, sessionToken } = req;
       if (event === 'ws_disconnect') {
-        expect(user).toBeDefined();
-        expect(user.id).toBe(requestedUser.id);
-        expect(user.get('username')).toBe('username');
         expect(sessionToken).toBeDefined();
         expect(sessionToken).toBe(requestedUser.getSessionToken());
         done();

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -35,6 +35,33 @@ describe('ParseLiveQuery', function () {
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     client.close();
   });
+  it('remove user on onLiveQueryEvent after session token is deleted', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['TestObject'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+    const requestedUser = new Parse.User();
+    requestedUser.setUsername('username');
+    requestedUser.setPassword('password');
+    Parse.Cloud.onLiveQueryEvent(req => {
+      const { event, sessionToken, user } = req;
+      if (event === 'ws_disconnect') {
+        expect(user).toBe(undefined);
+        expect(sessionToken).toBe(undefined);
+        done();
+      }
+    });
+    await requestedUser.signUp();
+    const query = new Parse.Query(TestObject);
+    await query.subscribe();
+    await Parse.User.logOut();
+    const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
+    client.close();
+  });
   it('can subscribe to query', async done => {
     await reconfigureServer({
       liveQuery: {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -18,7 +18,7 @@ describe('ParseLiveQuery', function () {
     const requestedUser = new Parse.User();
     requestedUser.setUsername('username');
     requestedUser.setPassword('password');
-    Parse.Cloud.onLiveQueryEvent(async req => {
+    Parse.Cloud.onLiveQueryEvent(req => {
       const { event, sessionToken, user } = req;
       if (event === 'ws_disconnect') {
         expect(user).toBeDefined();

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -573,7 +573,6 @@ describe('ParseLiveQuery', function () {
       expect(req.useMasterKey).toBe(false);
       expect(req.installationId).toBeDefined();
       expect(req.user).toBeUndefined();
-      expect(req.sessionToken).toBeUndefined();
       expect(req.client).toBeDefined();
     });
     const query = new Parse.Query(TestObject);

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -35,33 +35,7 @@ describe('ParseLiveQuery', function () {
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     client.close();
   });
-  it('remove user on onLiveQueryEvent after session token is deleted', async done => {
-    await reconfigureServer({
-      liveQuery: {
-        classNames: ['TestObject'],
-      },
-      startLiveQueryServer: true,
-      verbose: false,
-      silent: true,
-    });
-    const requestedUser = new Parse.User();
-    requestedUser.setUsername('username');
-    requestedUser.setPassword('password');
-    Parse.Cloud.onLiveQueryEvent(req => {
-      const { event, sessionToken, user } = req;
-      if (event === 'ws_disconnect') {
-        expect(user).toBe(undefined);
-        expect(sessionToken).toBe(undefined);
-        done();
-      }
-    });
-    await requestedUser.signUp();
-    const query = new Parse.Query(TestObject);
-    await query.subscribe();
-    await Parse.User.logOut();
-    const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
-    client.close();
-  });
+
   it('can subscribe to query', async done => {
     await reconfigureServer({
       liveQuery: {
@@ -84,6 +58,7 @@ describe('ParseLiveQuery', function () {
     object.set({ foo: 'bar' });
     await object.save();
   });
+
   it('expect afterEvent create', async done => {
     await reconfigureServer({
       liveQuery: {

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -423,6 +423,7 @@ class ParseLiveQueryServer {
         subscriptions: this.subscriptions.size,
         useMasterKey: client.hasMasterKey,
         installationId: client.installationId,
+        sessionToken: client.sessionToken,
       });
     });
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -845,17 +845,9 @@ export function inflate(data, restObject) {
   return Parse.Object.fromJSON(copy);
 }
 
-export async function runLiveQueryEventHandlers(data, applicationId = Parse.applicationId) {
-  if (
-    !_triggerStore ||
-    !_triggerStore[applicationId] ||
-    !_triggerStore[applicationId].LiveQuery ||
-    _triggerStore[applicationId].LiveQuery.length == 0
-  ) {
+export function runLiveQueryEventHandlers(data, applicationId = Parse.applicationId) {
+  if (!_triggerStore || !_triggerStore[applicationId] || !_triggerStore[applicationId].LiveQuery) {
     return;
-  }
-  if (data.sessionToken && !data.user) {
-    data.user = await userForSessionToken(data.sessionToken);
   }
   _triggerStore[applicationId].LiveQuery.forEach(handler => handler(data));
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -856,9 +856,6 @@ export async function runLiveQueryEventHandlers(data, applicationId = Parse.appl
   }
   if (data.sessionToken && !data.user) {
     data.user = await userForSessionToken(data.sessionToken);
-    if (!data.user) {
-      data.sessionToken = undefined;
-    }
   }
   _triggerStore[applicationId].LiveQuery.forEach(handler => handler(data));
 }
@@ -926,9 +923,6 @@ export async function maybeRunConnectTrigger(triggerType, request) {
     return;
   }
   request.user = await userForSessionToken(request.sessionToken);
-  if (!request.user) {
-    request.sessionToken = undefined;
-  }
   await maybeRunValidator(request, `${triggerType}.${ConnectClassName}`);
   if (request.skipWithMasterKey) {
     return;
@@ -945,9 +939,6 @@ export async function maybeRunSubscribeTrigger(triggerType, className, request) 
   parseQuery.withJSON(request.query);
   request.query = parseQuery;
   request.user = await userForSessionToken(request.sessionToken);
-  if (!request.user) {
-    request.sessionToken = undefined;
-  }
   await maybeRunValidator(request, `${triggerType}.${className}`);
   if (request.skipWithMasterKey) {
     return;
@@ -972,9 +963,6 @@ export async function maybeRunAfterEventTrigger(triggerType, className, request)
     request.original = Parse.Object.fromJSON(request.original);
   }
   request.user = await userForSessionToken(request.sessionToken);
-  if (!request.user) {
-    request.sessionToken = undefined;
-  }
   await maybeRunValidator(request, `${triggerType}.${className}`);
   if (request.skipWithMasterKey) {
     return;


### PR DESCRIPTION
Closes #1906.

If a sessionToken is passed onLiveQueryEvent, lookup the associated Parse.User, and set req.user.