### PR TITLE
Properly handle serverURL and publicServerUrl in Batch requests #6980

### DIFF
--- a/spec/batch.spec.js
+++ b/spec/batch.spec.js
@@ -9,6 +9,7 @@ const serverURL1 = 'http://localhost:1234/1';
 const serverURLNaked = 'http://localhost:1234/';
 const publicServerURL = 'http://domain.com/parse';
 const publicServerURLNaked = 'http://domain.com/';
+const publicServerURLLong = 'https://domain.com/something/really/long';
 
 const headers = {
   'Content-Type': 'application/json',
@@ -21,6 +22,26 @@ describe('batch', () => {
   it('should return the proper url', () => {
     const internalURL = batch.makeBatchRoutingPathFunction(originalURL)('/parse/classes/Object');
 
+    expect(internalURL).toEqual('/classes/Object');
+  });
+
+  it('should return the proper url given a public url-only path', () => {
+    const originalURL = '/something/really/long/batch';
+    const internalURL = batch.makeBatchRoutingPathFunction(
+      originalURL,
+      serverURL,
+      publicServerURLLong
+    )('/parse/classes/Object');
+    expect(internalURL).toEqual('/classes/Object');
+  });
+
+  it('should return the proper url given a server url-only path', () => {
+    const originalURL = '/parse/batch';
+    const internalURL = batch.makeBatchRoutingPathFunction(
+      originalURL,
+      serverURL,
+      publicServerURLLong
+    )('/parse/classes/Object');
     expect(internalURL).toEqual('/classes/Object');
   });
 

--- a/src/batch.js
+++ b/src/batch.js
@@ -50,9 +50,9 @@ function makeBatchRoutingPathFunction(originalUrl, serverURL, publicServerURL) {
           : startsWithLocal
             ? localPath.length
             : publicPath.length;
-      // Build the new path by removing the public path
-      // and joining with the local path
+
       const newPath = path.posix.join('/', localPath, '/', requestPath.slice(pathLengthToUse));
+
       // Use the method for local routing
       return makeRoutablePath(newPath);
     };

--- a/src/batch.js
+++ b/src/batch.js
@@ -36,12 +36,23 @@ function makeBatchRoutingPathFunction(originalUrl, serverURL, publicServerURL) {
   if (serverURL && publicServerURL && serverURL.path != publicServerURL.path) {
     const localPath = serverURL.path;
     const publicPath = publicServerURL.path;
+
     // Override the api prefix
     apiPrefix = localPath;
     return function (requestPath) {
+      // Figure out which server url was used by figuring out which
+      // path more closely matches requestPath
+      const startsWithLocal = requestPath.startsWith(localPath);
+      const startsWithPublic = requestPath.startsWith(publicPath);
+      const pathLengthToUse =
+        startsWithLocal && startsWithPublic
+          ? Math.max(localPath.length, publicPath.length)
+          : startsWithLocal
+            ? localPath.length
+            : publicPath.length;
       // Build the new path by removing the public path
       // and joining with the local path
-      const newPath = path.posix.join('/', localPath, '/', requestPath.slice(publicPath.length));
+      const newPath = path.posix.join('/', localPath, '/', requestPath.slice(pathLengthToUse));
       // Use the method for local routing
       return makeRoutablePath(newPath);
     };


### PR DESCRIPTION
See #6980 for more context

I'm not 100% confident I understand the intended distinction between `serverUrl` and `publicServerUrl` but my instinct is that on a production machine I should be able to access parse server via either URL.  That seems to be the case for everything BUT batch requests which have an assumption that requests come only from the pubic URL.  This patch has a rough-shod attempt at a quick-and-dirty detection of which kind of URL is being used to construct the `newPath` appropriately.

The included test fails before the patch, passes afterwards.