### PR TITLE
Optimize redundant logic used in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...master)
+- IMPROVE: Optimize queries on classes with pointer permissions.
 
 ### 4.4.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.3.0...4.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### master
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...master)
-- IMPROVE: Optimize queries on classes with pointer permissions.
+- IMPROVE: Optimize queries on classes with pointer permissions. [#7061](https://github.com/parse-community/parse-server/pull/7061). Thanks to [Pedro Diaz](https://github.com/pdiaz)
 
 ### 4.4.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.3.0...4.4.0)

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -236,6 +236,65 @@ describe('DatabaseController', function () {
       done();
     });
 
+    it('should not return a $or operation if the query involves one of the two fields also used as array/pointer permissions', done => {
+      const clp = buildCLP(['users', 'user']);
+      const query = { a: 'b', user: createUserPointer(USER_ID) };
+
+      schemaController.testPermissionsForClassName
+        .withArgs(CLASS_NAME, ACL_GROUP, OPERATION)
+        .and.returnValue(false);
+      schemaController.getClassLevelPermissions.withArgs(CLASS_NAME).and.returnValue(clp);
+      schemaController.getExpectedType
+        .withArgs(CLASS_NAME, 'user')
+        .and.returnValue({ type: 'Pointer' });
+      schemaController.getExpectedType
+        .withArgs(CLASS_NAME, 'users')
+        .and.returnValue({ type: 'Array' });
+
+      const output = databaseController.addPointerPermissions(
+        schemaController,
+        CLASS_NAME,
+        OPERATION,
+        query,
+        ACL_GROUP
+      );
+
+      expect(output).toEqual({ ...query, user: createUserPointer(USER_ID) });
+
+      done();
+    });
+
+    it('should not return a $or operation if the query involves one of the fields also used as array/pointer permissions', done => {
+      const clp = buildCLP(['user', 'users', 'userObject']);
+      const query = { a: 'b', user: createUserPointer(USER_ID) };
+
+      schemaController.testPermissionsForClassName
+        .withArgs(CLASS_NAME, ACL_GROUP, OPERATION)
+        .and.returnValue(false);
+      schemaController.getClassLevelPermissions.withArgs(CLASS_NAME).and.returnValue(clp);
+      schemaController.getExpectedType
+        .withArgs(CLASS_NAME, 'user')
+        .and.returnValue({ type: 'Pointer' });
+      schemaController.getExpectedType
+        .withArgs(CLASS_NAME, 'users')
+        .and.returnValue({ type: 'Array' });
+      schemaController.getExpectedType
+        .withArgs(CLASS_NAME, 'userObject')
+        .and.returnValue({ type: 'Object' });
+
+      const output = databaseController.addPointerPermissions(
+        schemaController,
+        CLASS_NAME,
+        OPERATION,
+        query,
+        ACL_GROUP
+      );
+
+      expect(output).toEqual({ ...query, user: createUserPointer(USER_ID) });
+
+      done();
+    });
+
     it('should throw an error if for some unexpected reason the property specified in the CLP is neither a pointer nor an array', done => {
       const clp = buildCLP(['user']);
       const query = { a: 'b' };

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -276,6 +276,7 @@ describe('DatabaseController', function () {
     });
 
     it('reduceOrOperation', done => {
+      expect(databaseController.reduceOrOperation({ a: 1 })).toEqual({ a: 1 });
       expect(databaseController.reduceOrOperation({ $or: [{ a: 1 }, { b: 2 }] })).toEqual({
         $or: [{ a: 1 }, { b: 2 }],
       });
@@ -293,6 +294,7 @@ describe('DatabaseController', function () {
     });
 
     it('reduceAndOperation', done => {
+      expect(databaseController.reduceAndOperation({ a: 1 })).toEqual({ a: 1 });
       expect(databaseController.reduceAndOperation({ $and: [{ a: 1 }, { b: 2 }] })).toEqual({
         $and: [{ a: 1 }, { b: 2 }],
       });

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -265,6 +265,49 @@ describe('DatabaseController', function () {
       done();
     });
   });
+
+  describe('reduceOperations', function () {
+    const databaseController = new DatabaseController();
+
+    it('objectToEntriesStrings', done => {
+      const output = databaseController.objectToEntriesStrings({ a: 1, b: 2, c: 3 });
+      expect(output).toEqual(['"a":1', '"b":2', '"c":3']);
+      done();
+    });
+
+    it('reduceOrOperation', done => {
+      expect(databaseController.reduceOrOperation({ $or: [{ a: 1 }, { b: 2 }] })).toEqual({
+        $or: [{ a: 1 }, { b: 2 }],
+      });
+      expect(databaseController.reduceOrOperation({ $or: [{ a: 1 }, { a: 2 }] })).toEqual({
+        $or: [{ a: 1 }, { a: 2 }],
+      });
+      expect(databaseController.reduceOrOperation({ $or: [{ a: 1 }, { a: 1 }] })).toEqual({ a: 1 });
+      expect(
+        databaseController.reduceOrOperation({ $or: [{ a: 1, b: 2, c: 3 }, { a: 1 }] })
+      ).toEqual({ a: 1 });
+      expect(
+        databaseController.reduceOrOperation({ $or: [{ b: 2 }, { a: 1, b: 2, c: 3 }] })
+      ).toEqual({ b: 2 });
+      done();
+    });
+
+    it('reduceAndOperation', done => {
+      expect(databaseController.reduceAndOperation({ $and: [{ a: 1 }, { b: 2 }] })).toEqual({
+        $and: [{ a: 1 }, { b: 2 }],
+      });
+      expect(databaseController.reduceAndOperation({ $and: [{ a: 1 }, { a: 2 }] })).toEqual({
+        $and: [{ a: 1 }, { a: 2 }],
+      });
+      expect(databaseController.reduceAndOperation({ $and: [{ a: 1 }, { a: 1 }] })).toEqual({
+        a: 1,
+      });
+      expect(
+        databaseController.reduceAndOperation({ $and: [{ a: 1, b: 2, c: 3 }, { b: 2 }] })
+      ).toEqual({ a: 1, b: 2, c: 3 });
+      done();
+    });
+  });
 });
 
 function buildCLP(pointerNames) {

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -239,7 +239,6 @@ describe('DatabaseController', function () {
     it('should not return a $or operation if the query involves one of the two fields also used as array/pointer permissions', done => {
       const clp = buildCLP(['users', 'user']);
       const query = { a: 'b', user: createUserPointer(USER_ID) };
-
       schemaController.testPermissionsForClassName
         .withArgs(CLASS_NAME, ACL_GROUP, OPERATION)
         .and.returnValue(false);
@@ -250,7 +249,6 @@ describe('DatabaseController', function () {
       schemaController.getExpectedType
         .withArgs(CLASS_NAME, 'users')
         .and.returnValue({ type: 'Array' });
-
       const output = databaseController.addPointerPermissions(
         schemaController,
         CLASS_NAME,
@@ -258,16 +256,13 @@ describe('DatabaseController', function () {
         query,
         ACL_GROUP
       );
-
       expect(output).toEqual({ ...query, user: createUserPointer(USER_ID) });
-
       done();
     });
 
     it('should not return a $or operation if the query involves one of the fields also used as array/pointer permissions', done => {
       const clp = buildCLP(['user', 'users', 'userObject']);
       const query = { a: 'b', user: createUserPointer(USER_ID) };
-
       schemaController.testPermissionsForClassName
         .withArgs(CLASS_NAME, ACL_GROUP, OPERATION)
         .and.returnValue(false);
@@ -281,7 +276,6 @@ describe('DatabaseController', function () {
       schemaController.getExpectedType
         .withArgs(CLASS_NAME, 'userObject')
         .and.returnValue({ type: 'Object' });
-
       const output = databaseController.addPointerPermissions(
         schemaController,
         CLASS_NAME,
@@ -289,9 +283,7 @@ describe('DatabaseController', function () {
         query,
         ACL_GROUP
       );
-
       expect(output).toEqual({ ...query, user: createUserPointer(USER_ID) });
-
       done();
     });
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1365,6 +1365,9 @@ class DatabaseController {
       });
   }
 
+  // This helps to create intermediate objects for simpler comparison of
+  // key value pairs used in query objects. Each key value pair will represented
+  // in a similar way to json
   objectToEntriesStrings(query: any): Array<string> {
     return Object.entries(query).map(a => a.map(s => JSON.stringify(s)).join(':'));
   }
@@ -1374,12 +1377,13 @@ class DatabaseController {
     for (let i = 0; i < queries.length - 1; i++) {
       for (let j = i + 1; j < queries.length; j++) {
         const [shorter, longer] = queries[i].length > queries[j].length ? [j, i] : [i, j];
-        const foundEntries = queries[longer].reduce(
-          (acc, entry) => acc + (queries[shorter].includes(entry) ? 1 : 0),
+        const foundEntries = queries[shorter].reduce(
+          (acc, entry) => acc + (queries[longer].includes(entry) ? 1 : 0),
           0
         );
         if (foundEntries === queries[shorter].length) {
-          // If the shorter query is completely contained on the longer one, we can skip it.
+          // If the shorter query is completely contained in the longer one, we can strike
+          // out the longer query.
           query.$or.splice(longer, 1);
           queries.splice(longer, 1);
         }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1385,9 +1385,9 @@ class DatabaseController {
         }
       }
     }
-
-    if (query.$or.length === 1) return query.$or[0];
-
+    if (query.$or.length === 1) {
+      return query.$or[0];
+    }
     return query;
   }
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1483,7 +1483,6 @@ class DatabaseController {
           if (foundEntries === queryClauseEntries.length) {
             return query;
           }
-
           return { $and: [queryClause, query] };
         }
         // otherwise just add the constaint

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1378,21 +1378,28 @@ class DatabaseController {
       return query;
     }
     const queries = query.$or.map(q => this.objectToEntriesStrings(q));
-    for (let i = 0; i < queries.length - 1; i++) {
-      for (let j = i + 1; j < queries.length; j++) {
-        const [shorter, longer] = queries[i].length > queries[j].length ? [j, i] : [i, j];
-        const foundEntries = queries[shorter].reduce(
-          (acc, entry) => acc + (queries[longer].includes(entry) ? 1 : 0),
-          0
-        );
-        if (foundEntries === queries[shorter].length) {
-          // If the shorter query is completely contained in the longer one, we can strike
-          // out the longer query.
-          query.$or.splice(longer, 1);
-          queries.splice(longer, 1);
+    let repeat = false;
+    do {
+      repeat = false;
+      for (let i = 0; i < queries.length - 1; i++) {
+        for (let j = i + 1; j < queries.length; j++) {
+          const [shorter, longer] = queries[i].length > queries[j].length ? [j, i] : [i, j];
+          const foundEntries = queries[shorter].reduce(
+            (acc, entry) => acc + (queries[longer].includes(entry) ? 1 : 0),
+            0
+          );
+          const shorterEntries = queries[shorter].length;
+          if (foundEntries === shorterEntries) {
+            // If the shorter query is completely contained in the longer one, we can strike
+            // out the longer query.
+            query.$or.splice(longer, 1);
+            queries.splice(longer, 1);
+            repeat = true;
+            break;
+          }
         }
       }
-    }
+    } while (repeat);
     if (query.$or.length === 1) {
       query = { ...query, ...query.$or[0] };
       delete query.$or;
@@ -1406,21 +1413,28 @@ class DatabaseController {
       return query;
     }
     const queries = query.$and.map(q => this.objectToEntriesStrings(q));
-    for (let i = 0; i < queries.length - 1; i++) {
-      for (let j = i + 1; j < queries.length; j++) {
-        const [shorter, longer] = queries[i].length > queries[j].length ? [j, i] : [i, j];
-        const foundEntries = queries[shorter].reduce(
-          (acc, entry) => acc + (queries[longer].includes(entry) ? 1 : 0),
-          0
-        );
-        if (foundEntries === queries[shorter].length) {
-          // If the shorter query is completely contained in the longer one, we can strike
-          // out the shorter query.
-          query.$and.splice(shorter, 1);
-          queries.splice(shorter, 1);
+    let repeat = false;
+    do {
+      repeat = false;
+      for (let i = 0; i < queries.length - 1; i++) {
+        for (let j = i + 1; j < queries.length; j++) {
+          const [shorter, longer] = queries[i].length > queries[j].length ? [j, i] : [i, j];
+          const foundEntries = queries[shorter].reduce(
+            (acc, entry) => acc + (queries[longer].includes(entry) ? 1 : 0),
+            0
+          );
+          const shorterEntries = queries[shorter].length;
+          if (foundEntries === shorterEntries) {
+            // If the shorter query is completely contained in the longer one, we can strike
+            // out the shorter query.
+            query.$and.splice(shorter, 1);
+            queries.splice(shorter, 1);
+            repeat = true;
+            break;
+          }
         }
       }
-    }
+    } while (repeat);
     if (query.$and.length === 1) {
       query = { ...query, ...query.$and[0] };
       delete query.$and;

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1372,6 +1372,7 @@ class DatabaseController {
     return Object.entries(query).map(a => a.map(s => JSON.stringify(s)).join(':'));
   }
 
+  // Naive logic reducer for OR operations meant to be used only for pointer permissions.
   reduceOrOperation(query: { $or: Array<any> }): any {
     if (!query.$or) {
       return query;
@@ -1393,11 +1394,13 @@ class DatabaseController {
       }
     }
     if (query.$or.length === 1) {
-      return query.$or[0];
+      query = { ...query, ...query.$or[0] };
+      delete query.$or;
     }
     return query;
   }
 
+  // Naive logic reducer for AND operations meant to be used only for pointer permissions.
   reduceAndOperation(query: { $and: Array<any> }): any {
     if (!query.$and) {
       return query;
@@ -1419,7 +1422,8 @@ class DatabaseController {
       }
     }
     if (query.$and.length === 1) {
-      return query.$and[0];
+      query = { ...query, ...query.$and[0] };
+      delete query.$and;
     }
     return query;
   }


### PR DESCRIPTION
After upgrading parse-server from 2.7.4 to 4.4.0, MongoDB 4.0 maxed CPU usage from what used to be barely 20% usage.

This does reduce the redundant complexity on queries that involve pointer permissions.