### PR TITLE
Fix max listener warning from livequery server

### DIFF
--- a/spec/EnableExpressErrorHandler.spec.js
+++ b/spec/EnableExpressErrorHandler.spec.js
@@ -2,6 +2,7 @@ const request = require('../lib/request');
 
 describe('Enable express error handler', () => {
   it('should call the default handler in case of error, like updating a non existing object', async done => {
+    spyOn(console, 'error');
     const parseServer = await reconfigureServer(
       Object.assign({}, defaultConfiguration, {
         enableExpressErrorHandler: true,

--- a/src/Adapters/PubSub/EventEmitterPubSub.js
+++ b/src/Adapters/PubSub/EventEmitterPubSub.js
@@ -49,7 +49,7 @@ function createSubscriber(): any {
   // createSubscriber is called once at live query server start
   // to avoid max listeners warning, we should clean up the event emitter
   // each time this function is called
-  if (emitter) emitter.removeAllListeners();
+  emitter.removeAllListeners();
   return new Subscriber(emitter);
 }
 

--- a/src/Adapters/PubSub/EventEmitterPubSub.js
+++ b/src/Adapters/PubSub/EventEmitterPubSub.js
@@ -46,6 +46,10 @@ function createPublisher(): any {
 }
 
 function createSubscriber(): any {
+  // createSubscriber is called once at live query server start
+  // to avoid max listeners warning, we should clean up the event emitter
+  // each time this function is called
+  if (emitter) emitter.removeAllListeners();
   return new Subscriber(emitter);
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
max event listener on our test and can occur for developers in their own tests

Related issue: FILL_THIS_OUT

### Approach
Clean event emitter

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [x] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...