### PR TITLE
Send email via Parse.Cloud.sendEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ __BREAKING CHANGES:__
 ___
 - IMPROVE: Optimize queries on classes with pointer permissions. [#7061](https://github.com/parse-community/parse-server/pull/7061). Thanks to [Pedro Diaz](https://github.com/pdiaz)
 - FIX: request.context for afterFind triggers. [#7078](https://github.com/parse-community/parse-server/pull/7078). Thanks to [dblythy](https://github.com/dblythy)
+- NEW: sendMail via Parse.Cloud.sendMail({...}). [#7089](https://github.com/parse-community/parse-server/pull/7089). Thanks to [dblythy](https://github.com/dblythy)
 
 ### 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ __BREAKING CHANGES:__
 ___
 - IMPROVE: Optimize queries on classes with pointer permissions. [#7061](https://github.com/parse-community/parse-server/pull/7061). Thanks to [Pedro Diaz](https://github.com/pdiaz)
 - FIX: request.context for afterFind triggers. [#7078](https://github.com/parse-community/parse-server/pull/7078). Thanks to [dblythy](https://github.com/dblythy)
-- NEW: sendMail via Parse.Cloud.sendMail({...}). [#7089](https://github.com/parse-community/parse-server/pull/7089). Thanks to [dblythy](https://github.com/dblythy)
+- NEW: Added convenience method Parse.Cloud.sendMail(...) to send email via mail adapter in Cloud Code. [#7089](https://github.com/parse-community/parse-server/pull/7089). Thanks to [dblythy](https://github.com/dblythy)
 
 ### 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3167,6 +3167,9 @@ describe('afterLogin hook', () => {
     const query = new Parse.Query(TestObject);
     await query.find({ context: { a: 'a' } });
   });
+});
+
+describe('sendMail', () => {
   it('can send email via Parse.Cloud', async done => {
     const emailAdapter = {
       sendMail: mailData => {
@@ -3181,12 +3184,15 @@ describe('afterLogin hook', () => {
     const mailData = { to: 'test' };
     await Parse.Cloud.sendMail(mailData);
   });
+
   it('cannot send email without adapter', async () => {
     try {
       await Parse.Cloud.sendMail({});
       fail('Should have failed to send emails.');
     } catch (e) {
-      expect(e).toBe('You cannot send mail without an email adapter');
+      expect(e).toBe(
+        'Failed to send email because no mail adapter is configured for Parse Server.'
+      );
     }
   });
 });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3167,4 +3167,18 @@ describe('afterLogin hook', () => {
     const query = new Parse.Query(TestObject);
     await query.find({ context: { a: 'a' } });
   });
+  it('can send email via Parse.Cloud', async done => {
+    const emailAdapter = {
+      sendMail: mailData => {
+        expect(mailData).toBeDefined();
+        expect(mailData.to).toBe('test');
+        done();
+      },
+    };
+    await reconfigureServer({
+      emailAdapter: emailAdapter,
+    });
+    const mailData = { to: 'test' };
+    await Parse.Cloud.sendMail(mailData);
+  });
 });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3186,13 +3186,11 @@ describe('sendMail', () => {
   });
 
   it('cannot send email without adapter', async () => {
-    try {
-      await Parse.Cloud.sendMail({});
-      fail('Should have failed to send emails.');
-    } catch (e) {
-      expect(e).toBe(
-        'Failed to send email because no mail adapter is configured for Parse Server.'
-      );
-    }
+    const logger = require('../lib/logger').logger;
+    spyOn(logger, 'warn').and.callFake(() => {});
+    await Parse.Cloud.sendMail({});
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to send email because no mail adapter is configured for Parse Server.'
+    );
   });
 });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3169,7 +3169,7 @@ describe('afterLogin hook', () => {
   });
 });
 
-describe('sendMail', () => {
+describe('sendEmail', () => {
   it('can send email via Parse.Cloud', async done => {
     const emailAdapter = {
       sendMail: mailData => {
@@ -3182,13 +3182,13 @@ describe('sendMail', () => {
       emailAdapter: emailAdapter,
     });
     const mailData = { to: 'test' };
-    await Parse.Cloud.sendMail(mailData);
+    await Parse.Cloud.sendEmail(mailData);
   });
 
   it('cannot send email without adapter', async () => {
     const logger = require('../lib/logger').logger;
     spyOn(logger, 'error').and.callFake(() => {});
-    await Parse.Cloud.sendMail({});
+    await Parse.Cloud.sendEmail({});
     expect(logger.error).toHaveBeenCalledWith(
       'Failed to send email because no mail adapter is configured for Parse Server.'
     );

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3187,9 +3187,9 @@ describe('sendMail', () => {
 
   it('cannot send email without adapter', async () => {
     const logger = require('../lib/logger').logger;
-    spyOn(logger, 'warn').and.callFake(() => {});
+    spyOn(logger, 'error').and.callFake(() => {});
     await Parse.Cloud.sendMail({});
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenCalledWith(
       'Failed to send email because no mail adapter is configured for Parse Server.'
     );
   });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3181,4 +3181,12 @@ describe('afterLogin hook', () => {
     const mailData = { to: 'test' };
     await Parse.Cloud.sendMail(mailData);
   });
+  it('cannot send email without adapter', async () => {
+    try {
+      await Parse.Cloud.sendMail({});
+      fail('Should have failed to send emails.');
+    } catch (e) {
+      expect(e).toBe('You cannot send mail without an email adapter');
+    }
+  });
 });

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -530,25 +530,29 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
 };
 
 /**
- * Sends email through your mail adapter
+ * Sends an email through the Parse Server mail adapter.
  *
  * **Available in Cloud Code only.**
- *
- * **Requires a mail adapter to be set**
+ * **Requires a mail adapter to be configured for Parse Server.**
  *
  * ```
- * Parse.Cloud.sendMail(data);
+ * Parse.Cloud.sendMail({
+ *   from: 'Example <test@example.com>',
+ *   to: 'contact@example.com',
+ *   subject: 'Test email.',
+ *   text: 'This email is a test'
+ * });
  *```
  *
  * @method sendMail
  * @name Parse.Cloud.sendMail
- * @param {Any} data The object of the mail data that you'd like to send
+ * @param {Object} data The object of the mail data to send
  */
 ParseCloud.sendMail = function (data) {
   const config = Config.get(Parse.applicationId) || {};
   const emailAdapter = config.userController.adapter;
   if (!emailAdapter) {
-    throw 'You cannot send mail without an email adapter';
+    throw 'Failed to send email because no mail adapter is configured for Parse Server.';
   }
   return emailAdapter.sendMail(data);
 };

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -551,10 +551,12 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
 ParseCloud.sendMail = function (data) {
   const config = Config.get(Parse.applicationId) || {};
   const emailAdapter = config.userController.adapter;
-  if (!emailAdapter) {
-    throw 'Failed to send email because no mail adapter is configured for Parse Server.';
+  if (emailAdapter) {
+    return emailAdapter.sendMail(data);
   }
-  return emailAdapter.sendMail(data);
+  config.loggerController.warn(
+    'Failed to send email because no mail adapter is configured for Parse Server.'
+  );
 };
 
 /**

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -551,12 +551,13 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
 ParseCloud.sendMail = function (data) {
   const config = Config.get(Parse.applicationId) || {};
   const emailAdapter = config.userController.adapter;
-  if (emailAdapter) {
-    return emailAdapter.sendMail(data);
+  if (!emailAdapter) {
+    config.loggerController.error(
+      'Failed to send email because no mail adapter is configured for Parse Server.'
+    );
+    return;
   }
-  config.loggerController.warn(
-    'Failed to send email because no mail adapter is configured for Parse Server.'
-  );
+  return emailAdapter.sendMail(data);
 };
 
 /**

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -544,12 +544,12 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
  * });
  *```
  *
- * @method sendMail
+ * @method sendEmail
  * @name Parse.Cloud.sendEmail
- * @param {Object} data The object of the mail data to send
+ * @param {Object} data The object of the mail data to send.
  */
 ParseCloud.sendEmail = function (data) {
-  const config = Config.get(Parse.applicationId) || {};
+  const config = Config.get(Parse.applicationId);
   const emailAdapter = config.userController.adapter;
   if (!emailAdapter) {
     config.loggerController.error(

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -536,19 +536,19 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
  * **Requires a mail adapter to be configured for Parse Server.**
  *
  * ```
- * Parse.Cloud.sendMail({
+ * Parse.Cloud.sendEmail({
  *   from: 'Example <test@example.com>',
  *   to: 'contact@example.com',
- *   subject: 'Test email.',
- *   text: 'This email is a test'
+ *   subject: 'Test email',
+ *   text: 'This email is a test.'
  * });
  *```
  *
  * @method sendMail
- * @name Parse.Cloud.sendMail
+ * @name Parse.Cloud.sendEmail
  * @param {Object} data The object of the mail data to send
  */
-ParseCloud.sendMail = function (data) {
+ParseCloud.sendEmail = function (data) {
   const config = Config.get(Parse.applicationId) || {};
   const emailAdapter = config.userController.adapter;
   if (!emailAdapter) {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -546,15 +546,11 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
  */
 ParseCloud.sendMail = function (data) {
   const config = Config.get(Parse.applicationId) || {};
-  const emailAdapter = config.emailAdapter;
+  const emailAdapter = config.userController.adapter;
   if (!emailAdapter) {
     throw 'You cannot send mail without an email adapter';
   }
-  const sendMail = emailAdapter.sendMail;
-  if (!sendMail || typeof sendMail !== 'function') {
-    throw 'This adapter does not support sendMail';
-  }
-  return sendMail(data);
+  return emailAdapter.sendMail(data);
 };
 
 /**

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -1,5 +1,6 @@
 import { Parse } from 'parse/node';
 import * as triggers from '../triggers';
+const Config = require('../Config');
 
 function isParseObjectConstructor(object) {
   return typeof object === 'function' && Object.prototype.hasOwnProperty.call(object, 'className');
@@ -526,6 +527,34 @@ ParseCloud.beforeConnect = function (handler, validationHandler) {
     Parse.applicationId,
     validationHandler
   );
+};
+
+/**
+ * Sends email through your mail adapter
+ *
+ * **Available in Cloud Code only.**
+ *
+ * **Requires a mail adapter to be set**
+ *
+ * ```
+ * Parse.Cloud.sendMail(data);
+ *```
+ *
+ * @method sendMail
+ * @name Parse.Cloud.sendMail
+ * @param {Any} data The object of the mail data that you'd like to send
+ */
+ParseCloud.sendMail = function (data) {
+  const config = Config.get(Parse.applicationId) || {};
+  const emailAdapter = config.emailAdapter;
+  if (!emailAdapter) {
+    throw 'You cannot send mail without an email adapter';
+  }
+  const sendMail = emailAdapter.sendMail;
+  if (!sendMail || typeof sendMail !== 'function') {
+    throw 'This adapter does not support sendMail';
+  }
+  return sendMail(data);
 };
 
 /**


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7089

### Approach
Helper function to send emails via attached mailAdapter. Usage:

`Parse.Cloud.sendMail(data)`

Mail data is dependent on the mail adapter.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)