### PR TITLE
Add Github process to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,19 @@
 
 We really want Parse to be yours, to see it grow and thrive in the open source community.
 
+Before you jump into the coding element of contributing, please make sure you first [open an issue](https://github.com/parse-community/parse-server/issues/new/choose) relating to your contribution, or continue the discussion in the existing issue.
+
+This helps us all plan out the best conceptual approach for the contribution, so that your time isn't wasted on approaches or features that could be tackled in a different way. Our team are also happy to give you pointers and suggestions to speed up the process.
+
+When opening an issue, please make sure you follow the templates and provide as much detail as possible.
+
+After you've completed the contribution, you'll need to submit a Pull Request (PR).
+
 If you are not familiar with Pull Requests and want to know more about them, you can visit the [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) article. It contains detailed informations about the process.
+
+If you need any help along the way, you can open a Draft PR where we can help finalize your contribution.
+
+Contributing can be challenging, so don't be discouraged if your having difficulties. Please don't hesitate to ask for help.
 
 ## Setting up the project for debugging and contributing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ Once you have babel running in watch mode, you can start making changes to parse
 * Run the tests for the whole project to make sure the code passes all tests. This can be done by running the test command for a single file but removing the test file argument. The results can be seen at *<PROJECT_ROOT>/coverage/lcov-report/index.html*.
 * Lint your code by running `npm run lint` to make sure the code is not going to be rejected by the CI.
 * **Do not** publish the *lib* folder.
+* Please consider if any changes to the [docs](http://docs.parseplatform.org) are needed or add additional sections in the case of an enhancement or feature.
 
 ### Run your tests against Postgres (optional)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you are not familiar with Pull Requests and want to know more about them, you
 
 If you need any help along the way, you can open a Draft PR where we can help finalize your contribution.
 
-Contributing can be challenging, so don't be discouraged if your having difficulties. Please don't hesitate to ask for help.
+Contributing can be challenging, so don't be discouraged if you're having difficulties. Please don't hesitate to ask for help.
 
 ## Setting up the project for debugging and contributing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,19 @@
 
 We really want Parse to be yours, to see it grow and thrive in the open source community.
 
+Before you jump into the coding element of contributing, please make sure you first [open an issue](https://github.com/parse-community/parse-server/issues/new/choose) relating to your contribution, or continue the discussion in the existing issue.
+
+This helps us all plan out the best conceptual approach for the contribution, so that your time isn't wasted on approaches or features that could be tackled in a different way. Our team are also happy to give you pointers and suggestions to speed up the process.
+
+When opening an issue, please make sure you follow the templates and provide as much detail as possible.
+
+After you've completed the contribution, you'll need to submit a Pull Request (PR).
+
 If you are not familiar with Pull Requests and want to know more about them, you can visit the [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) article. It contains detailed informations about the process.
+
+If you need any help along the way, you can open a Draft PR where we can help finalize your contribution.
+
+Contributing can be challenging, so don't be discouraged if you're having difficulties. Please don't hesitate to ask for help.
 
 ## Setting up the project for debugging and contributing:
 
@@ -47,8 +59,6 @@ Once you have babel running in watch mode, you can start making changes to parse
 
 ### Please Do's
 
-* Before you jump into the coding element of contributing, please make sure you first [open an issue](https://github.com/parse-community/parse-server/issues/new/choose) relating to your contribution, or continue the discussion in the existing issue.
-* Feel free to ask the team or community for assistance with your contribition. If needed, you can open a Draft PR where we can help finalize your contribution.
 * Begin by reading the [Development Guide](http://docs.parseplatform.org/parse-server/guide/#development-guide) to learn how to get started running the parse-server.
 * Take testing seriously! Aim to increase the test coverage with every pull request. To obtain the test coverage of the project, run: `npm run coverage`
 * Run the tests for the file you are working on with the following command: `npm test spec/MyFile.spec.js`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,7 @@
 
 We really want Parse to be yours, to see it grow and thrive in the open source community.
 
-Before you jump into the coding element of contributing, please make sure you first [open an issue](https://github.com/parse-community/parse-server/issues/new/choose) relating to your contribution, or continue the discussion in the existing issue.
-
-This helps us all plan out the best conceptual approach for the contribution, so that your time isn't wasted on approaches or features that could be tackled in a different way. Our team are also happy to give you pointers and suggestions to speed up the process.
-
-When opening an issue, please make sure you follow the templates and provide as much detail as possible.
-
-After you've completed the contribution, you'll need to submit a Pull Request (PR).
-
 If you are not familiar with Pull Requests and want to know more about them, you can visit the [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) article. It contains detailed informations about the process.
-
-If you need any help along the way, you can open a Draft PR where we can help finalize your contribution.
-
-Contributing can be challenging, so don't be discouraged if you're having difficulties. Please don't hesitate to ask for help.
 
 ## Setting up the project for debugging and contributing:
 
@@ -59,6 +47,8 @@ Once you have babel running in watch mode, you can start making changes to parse
 
 ### Please Do's
 
+* Before you jump into the coding element of contributing, please make sure you first [open an issue](https://github.com/parse-community/parse-server/issues/new/choose) relating to your contribution, or continue the discussion in the existing issue.
+* Feel free to ask the team or community for assistance with your contribition. If needed, you can open a Draft PR where we can help finalize your contribution.
 * Begin by reading the [Development Guide](http://docs.parseplatform.org/parse-server/guide/#development-guide) to learn how to get started running the parse-server.
 * Take testing seriously! Aim to increase the test coverage with every pull request. To obtain the test coverage of the project, run: `npm run coverage`
 * Run the tests for the file you are working on with the following command: `npm test spec/MyFile.spec.js`


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
As far as I can tell, there are no references in the contributing guide to the expected GitHub process (e.g open issue -> discuss approach -> open PR)

The guide currently jumps to "submit a PR", which I know makes @mtrezza annoyed, but more importantly, can make new contributors assume that any new feature should be submitted straight through a PR, not an FR first.

Related issue: #7100
