### PR TITLE
fix(Logger): Handle interpolating stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ___
 - IMPROVE: Optimize queries on classes with pointer permissions. [#7061](https://github.com/parse-community/parse-server/pull/7061). Thanks to [Pedro Diaz](https://github.com/pdiaz)
 - FIX: request.context for afterFind triggers. [#7078](https://github.com/parse-community/parse-server/pull/7078). Thanks to [dblythy](https://github.com/dblythy)
 - NEW: Added convenience method Parse.Cloud.sendEmail(...) to send email via email adapter in Cloud Code. [#7089](https://github.com/parse-community/parse-server/pull/7089). Thanks to [dblythy](https://github.com/dblythy)
+- FIX: Winston Logger interpolating stdout to console [#7114](https://github.com/parse-community/parse-server/pull/7114). Thanks to [dplewis](https://github.com/dplewis)
 
 ### 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -258,4 +258,15 @@ describe('verbose logs', () => {
     const log = results.find(x => x.message === 'testing verbose logs with 123');
     expect(log);
   });
+
+  it('verbose logs should interpolate stdout', async () => {
+    await reconfigureServer({ verbose: true, silent: false, logsFolder: null });
+    spyOn(process.stdout, 'write');
+    const winstonLoggerAdapter = new WinstonLoggerAdapter();
+    winstonLoggerAdapter.log('verbose', 'testing verbose logs with %j', {
+      hello: 'world',
+    });
+    const firstLog = process.stdout.write.calls.first().args[0];
+    expect(firstLog).toBe('verbose: testing verbose logs with {"hello":"world"}\n');
+  });
 });

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -52,7 +52,7 @@ function configureTransports(options) {
         colorize: true,
         name: 'console',
         silent,
-        format: consoleFormat,
+        format: format.combine(format.splat(), consoleFormat),
       },
       options
     );

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -79,7 +79,7 @@ class ParseLiveQueryServer {
     // Register message handler for subscriber. When publisher get messages, it will publish message
     // to the subscribers and the handler will be called.
     this.subscriber.on('message', (channel, messageStr) => {
-      logger.verbose('Subscribe messsage %j', messageStr);
+      logger.verbose('Subscribe message %j', messageStr);
       let message;
       try {
         message = JSON.parse(messageStr);


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

When running VERBOSE=1, you will see this if you are doing Live Queries

verbose: Subscribe messsage %j
verbose: testafterSave is triggered
verbose: ClassName: %s | ObjectId: %s
verbose: Current client number : %d
verbose: Request: %j
verbose: Push Response : %j

### Approach
<!-- Add a description of the approach in this PR. -->

From [winston's doc](https://github.com/winstonjs/winston#string-interpolation):

> The log method provides the string interpolation using util.format. It must be enabled using format.splat().

This PR correctly pipes interpolation into the console transport.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...