### PR TITLE
Test case for files in json in array. 

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -361,6 +361,33 @@ describe('Parse.File testing', () => {
       });
     });
 
+    it('supports files in json that inside of array', done => {
+      const file = {
+        __type: 'File',
+        url: 'http://myBaseUrl/myFile',
+        name: 'myFile',
+      };
+    
+      const jsonItem = {"file": file};
+
+      const fileArray = [jsonItem];
+      const obj = new Parse.Object('FilesInJsonInArrayTest');
+      obj.set('files', fileArray);
+      obj
+        .save()
+        .then(() => {
+          const query = new Parse.Query('FilesInJsonInArrayTest');
+          return query.first();
+        })
+        .then(result => {
+          const filesAgain = result.get('files');
+          expect(filesAgain.length).toEqual(1);
+          expect(filesAgain[0].file.name()).toEqual('myFile');
+          expect(filesAgain[0].file.url()).toEqual('http://myBaseUrl/myFile');
+          done();
+        });
+    });
+
     it('supports array of files', done => {
       const file = {
         __type: 'File',


### PR DESCRIPTION
Test Case for files in json in array. But In order to make this test fail, baseUrl in fileAdapter must be changed after ParseObject is saved.

### New Pull Request Checklist


- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue]https://github.com/parse-community/parse-server/issues/7123).

### Issue Description
There is a bug where files are saved hardcoded. Even fileAdapter is changed later, file url stays same in database. And Parse API doesnt change it when we fetch it..



### Approach
Simple test case for files in json in array. But In order to make this test case fail, we need to change baseUrl of fileAdapter after saving parseObject.


- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...