### PR TITLE
Supporting patterns in classNames for Live Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___
 - NEW: Added convenience method Parse.Cloud.sendEmail(...) to send email via email adapter in Cloud Code. [#7089](https://github.com/parse-community/parse-server/pull/7089). Thanks to [dblythy](https://github.com/dblythy)
 - FIX: Winston Logger interpolating stdout to console [#7114](https://github.com/parse-community/parse-server/pull/7114). Thanks to [dplewis](https://github.com/dplewis)
 - NEW: LiveQuery support for $and, $nor, $containedBy, $geoWithin, $geoIntersects queries [#7113](https://github.com/parse-community/parse-server/pull/7113). Thanks to [dplewis](https://github.com/dplewis)
+- NEW: Supporting patterns in LiveQuery server's config parameter `classNames` [#7131](https://github.com/parse-community/parse-server/pull/7131). Thanks to [Nes-si](https://github.com/Nes-si)
 
 ### 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -56,6 +56,29 @@ describe('ParseLiveQuery', function () {
     await object.save();
   });
 
+  it('can use patterns in className', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['Test.*'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+    subscription.on('update', object => {
+      expect(object.get('foo')).toBe('bar');
+      done();
+    });
+    object.set({ foo: 'bar' });
+    await object.save();
+  });
+
   it('expect afterEvent create', async done => {
     await reconfigureServer({
       liveQuery: {

--- a/src/Controllers/LiveQueryController.js
+++ b/src/Controllers/LiveQueryController.js
@@ -43,7 +43,13 @@ export class LiveQueryController {
   }
 
   hasLiveQuery(className: string): boolean {
-    return this.classNames.has(className);
+    for (const name of this.classNames) {
+      const exp = new RegExp("^" + name + "$");
+      if (exp.test(className)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   _makePublisherRequest(currentObject: any, originalObject: any, classLevelPermissions: ?any): any {

--- a/src/Controllers/LiveQueryController.js
+++ b/src/Controllers/LiveQueryController.js
@@ -9,7 +9,9 @@ export class LiveQueryController {
     if (!config || !config.classNames) {
       this.classNames = new Set();
     } else if (config.classNames instanceof Array) {
-      this.classNames = new Set(config.classNames);
+      const classNames = config.classNames
+        .map(name => new RegExp("^" + name + "$"));
+      this.classNames = new Set(classNames);
     } else {
       throw 'liveQuery.classes should be an array of string';
     }
@@ -44,8 +46,7 @@ export class LiveQueryController {
 
   hasLiveQuery(className: string): boolean {
     for (const name of this.classNames) {
-      const exp = new RegExp("^" + name + "$");
-      if (exp.test(className)) {
+      if (name.test(className)) {
         return true;
       }
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

The PR allows to use patterns (regexps) in LiveQuery's parameter `classNames`. This makes it possible to use subscription at classes that are not known at the time of server configuring.
There is full backward compatibility.

Related [issue](https://github.com/parse-community/parse-server/issues/4544)

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...