### PR TITLE
Fix schemaCacheTTL ParseServerOption is not working

### DIFF
--- a/spec/SchemaCache.spec.js
+++ b/spec/SchemaCache.spec.js
@@ -88,4 +88,17 @@ describe('SchemaCache', () => {
     await sleep(4000);
     expect(await schemaCache.getOneSchema(schema.className)).not.toBeNull();
   });
+
+  it('should be expired', async () => {
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    const schemaCacheTTL = 2000;
+    const schemaCache = new SchemaCache(cacheController, schemaCacheTTL, true);
+    const schema = {
+      className: 'Class1',
+    };
+    await schemaCache.setAllClasses([schema]);
+    await sleep(3000);
+    expect(await schemaCache.getOneSchema(schema.className)).toBeNull();
+  });
 });

--- a/spec/SchemaCache.spec.js
+++ b/spec/SchemaCache.spec.js
@@ -72,4 +72,20 @@ describe('SchemaCache', () => {
     const schemaCache = new SchemaCache(cacheController, ttl);
     expect(schemaCache.ttl).toBe(5000);
   });
+
+  it('should use the SchemaCache ttl', async () => {
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    const anotherCacheAdapter = new InMemoryCacheAdapter({ ttl: 2000 });
+    const anotherCacheController = new CacheController(anotherCacheAdapter, 'appId');
+
+    const schemaCacheTTL = 5000;
+    const schemaCache = new SchemaCache(anotherCacheController, schemaCacheTTL, true);
+    const schema = {
+      className: 'Class1',
+    };
+    await schemaCache.setAllClasses([schema]);
+    await sleep(4000);
+    expect(await schemaCache.getOneSchema(schema.className)).not.toBeNull();
+  });
 });

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -30,7 +30,7 @@ export default class SchemaCache {
     if (!this.ttl) {
       return Promise.resolve(null);
     }
-    return this.cache.put(this.prefix + MAIN_SCHEMA, schema);
+    return this.cache.put(this.prefix + MAIN_SCHEMA, schema, this.ttl);
   }
 
   getOneSchema(className) {


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
It seems `schemaCacheTTL` ParseServerOption is not working. It still follows cacheAdapter's setting.

Related issue: closes #7119

### Approach
Pass the schemaCacheTTL config to the cacheController while setting the schema cache.

### TODOs before merging
- [x] Add test cases
- [ ] Add entry to changelog