### PR TITLE
Case insensitive login & request password reset

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -2309,10 +2309,10 @@ describe('Parse.User testing', () => {
     user = new Parse.User();
     user.set('username', 'TEST1');
     user.set('password', 'test');
-    await user.logIn();
+    await expectAsync(user.logIn()).toBeResolved();
   });
 
-  it('case insensitive login with username should fail with wrong password', async done => {
+  it('case insensitive login with username should fail with wrong password', async () => {
     let user = new Parse.User();
     user.set('username', 'test1');
     user.set('password', 'test');
@@ -2321,12 +2321,9 @@ describe('Parse.User testing', () => {
     user = new Parse.User();
     user.set('username', 'TEST1');
     user.set('password', 'test1');
-    try {
-      await user.logIn();
-      done.fail();
-    } catch (error) {
-      done();
-    }
+    await expectAsync(user.logIn()).toBeRejectedWith(
+      new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.')
+    );
   });
 
   it('case insensitive login with email', async () => {
@@ -2339,10 +2336,10 @@ describe('Parse.User testing', () => {
     user = new Parse.User();
     user.set('username', 'FOO@EXAMPLE.COM');
     user.set('password', 'test');
-    await user.logIn();
+    await expectAsync(user.logIn()).toBeResolved();
   });
 
-  it('case insensitive login with email should fail with wrong password', async done => {
+  it('case insensitive login with email should fail with wrong password', async () => {
     let user = new Parse.User();
     user.set('username', 'test1');
     user.set('password', 'test');
@@ -2352,12 +2349,9 @@ describe('Parse.User testing', () => {
     user = new Parse.User();
     user.set('username', 'FOO@EXAMPLE.COM');
     user.set('password', 'test1');
-    try {
-      await user.logIn();
-      done.fail();
-    } catch (error) {
-      done();
-    }
+    await expectAsync(user.logIn()).toBeRejectedWith(
+      new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.')
+    );
   });
 
   it('user cannot update email to existing user', done => {

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3334,7 +3334,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to emailVerified', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3370,7 +3370,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/me (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3413,7 +3413,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/id (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3458,7 +3458,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on login (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3502,7 +3502,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to hidden fields', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -2300,6 +2300,66 @@ describe('Parse.User testing', () => {
     });
   });
 
+  it('case insensitive login with username', async () => {
+    let user = new Parse.User();
+    user.set('username', 'test1');
+    user.set('password', 'test');
+    await user.signUp();
+    await Parse.User.logOut();
+    user = new Parse.User();
+    user.set('username', 'TEST1');
+    user.set('password', 'test');
+    await user.logIn();
+  });
+
+  it('case insensitive login with username should fail with wrong password', async done => {
+    let user = new Parse.User();
+    user.set('username', 'test1');
+    user.set('password', 'test');
+    await user.signUp();
+    await Parse.User.logOut();
+    user = new Parse.User();
+    user.set('username', 'TEST1');
+    user.set('password', 'test1');
+    try {
+      await user.logIn();
+      done.fail();
+    } catch (error) {
+      done();
+    }
+  });
+
+  it('case insensitive login with email', async () => {
+    let user = new Parse.User();
+    user.set('username', 'test1');
+    user.set('password', 'test');
+    user.set('email', 'foo@example.com');
+    await user.signUp();
+    await Parse.User.logOut();
+    user = new Parse.User();
+    user.set('username', 'FOO@EXAMPLE.COM');
+    user.set('password', 'test');
+    await user.logIn();
+  });
+
+  it('case insensitive login with email should fail with wrong password', async done => {
+    let user = new Parse.User();
+    user.set('username', 'test1');
+    user.set('password', 'test');
+    user.set('email', 'foo@example.com');
+    await user.signUp();
+    await Parse.User.logOut();
+    user = new Parse.User();
+    user.set('username', 'FOO@EXAMPLE.COM');
+    user.set('password', 'test1');
+    try {
+      await user.logIn();
+      done.fail();
+    } catch (error) {
+      done();
+    }
+  });
+
   it('user cannot update email to existing user', done => {
     const user = new Parse.User();
     user.set('username', 'test1');
@@ -3274,7 +3334,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to emailVerified', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3310,7 +3370,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/me (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3353,7 +3413,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/id (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3398,7 +3458,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on login (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3442,7 +3502,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to hidden fields', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -527,8 +527,8 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       });
   });
 
-  it('succeeds sending a password reset email with case insensitive email', done => {
-    reconfigureServer({
+  it('succeeds sending a password reset email with case insensitive email', async () => {
+    await reconfigureServer({
       appName: 'coolapp',
       publicServerURL: 'http://localhost:1337/1',
       emailAdapter: MockEmailAdapterWithOptions({
@@ -536,28 +536,14 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
         apiKey: 'k',
         domain: 'd',
       }),
-    })
-      .then(() => {
-        const user = new Parse.User();
-        user.setPassword('asdf');
-        user.setUsername('zxcv');
-        user.set('email', 'testCaseInsensitive@parse.com');
-        user
-          .signUp(null)
-          .then(() => Parse.User.requestPasswordReset('TESTCASEINSENSITIVE@parse.com'))
-          .then(
-            () => {
-              done();
-            },
-            error => {
-              done(error);
-            }
-          );
-      })
-      .catch(error => {
-        fail(JSON.stringify(error));
-        done();
-      });
+    });
+
+    const user = new Parse.User();
+    user.setPassword('asdf');
+    user.setUsername('zxcv');
+    user.set('email', 'testCaseInsensitive@example.com');
+    await user.signUp();
+    expectAsync(Parse.User.requestPasswordReset('TESTCASEINSENSITIVE@example.com')).toBeResolved();
   });
 
   it('does not send verification email if email verification is disabled', done => {

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -543,7 +543,9 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
     user.setUsername('zxcv');
     user.set('email', 'testCaseInsensitive@example.com');
     await user.signUp();
-    expectAsync(Parse.User.requestPasswordReset('TESTCASEINSENSITIVE@example.com')).toBeResolved();
+    await expectAsync(
+      Parse.User.requestPasswordReset('TESTCASEINSENSITIVE@example.com')
+    ).toBeResolved();
   });
 
   it('does not send verification email if email verification is disabled', done => {

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -527,6 +527,39 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
       });
   });
 
+  it('succeeds sending a password reset email with case insensitive email', done => {
+    reconfigureServer({
+      appName: 'coolapp',
+      publicServerURL: 'http://localhost:1337/1',
+      emailAdapter: MockEmailAdapterWithOptions({
+        fromAddress: 'parse@example.com',
+        apiKey: 'k',
+        domain: 'd',
+      }),
+    })
+      .then(() => {
+        const user = new Parse.User();
+        user.setPassword('asdf');
+        user.setUsername('zxcv');
+        user.set('email', 'testCaseInsensitive@parse.com');
+        user
+          .signUp(null)
+          .then(() => Parse.User.requestPasswordReset('TESTCASEINSENSITIVE@parse.com'))
+          .then(
+            () => {
+              done();
+            },
+            error => {
+              done(error);
+            }
+          );
+      })
+      .catch(error => {
+        fail(JSON.stringify(error));
+        done();
+      });
+  });
+
   it('does not send verification email if email verification is disabled', done => {
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -222,7 +222,10 @@ export class UserController extends AdaptableController {
             { username: email, email: { $exists: false }, _perishable_token: { $exists: true } },
           ],
         },
-        { limit: 1 }
+        {
+          limit: 1,
+          caseInsensitive: true,
+        }
       );
       if (results.length == 1) {
         let expiresDate = results[0]._perishable_token_expires_at;

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -74,7 +74,7 @@ export class UsersRouter extends ClassesRouter {
         query = { $or: [{ username }, { email: username }] };
       }
       return req.config.database
-        .find('_User', query)
+        .find('_User', query, { caseInsensitive: true })
         .then(results => {
           if (!results.length) {
             throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Adds the possibility to login case insensitive with username / email and request password reset.

This is my first PR that changes the source code of parse-server. I hope that everything is correct, especially the tests.
Closes #7143.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
