### PR TITLE
Run Prettier after Definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prettier": "2.0.5"
   },
   "scripts": {
-    "definitions": "node ./resources/buildConfigDefinitions.js",
+    "definitions": "node ./resources/buildConfigDefinitions.js && prettier --write 'src/Options/*.js'",
     "docs": "jsdoc -c ./jsdoc-conf.json",
     "lint": "flow && eslint --cache ./",
     "lint-fix": "eslint --fix --cache ./",


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`npm run definitions` replaces quotation marks resulting in a lot of changes across the options files, until prettier is ran. This runs prettier on the options folder straight after the options files are built.
