### PR TITLE
fix: Pass customObjectId in beforeSave

### DIFF
--- a/src/triggers.js
+++ b/src/triggers.js
@@ -327,6 +327,7 @@ export function getResponseObject(request, resolve, reject) {
       response = {};
       if (request.triggerName === Types.beforeSave) {
         response['object'] = request.object._getSaveJSON();
+        response['object']['objectId'] = request.object.id;
       }
       return resolve(response);
     },


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ x ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ x ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
beforeSave hooks don't integrate with custom object ids.

Related issue: [Issue 6733](https://github.com/parse-community/parse-server/issues/6733)

### Approach
<!-- Add a description of the approach in this PR. -->
triggers.js sets the objectId field

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...