### PR TITLE
Fix for authenticating with instagram

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -5,7 +5,7 @@ const authenticationLoader = require('../lib/Adapters/Auth');
 const path = require('path');
 const responses = {
   gpgames: { playerId: 'userId' },
-  instagram: { data: { id: 'userId' } },
+  instagram: { id: 'userId' },
   janrainengage: { stat: 'ok', profile: { identifier: 'userId' } },
   janraincapture: { stat: 'ok', result: 'userId' },
   line: { userId: 'userId' },
@@ -492,7 +492,15 @@ describe('instagram auth adapter', () => {
       'https://graph.instagram.com/me?fields=id&access_token=the_token'
     );
   });
-
+  it('response object without data child', async () => {
+    spyOn(httpsRequest, 'get').and.callFake(() => {
+      return Promise.resolve({ id: 'userId' });
+    });
+    await instagram.validateAuthData({ id: 'userId', access_token: 'the_token' }, {});
+    expect(httpsRequest.get).toHaveBeenCalledWith(
+      'https://graph.instagram.com/me?fields=id&access_token=the_token'
+    );
+  });
   it('should pass in api url', async () => {
     spyOn(httpsRequest, 'get').and.callFake(() => {
       return Promise.resolve({ data: { id: 'userId' } });

--- a/src/Adapters/Auth/instagram.js
+++ b/src/Adapters/Auth/instagram.js
@@ -8,7 +8,8 @@ function validateAuthData(authData) {
   const apiURL = authData.apiURL || defaultURL;
   const path = `${apiURL}me?fields=id&access_token=${authData.access_token}`;
   return httpsRequest.get(path).then(response => {
-    if (response && response.id == authData.id) {
+    const user = response.data ? response.data : response
+    if (user && user.id == authData.id) {
       return;
     }
     throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Instagram auth is invalid for this user.');

--- a/src/Adapters/Auth/instagram.js
+++ b/src/Adapters/Auth/instagram.js
@@ -8,7 +8,7 @@ function validateAuthData(authData) {
   const apiURL = authData.apiURL || defaultURL;
   const path = `${apiURL}me?fields=id&access_token=${authData.access_token}`;
   return httpsRequest.get(path).then(response => {
-    if (response && response.data && response.data.id == authData.id) {
+    if (response && response.id == authData.id) {
       return;
     }
     throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Instagram auth is invalid for this user.');


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Instagram authentication is not working, it always returns 'Instagram auth is invalid for this user.'

The response of function httpsRequest.get(path) does not include the data object.

The user id is directly presented in the response 


### Approach

Remove the 'data' part from 'response.data' 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...