### PR TITLE
Fix: Proper handling of arrays for cloud validator

### DIFF
--- a/spec/CloudCode.Validator.spec.js
+++ b/spec/CloudCode.Validator.spec.js
@@ -278,7 +278,8 @@ describe('cloud validator', () => {
         },
       }
     );
-    await Parse.Cloud.run('hello', { data: [{ foo: 'bar' }] });
+    const result = await Parse.Cloud.run('hello', { data: [{ foo: 'bar' }] });
+    expect(result).toBe('Hello world!');
   });
 
   it('set params type', done => {

--- a/spec/CloudCode.Validator.spec.js
+++ b/spec/CloudCode.Validator.spec.js
@@ -264,6 +264,23 @@ describe('cloud validator', () => {
       });
   });
 
+  it('set params type allow array', async () => {
+    Parse.Cloud.define(
+      'hello',
+      () => {
+        return 'Hello world!';
+      },
+      {
+        fields: {
+          data: {
+            type: Array,
+          },
+        },
+      }
+    );
+    await Parse.Cloud.run('hello', { data: [{ foo: 'bar' }] });
+  });
+
   it('set params type', done => {
     Parse.Cloud.define(
       'hello',

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -710,9 +710,8 @@ function builtInTriggerValidator(options, request) {
         }
         if (opt.type) {
           const type = getType(opt.type);
-          if (type == 'array' && !Array.isArray(val)) {
-            throw `Validation failed. Invalid type for ${key}. Expected: array`;
-          } else if (typeof val !== type) {
+          const valType = Array.isArray(val) ? 'array' : typeof val;
+          if (valType !== type) {
             throw `Validation failed. Invalid type for ${key}. Expected: ${type}`;
           }
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

I've just realised that Cloud Validators fail with expected type `array`, even when an array is provided.

Here's the test that fails on the master:

```js
  it('set params type allow array', async () => {
    Parse.Cloud.define(
      'hello',
      () => {
        return 'Hello world!';
      },
      {
        fields: {
          data: {
            type: Array,
          },
        },
      }
    );
    await Parse.Cloud.run('hello', { data: [{ foo: 'bar' }] });
  });
```

Related issue: closes #7179