### PR TITLE
Should not call next when validateAuthData throw an error

### DIFF
--- a/spec/FailCustomAuth.spec.js
+++ b/spec/FailCustomAuth.spec.js
@@ -1,0 +1,10 @@
+const testFailOAuth = require('./testFailOAuth');
+
+it('Should not call next when validateAuthData throw an error', done => {
+  reconfigureServer({ auth: { testFailOAuth: testFailOAuth } }).then(() => {
+    const authData = { authData: { id: 'testuser', password: 'secret' } };
+    Parse.User.logInWith('testFailOAuth', authData).catch(() => {
+      done();
+    });
+  });
+});

--- a/spec/testFailOAuth.js
+++ b/spec/testFailOAuth.js
@@ -1,0 +1,14 @@
+// Custom oauth provider by module
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData() {
+  return Promise.reject();
+}
+function validateAppId() {
+  return Promise.resolve();
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData,
+};


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

this pull request is related to #7200 issue.
I added the tests.

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7200).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue:  #7200

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...