### PR TITLE
Add ability to trigger password reset by web form POST

### DIFF
--- a/public/password_reset_initiated.html
+++ b/public/password_reset_initiated.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!--
+  This page is displayed when a user triggers password reset flow
+  by POST to /parse/apps/APP_ID/request_password_reset with username arg.
+-->
+<html>
+
+<head>
+  <title>Password Reset Instructions Sent</title>
+</head>
+
+<body>
+  <h1>{{appName}}</h1>
+  <h1>Success!</h1>
+  <p>Instructions to reset your password were sent to {{username}}.</p>
+</body>
+
+</html>

--- a/public_html/password_reset_initiated.html
+++ b/public_html/password_reset_initiated.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+  This page is displayed when a user triggers password reset flow
+  by POST to /parse/apps/APP_ID/request_password_reset with username arg.
+-->
+<html>
+  <head>
+  <title>Password Reset Instructions Sent</title>
+  <style type='text/css'>
+    h1 {
+      color: #0067AB;
+      display: block;
+      font: inherit;
+      font-family: 'Open Sans', 'Helvetica Neue', Helvetica;
+      font-size: 30px;
+      font-weight: 600;
+      height: 30px;
+      line-height: 30px;
+      margin: 45px 0px 0px 45px;
+      padding: 0px 8px 0px 8px;
+    }
+  </style>
+  <body>
+    <h1>Instructions to reset your password were sent to your email address.</h1>
+  </body>
+</html>

--- a/src/Config.js
+++ b/src/Config.js
@@ -446,6 +446,13 @@ export class Config {
     );
   }
 
+  get passwordResetInitiatedURL() {
+    return (
+      this.customPages.passwordResetInitiated ||
+      `${this.publicServerURL}/apps/password_reset_initiated.html`
+    );
+  }
+
   get choosePasswordURL() {
     return this.customPages.choosePassword || `${this.publicServerURL}/apps/choose_password`;
   }

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -502,6 +502,10 @@ module.exports.PagesCustomUrlsOptions = {
     env: 'PARSE_SERVER_PAGES_CUSTOM_URL_EMAIL_VERIFICATION_SUCCESS',
     help: 'The URL to the custom page for email verification -> success.',
   },
+  passwordResetInitiated: {
+    env: 'PARSE_SERVER_PAGES_CUSTOM_URL_PASSWORD_RESET_INITIATED',
+    help: 'The URL to the custom page for password reset initiated.',
+  },
   passwordReset: {
     env: 'PARSE_SERVER_PAGES_CUSTOM_URL_PASSWORD_RESET',
     help: 'The URL to the custom page for password reset.',
@@ -516,6 +520,10 @@ module.exports.PagesCustomUrlsOptions = {
   },
 };
 module.exports.CustomPagesOptions = {
+  passwordResetInitiated: {
+    env: 'PARSE_SERVER_CUSTOM_PAGES_PASSWORD_RESET_INITIATED',
+    help: 'password reset initiated page path',
+  },
   choosePassword: {
     env: 'PARSE_SERVER_CUSTOM_PAGES_CHOOSE_PASSWORD',
     help: 'choose password page path',

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -282,6 +282,8 @@ export interface CustomPagesOptions {
   invalidLink: ?string;
   /* verification link send fail page path */
   linkSendFail: ?string;
+  /* password reset initiated page path */
+  passwordResetInitiated: ?string;
   /* choose password page path */
   choosePassword: ?string;
   /* verification link send success page path */

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -157,6 +157,25 @@ export class PublicAPIRouter extends PromiseRouter {
     const { username, new_password, token: rawToken } = req.body;
     const token = rawToken && typeof rawToken !== 'string' ? rawToken.toString() : rawToken;
 
+    if (username && (!token || !new_password) && req.xhr === false) {
+      return config.userController
+        .sendPasswordResetEmail(username)
+        .catch(() => {
+          /* ignore any errors */
+        })
+        .finally(() => {
+          const params = qs.stringify({
+            id: config.applicationId,
+            username,
+            app: config.appName,
+          });
+          return Promise.resolve({
+            status: 302,
+            location: `${config.passwordResetInitiatedURL}?${params}`,
+          });
+        });
+    }
+
     if ((!username || !token || !new_password) && req.xhr === false) {
       return this.invalidLink(req);
     }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7210).

### Issue Description
Right now when a user wants to change his password, a ``POST`` request needs to be made to REST API endpoint ``/parse/requestPasswordReset`` with properly filled HTTP headers ``X-Parse-Application-Id`` and ``X-Parse-REST-API-Key``. This is very difficult to achieve from a simple HTML email or simple webpage without using JavaScript and AJAX.

Related issue: #7210 

### Approach
When looking at https://github.com/parse-community/parse-server/blob/9a9fc5fa5fef6bdeb4ce2c5aee4c019f94e599f8/src/Routers/PublicAPIRouter.js#L278 there is actually a precedent implementing the same requirement to trigger the re-sending of verification emails simply via web form by POST-ing a url-encoded ``username`` along.

I got inspired and implemented the same functionality with this PR for password reset. So when you need to include a simple button on a webpage or in HTML email to reset user's password, simply POST the url-encoded ``username`` towards the ``/parse/apps/APP_ID/request_password_reset`` endpoint and you will get redirected to the ``/parse/apps/password_reset_initiated.html`` webpage.

The PR adds one new URL to legacy ``customPages`` configuration describing where to redirect when password reset flow is initiated. It also supports the new ``PagesRouter`` to achieve the same.

More discussion around the topic is here: https://community.parseplatform.org/t/parse-server-rest-api-vs-public-api/1321/9

### TODOs before merging

- [x ] Add test cases
- [ x] Add entry to changelog
- [ x] Add changes to documentation (guides, repository pages, in-code descriptions)
