### PR TITLE
Fix session expiration test

### DIFF
--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -531,7 +531,7 @@ describe('rest create', () => {
     });
   });
 
-  fit('test default session length', done => {
+  it('test default session length', done => {
     const user = {
       username: 'asdf',
       password: 'zxcv',
@@ -563,7 +563,7 @@ describe('rest create', () => {
       });
   });
 
-  fit('test specified session length', done => {
+  it('test specified session length', done => {
     const user = {
       username: 'asdf',
       password: 'zxcv',

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -531,7 +531,7 @@ describe('rest create', () => {
     });
   });
 
-  it('test default session length', done => {
+  fit('test default session length', done => {
     const user = {
       username: 'asdf',
       password: 'zxcv',
@@ -557,17 +557,13 @@ describe('rest create', () => {
         const actual = new Date(session.expiresAt.iso);
         const expected = new Date(now.getTime() + 1000 * 3600 * 24 * 365);
 
-        expect(actual.getFullYear()).toEqual(expected.getFullYear());
-        expect(actual.getMonth()).toEqual(expected.getMonth());
-        expect(actual.getDate()).toEqual(expected.getDate());
-        // less than a minute, if test happen at the wrong time :/
-        expect(actual.getMinutes() - expected.getMinutes() <= 1).toBe(true);
+        expect(Math.abs(actual - expected) <= jasmine.DEFAULT_TIMEOUT_INTERVAL).toEqual(true);
 
         done();
       });
   });
 
-  it('test specified session length', done => {
+  fit('test specified session length', done => {
     const user = {
       username: 'asdf',
       password: 'zxcv',

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -595,11 +595,7 @@ describe('rest create', () => {
         const actual = new Date(session.expiresAt.iso);
         const expected = new Date(now.getTime() + sessionLength * 1000);
 
-        expect(actual.getFullYear()).toEqual(expected.getFullYear());
-        expect(actual.getMonth()).toEqual(expected.getMonth());
-        expect(actual.getDate()).toEqual(expected.getDate());
-        expect(actual.getHours()).toEqual(expected.getHours());
-        expect(actual.getMinutes()).toEqual(expected.getMinutes());
+        expect(Math.abs(actual - expected) <= jasmine.DEFAULT_TIMEOUT_INTERVAL).toEqual(true);
 
         done();
       })


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ X ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ X ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

The session is flaky because a session is created and then the expiration date (that parse server created) is compared to a time got from the beginning of the test + the expiration span. Even if it is very fast, it can happen the two dates having different total minutes.

Related issue: https://github.com/parse-community/parse-server/issues/7180

### Approach
<!-- Add a description of the approach in this PR. -->

I changed the test to check if the difference between the two dates is less then or equal to the jasmine test timeout limit.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...