### PR TITLE
Upgrade parse from 2.19.0 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6484,6 +6484,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "idb-keyval": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.2.tgz",
+      "integrity": "sha512-1DYjY/nX2U9pkTkwFoAmKcK1ZWmkNgO32Oon9tp/9+HURizxUQ4fZRxMJZs093SldP7q6dotVj03kIkiqOILyA=="
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -9387,16 +9392,17 @@
       }
     },
     "parse": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-2.19.0.tgz",
-      "integrity": "sha512-twxq/Kzyd0c9exxK0jMEPISwDpFzukmexSa+VAFL4a6K+lqGeJ9TuysYhfR9Bkcd0mHGcMFM5gn4uycu1xykvA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-3.0.0.tgz",
+      "integrity": "sha512-Iye674gVAN6pJOTX66Q9L6nrq/DNVJdhM5Iz/QdLghuhoeCcUF4C7DH65yOPRH4H/4nBytVrfhRUgxZpWOKr7A==",
       "requires": {
         "@babel/runtime": "7.12.5",
         "@babel/runtime-corejs3": "7.12.5",
         "crypto-js": "4.0.0",
+        "idb-keyval": "5.0.2",
         "react-native-crypto-js": "1.0.0",
         "uuid": "3.4.0",
-        "ws": "7.4.0",
+        "ws": "7.4.2",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
@@ -9413,11 +9419,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mime": "2.5.0",
     "mongodb": "3.6.3",
     "mustache": "4.1.0",
-    "parse": "2.19.0",
+    "parse": "3.0.0",
     "pg-promise": "10.9.2",
     "pluralize": "8.0.0",
     "redis": "3.0.2",


### PR DESCRIPTION
https://github.com/parse-community/Parse-SDK-JS/releases/tag/3.0.0