### PR TITLE
Ensure pushStatus is properly running

### DIFF
--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -79,19 +79,6 @@ describe('PushController', () => {
     done();
   });
 
-  it('can throw on validateDeviceType when single invalid device type is set', done => {
-    // Make query condition
-    const where = {
-      deviceType: 'osx',
-    };
-    const validPushTypes = ['ios', 'android'];
-
-    expect(function () {
-      validatePushType(where, validPushTypes);
-    }).toThrow();
-    done();
-  });
-
   it('can get expiration time in string format', done => {
     // Make mock request
     const timeStr = '2015-03-19T22:05:08Z';

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -314,6 +314,7 @@ describe('PushWorker', () => {
               amount: 1,
             },
             count: { __op: 'Increment', amount: -1 },
+            status: 'running',
           });
           const query = new Parse.Query('_PushStatus');
           return query.get(handler.objectId, { useMasterKey: true });
@@ -409,6 +410,7 @@ describe('PushWorker', () => {
               amount: 1,
             },
             count: { __op: 'Increment', amount: -1 },
+            status: 'running',
           });
           done();
         });

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -295,9 +295,8 @@ export function pushStatusHandler(config, existingObjectId) {
         }
       );
     }
-
-    // indicate this batch is complete
     incrementOp(update, 'count', -1);
+    update.status = 'running';
 
     return handler.update({ objectId }, update).then(res => {
       if (res && res.count === 0) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

This fixes a flaky test. 

```
PushController properly creates _PushStatus
Message:
Expected 'pending' to be 'running'.
Stack:
Error: Expected 'pending' to be 'running'.
at
at reconfigureServer.then.then.then.then.then.catch.then (/home/runner/work/parse-server/parse-server/spec/PushController.spec.js:618:48)
at process._tickCallback (internal/process/next_tick.js:68:7)
```

This issue is the status of a push doesn't get updated properly. Here are the push status.

1) pending - initial state
2) running - set Running
3) running - still running, updated counts, numSent, numFailed etc.
4) succeeded - final state

The test fails because the status in step 2 never gets updated to `running` and as a result step 3 is never set to `running`.

### Approach
<!-- Add a description of the approach in this PR. -->

Ensure status is set to running if you are keeping track of pushes sent, failed etc. I don't know if there is a bigger issue here because it looks like the same is happening to the Job status flaky tests. This is fixing a potential server bug.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...