### PR TITLE
chore(ci): Bump node to 15.10.0, 14.16.0, 12.21.0, 10.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,43 +60,43 @@ jobs:
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 14.15.5
+            NODE_VERSION: 14.16.0
           - name: Mongo 4.2, ReplicaSet, WiredTiger
             MONGODB_VERSION: 4.2.12
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 14.15.5
+            NODE_VERSION: 14.16.0
           - name: Mongo 4.0, ReplicaSet, WiredTiger
             MONGODB_VERSION: 4.0.23
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 14.15.5
+            NODE_VERSION: 14.16.0
           - name: Mongo 3.6, Standalone, MMAPv1
             MONGODB_VERSION: 3.6.22
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: mmapv1
-            NODE_VERSION: 14.15.5
+            NODE_VERSION: 14.16.0
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 14.15.5
+            NODE_VERSION: 14.16.0
           - name: Node 10
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 10.23.3
+            NODE_VERSION: 10.24.0
           - name: Node 12
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 12.20.2
+            NODE_VERSION: 12.21.0
           - name: Node 15
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 15.9.0
+            NODE_VERSION: 15.10.0
     name: ${{ matrix.name }}
     timeout-minutes: 30
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Patch Version | End-of-Life Date | Compatibility      |
 |------------|----------------------|------------------|--------------------|
-| Node.js 10 | 10.23.2              | April 2021       | ✅ Fully compatible |
-| Node.js 12 | 12.20.1              | April 2022       | ✅ Fully compatible |
-| Node.js 14 | 14.15.4              | April 2023       | ✅ Fully compatible |
-| Node.js 15 | 15.9.0               | June 2021        | ✅ Fully compatible |
+| Node.js 10 | 10.24.0              | April 2021       | ✅ Fully compatible |
+| Node.js 12 | 12.21.0              | April 2022       | ✅ Fully compatible |
+| Node.js 14 | 14.16.0              | April 2023       | ✅ Fully compatible |
+| Node.js 15 | 15.10.0               | June 2021        | ✅ Fully compatible |
 
 #### MongoDB
 Parse Server is continuously tested with the most recent releases of MongoDB to ensure compatibility. We follow the [MongoDB support schedule](https://www.mongodb.com/support-policy) and only test against versions that are officially supported and have not reached their end-of-life date.


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Fix CI failure by updating node 15.10.0, 14.16.0, 12.21.0, 10.24.0
Related issue: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...