### PR TITLE
GraphQL Subscriptions

### DIFF
--- a/src/Controllers/ParseGraphQLController.js
+++ b/src/Controllers/ParseGraphQLController.js
@@ -145,7 +145,14 @@ class ParseGraphQLController {
     if (!isValidSimpleObject(classConfig)) {
       return 'it must be a valid object';
     } else {
-      const { className, type = null, query = null, mutation = null, ...invalidKeys } = classConfig;
+      const {
+        className,
+        type = null,
+        query = null,
+        mutation = null,
+        subscription = null,
+        ...invalidKeys
+      } = classConfig;
       if (Object.keys(invalidKeys).length) {
         return `"invalidKeys" [${Object.keys(invalidKeys)}] should not be present`;
       }
@@ -287,6 +294,20 @@ class ParseGraphQLController {
           return `"mutation" must be a valid object`;
         }
       }
+      if (subscription !== null) {
+        if (isValidSimpleObject(subscription)) {
+          const { enabled = null, alias = null, ...invalidKeys } = query;
+          if (Object.keys(invalidKeys).length) {
+            return `"subscription" contains invalid keys, [${Object.keys(invalidKeys)}]`;
+          } else if (enabled !== null && typeof enabled !== 'boolean') {
+            return `"subscription.enabled" must be a boolean`;
+          } else if (alias !== null && typeof alias !== 'string') {
+            return `"subscription.alias" must be a string`;
+          }
+        } else {
+          return `"subscription" must be a valid object`;
+        }
+      }
     }
   }
 }
@@ -354,6 +375,11 @@ export interface ParseGraphQLClassConfig {
     createAlias: ?String,
     updateAlias: ?String,
     destroyAlias: ?String,
+  };
+  /* The `subscription` object contains options for which class subscriptions are generated */
+  subscription: ?{
+    enabled: ?boolean,
+    alias: ?String,
   };
 }
 

--- a/src/Controllers/ParseGraphQLController.js
+++ b/src/Controllers/ParseGraphQLController.js
@@ -24,7 +24,7 @@ class ParseGraphQLController {
         `ParseGraphQLController requires a "databaseController" to be instantiated.`
       );
     this.cacheController = params.cacheController;
-    this.isMounted = !!params.mountGraphQL;
+    this.isMounted = !!params.mountGraphQL || !!params.mountSubscriptions;
     this.configCacheKey = GraphQLConfigKey;
   }
 

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -127,6 +127,7 @@ export function getParseGraphQLController(
 ): ParseGraphQLController {
   return new ParseGraphQLController({
     mountGraphQL: options.mountGraphQL,
+    mountSubscriptions: options.mountSubscriptions,
     ...controllerDeps,
   });
 }

--- a/src/GraphQL/loaders/defaultGraphQLTypes.js
+++ b/src/GraphQL/loaders/defaultGraphQLTypes.js
@@ -1222,6 +1222,29 @@ const loadArrayResult = (parseGraphQLSchema, parseClasses) => {
   parseGraphQLSchema.graphQLTypes.push(ARRAY_RESULT);
 };
 
+const EVENT_KIND = new GraphQLEnumType({
+  name: 'EventKind',
+  description: 'The EventKind enum type is used in subscriptions to identify listened events.',
+  values: {
+    create: { value: 'create' },
+    enter: { value: 'enter' },
+    update: { value: 'update' },
+    leave: { value: 'leave' },
+    delete: { value: 'delete' },
+    all: { value: 'all' },
+  },
+});
+
+const EVENT_KIND_ATT = {
+  description: 'The event kind that was fired.',
+  type: new GraphQLNonNull(EVENT_KIND),
+};
+
+const EVENT_KINDS_ATT = {
+  description: 'The event kinds to be listened in the subscription.',
+  type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(EVENT_KIND))),
+};
+
 const load = parseGraphQLSchema => {
   parseGraphQLSchema.addGraphQLType(GraphQLUpload, true);
   parseGraphQLSchema.addGraphQLType(ANY, true);
@@ -1266,6 +1289,7 @@ const load = parseGraphQLSchema => {
   parseGraphQLSchema.addGraphQLType(PUBLIC_ACL, true);
   parseGraphQLSchema.addGraphQLType(SUBQUERY_INPUT, true);
   parseGraphQLSchema.addGraphQLType(SELECT_INPUT, true);
+  parseGraphQLSchema.addGraphQLType(EVENT_KIND, true);
 };
 
 export {
@@ -1358,6 +1382,9 @@ export {
   USER_ACL,
   ROLE_ACL,
   PUBLIC_ACL,
+  EVENT_KIND,
+  EVENT_KIND_ATT,
+  EVENT_KINDS_ATT,
   load,
   loadArrayResult,
 };

--- a/src/GraphQL/loaders/parseClassSubscriptions.js
+++ b/src/GraphQL/loaders/parseClassSubscriptions.js
@@ -1,0 +1,156 @@
+import { GraphQLNonNull } from 'graphql';
+import getFieldNames from 'graphql-list-fields';
+import { ParseGraphQLClassConfig } from '../../Controllers/ParseGraphQLController';
+import { transformClassNameToGraphQL } from '../transformers/className';
+import * as defaultGraphQLTypes from './defaultGraphQLTypes';
+import { extractKeysAndInclude } from '../parseGraphQLUtils';
+import { transformQueryInputToParse } from '../transformers/query';
+
+const getParseClassSubscriptionConfig = function (parseClassConfig: ?ParseGraphQLClassConfig) {
+  return (parseClassConfig && parseClassConfig.subscription) || {};
+};
+
+const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLClassConfig) {
+  const {
+    enabled: isSubscriptionEnabled = true,
+    alias: subscriptionAlias = '',
+  } = getParseClassSubscriptionConfig(parseClassConfig);
+
+  if (isSubscriptionEnabled) {
+    const className = parseClass.className;
+
+    const graphQLClassName = transformClassNameToGraphQL(className);
+    const lowerCaseClassName = graphQLClassName.charAt(0).toLowerCase() + graphQLClassName.slice(1);
+    const graphQLSubscriptionName = subscriptionAlias || lowerCaseClassName;
+
+    const {
+      classGraphQLConstraintsType,
+      classGraphQLSubscriptionType,
+    } = parseGraphQLSchema.parseClassTypes[className];
+
+    parseGraphQLSchema.addGraphQLSubscription(graphQLSubscriptionName, {
+      description: `The ${graphQLSubscriptionName} subscription can be used to listen events on objects of the ${graphQLClassName} class under given conditions.`,
+      args: {
+        on: defaultGraphQLTypes.EVENT_KINDS_ATT,
+        where: {
+          description:
+            'These are the conditions that the objects need to match in the subscription.',
+          type: classGraphQLConstraintsType,
+        },
+      },
+      type: new GraphQLNonNull(classGraphQLSubscriptionType),
+      subscribe(_source, args, context, queryInfo) {
+        let nextResolve;
+        let nextReject;
+        let nextPromise;
+
+        const newNextPromise = () => {
+          nextPromise = new Promise((resolve, reject) => {
+            nextResolve = resolve;
+            nextReject = reject;
+          });
+        };
+
+        newNextPromise();
+
+        const { on } = args;
+        const { liveQuery, keyPairs } = context;
+
+        const listener = message => {
+          switch (message.op) {
+            case 'create':
+            case 'enter':
+            case 'update':
+            case 'leave':
+            case 'delete':
+              if (!on.includes('all') && !on.includes(message.op)) {
+                return;
+              }
+
+              nextResolve({
+                done: false,
+                value: {
+                  [graphQLSubscriptionName]: {
+                    event: message.op,
+                    node: message.object,
+                    originalNode: message.original,
+                  },
+                },
+              });
+              break;
+            case 'error':
+              nextReject({
+                code: message.code,
+                message: message.error,
+              });
+              return;
+            default:
+              return;
+          }
+
+          newNextPromise();
+        };
+
+        const unsubscribe = () => liveQuery.unsubscribe(listener);
+
+        const selectedFields = getFieldNames(queryInfo);
+        const { keys: nodeKeys } = extractKeysAndInclude(
+          selectedFields
+            .filter(field => field.startsWith('node.'))
+            .map(field => field.replace('node.', ''))
+        );
+        const { keys: originalNodeKeys } = extractKeysAndInclude(
+          selectedFields
+            .filter(field => field.startsWith('originalNode.'))
+            .map(field => field.replace('originalNode.', ''))
+        );
+
+        const fields = [...new Set(nodeKeys.split(',').concat(originalNodeKeys.split(',')))];
+
+        let { where } = args;
+        if (!where) {
+          where = {};
+        }
+        transformQueryInputToParse(where, className, parseGraphQLSchema.parseClasses);
+
+        liveQuery.subscribe(
+          {
+            className,
+            where,
+            fields,
+          },
+          keyPairs.sessionToken,
+          listener
+        );
+
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              next() {
+                return nextPromise;
+              },
+              return() {
+                unsubscribe();
+
+                return Promise.resolve({
+                  done: true,
+                  value: undefined,
+                });
+              },
+              throw(error) {
+                unsubscribe();
+
+                return Promise.resolve({
+                  done: true,
+                  value: error,
+                });
+              },
+            };
+          },
+        };
+      },
+    });
+  }
+};
+
+export { load };

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -494,6 +494,24 @@ const load = (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLCla
     classGraphQLFindResultType = connectionType;
   }
 
+  const classGraphQLSubscriptionTypeName = `${graphQLClassName}Subscription`;
+  let classGraphQLSubscriptionType = new GraphQLObjectType({
+    name: classGraphQLSubscriptionTypeName,
+    description: `The ${classGraphQLSubscriptionTypeName} object type is used in subscriptions that involve objects of ${graphQLClassName} class.`,
+    fields: {
+      event: defaultGraphQLTypes.EVENT_KIND_ATT,
+      node: {
+        description: 'The node in which the event happened',
+        type: new GraphQLNonNull(classGraphQLOutputType || defaultGraphQLTypes.OBJECT),
+      },
+      originalNode: {
+        description: 'The original node in which the event happened',
+        type: classGraphQLOutputType || defaultGraphQLTypes.OBJECT,
+      },
+    },
+  });
+  classGraphQLSubscriptionType = parseGraphQLSchema.addGraphQLType(classGraphQLSubscriptionType);
+
   parseGraphQLSchema.parseClassTypes[className] = {
     classGraphQLPointerType,
     classGraphQLRelationType,
@@ -504,6 +522,7 @@ const load = (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLCla
     classGraphQLFindArgs,
     classGraphQLOutputType,
     classGraphQLFindResultType,
+    classGraphQLSubscriptionType,
     config: {
       parseClassConfig,
       isCreateEnabled,

--- a/src/LiveQuery/QueryTools.js
+++ b/src/LiveQuery/QueryTools.js
@@ -242,6 +242,11 @@ function matchesKeyConstraints(object, key, constraints) {
           return false;
         }
         break;
+      case '$eq':
+        if (!equalObjects(object[key], compareTo)) {
+          return false;
+        }
+        break;
       case '$in':
         if (!contains(compareTo, object[key])) {
           return false;

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -283,6 +283,12 @@ module.exports.ParseServerOptions = {
     action: parsers.booleanParser,
     default: false,
   },
+  mountSubscriptions: {
+    env: 'PARSE_SERVER_MOUNT_SUBSCRIPTIONS',
+    help: 'Mounts the GraphQL Subscriptions endpoint',
+    action: parsers.booleanParser,
+    default: false,
+  },
   objectIdSize: {
     env: 'PARSE_SERVER_OBJECT_ID_SIZE',
     help: "Sets the number of characters in generated object id's, default 10",
@@ -401,6 +407,11 @@ module.exports.ParseServerOptions = {
     env: 'PARSE_SERVER_START_LIVE_QUERY_SERVER',
     help: 'Starts the liveQuery server',
     action: parsers.booleanParser,
+  },
+  subscriptionsPath: {
+    env: 'PARSE_SERVER_SUBSCRIPTIONS_PATH',
+    help: 'Mount path for the GraphQL Subscriptions endpoint, defaults to /subscriptions',
+    default: '/subscriptions',
   },
   userSensitiveFields: {
     env: 'PARSE_SERVER_USER_SENSITIVE_FIELDS',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -53,6 +53,7 @@
  * @property {Boolean} mountGraphQL Mounts the GraphQL endpoint
  * @property {String} mountPath Mount path for the server, defaults to /parse
  * @property {Boolean} mountPlayground Mounts the GraphQL Playground - never use this option in production
+ * @property {Boolean} mountSubscriptions Mounts the GraphQL Subscriptions endpoint
  * @property {Number} objectIdSize Sets the number of characters in generated object id's, default 10
  * @property {PagesOptions} pages The options for pages such as password reset and email verification. Caution, this is an experimental feature that may not be appropriate for production.
  * @property {PasswordPolicyOptions} passwordPolicy Password policy for enforcing password related rules
@@ -74,6 +75,7 @@
  * @property {Number} sessionLength Session duration, in seconds, defaults to 1 year
  * @property {Boolean} silent Disables console output
  * @property {Boolean} startLiveQueryServer Starts the liveQuery server
+ * @property {String} subscriptionsPath Mount path for the GraphQL Subscriptions endpoint, defaults to /subscriptions
  * @property {String[]} userSensitiveFields Personally identifiable information fields in the user table the should be removed for non-authorized users. Deprecated @see protectedFields
  * @property {Boolean} verbose Set the logging to verbose
  * @property {Boolean} verifyUserEmails Enable (or disable) user email validation, defaults to false

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -215,6 +215,14 @@ export interface ParseServerOptions {
   :ENV: PARSE_SERVER_GRAPHQL_PATH
   :DEFAULT: /graphql */
   graphQLPath: ?string;
+  /* Mounts the GraphQL Subscriptions endpoint
+  :ENV: PARSE_SERVER_MOUNT_SUBSCRIPTIONS
+  :DEFAULT: false */
+  mountSubscriptions: ?boolean;
+  /* Mount path for the GraphQL Subscriptions endpoint, defaults to /subscriptions
+  :ENV: PARSE_SERVER_SUBSCRIPTIONS_PATH
+  :DEFAULT: /subscriptions */
+  subscriptionsPath: ?string;
   /* Mounts the GraphQL Playground - never use this option in production
   :ENV: PARSE_SERVER_MOUNT_PLAYGROUND
   :DEFAULT: false */

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -251,7 +251,12 @@ class ParseServer {
 
     app.use(options.mountPath, this.app);
 
-    if (options.mountGraphQL === true || options.mountPlayground === true) {
+    let parseGraphQLServer;
+    if (
+      options.mountGraphQL === true ||
+      options.mountSubscriptions === true ||
+      options.mountPlayground === true
+    ) {
       let graphQLCustomTypeDefs = undefined;
       if (typeof options.graphQLSchema === 'string') {
         graphQLCustomTypeDefs = parse(fs.readFileSync(options.graphQLSchema, 'utf8'));
@@ -262,8 +267,9 @@ class ParseServer {
         graphQLCustomTypeDefs = options.graphQLSchema;
       }
 
-      const parseGraphQLServer = new ParseGraphQLServer(this, {
+      parseGraphQLServer = new ParseGraphQLServer(this, {
         graphQLPath: options.graphQLPath,
+        subscriptionsPath: options.subscriptionsPath,
         playgroundPath: options.playgroundPath,
         graphQLCustomTypeDefs,
       });
@@ -279,6 +285,10 @@ class ParseServer {
 
     const server = app.listen(options.port, options.host, callback);
     this.server = server;
+
+    if (options.mountSubscriptions) {
+      parseGraphQLServer.createSubscriptions(server);
+    }
 
     if (options.startLiveQueryServer || options.liveQueryServerOptions) {
       this.liveQueryServer = ParseServer.createLiveQueryServer(

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -91,6 +91,15 @@ runner({
             options.graphQLPath
         );
       }
+      if (options.mountSubscriptions) {
+        console.log(
+          '[' +
+            process.pid +
+            '] Subscriptions running on ws://localhost:' +
+            options.port +
+            options.subscriptionsPath
+        );
+      }
       if (options.mountPlayground) {
         console.log(
           '[' +


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ X ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ X ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

This PR add subscription support to the GraphQL API.

Related issue: https://github.com/parse-community/parse-server/issues/6617

### Approach
<!-- Add a description of the approach in this PR. -->

We are basically taking a ride with the existing Live Query implementation. In order to use subscriptions, the allowed class names needs to be listed in the liveQuery configuration. A Live Query server is not needed though. We are simulating a ws adapter in order to connect directly to the live query implementation without actually creating sockets (which would not make sense).

With something like the following, the GraphQL API, Subscriptions, and Playground will be mounted and can be tested via this PR:

```sh
./bin/parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://localhost/test --liveQuery '{"classNames": ["MyClass"]}' --mountGraphQL --mountSubscriptions --mountPlayground
```

It is still a work in progress. We need to improve the where input (since most of operations are not available at Live Query), and test/improve the node/originalNode output. We still need to create/fix test-cases.

But overall it is working and can be tested.

@Moumouls any feedback?

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...