### PR TITLE
Invalid field beforesave failing test

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -90,6 +90,27 @@ describe('Cloud Code', () => {
     );
   });
 
+  it('beforeSave invalid field name rejection', function (done) {
+    Parse.Cloud.beforeSave('BeforeSaveFail', function () {
+      throw new Error('Error from BeforeSave');
+    });
+
+    const obj = new Parse.Object('BeforeSaveFail');
+    obj.set('length', 1);
+    obj.save().then(
+      () => {
+        fail('Should not have been able to save BeforeSaveFailure class.');
+        done();
+      },
+      error => {
+        if (error.message != 'Error from BeforeSave') {
+          fail('Save failed before beforeSave was called.');
+        }
+        done();
+      }
+    );
+  });
+
   it('returns an error', done => {
     Parse.Cloud.define('cloudCodeWithError', () => {
       /* eslint-disable no-undef */

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -90,23 +90,33 @@ describe('Cloud Code', () => {
     );
   });
 
-  it('beforeSave invalid field name rejection', function (done) {
-    Parse.Cloud.beforeSave('BeforeSaveFail', function () {
-      throw new Error('Error from BeforeSave');
+  it('unsets invalid field name in beforeSave on update', function (done) {
+    Parse.Cloud.beforeSave('InvalidFieldNameObject', function (request) {
+      const object = request.object;
+      object.unset('length');
     });
 
-    const obj = new Parse.Object('BeforeSaveFail');
-    obj.set('length', 1);
+    const obj = new Parse.Object('InvalidFieldNameObject');
+    // Create object
     obj.save().then(
       () => {
-        fail('Should not have been able to save BeforeSaveFailure class.');
-        done();
+        obj.set('length', 1);
+        // Update object
+        obj.save().then(
+          () => {
+            done();
+          },
+          error => {
+            fail(
+              'Should have unset invalid field name in beforeSave and saved successfully, \
+              but error occured before beforeSave: ' +
+                error.message
+            );
+          }
+        );
       },
       error => {
-        if (error.message != 'Error from BeforeSave') {
-          fail('Save failed before beforeSave was called.');
-        }
-        done();
+        fail(error.message);
       }
     );
   });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to issue [#7130](https://github.com/parse-community/parse-server/issues/7130).

### Issue Description
This PR doesn't fix the issue, but adds a failing test which demonstrates the problem. 

The test 
1. saves a test object
2. sets an invalid field `length` to `1`
3. saves the test object again
4. `beforeSave` hook `unset`s the invalid field `length`

**Expected result**: 
The `beforeSave` hook succeeds to `unset` the invalid field.

**Actual result**:
An error `105` – `Invalid field name for update: length` is thrown before the `beforeSave` hook is executed, and no `unset` operation is done.

Related issue: [#7130](https://github.com/parse-community/parse-server/issues/7130)

### Approach
<!-- Add a description of the approach in this PR. -->
The test was added in the `CloudCode.spec.js` file.