### PR TITLE
Fix Parse.Push flaky tests

### DIFF
--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -2,327 +2,230 @@
 
 const request = require('../lib/request');
 
-const delayPromise = delay => {
-  return new Promise(resolve => {
-    setTimeout(resolve, delay);
+const pushCompleted = async pushId => {
+  let result = await Parse.Push.getPushStatus(pushId);
+  while (!(result && result.get('status') === 'succeeded')) {
+    result = await Parse.Push.getPushStatus(pushId);
+  }
+};
+
+const successfulAny = function (body, installations) {
+  const promises = installations.map(device => {
+    return Promise.resolve({
+      transmitted: true,
+      device: device,
+    });
   });
+
+  return Promise.all(promises);
+};
+
+const provideInstallations = function (num) {
+  if (!num) {
+    num = 2;
+  }
+
+  const installations = [];
+  while (installations.length !== num) {
+    // add Android installations
+    const installation = new Parse.Object('_Installation');
+    installation.set('installationId', 'installation_' + installations.length);
+    installation.set('deviceToken', 'device_token_' + installations.length);
+    installation.set('deviceType', 'android');
+    installations.push(installation);
+  }
+
+  return installations;
+};
+
+const losingAdapter = {
+  send: function (body, installations) {
+    // simulate having lost an installation before this was called
+    // thus invalidating our 'count' in _PushStatus
+    installations.pop();
+
+    return successfulAny(body, installations);
+  },
+  getValidPushTypes: function () {
+    return ['android'];
+  },
+};
+
+const setup = function () {
+  const sendToInstallationSpy = jasmine.createSpy();
+
+  const pushAdapter = {
+    send: function (body, installations) {
+      const badge = body.data.badge;
+      const promises = installations.map(installation => {
+        sendToInstallationSpy(installation);
+
+        if (installation.deviceType == 'ios') {
+          expect(installation.badge).toEqual(badge);
+          expect(installation.originalBadge + 1).toEqual(installation.badge);
+        } else {
+          expect(installation.badge).toBeUndefined();
+        }
+        return Promise.resolve({
+          err: null,
+          device: installation,
+          transmitted: true,
+        });
+      });
+      return Promise.all(promises);
+    },
+    getValidPushTypes: function () {
+      return ['ios', 'android'];
+    },
+  };
+
+  return reconfigureServer({
+    appId: Parse.applicationId,
+    masterKey: Parse.masterKey,
+    serverURL: Parse.serverURL,
+    push: {
+      adapter: pushAdapter,
+    },
+  })
+    .then(() => {
+      const installations = [];
+      while (installations.length != 10) {
+        const installation = new Parse.Object('_Installation');
+        installation.set('installationId', 'installation_' + installations.length);
+        installation.set('deviceToken', 'device_token_' + installations.length);
+        installation.set('badge', installations.length);
+        installation.set('originalBadge', installations.length);
+        installation.set('deviceType', 'ios');
+        installations.push(installation);
+      }
+      return Parse.Object.saveAll(installations);
+    })
+    .then(() => {
+      return {
+        sendToInstallationSpy,
+      };
+    });
 };
 
 describe('Parse.Push', () => {
-  const setup = function () {
-    const sendToInstallationSpy = jasmine.createSpy();
-
-    const pushAdapter = {
-      send: function (body, installations) {
-        const badge = body.data.badge;
-        const promises = installations.map(installation => {
-          sendToInstallationSpy(installation);
-
-          if (installation.deviceType == 'ios') {
-            expect(installation.badge).toEqual(badge);
-            expect(installation.originalBadge + 1).toEqual(installation.badge);
-          } else {
-            expect(installation.badge).toBeUndefined();
-          }
-          return Promise.resolve({
-            err: null,
-            device: installation,
-            transmitted: true,
-          });
-        });
-        return Promise.all(promises);
+  it('should properly send push', async () => {
+    const { sendToInstallationSpy } = await setup();
+    const pushStatusId = await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
       },
-      getValidPushTypes: function () {
-        return ['ios', 'android'];
+      data: {
+        badge: 'Increment',
+        alert: 'Hello world!',
       },
-    };
-
-    return reconfigureServer({
-      appId: Parse.applicationId,
-      masterKey: Parse.masterKey,
-      serverURL: Parse.serverURL,
-      push: {
-        adapter: pushAdapter,
-      },
-    })
-      .then(() => {
-        const installations = [];
-        while (installations.length != 10) {
-          const installation = new Parse.Object('_Installation');
-          installation.set('installationId', 'installation_' + installations.length);
-          installation.set('deviceToken', 'device_token_' + installations.length);
-          installation.set('badge', installations.length);
-          installation.set('originalBadge', installations.length);
-          installation.set('deviceType', 'ios');
-          installations.push(installation);
-        }
-        return Parse.Object.saveAll(installations);
-      })
-      .then(() => {
-        return {
-          sendToInstallationSpy,
-        };
-      })
-      .catch(err => {
-        console.error(err);
-
-        throw err;
-      });
-  };
-
-  it('should properly send push', done => {
-    return setup()
-      .then(({ sendToInstallationSpy }) => {
-        return Parse.Push.send(
-          {
-            where: {
-              deviceType: 'ios',
-            },
-            data: {
-              badge: 'Increment',
-              alert: 'Hello world!',
-            },
-          },
-          { useMasterKey: true }
-        )
-          .then(() => {
-            return delayPromise(500);
-          })
-          .then(() => {
-            expect(sendToInstallationSpy.calls.count()).toEqual(10);
-          });
-      })
-      .then(() => {
-        done();
-      })
-      .catch(err => {
-        jfail(err);
-        done();
-      });
-  });
-
-  it('should properly send push with lowercaseIncrement', done => {
-    return setup()
-      .then(() => {
-        return Parse.Push.send(
-          {
-            where: {
-              deviceType: 'ios',
-            },
-            data: {
-              badge: 'increment',
-              alert: 'Hello world!',
-            },
-          },
-          { useMasterKey: true }
-        );
-      })
-      .then(() => {
-        return delayPromise(500);
-      })
-      .then(() => {
-        done();
-      })
-      .catch(err => {
-        jfail(err);
-        done();
-      });
-  });
-
-  it('should not allow clients to query _PushStatus', done => {
-    setup()
-      .then(() =>
-        Parse.Push.send(
-          {
-            where: {
-              deviceType: 'ios',
-            },
-            data: {
-              badge: 'increment',
-              alert: 'Hello world!',
-            },
-          },
-          { useMasterKey: true }
-        )
-      )
-      .then(() => delayPromise(500))
-      .then(() => {
-        request({
-          url: 'http://localhost:8378/1/classes/_PushStatus',
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-          },
-        }).then(fail, response => {
-          expect(response.data.error).toEqual('unauthorized');
-          done();
-        });
-      })
-      .catch(err => {
-        jfail(err);
-        done();
-      });
-  });
-
-  it('should allow master key to query _PushStatus', done => {
-    setup()
-      .then(() =>
-        Parse.Push.send(
-          {
-            where: {
-              deviceType: 'ios',
-            },
-            data: {
-              badge: 'increment',
-              alert: 'Hello world!',
-            },
-          },
-          { useMasterKey: true }
-        )
-      )
-      .then(() => delayPromise(500)) // put a delay as we keep writing
-      .then(() => {
-        request({
-          url: 'http://localhost:8378/1/classes/_PushStatus',
-          json: true,
-          headers: {
-            'X-Parse-Application-Id': 'test',
-            'X-Parse-Master-Key': 'test',
-          },
-        }).then(response => {
-          const body = response.data;
-          try {
-            expect(body.results.length).toEqual(1);
-            expect(body.results[0].query).toEqual('{"deviceType":"ios"}');
-            expect(body.results[0].payload).toEqual('{"badge":"increment","alert":"Hello world!"}');
-          } catch (e) {
-            jfail(e);
-          }
-          done();
-        });
-      })
-      .catch(err => {
-        jfail(err);
-        done();
-      });
-  });
-
-  it('should throw error if missing push configuration', done => {
-    reconfigureServer({ push: null })
-      .then(() => {
-        return Parse.Push.send(
-          {
-            where: {
-              deviceType: 'ios',
-            },
-            data: {
-              badge: 'increment',
-              alert: 'Hello world!',
-            },
-          },
-          { useMasterKey: true }
-        );
-      })
-      .then(
-        () => {
-          fail('should not succeed');
-        },
-        err => {
-          expect(err.code).toEqual(Parse.Error.PUSH_MISCONFIGURED);
-          done();
-        }
-      )
-      .catch(err => {
-        jfail(err);
-        done();
-      });
-  });
-
-  const successfulAny = function (body, installations) {
-    const promises = installations.map(device => {
-      return Promise.resolve({
-        transmitted: true,
-        device: device,
-      });
     });
+    await pushCompleted(pushStatusId);
+    expect(sendToInstallationSpy.calls.count()).toEqual(10);
+  });
 
-    return Promise.all(promises);
-  };
+  it('should properly send push with lowercaseIncrement', async () => {
+    await setup();
+    const pushStatusId = await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
+      },
+      data: {
+        badge: 'increment',
+        alert: 'Hello world!',
+      },
+    });
+    await pushCompleted(pushStatusId);
+  });
 
-  const provideInstallations = function (num) {
-    if (!num) {
-      num = 2;
+  it('should not allow clients to query _PushStatus', async () => {
+    await setup();
+    const pushStatusId = await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
+      },
+      data: {
+        badge: 'increment',
+        alert: 'Hello world!',
+      },
+    });
+    await pushCompleted(pushStatusId);
+    try {
+      await request({
+        url: 'http://localhost:8378/1/classes/_PushStatus',
+        json: true,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+        },
+      });
+      fail();
+    } catch (response) {
+      expect(response.data.error).toEqual('unauthorized');
     }
+  });
 
-    const installations = [];
-    while (installations.length !== num) {
-      // add Android installations
-      const installation = new Parse.Object('_Installation');
-      installation.set('installationId', 'installation_' + installations.length);
-      installation.set('deviceToken', 'device_token_' + installations.length);
-      installation.set('deviceType', 'android');
-      installations.push(installation);
+  it('should allow master key to query _PushStatus', async () => {
+    await setup();
+    const pushStatusId = await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
+      },
+      data: {
+        badge: 'increment',
+        alert: 'Hello world!',
+      },
+    });
+    await pushCompleted(pushStatusId);
+    const response = await request({
+      url: 'http://localhost:8378/1/classes/_PushStatus',
+      json: true,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Master-Key': 'test',
+      },
+    });
+    const body = response.data;
+    expect(body.results.length).toEqual(1);
+    expect(body.results[0].query).toEqual('{"deviceType":"ios"}');
+    expect(body.results[0].payload).toEqual('{"badge":"increment","alert":"Hello world!"}');
+  });
+
+  it('should throw error if missing push configuration', async () => {
+    await reconfigureServer({ push: null });
+    try {
+      await Parse.Push.send({
+        where: {
+          deviceType: 'ios',
+        },
+        data: {
+          badge: 'increment',
+          alert: 'Hello world!',
+        },
+      });
+      fail();
+    } catch (err) {
+      expect(err.code).toEqual(Parse.Error.PUSH_MISCONFIGURED);
     }
-
-    return installations;
-  };
-
-  const losingAdapter = {
-    send: function (body, installations) {
-      // simulate having lost an installation before this was called
-      // thus invalidating our 'count' in _PushStatus
-      installations.pop();
-
-      return successfulAny(body, installations);
-    },
-    getValidPushTypes: function () {
-      return ['android'];
-    },
-  };
+  });
 
   /**
    * Verifies that _PushStatus cannot get stuck in a 'running' state
    * Simulates a simple push where 1 installation is removed between _PushStatus
    * count being set and the pushes being sent
    */
-  it("does not get stuck with _PushStatus 'running' on 1 installation lost", done => {
-    reconfigureServer({
+  it("does not get stuck with _PushStatus 'running' on 1 installation lost", async () => {
+    await reconfigureServer({
       push: { adapter: losingAdapter },
-    })
-      .then(() => {
-        return Parse.Object.saveAll(provideInstallations());
-      })
-      .then(() => {
-        return Parse.Push.send(
-          {
-            data: { alert: 'We fixed our status!' },
-            where: { deviceType: 'android' },
-          },
-          { useMasterKey: true }
-        );
-      })
-      .then(() => {
-        // it is enqueued so it can take time
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve();
-          }, 1000);
-        });
-      })
-      .then(() => {
-        // query for push status
-        const query = new Parse.Query('_PushStatus');
-        return query.find({ useMasterKey: true });
-      })
-      .then(results => {
-        // verify status is NOT broken
-        expect(results.length).toBe(1);
-        const result = results[0];
-        expect(result.get('status')).toEqual('succeeded');
-        expect(result.get('numSent')).toEqual(1);
-        expect(result.get('count')).toEqual(undefined);
-        done();
-      });
+    });
+    await Parse.Object.saveAll(provideInstallations());
+    const pushStatusId = await Parse.Push.send({
+      data: { alert: 'We fixed our status!' },
+      where: { deviceType: 'android' },
+    });
+    await pushCompleted(pushStatusId);
+    const result = await Parse.Push.getPushStatus(pushStatusId);
+    expect(result.get('status')).toEqual('succeeded');
+    expect(result.get('numSent')).toEqual(1);
+    expect(result.get('count')).toEqual(undefined);
   });
 
   /**
@@ -330,7 +233,7 @@ describe('Parse.Push', () => {
    * Simulates a simple push where 1 installation is added between _PushStatus
    * count being set and the pushes being sent
    */
-  it("does not get stuck with _PushStatus 'running' on 1 installation added", done => {
+  it("does not get stuck with _PushStatus 'running' on 1 installation added", async () => {
     const installations = provideInstallations();
 
     // add 1 iOS installation which we will omit & add later on
@@ -340,14 +243,13 @@ describe('Parse.Push', () => {
     iOSInstallation.set('deviceType', 'ios');
     installations.push(iOSInstallation);
 
-    reconfigureServer({
+    await reconfigureServer({
       push: {
         adapter: {
           send: function (body, installations) {
             // simulate having added an installation before this was called
             // thus invalidating our 'count' in _PushStatus
             installations.push(iOSInstallation);
-
             return successfulAny(body, installations);
           },
           getValidPushTypes: function () {
@@ -355,41 +257,17 @@ describe('Parse.Push', () => {
           },
         },
       },
-    })
-      .then(() => {
-        return Parse.Object.saveAll(installations);
-      })
-      .then(() => {
-        return Parse.Push.send(
-          {
-            data: { alert: 'We fixed our status!' },
-            where: { deviceType: { $ne: 'random' } },
-          },
-          { useMasterKey: true }
-        );
-      })
-      .then(() => {
-        // it is enqueued so it can take time
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve();
-          }, 1000);
-        });
-      })
-      .then(() => {
-        // query for push status
-        const query = new Parse.Query('_PushStatus');
-        return query.find({ useMasterKey: true });
-      })
-      .then(results => {
-        // verify status is NOT broken
-        expect(results.length).toBe(1);
-        const result = results[0];
-        expect(result.get('status')).toEqual('succeeded');
-        expect(result.get('numSent')).toEqual(3);
-        expect(result.get('count')).toEqual(undefined);
-        done();
-      });
+    });
+    await Parse.Object.saveAll(installations);
+    const pushStatusId = await Parse.Push.send({
+      data: { alert: 'We fixed our status!' },
+      where: { deviceType: { $ne: 'random' } },
+    });
+    await pushCompleted(pushStatusId);
+    const result = await Parse.Push.getPushStatus(pushStatusId);
+    expect(result.get('status')).toEqual('succeeded');
+    expect(result.get('numSent')).toEqual(3);
+    expect(result.get('count')).toEqual(undefined);
   });
 
   /**
@@ -397,48 +275,24 @@ describe('Parse.Push', () => {
    * Simulates an extended push, where some installations may be removed,
    * resulting in a non-zero count
    */
-  it("does not get stuck with _PushStatus 'running' on many installations removed", done => {
+  it("does not get stuck with _PushStatus 'running' on many installations removed", async () => {
     const devices = 1000;
     const installations = provideInstallations(devices);
 
-    reconfigureServer({
+    await reconfigureServer({
       push: { adapter: losingAdapter },
-    })
-      .then(() => {
-        return Parse.Object.saveAll(installations);
-      })
-      .then(() => {
-        return Parse.Push.send(
-          {
-            data: { alert: 'We fixed our status!' },
-            where: { deviceType: 'android' },
-          },
-          { useMasterKey: true }
-        );
-      })
-      .then(() => {
-        // it is enqueued so it can take time
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve();
-          }, 1000);
-        });
-      })
-      .then(() => {
-        // query for push status
-        const query = new Parse.Query('_PushStatus');
-        return query.find({ useMasterKey: true });
-      })
-      .then(results => {
-        // verify status is NOT broken
-        expect(results.length).toBe(1);
-        const result = results[0];
-        expect(result.get('status')).toEqual('succeeded');
-        // expect # less than # of batches used, assuming each batch is 100 pushes
-        expect(result.get('numSent')).toEqual(devices - devices / 100);
-        expect(result.get('count')).toEqual(undefined);
-        done();
-      });
+    });
+    await Parse.Object.saveAll(installations);
+    const pushStatusId = await Parse.Push.send({
+      data: { alert: 'We fixed our status!' },
+      where: { deviceType: 'android' },
+    });
+    await pushCompleted(pushStatusId);
+    const result = await Parse.Push.getPushStatus(pushStatusId);
+    expect(result.get('status')).toEqual('succeeded');
+    // expect # less than # of batches used, assuming each batch is 100 pushes
+    expect(result.get('numSent')).toEqual(devices - devices / 100);
+    expect(result.get('count')).toEqual(undefined);
   });
 
   /**
@@ -446,13 +300,12 @@ describe('Parse.Push', () => {
    * Simulates an extended push, where some installations may be added,
    * resulting in a non-zero count
    */
-  it("does not get stuck with _PushStatus 'running' on many installations added", done => {
+  it("does not get stuck with _PushStatus 'running' on many installations added", async () => {
     const devices = 1000;
     const installations = provideInstallations(devices);
 
     // add 1 iOS installation which we will omit & add later on
     const iOSInstallations = [];
-
     while (iOSInstallations.length !== devices / 100) {
       const iOSInstallation = new Parse.Object('_Installation');
       iOSInstallation.set('installationId', 'installation_' + installations.length);
@@ -461,15 +314,13 @@ describe('Parse.Push', () => {
       installations.push(iOSInstallation);
       iOSInstallations.push(iOSInstallation);
     }
-
-    reconfigureServer({
+    await reconfigureServer({
       push: {
         adapter: {
           send: function (body, installations) {
             // simulate having added an installation before this was called
             // thus invalidating our 'count' in _PushStatus
             installations.push(iOSInstallations.pop());
-
             return successfulAny(body, installations);
           },
           getValidPushTypes: function () {
@@ -477,41 +328,18 @@ describe('Parse.Push', () => {
           },
         },
       },
-    })
-      .then(() => {
-        return Parse.Object.saveAll(installations);
-      })
-      .then(() => {
-        return Parse.Push.send(
-          {
-            data: { alert: 'We fixed our status!' },
-            where: { deviceType: { $ne: 'random' } },
-          },
-          { useMasterKey: true }
-        );
-      })
-      .then(() => {
-        // it is enqueued so it can take time
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve();
-          }, 1000);
-        });
-      })
-      .then(() => {
-        // query for push status
-        const query = new Parse.Query('_PushStatus');
-        return query.find({ useMasterKey: true });
-      })
-      .then(results => {
-        // verify status is NOT broken
-        expect(results.length).toBe(1);
-        const result = results[0];
-        expect(result.get('status')).toEqual('succeeded');
-        // expect # less than # of batches used, assuming each batch is 100 pushes
-        expect(result.get('numSent')).toEqual(devices + devices / 100);
-        expect(result.get('count')).toEqual(undefined);
-        done();
-      });
+    });
+    await Parse.Object.saveAll(installations);
+
+    const pushStatusId = await Parse.Push.send({
+      data: { alert: 'We fixed our status!' },
+      where: { deviceType: { $ne: 'random' } },
+    });
+    await pushCompleted(pushStatusId);
+    const result = await Parse.Push.getPushStatus(pushStatusId);
+    expect(result.get('status')).toEqual('succeeded');
+    // expect # less than # of batches used, assuming each batch is 100 pushes
+    expect(result.get('numSent')).toEqual(devices + devices / 100);
+    expect(result.get('count')).toEqual(undefined);
   });
 });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
There are flaky tests in `Parse.Push.spec.js` and `PushController.spec.js`. 
* PushController properly creates _PushStatus
* PushController should not enqueue push when device token is not set
* Parse.Push does not get stuck with _PushStatus 'running' on 1 installation added
* Parse.Push does not get stuck with _PushStatus 'running' on 1 installation removed
* Many others

Related issue: FILL_THIS_OUT

### Approach
* Ensure a sent push is completed before continuing
* Remove setTimeout
* Use async/await
* Utilize new `Parse.Push.getPushStatus`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...