### PR TITLE
Excluding keys that have trailing "edges.node" on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ ___
 - Randomize test suite (Diamond Lewis) [#7265](https://github.com/parse-community/parse-server/pull/7265)
 - LDAP: Properly unbind client on group search error (Diamond Lewis) [#7265](https://github.com/parse-community/parse-server/pull/7265)
 - Improve data consistency in Push and Job Status update (Diamond Lewis) [#7267](https://github.com/parse-community/parse-server/pull/7267)
+- Excluding keys that have trailing edges.node when performing GraphQL resolver (Chris Bland) [#7273](https://github.com/parse-community/parse-server/pull/7273)
 ___
 ## 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -5704,7 +5704,7 @@ describe('ParseGraphQLServer', () => {
             ).toEqual([object3.id, object1.id, object2.id]);
           });
 
-          fit('should support including relation', async () => {
+          it('should support including relation', async () => {
             await prepareData();
 
             await parseGraphQLServer.parseGraphQLSchema.schemaCache.clear();

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -5703,6 +5703,67 @@ describe('ParseGraphQLServer', () => {
               result.data.parentClass.graphQLClasses.edges.map(edge => edge.node.objectId)
             ).toEqual([object3.id, object1.id, object2.id]);
           });
+
+          fit('should support including relation', async () => {
+            await prepareData();
+
+            await parseGraphQLServer.parseGraphQLSchema.schemaCache.clear();
+
+            const result1 = await apolloClient.query({
+              query: gql`
+                query FindRoles {
+                  roles {
+                    edges {
+                      node {
+                        name
+                      }
+                    }
+                  }
+                }
+              `,
+              variables: {},
+              context: {
+                headers: {
+                  'X-Parse-Session-Token': user1.getSessionToken(),
+                },
+              },
+            });
+
+            const result2 = await apolloClient.query({
+              query: gql`
+                query FindRoles {
+                  roles {
+                    edges {
+                      node {
+                        name
+                        users {
+                          edges {
+                            node {
+                              username
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `,
+              variables: {},
+              context: {
+                headers: {
+                  'X-Parse-Session-Token': user1.getSessionToken(),
+                },
+              },
+            });
+
+            expect(result1.data.roles.edges[0].node.name).toBeDefined();
+            expect(result1.data.roles.edges[0].node.users).toBeUndefined();
+            expect(result1.data.roles.edges[0].node.roles).toBeUndefined();
+            expect(result2.data.roles.edges[0].node.name).toBeDefined();
+            expect(result2.data.roles.edges[0].node.users).toBeDefined();
+            expect(result2.data.roles.edges[0].node.users.edges[0].node.username).toBeDefined();
+            expect(result2.data.roles.edges[0].node.roles).toBeUndefined();
+          });
         });
       });
 

--- a/src/GraphQL/loaders/parseClassQueries.js
+++ b/src/GraphQL/loaders/parseClassQueries.js
@@ -106,6 +106,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
             selectedFields
               .filter(field => field.startsWith('edges.node.'))
               .map(field => field.replace('edges.node.', ''))
+              .filter(field => field.indexOf('edges.node') < 0)
           );
           const parseOrder = order && order.join(',');
 

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -382,6 +382,7 @@ const load = (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLCla
                   selectedFields
                     .filter(field => field.startsWith('edges.node.'))
                     .map(field => field.replace('edges.node.', ''))
+                    .filter(field => field.indexOf('edges.node') < 0)
                 );
                 const parseOrder = order && order.join(',');
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
The issue is trying to call resolvers on relations do not work with Postgres. For example the following query will fail when using Posgres:

```
roles(where: { users: { have: { id: { equalTo: $userId } } } }) {
  edges {
    node {
      name
      users {
        edges {
          node {
            username
          }
        }
      }
    }
  }
}
```

Related issue: https://github.com/parse-community/parse-server/issues/6419

### Approach
The approach with this PR is to ignore any keys that have a trailing `edges.node` on them. Using the example above, it will initially have these select keys:

This fails because the following fields are being sent to the resolver:
```
[
  'edges.node.name',
  'edges.node.users.edges.node.username'
]
```

This then gets modified down to:

```
[
  'name',
  'users.edges.node.username'
]
```

This array gets passed as the "keys" to the REST query. Down the processing chain the `RestQuery` will chop off everything after the first `.` so then we're left with `['name', 'users']` and  `users` is not a valid column on the `_Role` table. This PR will drop the `users.edges.node.username` key all together as it would never need to be a selected key in any query.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...