### PR TITLE
Allow logout with invalid session

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3860,6 +3860,28 @@ describe('Parse.User testing', () => {
       });
   });
 
+  it('can logout with expired session token', async () => {
+    await Parse.User.signUp('asdf', 'zxcv');
+    const sessionQuery = new Parse.Query(Parse.Session);
+    const session = await sessionQuery.first({ useMasterKey: true });
+    const database = Config.get(Parse.applicationId).database;
+    await database.update(
+      '_Session',
+      { objectId: session.id },
+      { expiresAt: new Date().setFullYear(2010) },
+      {}
+    );
+    await Parse.User.logOut();
+  });
+
+  it('can logout with invalid session token', async () => {
+    await Parse.User.signUp('asdf', 'zxcv');
+    const sessionQuery = new Parse.Query(Parse.Session);
+    const session = await sessionQuery.first({ useMasterKey: true });
+    await session.destroy({ useMasterKey: true });
+    await Parse.User.logOut();
+  });
+
   it('does not duplicate session when logging in multiple times #3451', done => {
     const user = new Parse.User();
     user

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -220,6 +220,9 @@ export function handleParseHeaders(req, res, next) {
   return Promise.resolve()
     .then(() => {
       // handle the upgradeToRevocableSession path on it's own
+      if (req.url === '/logout') {
+        return Promise.resolve();
+      }
       if (
         info.sessionToken &&
         req.url === '/upgradeToRevocableSession' &&
@@ -241,8 +244,8 @@ export function handleParseHeaders(req, res, next) {
     .then(auth => {
       if (auth) {
         req.auth = auth;
-        next();
       }
+      next();
     })
     .catch(error => {
       if (error instanceof Parse.Error) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Returns "success" for logout call even if associated session is invalid. First commit is failing test to show how users can get stuck not being able to logout if their session becomes invalid.

Related issue: Closes #7277

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog