### PR TITLE
GraphQL: reset password with emailed token

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -7065,8 +7065,8 @@ describe('ParseGraphQLServer', () => {
           await Parse.User.logOut();
           const result = await apolloClient.mutate({
             mutation: gql`
-              mutation RequestResetPassword($input: RequestResetPasswordInput!) {
-                requestResetPassword(input: $input) {
+              mutation ResetPassword($input: ResetPasswordInput!) {
+                resetPassword(input: $input) {
                   clientMutationId
                   ok
                 }
@@ -7080,8 +7080,8 @@ describe('ParseGraphQLServer', () => {
             },
           });
 
-          expect(result.data.requestResetPassword.clientMutationId).toEqual(clientMutationId);
-          expect(result.data.requestResetPassword.ok).toBeTruthy();
+          expect(result.data.resetPassword.clientMutationId).toEqual(clientMutationId);
+          expect(result.data.resetPassword.ok).toBeTruthy();
         });
 
         it('should reset password', async () => {
@@ -7113,8 +7113,8 @@ describe('ParseGraphQLServer', () => {
           await Parse.User.requestPasswordReset('user1@user1.user1');
           await apolloClient.mutate({
             mutation: gql`
-              mutation ResetPassword($input: ResetPasswordInput!) {
-                resetPassword(input: $input) {
+              mutation ConfirmResetPassword($input: ConfirmResetPasswordInput!) {
+                confirmResetPassword(input: $input) {
                   clientMutationId
                   ok
                 }
@@ -7148,7 +7148,7 @@ describe('ParseGraphQLServer', () => {
               },
             },
           });
-
+          console.log(result);
           expect(result.data.logIn.clientMutationId).toEqual(clientMutationId);
           expect(result.data.logIn.viewer.sessionToken).toBeDefined();
           expect(typeof result.data.logIn.viewer.sessionToken).toBe('string');

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -7065,8 +7065,8 @@ describe('ParseGraphQLServer', () => {
           await Parse.User.logOut();
           const result = await apolloClient.mutate({
             mutation: gql`
-              mutation ResetPassword($input: ResetPasswordInput!) {
-                resetPassword(input: $input) {
+              mutation RequestResetPassword($input: RequestResetPasswordInput!) {
+                requestResetPassword(input: $input) {
                   clientMutationId
                   ok
                 }
@@ -7080,8 +7080,8 @@ describe('ParseGraphQLServer', () => {
             },
           });
 
-          expect(result.data.resetPassword.clientMutationId).toEqual(clientMutationId);
-          expect(result.data.resetPassword.ok).toBeTruthy();
+          expect(result.data.requestResetPassword.clientMutationId).toEqual(clientMutationId);
+          expect(result.data.requestResetPassword.ok).toBeTruthy();
         });
         it('should send verification email again', async () => {
           const clientMutationId = uuidv4();

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -7148,7 +7148,7 @@ describe('ParseGraphQLServer', () => {
               },
             },
           });
-          console.log(result);
+
           expect(result.data.logIn.clientMutationId).toEqual(clientMutationId);
           expect(result.data.logIn.viewer.sessionToken).toBeDefined();
           expect(typeof result.data.logIn.viewer.sessionToken).toBe('string');

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -215,10 +215,10 @@ const load = parseGraphQLSchema => {
   parseGraphQLSchema.addGraphQLType(logOutMutation.type, true, true);
   parseGraphQLSchema.addGraphQLMutation('logOut', logOutMutation, true, true);
 
-  const requestResetPasswordMutation = mutationWithClientMutationId({
-    name: 'RequestResetPassword',
+  const resetPasswordMutation = mutationWithClientMutationId({
+    name: 'ResetPassword',
     description:
-      'The requestResetPassword mutation can be used to reset the password of an existing user.',
+      'The resetPassword mutation can be used to reset the password of an existing user.',
     inputFields: {
       email: {
         descriptions: 'Email of the user that should receive the reset email',
@@ -247,23 +247,14 @@ const load = parseGraphQLSchema => {
     },
   });
 
-  parseGraphQLSchema.addGraphQLType(
-    requestResetPasswordMutation.args.input.type.ofType,
-    true,
-    true
-  );
-  parseGraphQLSchema.addGraphQLType(requestResetPasswordMutation.type, true, true);
-  parseGraphQLSchema.addGraphQLMutation(
-    'requestResetPassword',
-    requestResetPasswordMutation,
-    true,
-    true
-  );
+  parseGraphQLSchema.addGraphQLType(resetPasswordMutation.args.input.type.ofType, true, true);
+  parseGraphQLSchema.addGraphQLType(resetPasswordMutation.type, true, true);
+  parseGraphQLSchema.addGraphQLMutation('resetPassword', resetPasswordMutation, true, true);
 
-  const resetPasswordMutation = mutationWithClientMutationId({
-    name: 'ResetPassword',
+  const confirmResetPasswordMutation = mutationWithClientMutationId({
+    name: 'ConfirmResetPassword',
     description:
-      'The resetPassword mutation can be used to reset the password of an existing user.',
+      'The confirmResetPassword mutation can be used to reset the password of an existing user.',
     inputFields: {
       username: {
         descriptions: 'Username of the user that have received the reset email',
@@ -302,9 +293,18 @@ const load = parseGraphQLSchema => {
     },
   });
 
-  parseGraphQLSchema.addGraphQLType(resetPasswordMutation.args.input.type.ofType, true, true);
-  parseGraphQLSchema.addGraphQLType(resetPasswordMutation.type, true, true);
-  parseGraphQLSchema.addGraphQLMutation('resetPassword', resetPasswordMutation, true, true);
+  parseGraphQLSchema.addGraphQLType(
+    confirmResetPasswordMutation.args.input.type.ofType,
+    true,
+    true
+  );
+  parseGraphQLSchema.addGraphQLType(confirmResetPasswordMutation.type, true, true);
+  parseGraphQLSchema.addGraphQLMutation(
+    'confirmResetPassword',
+    confirmResetPasswordMutation,
+    true,
+    true
+  );
 
   const sendVerificationEmailMutation = mutationWithClientMutationId({
     name: 'SendVerificationEmail',

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -273,7 +273,7 @@ const load = parseGraphQLSchema => {
         type: new GraphQLNonNull(GraphQLString),
       },
       token: {
-        descriptions: 'Reset email token that was emailed to the user',
+        descriptions: 'Reset token that was emailed to the user',
         type: new GraphQLNonNull(GraphQLString),
       },
     },

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -273,7 +273,7 @@ const load = parseGraphQLSchema => {
         type: new GraphQLNonNull(GraphQLString),
       },
       token: {
-        descriptions: 'Reset email token that was sent to user',
+        descriptions: 'Reset email token that was emailed to the user',
         type: new GraphQLNonNull(GraphQLString),
       },
     },

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -5,6 +5,7 @@ import * as objectsMutations from '../helpers/objectsMutations';
 import { OBJECT } from './defaultGraphQLTypes';
 import { getUserFromSessionToken } from './usersQueries';
 import { transformTypes } from '../transformers/mutation';
+import Parse from 'parse/node';
 
 const usersRouter = new UsersRouter();
 
@@ -284,18 +285,19 @@ const load = parseGraphQLSchema => {
       },
     },
     mutateAndGetPayload: async ({ username, password, token }, context) => {
-      const { config, auth, info } = context;
-      await usersRouter.handleResetPassword({
-        body: {
-          username,
-          password,
-          token,
-        },
-        config,
-        auth,
-        info,
-      });
+      const { config } = context;
+      if (!username) {
+        throw new Parse.Error(Parse.Error.USERNAME_MISSING, 'you must provide a username');
+      }
+      if (!password) {
+        throw new Parse.Error(Parse.Error.PASSWORD_MISSING, 'you must provide a password');
+      }
+      if (!token) {
+        throw new Parse.Error(Parse.Error.OTHER_CAUSE, 'you must provide a token');
+      }
 
+      const userController = config.userController;
+      await userController.updatePassword(username, token, password);
       return { ok: true };
     },
   });

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -214,10 +214,10 @@ const load = parseGraphQLSchema => {
   parseGraphQLSchema.addGraphQLType(logOutMutation.type, true, true);
   parseGraphQLSchema.addGraphQLMutation('logOut', logOutMutation, true, true);
 
-  const resetPasswordMutation = mutationWithClientMutationId({
-    name: 'ResetPassword',
+  const requestResetPasswordMutation = mutationWithClientMutationId({
+    name: 'RequestResetPassword',
     description:
-      'The resetPassword mutation can be used to reset the password of an existing user.',
+      'The requestResetPassword mutation can be used to reset the password of an existing user.',
     inputFields: {
       email: {
         descriptions: 'Email of the user that should receive the reset email',
@@ -236,6 +236,60 @@ const load = parseGraphQLSchema => {
       await usersRouter.handleResetRequest({
         body: {
           email,
+        },
+        config,
+        auth,
+        info,
+      });
+
+      return { ok: true };
+    },
+  });
+
+  parseGraphQLSchema.addGraphQLType(
+    requestResetPasswordMutation.args.input.type.ofType,
+    true,
+    true
+  );
+  parseGraphQLSchema.addGraphQLType(requestResetPasswordMutation.type, true, true);
+  parseGraphQLSchema.addGraphQLMutation(
+    'requestResetPassword',
+    requestResetPasswordMutation,
+    true,
+    true
+  );
+
+  const resetPasswordMutation = mutationWithClientMutationId({
+    name: 'ResetPassword',
+    description:
+      'The resetPassword mutation can be used to reset the password of an existing user.',
+    inputFields: {
+      username: {
+        descriptions: 'Username of the user that have received the reset email',
+        type: new GraphQLNonNull(GraphQLString),
+      },
+      password: {
+        descriptions: 'New password of the user',
+        type: new GraphQLNonNull(GraphQLString),
+      },
+      token: {
+        descriptions: 'Reset email token that was sent to user',
+        type: new GraphQLNonNull(GraphQLString),
+      },
+    },
+    outputFields: {
+      ok: {
+        description: "It's always true.",
+        type: new GraphQLNonNull(GraphQLBoolean),
+      },
+    },
+    mutateAndGetPayload: async ({ username, password, token }, context) => {
+      const { config, auth, info } = context;
+      await usersRouter.handleResetPassword({
+        body: {
+          username,
+          password,
+          token,
         },
         config,
         auth,

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -357,30 +357,6 @@ export class UsersRouter extends ClassesRouter {
     );
   }
 
-  handleResetPassword(req) {
-    const { username, password, token } = req.body;
-    if (!username) {
-      throw new Parse.Error(Parse.Error.USERNAME_MISSING, 'you must provide a username');
-    }
-    if (!password) {
-      throw new Parse.Error(Parse.Error.PASSWORD_MISSING, 'you must provide a password');
-    }
-    if (typeof password !== 'string' || typeof username !== 'string') {
-      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
-    }
-    const userController = req.config.userController;
-    return userController.updatePassword(username, token, password).then(
-      () => {
-        return Promise.resolve({
-          response: {},
-        });
-      },
-      err => {
-        throw err;
-      }
-    );
-  }
-
   handleVerificationEmailRequest(req) {
     this._throwOnBadEmailConfig(req);
 
@@ -446,9 +422,6 @@ export class UsersRouter extends ClassesRouter {
     });
     this.route('POST', '/requestPasswordReset', req => {
       return this.handleResetRequest(req);
-    });
-    this.route('POST', '/resetPassword', req => {
-      return this.handleResetPassword(req);
     });
     this.route('POST', '/verificationEmailRequest', req => {
       return this.handleVerificationEmailRequest(req);

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -357,6 +357,30 @@ export class UsersRouter extends ClassesRouter {
     );
   }
 
+  handleResetPassword(req) {
+    const { username, password, token } = req.body;
+    if (!username) {
+      throw new Parse.Error(Parse.Error.USERNAME_MISSING, 'you must provide a username');
+    }
+    if (!password) {
+      throw new Parse.Error(Parse.Error.PASSWORD_MISSING, 'you must provide a password');
+    }
+    if (typeof password !== 'string' || typeof username !== 'string') {
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
+    }
+    const userController = req.config.userController;
+    return userController.updatePassword(username, token, password).then(
+      () => {
+        return Promise.resolve({
+          response: {},
+        });
+      },
+      err => {
+        throw err;
+      }
+    );
+  }
+
   handleVerificationEmailRequest(req) {
     this._throwOnBadEmailConfig(req);
 
@@ -422,6 +446,9 @@ export class UsersRouter extends ClassesRouter {
     });
     this.route('POST', '/requestPasswordReset', req => {
       return this.handleResetRequest(req);
+    });
+    this.route('POST', '/resetPassword', req => {
+      return this.handleResetPassword(req);
     });
     this.route('POST', '/verificationEmailRequest', req => {
       return this.handleVerificationEmailRequest(req);


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7033).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: resetting password with emailed token

### Approach
 - add one more mutation in [userMutation.js](https://github.com/parse-community/parse-server/blob/e88f2e38f9c38151869055878e52f1da8f7f6f99/src/GraphQL/loaders/usersMutations.js) file that will take username, password, token as arguments.
 - add one more route in [userRoutes.js](https://github.com/parse-community/parse-server/blob/e88f2e38f9c38151869055878e52f1da8f7f6f99/src/Routers/UsersRouter.js) file, that will add route POST `/resetPassword` that will basically call this [updatePassword](https://github.com/parse-community/parse-server/blob/e88f2e38f9c38151869055878e52f1da8f7f6f99/src/Controllers/UserController.js#L259) function

and with this, I think we should be able to complete reset password flow for GraphQL API also

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->