### PR TITLE
Fix: properly pass req.user to liveQuery triggers

### DIFF
--- a/spec/OAuth1.spec.js
+++ b/spec/OAuth1.spec.js
@@ -93,7 +93,7 @@ describe('OAuth', function () {
       consumer_key: 'XXXXXXXXXXXXXXXXXXXXXXXXX',
       consumer_secret: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     };
-    const path = '/1.1/help/configuration.json';
+    const path = '/1.1/oauth/request_token';
     const params = { lang: 'en' };
     const oauthClient = new OAuth(options);
     oauthClient.get(path, params).then(function (data) {

--- a/spec/OAuth1.spec.js
+++ b/spec/OAuth1.spec.js
@@ -93,7 +93,7 @@ describe('OAuth', function () {
       consumer_key: 'XXXXXXXXXXXXXXXXXXXXXXXXX',
       consumer_secret: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     };
-    const path = '/1.1/oauth/request_token';
+    const path = '/1.1/help/configuration.json';
     const params = { lang: 'en' };
     const oauthClient = new OAuth(options);
     oauthClient.get(path, params).then(function (data) {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -645,7 +645,7 @@ describe('ParseLiveQuery', function () {
     await object.save();
   });
 
-  fit('LiveQuery with ACL', async done => {
+  it('LiveQuery with ACL', async done => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['Chat'],

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -645,7 +645,7 @@ describe('ParseLiveQuery', function () {
     await object.save();
   });
 
-  it('LiveQuery with ACL', async done => {
+  it('LiveQuery with ACL', async () => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['Chat'],
@@ -659,49 +659,54 @@ describe('ParseLiveQuery', function () {
     user.setPassword('password');
     await user.signUp();
 
-    let calls = 0;
-
-    Parse.Cloud.beforeConnect(req => {
-      expect(req.event).toBe('connect');
-      expect(req.clients).toBe(0);
-      expect(req.subscriptions).toBe(0);
-      expect(req.useMasterKey).toBe(false);
-      expect(req.installationId).toBeDefined();
-      expect(req.client).toBeDefined();
-      calls++;
-    });
-
-    Parse.Cloud.beforeSubscribe('Chat', req => {
-      expect(req.op).toBe('subscribe');
-      expect(req.requestId).toBe(1);
-      expect(req.query).toBeDefined();
-      expect(req.user).toBeDefined();
-      calls++;
-    });
-
-    Parse.Cloud.afterLiveQueryEvent('Chat', req => {
-      expect(req.user).toBeDefined();
-      expect(req.object.get('foo')).toBe('bar');
-      calls++;
-    });
+    const calls = {
+      beforeConnect(req) {
+        expect(req.event).toBe('connect');
+        expect(req.clients).toBe(0);
+        expect(req.subscriptions).toBe(0);
+        expect(req.useMasterKey).toBe(false);
+        expect(req.installationId).toBeDefined();
+        expect(req.client).toBeDefined();
+      },
+      beforeSubscribe(req) {
+        expect(req.op).toBe('subscribe');
+        expect(req.requestId).toBe(1);
+        expect(req.query).toBeDefined();
+        expect(req.user).toBeDefined();
+      },
+      afterLiveQueryEvent(req) {
+        expect(req.user).toBeDefined();
+        expect(req.object.get('foo')).toBe('bar');
+      },
+      create(object) {
+        expect(object.get('foo')).toBe('bar');
+      },
+      delete(object) {
+        expect(object.get('foo')).toBe('bar');
+      },
+    };
+    for (const key in calls) {
+      console.log(key);
+      spyOn(calls, key).and.callThrough();
+    }
+    Parse.Cloud.beforeConnect(calls.beforeConnect);
+    Parse.Cloud.beforeSubscribe('Chat', calls.beforeSubscribe);
+    Parse.Cloud.afterLiveQueryEvent('Chat', calls.afterLiveQueryEvent);
 
     const chatQuery = new Parse.Query('Chat');
     const subscription = await chatQuery.subscribe();
-    subscription.on('create', object => {
-      expect(object.get('foo')).toBe('bar');
-      expect(calls).toEqual(3);
-    });
-    subscription.on('delete', object => {
-      expect(object.get('foo')).toBe('bar');
-      expect(calls).toEqual(4);
-      done();
-    });
+    subscription.on('create', calls.create);
+    subscription.on('delete', calls.delete);
     const object = new Parse.Object('Chat');
     const acl = new Parse.ACL(user);
     object.setACL(acl);
     object.set({ foo: 'bar' });
     await object.save();
     await object.destroy();
+    await new Promise(resolve => setTimeout(resolve, 200));
+    for (const key in calls) {
+      expect(calls[key]).toHaveBeenCalled();
+    }
   });
 
   it('handle invalid websocket payload length', async done => {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -680,7 +680,6 @@ describe('ParseLiveQuery', function () {
     });
 
     Parse.Cloud.afterLiveQueryEvent('Chat', req => {
-      expect(req.event).toBe('create');
       expect(req.user).toBeDefined();
       expect(req.object.get('foo')).toBe('bar');
       calls++;
@@ -691,6 +690,10 @@ describe('ParseLiveQuery', function () {
     subscription.on('create', object => {
       expect(object.get('foo')).toBe('bar');
       expect(calls).toEqual(3);
+    });
+    subscription.on('delete', object => {
+      expect(object.get('foo')).toBe('bar');
+      expect(calls).toEqual(4);
       done();
     });
     const object = new Parse.Object('Chat');
@@ -698,6 +701,7 @@ describe('ParseLiveQuery', function () {
     object.setACL(acl);
     object.set({ foo: 'bar' });
     await object.save();
+    await object.destroy();
   });
 
   it('handle invalid websocket payload length', async done => {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -645,7 +645,7 @@ describe('ParseLiveQuery', function () {
     await object.save();
   });
 
-  it('LiveQuery with ACL', async done => {
+  fit('LiveQuery with ACL', async done => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['Chat'],

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -686,7 +686,6 @@ describe('ParseLiveQuery', function () {
       },
     };
     for (const key in calls) {
-      console.log(key);
       spyOn(calls, key).and.callThrough();
     }
     Parse.Cloud.beforeConnect(calls.beforeConnect);

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -667,7 +667,6 @@ describe('ParseLiveQuery', function () {
       expect(req.subscriptions).toBe(0);
       expect(req.useMasterKey).toBe(false);
       expect(req.installationId).toBeDefined();
-      expect(req.user).toBeDefined();
       expect(req.client).toBeDefined();
       calls++;
     });

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -317,6 +317,8 @@ class ParseLiveQueryServer {
                 res.original = Parse.Object.fromJSON(res.original);
               }
               const auth = this.getAuthFromClient(client, res, requestId);
+              console.log('auth', auth);
+              console.log('user', res.user);
               await runTrigger(trigger, `afterEvent.${className}`, res, auth);
             }
             if (!res.sendEvent) {
@@ -577,7 +579,6 @@ class ParseLiveQueryServer {
       });
   }
   async getAuthFromClient(client: any, res: any, requestId: number) {
-    console.log('client', client);
     const getSessionFromClient = () => {
       const subscriptionInfo = client.getSubscriptionInfo(requestId);
       if (typeof subscriptionInfo === 'undefined') {
@@ -587,7 +588,6 @@ class ParseLiveQueryServer {
     };
     const sessionToken = getSessionFromClient();
     const { auth } = await this.getAuthForSessionToken(sessionToken);
-    console.log('auth', auth);
     if (auth && auth.user) {
       res.user = auth.user;
     }

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -585,9 +585,6 @@ class ParseLiveQueryServer {
       });
   }
   getSessionFromClient(client: any, requestId: number): String {
-    if (!client) {
-      return;
-    }
     const subscriptionInfo = client.getSubscriptionInfo(requestId);
     if (typeof subscriptionInfo === 'undefined') {
       return client.sessionToken;

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -588,14 +588,11 @@ class ParseLiveQueryServer {
     if (!client) {
       return;
     }
-    if (client.sessionToken) {
-      return client.sessionToken;
-    }
     const subscriptionInfo = client.getSubscriptionInfo(requestId);
     if (typeof subscriptionInfo === 'undefined') {
-      return;
+      return client.sessionToken;
     }
-    return subscriptionInfo.sessionToken;
+    return subscriptionInfo.sessionToken || client.sessionToken;
   }
   async _matchesACL(acl: any, client: any, requestId: number): Promise<boolean> {
     // Return true directly if ACL isn't present, ACL is public read, or client has master key

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -170,7 +170,8 @@ class ParseLiveQueryServer {
             };
             const trigger = getTrigger(className, 'afterEvent', Parse.applicationId);
             if (trigger) {
-              const { auth } = await this.getAuthForSessionToken(res.sessionToken);
+              const sessionToken = this.getSessionFromClient(client, requestId);
+              const { auth } = await this.getAuthForSessionToken(sessionToken);
               if (auth && auth.user) {
                 res.user = auth.user;
               }
@@ -319,7 +320,8 @@ class ParseLiveQueryServer {
               if (res.original) {
                 res.original = Parse.Object.fromJSON(res.original);
               }
-              const { auth } = await this.getAuthForSessionToken(res.sessionToken);
+              const sessionToken = this.getSessionFromClient(client, requestId);
+              const { auth } = await this.getAuthForSessionToken(sessionToken);
               if (auth && auth.user) {
                 res.user = auth.user;
               }
@@ -582,7 +584,19 @@ class ParseLiveQueryServer {
         return false;
       });
   }
-
+  getSessionFromClient(client: any, requestId: number): String {
+    if (!client) {
+      return;
+    }
+    if (client.sessionToken) {
+      return client.sessionToken;
+    }
+    const subscriptionInfo = client.getSubscriptionInfo(requestId);
+    if (typeof subscriptionInfo === 'undefined') {
+      return;
+    }
+    return subscriptionInfo.sessionToken;
+  }
   async _matchesACL(acl: any, client: any, requestId: number): Promise<boolean> {
     // Return true directly if ACL isn't present, ACL is public read, or client has master key
     if (!acl || acl.getPublicReadAccess() || client.hasMasterKey) {

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -171,9 +171,7 @@ class ParseLiveQueryServer {
             const trigger = getTrigger(className, 'afterEvent', Parse.applicationId);
             if (trigger) {
               const auth = await this.getAuthFromClient(client, requestId);
-              if (auth && auth.user) {
-                res.user = auth.user;
-              }
+              res.user = auth.user;
               if (res.object) {
                 res.object = Parse.Object.fromJSON(res.object);
               }
@@ -320,9 +318,7 @@ class ParseLiveQueryServer {
                 res.original = Parse.Object.fromJSON(res.original);
               }
               const auth = await this.getAuthFromClient(client, requestId);
-              if (auth && auth.user) {
-                res.user = auth.user;
-              }
+              res.user = auth.user;
               await runTrigger(trigger, `afterEvent.${className}`, res, auth);
             }
             if (!res.sendEvent) {
@@ -595,7 +591,7 @@ class ParseLiveQueryServer {
       sessionToken = getSessionFromClient();
     }
     const { auth } = await this.getAuthForSessionToken(sessionToken);
-    return auth;
+    return auth || {};
   }
 
   async _matchesACL(acl: any, client: any, requestId: number): Promise<boolean> {
@@ -651,9 +647,7 @@ class ParseLiveQueryServer {
       const trigger = getTrigger('@Connect', 'beforeConnect', Parse.applicationId);
       if (trigger) {
         const auth = await this.getAuthFromClient(client, request.requestId, req.sessionToken);
-        if (auth && auth.user) {
-          req.user = auth.user;
-        }
+        req.user = auth.user;
         await runTrigger(trigger, `beforeConnect.@Connect`, req, auth);
       }
       parseWebsocket.clientId = clientId;
@@ -712,9 +706,7 @@ class ParseLiveQueryServer {
       const trigger = getTrigger(className, 'beforeSubscribe', Parse.applicationId);
       if (trigger) {
         const auth = await this.getAuthFromClient(client, request.requestId, request.sessionToken);
-        if (auth && auth.user) {
-          request.user = auth.user;
-        }
+        request.user = auth.user;
 
         const parseQuery = new Parse.Query(className);
         parseQuery.withJSON(request.query);

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -577,6 +577,7 @@ class ParseLiveQueryServer {
       });
   }
   async getAuthFromClient(client: any, res: any, requestId: number) {
+    console.log('client', client);
     const getSessionFromClient = () => {
       const subscriptionInfo = client.getSubscriptionInfo(requestId);
       if (typeof subscriptionInfo === 'undefined') {
@@ -586,6 +587,7 @@ class ParseLiveQueryServer {
     };
     const sessionToken = getSessionFromClient();
     const { auth } = await this.getAuthForSessionToken(sessionToken);
+    console.log('auth', auth);
     if (auth && auth.user) {
       res.user = auth.user;
     }

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -171,7 +171,9 @@ class ParseLiveQueryServer {
             const trigger = getTrigger(className, 'afterEvent', Parse.applicationId);
             if (trigger) {
               const { auth } = await this.getAuthForSessionToken(res.sessionToken);
-              res.user = auth.user;
+              if (auth && auth.user) {
+                res.user = auth.user;
+              }
               if (res.object) {
                 res.object = Parse.Object.fromJSON(res.object);
               }
@@ -318,7 +320,9 @@ class ParseLiveQueryServer {
                 res.original = Parse.Object.fromJSON(res.original);
               }
               const { auth } = await this.getAuthForSessionToken(res.sessionToken);
-              res.user = auth.user;
+              if (auth && auth.user) {
+                res.user = auth.user;
+              }
               await runTrigger(trigger, `afterEvent.${className}`, res, auth);
             }
             if (!res.sendEvent) {
@@ -632,7 +636,9 @@ class ParseLiveQueryServer {
       const trigger = getTrigger('@Connect', 'beforeConnect', Parse.applicationId);
       if (trigger) {
         const { auth } = await this.getAuthForSessionToken(req.sessionToken);
-        req.user = auth.user;
+        if (auth && auth.user) {
+          req.user = auth.user;
+        }
         await runTrigger(trigger, `beforeConnect.@Connect`, req, auth);
       }
       parseWebsocket.clientId = clientId;
@@ -691,7 +697,9 @@ class ParseLiveQueryServer {
       const trigger = getTrigger(className, 'beforeSubscribe', Parse.applicationId);
       if (trigger) {
         const { auth } = await this.getAuthForSessionToken(request.sessionToken);
-        request.user = auth.user;
+        if (auth && auth.user) {
+          request.user = auth.user;
+        }
 
         const parseQuery = new Parse.Query(className);
         parseQuery.withJSON(request.query);

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -171,7 +171,9 @@ class ParseLiveQueryServer {
             const trigger = getTrigger(className, 'afterEvent', Parse.applicationId);
             if (trigger) {
               const auth = await this.getAuthFromClient(client, requestId);
-              res.user = auth.user;
+              if (auth && auth.user) {
+                res.user = auth.user;
+              }
               if (res.object) {
                 res.object = Parse.Object.fromJSON(res.object);
               }
@@ -318,7 +320,9 @@ class ParseLiveQueryServer {
                 res.original = Parse.Object.fromJSON(res.original);
               }
               const auth = await this.getAuthFromClient(client, requestId);
-              res.user = auth.user;
+              if (auth && auth.user) {
+                res.user = auth.user;
+              }
               await runTrigger(trigger, `afterEvent.${className}`, res, auth);
             }
             if (!res.sendEvent) {
@@ -590,8 +594,11 @@ class ParseLiveQueryServer {
     if (!sessionToken) {
       sessionToken = getSessionFromClient();
     }
+    if (!sessionToken) {
+      return;
+    }
     const { auth } = await this.getAuthForSessionToken(sessionToken);
-    return auth || {};
+    return auth;
   }
 
   async _matchesACL(acl: any, client: any, requestId: number): Promise<boolean> {
@@ -647,7 +654,9 @@ class ParseLiveQueryServer {
       const trigger = getTrigger('@Connect', 'beforeConnect', Parse.applicationId);
       if (trigger) {
         const auth = await this.getAuthFromClient(client, request.requestId, req.sessionToken);
-        req.user = auth.user;
+        if (auth && auth.user) {
+          req.user = auth.user;
+        }
         await runTrigger(trigger, `beforeConnect.@Connect`, req, auth);
       }
       parseWebsocket.clientId = clientId;
@@ -706,7 +715,9 @@ class ParseLiveQueryServer {
       const trigger = getTrigger(className, 'beforeSubscribe', Parse.applicationId);
       if (trigger) {
         const auth = await this.getAuthFromClient(client, request.requestId, request.sessionToken);
-        request.user = auth.user;
+        if (auth && auth.user) {
+          request.user = auth.user;
+        }
 
         const parseQuery = new Parse.Query(className);
         parseQuery.withJSON(request.query);

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -576,6 +576,7 @@ class ParseLiveQueryServer {
         return false;
       });
   }
+
   async getAuthFromClient(client: any, res: any, requestId: number, sessionToken: string) {
     const getSessionFromClient = () => {
       const subscriptionInfo = client.getSubscriptionInfo(requestId);
@@ -593,6 +594,7 @@ class ParseLiveQueryServer {
     }
     return auth;
   }
+
   async _matchesACL(acl: any, client: any, requestId: number): Promise<boolean> {
     // Return true directly if ACL isn't present, ACL is public read, or client has master key
     if (!acl || acl.getPublicReadAccess() || client.hasMasterKey) {

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -170,7 +170,7 @@ class ParseLiveQueryServer {
             };
             const trigger = getTrigger(className, 'afterEvent', Parse.applicationId);
             if (trigger) {
-              const auth = await this.getAuthForSessionToken(res.sessionToken);
+              const { auth } = await this.getAuthForSessionToken(res.sessionToken);
               res.user = auth.user;
               if (res.object) {
                 res.object = Parse.Object.fromJSON(res.object);
@@ -317,7 +317,7 @@ class ParseLiveQueryServer {
               if (res.original) {
                 res.original = Parse.Object.fromJSON(res.original);
               }
-              const auth = await this.getAuthForSessionToken(res.sessionToken);
+              const { auth } = await this.getAuthForSessionToken(res.sessionToken);
               res.user = auth.user;
               await runTrigger(trigger, `afterEvent.${className}`, res, auth);
             }
@@ -631,7 +631,7 @@ class ParseLiveQueryServer {
       };
       const trigger = getTrigger('@Connect', 'beforeConnect', Parse.applicationId);
       if (trigger) {
-        const auth = await this.getAuthForSessionToken(req.sessionToken);
+        const { auth } = await this.getAuthForSessionToken(req.sessionToken);
         req.user = auth.user;
         await runTrigger(trigger, `beforeConnect.@Connect`, req, auth);
       }
@@ -690,7 +690,7 @@ class ParseLiveQueryServer {
     try {
       const trigger = getTrigger(className, 'beforeSubscribe', Parse.applicationId);
       if (trigger) {
-        const auth = await this.getAuthForSessionToken(request.sessionToken);
+        const { auth } = await this.getAuthForSessionToken(request.sessionToken);
         request.user = auth.user;
 
         const parseQuery = new Parse.Query(className);

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -170,7 +170,7 @@ class ParseLiveQueryServer {
             };
             const trigger = getTrigger(className, 'afterEvent', Parse.applicationId);
             if (trigger) {
-              const auth = this.getAuthFromClient(client, res, requestId);
+              const auth = await this.getAuthFromClient(client, res, requestId);
               if (res.object) {
                 res.object = Parse.Object.fromJSON(res.object);
               }
@@ -316,9 +316,7 @@ class ParseLiveQueryServer {
               if (res.original) {
                 res.original = Parse.Object.fromJSON(res.original);
               }
-              const auth = this.getAuthFromClient(client, res, requestId);
-              console.log('auth', auth);
-              console.log('user', res.user);
+              const auth = await this.getAuthFromClient(client, res, requestId);
               await runTrigger(trigger, `afterEvent.${className}`, res, auth);
             }
             if (!res.sendEvent) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

When I replaced the LQ triggers auth lookup with `getAuthForSessionToken`, I forgot to destructure auth. My bad.

This results in req.user always being undefined for LQ triggers. This only affects the master branch.

First commit is failing test.

Closes: #7318