### PR TITLE
fix: empty file tags cause upload error for some providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ ___
 - Added centralized feature deprecation with standardized warning logs (Manuel Trezza) [#7303](https://github.com/parse-community/parse-server/pull/7303)
 - Use Node.js 15.13.0 in CI (Olle Jonsson) [#7312](https://github.com/parse-community/parse-server/pull/7312)
 - Ignore empty tags while creating a file. This fixes the file upload problem for Linode and DigitalOcean) (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
+- Fix file upload issue for S3 compatible storage (Linode, DigitalOcean) by avoiding empty tags property when creating a file (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
 ___
 ## 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,6 @@ ___
 - Excluding keys that have trailing edges.node when performing GraphQL resolver (Chris Bland) [#7273](https://github.com/parse-community/parse-server/pull/7273)
 - Added centralized feature deprecation with standardized warning logs (Manuel Trezza) [#7303](https://github.com/parse-community/parse-server/pull/7303)
 - Use Node.js 15.13.0 in CI (Olle Jonsson) [#7312](https://github.com/parse-community/parse-server/pull/7312)
-- Ignore empty tags while creating a file. This fixes the file upload problem for Linode and DigitalOcean) (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
 - Fix file upload issue for S3 compatible storage (Linode, DigitalOcean) by avoiding empty tags property when creating a file (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
 ___
 ## 4.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ ___
 - Excluding keys that have trailing edges.node when performing GraphQL resolver (Chris Bland) [#7273](https://github.com/parse-community/parse-server/pull/7273)
 - Added centralized feature deprecation with standardized warning logs (Manuel Trezza) [#7303](https://github.com/parse-community/parse-server/pull/7303)
 - Use Node.js 15.13.0 in CI (Olle Jonsson) [#7312](https://github.com/parse-community/parse-server/pull/7312)
+- Ignore empty tags while creating a file. This fixes the file upload problem for Linode and DigitalOcean) (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
 ___
 ## 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+const { FilesController } = require('../lib/Controllers/FilesController');
 const request = require('../lib/request');
 
 const str = 'Hello World!';
@@ -203,6 +204,29 @@ describe('Parse.File testing', () => {
       ok(file.name());
       ok(file.url());
       notEqual(file.name(), 'hello.txt');
+    });
+
+    it('save file with tags', async () => {
+      spyOn(FilesController.prototype, 'createFile').and.callThrough();
+      const file = new Parse.File('hello.txt', data, 'text/plain');
+      file.setTags({ hello: 'world' });
+      ok(!file.url());
+      const result = await file.save();
+      equal(result.tags(), { hello: 'world' });
+      expect(FilesController.prototype.createFile.calls.argsFor(0)[4]).toEqual({
+        tags: { hello: 'world' },
+        metadata: {},
+      });
+    });
+
+    it('empty file tags should not be passed while saving', async () => {
+      spyOn(FilesController.prototype, 'createFile').and.callThrough();
+      const file = new Parse.File('hello.txt', data, 'text/plain');
+      ok(!file.url());
+      await file.save();
+      expect(FilesController.prototype.createFile.calls.argsFor(0)[4]).toEqual({
+        metadata: {},
+      });
     });
 
     it('save file in object', async done => {

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -213,6 +213,8 @@ describe('Parse.File testing', () => {
       file.setTags(tags);
       expect(file.url()).toBeUndefined();
       const result = await file.save();
+      expect(file.name()).toBeDefined();
+      expect(file.url()).toBeDefined();
       expect(result.tags()).toEqual(tags);
       expect(FilesController.prototype.createFile.calls.argsFor(0)[4]).toEqual({
         tags: tags,
@@ -224,7 +226,9 @@ describe('Parse.File testing', () => {
       spyOn(FilesController.prototype, 'createFile').and.callThrough();
       const file = new Parse.File('hello.txt', data, 'text/plain');
       expect(file.url()).toBeUndefined();
+      expect(file.name()).toBeDefined();
       await file.save();
+      expect(file.url()).toBeDefined();
       expect(FilesController.prototype.createFile.calls.argsFor(0)[4]).toEqual({
         metadata: {},
       });

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -206,23 +206,24 @@ describe('Parse.File testing', () => {
       notEqual(file.name(), 'hello.txt');
     });
 
-    it('save file with tags', async () => {
+    it('saves the file with tags', async () => {
       spyOn(FilesController.prototype, 'createFile').and.callThrough();
       const file = new Parse.File('hello.txt', data, 'text/plain');
-      file.setTags({ hello: 'world' });
-      ok(!file.url());
+      const tags = { hello: 'world' };
+      file.setTags(tags);
+      expect(file.url()).toBeUndefined();
       const result = await file.save();
-      equal(result.tags(), { hello: 'world' });
+      expect(result.tags()).toEqual(tags);
       expect(FilesController.prototype.createFile.calls.argsFor(0)[4]).toEqual({
-        tags: { hello: 'world' },
+        tags: tags,
         metadata: {},
       });
     });
 
-    it('empty file tags should not be passed while saving', async () => {
+    it('does not pass empty file tags while saving', async () => {
       spyOn(FilesController.prototype, 'createFile').and.callThrough();
       const file = new Parse.File('hello.txt', data, 'text/plain');
-      ok(!file.url());
+      expect(file.url()).toBeUndefined();
       await file.save();
       expect(FilesController.prototype.createFile.calls.argsFor(0)[4]).toEqual({
         metadata: {},

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -166,16 +166,26 @@ export class FilesRouter {
         // update fileSize
         const bufferData = Buffer.from(fileObject.file._data, 'base64');
         fileObject.fileSize = Buffer.byteLength(bufferData);
+        // prepare file options
+        const fileTags = fileObject.file._tags;
+        let fileOptions = {
+          metadata: fileObject.file._metadata,
+        };
+        if (Object.keys(fileTags).length > 0) {
+          // some s3-compatible providers (DigitalOcean, Linode) do not accept tags
+          // so we do not include the tags option if it is empty.
+          fileOptions = {
+            ...fileOptions,
+            tags: fileTags,
+          };
+        }
         // save file
         const createFileResult = await filesController.createFile(
           config,
           fileObject.file._name,
           bufferData,
           fileObject.file._source.type,
-          {
-            tags: fileObject.file._tags,
-            metadata: fileObject.file._metadata,
-          }
+          fileOptions
         );
         // update file with new data
         fileObject.file._name = createFileResult.name;

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -167,18 +167,14 @@ export class FilesRouter {
         const bufferData = Buffer.from(fileObject.file._data, 'base64');
         fileObject.fileSize = Buffer.byteLength(bufferData);
         // prepare file options
-        const fileTags = fileObject.file._tags;
-        let fileOptions = {
+        const fileOptions = {
           metadata: fileObject.file._metadata,
         };
-        if (Object.keys(fileTags).length > 0) {
-          // some s3-compatible providers (DigitalOcean, Linode) do not accept tags
-          // so we do not include the tags option if it is empty.
-          fileOptions = {
-            ...fileOptions,
-            tags: fileTags,
-          };
-        }
+        // some s3-compatible providers (DigitalOcean, Linode) do not accept tags
+        // so we do not include the tags option if it is empty.
+        const fileTags =
+          Object.keys(fileObject.file._tags).length > 0 ? { tags: fileObject.file._tags } : {};
+        Object.assign(fileOptions, fileTags);
         // save file
         const createFileResult = await filesController.createFile(
           config,


### PR DESCRIPTION
DigitalOcean and Linode object storage solutions do not accept the `tags` option while uploading a file. Previously, the `tags` option was set to default empty object. Now, we do not include it if it is empty.

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7129 

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog