### PR TITLE
fix: set objects in afterFind triggers

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2383,6 +2383,25 @@ describe('afterFind hooks', () => {
     });
   });
 
+  it('can set a pointer object in afterFind', async done => {
+    const obj = new Parse.Object('MyObject');
+    await obj.save();
+    Parse.Cloud.afterFind('MyObject', async ({ objects }) => {
+      const otherObject = new Parse.Object('Test');
+      otherObject.set('foo', 'bar');
+      await otherObject.save();
+      objects[0].set('Pointer', otherObject);
+      expect(objects[0].get('Pointer').get('foo')).toBe('bar');
+      return objects;
+    });
+    const query = new Parse.Query('MyObject');
+    query.equalTo('objectId', obj.id);
+    const [obj2] = await query.find();
+    const pointer = obj2.get('Pointer');
+    expect(pointer.get('foo')).toBe('bar');
+    done();
+  });
+
   it('should have request headers', done => {
     Parse.Cloud.afterFind('MyObject', req => {
       expect(req.headers).toBeDefined();

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -358,6 +358,44 @@ describe('ParseLiveQuery', function () {
     await object.save();
   });
 
+  it('can handle afterEvent set pointers', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: ['TestObject'],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+
+    const object = new TestObject();
+    await object.save();
+
+    const secondObject = new Parse.Object('Test2');
+    secondObject.set('foo', 'bar');
+    await secondObject.save();
+
+    Parse.Cloud.afterLiveQueryEvent('TestObject', async ({ object }) => {
+      const query = new Parse.Query('Test2');
+      const obj = await query.first();
+      object.set('obj', obj);
+    });
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+    subscription.on('update', object => {
+      expect(object.get('obj')).toBeDefined();
+      expect(object.get('obj').get('foo')).toBe('bar');
+      done();
+    });
+    subscription.on('error', () => {
+      fail('error should not have been called.');
+    });
+    object.set({ foo: 'bar' });
+    await object.save();
+  });
+
   it('can handle async afterEvent modification', async done => {
     await reconfigureServer({
       liveQuery: {

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -10,7 +10,7 @@ import { ParsePubSub } from './ParsePubSub';
 import SchemaController from '../Controllers/SchemaController';
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { runLiveQueryEventHandlers, getTrigger, runTrigger } from '../triggers';
+import { runLiveQueryEventHandlers, getTrigger, runTrigger, toJSONwithObjects } from '../triggers';
 import { getAuthForSessionToken, Auth } from '../Auth';
 import { getCacheController } from '../Controllers';
 import LRU from 'lru-cache';
@@ -181,8 +181,7 @@ class ParseLiveQueryServer {
               return;
             }
             if (res.object && typeof res.object.toJSON === 'function') {
-              deletedParseObject = res.object.toJSON();
-              deletedParseObject.className = className;
+              deletedParseObject = toJSONwithObjects(res.object);
             }
             client.pushDelete(requestId, deletedParseObject);
           } catch (error) {
@@ -326,12 +325,11 @@ class ParseLiveQueryServer {
               return;
             }
             if (res.object && typeof res.object.toJSON === 'function') {
-              currentParseObject = res.object.toJSON();
+              currentParseObject = toJSONwithObjects(res.object);
               currentParseObject.className = res.object.className || className;
             }
-
             if (res.original && typeof res.original.toJSON === 'function') {
-              originalParseObject = res.original.toJSON();
+              originalParseObject = toJSONwithObjects(res.original);
               originalParseObject.className = res.original.className || className;
             }
             const functionName =

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -161,6 +161,25 @@ export function _unregisterAll() {
   Object.keys(_triggerStore).forEach(appId => delete _triggerStore[appId]);
 }
 
+export function toJSONwithObjects(object) {
+  if (!object || !object.toJSON) {
+    return {};
+  }
+  const toJSON = object.toJSON();
+  for (const key of Object.keys(toJSON)) {
+    const val = toJSON[key];
+    if (!val || !val.__type || val.__type !== 'Pointer') {
+      continue;
+    }
+    const pointer = object.get(key);
+    const json = pointer.toJSON();
+    json.className = pointer.className;
+    json.__type = 'Object';
+    toJSON[key] = json;
+  }
+  return toJSON;
+}
+
 export function getTrigger(className, triggerType, applicationId) {
   if (!applicationId) {
     throw 'Missing ApplicationID';
@@ -316,7 +335,7 @@ export function getResponseObject(request, resolve, reject) {
           response = request.objects;
         }
         response = response.map(object => {
-          return object.toJSON();
+          return toJSONwithObjects(object);
         });
         return resolve(response);
       }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7310

### Approach
<!-- Add a description of the approach in this PR. -->

Closes #7310 by expanding pointers that are set via afterFind.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...