### PR TITLE
Use Node.js 15.13.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 15.12.0
+            NODE_VERSION: 15.13.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             POSTGRES_IMAGE: postgis/postgis:13-3.1
       fail-fast: false
     name: ${{ matrix.name }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-18.04
     services:
       redis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             POSTGRES_IMAGE: postgis/postgis:13-3.1
       fail-fast: false
     name: ${{ matrix.name }}
-    timeout-minutes: 30
+    timeout-minutes: 15
     runs-on: ubuntu-18.04
     services:
       redis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             POSTGRES_IMAGE: postgis/postgis:13-3.1
       fail-fast: false
     name: ${{ matrix.name }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-18.04
     services:
       redis:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ ___
 - Improve data consistency in Push and Job Status update (Diamond Lewis) [#7267](https://github.com/parse-community/parse-server/pull/7267)
 - Excluding keys that have trailing edges.node when performing GraphQL resolver (Chris Bland) [#7273](https://github.com/parse-community/parse-server/pull/7273)
 - Added centralized feature deprecation with standardized warning logs (Manuel Trezza) [#7303](https://github.com/parse-community/parse-server/pull/7303)
+- Use Node.js 15.13.0 in CI (Olle Jonsson) [#7312](https://github.com/parse-community/parse-server/pull/7312)
 ___
 ## 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 | Node.js 10 | 10.24.0              | April 2021       | ✅ Fully compatible |
 | Node.js 12 | 12.22.0              | April 2022       | ✅ Fully compatible |
 | Node.js 14 | 14.16.0              | April 2023       | ✅ Fully compatible |
-| Node.js 15 | 15.12.0              | June 2021        | ✅ Fully compatible |
+| Node.js 15 | 15.13.0              | June 2021        | ✅ Fully compatible |
 
 #### MongoDB
 Parse Server is continuously tested with the most recent releases of MongoDB to ensure compatibility. We follow the [MongoDB support schedule](https://www.mongodb.com/support-policy) and only test against versions that are officially supported and have not reached their end-of-life date.


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

This fixes a warning in the CI Self-Check

```
❌ CI environment 'Node 15' uses an old Node.js minor version 15.12.0 instead of 15.13.0.
❌ CI does not have environments using the following versions of Node.js: 15.13.0.
Error: CI environments are not up-to-date with the latest Node.js versions.
```


### Approach

Followed an old update to the CI and imitated it.

