### PR TITLE
Remove Node 10 support (EOL)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
     "presets": [
         ["@babel/preset-env", {
             "targets": {
-                "node": "8"
+                "node": "12"
             }
         }]
     ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - '**'
 env:
   COVERAGE_OPTION: ./node_modules/.bin/nyc
-  NODE_VERSION: 10
+  NODE_VERSION: 14.16.0
   PARSE_SERVER_TEST_TIMEOUT: 20000
 jobs:
   check-ci:
@@ -82,11 +82,6 @@ jobs:
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 14.16.0
-          - name: Node 10
-            MONGODB_VERSION: 4.4.4
-            MONGODB_TOPOLOGY: standalone
-            MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 10.24.0
           - name: Node 12
             MONGODB_VERSION: 4.4.4
             MONGODB_TOPOLOGY: standalone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ ___
 - Added Parse Server Security Check to report weak security settings (Manuel Trezza, dblythy) [#7247](https://github.com/parse-community/parse-server/issues/7247)
 - EXPERIMENTAL: Added new page router with placeholder rendering and localization of custom and feature pages such as password reset and email verification (Manuel Trezza) [#6891](https://github.com/parse-community/parse-server/issues/6891)
 - EXPERIMENTAL: Added custom routes to easily customize flows for password reset, email verification or build entirely new flows (Manuel Trezza) [#7231](https://github.com/parse-community/parse-server/issues/7231)
+- Remove support for Node 10 which has reached its End-of-Life support date (Manuel Trezza) [#7314](https://github.com/parse-community/parse-server/pull/7314)
 ### Other Changes
 - Fix error when a not yet inserted job is updated (Antonio Davi Macedo Coelho de Castro) [#7196](https://github.com/parse-community/parse-server/pull/7196)
 - request.context for afterFind triggers (dblythy) [#7078](https://github.com/parse-community/parse-server/pull/7078)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <a href="https://www.npmjs.com/package/parse-server"><img alt="npm version" src="https://img.shields.io/npm/v/parse-server.svg?style=flat"></a>
     <a href="https://community.parseplatform.org/"><img alt="Join the conversation" src="https://img.shields.io/discourse/https/community.parseplatform.org/topics.svg"></a>
     <a href="https://snyk.io/test/github/parse-community/parse-server"><img alt="Snyk badge" src="https://snyk.io/test/github/parse-community/parse-server/badge.svg"></a>
-    <a href="https://nodejs.org/"><img alt="Node.js 10,12,14,15" src="https://img.shields.io/badge/nodejs-10,_12,_14,_15-green.svg?logo=node.js&style=flat"></a>
+    <a href="https://nodejs.org/"><img alt="Node.js 12,14,15" src="https://img.shields.io/badge/nodejs-12,_14,_15-green.svg?logo=node.js&style=flat"></a>
     <a href="https://www.mongodb.com/"><img alt="MongoDB 3.6,4.0,4.2,4.4" src="https://img.shields.io/badge/mongodb-3.6,_4.0,_4.2,_4.4-green.svg?logo=mongodb&style=flat"></a>
    <a href="https://www.postgresql.org"> <img alt="PostgreSQL 10,11,12,13" src="https://img.shields.io/badge/postgresql-10,_11,_12,_13-green.svg?logo=postgresql&style=flat"></a>
 </p>
@@ -112,7 +112,6 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Patch Version | End-of-Life Date | Compatibility      |
 |------------|----------------------|------------------|--------------------|
-| Node.js 10 | 10.24.0              | April 2021       | ✅ Fully compatible |
 | Node.js 12 | 12.22.0              | April 2022       | ✅ Fully compatible |
 | Node.js 14 | 14.16.0              | April 2023       | ✅ Fully compatible |
 | Node.js 15 | 15.13.0              | June 2021        | ✅ Fully compatible |

--- a/resources/ci/ciCheck.js
+++ b/resources/ci/ciCheck.js
@@ -59,8 +59,7 @@ async function checkNodeVersions() {
     releasedVersions,
     latestComponent: CiVersionCheck.versionComponents.minor,
     ignoreReleasedVersions: [
-      '<10.0.0', // These versions have reached their end-of-life support date
-      '>=11.0.0 <12.0.0', // These versions have reached their end-of-life support date
+      '<12.0.0', // These versions have reached their end-of-life support date
       '>=13.0.0 <14.0.0', // These versions have reached their end-of-life support date
       '>=16.0.0', // This version has not been officially released yet
     ],


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Node 10 reached its EOL support date in April 2021.

Related issue: (n/a, meta)

### Approach
Node 10 is removed from official Parse Server support.
This reduces the number of CI test by 1.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)