### PR TITLE
Remove MongoDB 3.6 support (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 14.16.0
-          - name: Mongo 3.6, Standalone, MMAPv1
-            MONGODB_VERSION: 3.6.23
+          - name: Mongo 4.0, Standalone, MMAPv1
+            MONGODB_VERSION: 4.0.23
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: mmapv1
             NODE_VERSION: 14.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ ___
 - Added Parse Server Security Check to report weak security settings (Manuel Trezza, dblythy) [#7247](https://github.com/parse-community/parse-server/issues/7247)
 - EXPERIMENTAL: Added new page router with placeholder rendering and localization of custom and feature pages such as password reset and email verification (Manuel Trezza) [#6891](https://github.com/parse-community/parse-server/issues/6891)
 - EXPERIMENTAL: Added custom routes to easily customize flows for password reset, email verification or build entirely new flows (Manuel Trezza) [#7231](https://github.com/parse-community/parse-server/issues/7231)
+- Remove support for MongoDB 3.6 which has reached its End-of-Life support date (Manuel Trezza) [#7315](https://github.com/parse-community/parse-server/pull/7315)
 ### Other Changes
 - Fix error when a not yet inserted job is updated (Antonio Davi Macedo Coelho de Castro) [#7196](https://github.com/parse-community/parse-server/pull/7196)
 - request.context for afterFind triggers (dblythy) [#7078](https://github.com/parse-community/parse-server/pull/7078)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <a href="https://community.parseplatform.org/"><img alt="Join the conversation" src="https://img.shields.io/discourse/https/community.parseplatform.org/topics.svg"></a>
     <a href="https://snyk.io/test/github/parse-community/parse-server"><img alt="Snyk badge" src="https://snyk.io/test/github/parse-community/parse-server/badge.svg"></a>
     <a href="https://nodejs.org/"><img alt="Node.js 10,12,14,15" src="https://img.shields.io/badge/nodejs-10,_12,_14,_15-green.svg?logo=node.js&style=flat"></a>
-    <a href="https://www.mongodb.com/"><img alt="MongoDB 3.6,4.0,4.2,4.4" src="https://img.shields.io/badge/mongodb-3.6,_4.0,_4.2,_4.4-green.svg?logo=mongodb&style=flat"></a>
+    <a href="https://www.mongodb.com/"><img alt="MongoDB 4.0,4.2,4.4" src="https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4-green.svg?logo=mongodb&style=flat"></a>
    <a href="https://www.postgresql.org"> <img alt="PostgreSQL 10,11,12,13" src="https://img.shields.io/badge/postgresql-10,_11,_12,_13-green.svg?logo=postgresql&style=flat"></a>
 </p>
 
@@ -122,7 +122,6 @@ Parse Server is continuously tested with the most recent releases of MongoDB to 
 
 | Version     | Latest Patch Version | End-of-Life Date | Compatibility      |
 |-------------|----------------------|------------------|--------------------|
-| MongoDB 3.6 | 3.6.23               | April 2021       | ✅ Fully compatible |
 | MongoDB 4.0 | 4.0.23               | January 2022     | ✅ Fully compatible |
 | MongoDB 4.2 | 4.2.13               | TBD              | ✅ Fully compatible |
 | MongoDB 4.4 | 4.4.4                | TBD              | ✅ Fully compatible |

--- a/resources/ci/ciCheck.js
+++ b/resources/ci/ciCheck.js
@@ -33,8 +33,7 @@ async function checkMongoDbVersions() {
     releasedVersions,
     latestComponent: CiVersionCheck.versionComponents.path,
     ignoreReleasedVersions: [
-      '<3.6.0', // These versions have reached their MongoDB end-of-life support date
-      '~3.7.0', // This is a development release according to MongoDB support
+      '<4.0.0', // These versions have reached their MongoDB end-of-life support date
       '~4.1.0', // This is a development release according to MongoDB support
       '~4.3.0', // This is a development release according to MongoDB support
       '~4.7.0', // This is a development release according to MongoDB support


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
MongoDB 3.6 reached its EOL support date in April 2021.

Related issue: (n/a, meta)

### Approach
MongoDB 3.6 support is removed from official Parse Server support.

This does not reduce the number of CI tests, because it was the only test with MMAPv1 engine and standalone topology. Consequently, that test now runs with MongoDB 4.0.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)