### PR TITLE
Improve default User Security

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -13,20 +13,6 @@ const passwordCrypto = require('../lib/password');
 const Config = require('../lib/Config');
 const cryptoUtils = require('../lib/cryptoUtils');
 
-function verifyACL(user) {
-  const ACL = user.getACL();
-  expect(ACL.getReadAccess(user)).toBe(true);
-  expect(ACL.getWriteAccess(user)).toBe(true);
-  expect(ACL.getPublicReadAccess()).toBe(true);
-  expect(ACL.getPublicWriteAccess()).toBe(false);
-  const perms = ACL.permissionsById;
-  expect(Object.keys(perms).length).toBe(2);
-  expect(perms[user.id].read).toBe(true);
-  expect(perms[user.id].write).toBe(true);
-  expect(perms['*'].read).toBe(true);
-  expect(perms['*'].write).not.toBe(true);
-}
-
 describe('Parse.User testing', () => {
   it('user sign up class method', async done => {
     const user = await Parse.User.signUp('asdf', 'zxcv');
@@ -146,7 +132,17 @@ describe('Parse.User testing', () => {
     await Parse.User.signUp('asdf', 'zxcv');
     const user = await Parse.User.logIn('asdf', 'zxcv');
     equal(user.get('username'), 'asdf');
-    verifyACL(user);
+    const ACL = user.getACL();
+    expect(ACL.getReadAccess(user)).toBe(true);
+    expect(ACL.getWriteAccess(user)).toBe(true);
+    expect(ACL.getPublicReadAccess()).toBe(true);
+    expect(ACL.getPublicWriteAccess()).toBe(false);
+    const perms = ACL.permissionsById;
+    expect(Object.keys(perms).length).toBe(2);
+    expect(perms[user.id].read).toBe(true);
+    expect(perms[user.id].write).toBe(true);
+    expect(perms['*'].read).toBe(true);
+    expect(perms['*'].write).not.toBe(true);
     done();
   });
 
@@ -3928,6 +3924,35 @@ describe('Parse.User testing', () => {
     } catch (e) {
       expect(e.code).toBe(Parse.Error.SESSION_MISSING);
     }
+  });
+
+  it('should throw when enforcePrivateUsers is invalid', async () => {
+    try {
+      await reconfigureServer({
+        enforcePrivateUsers: [],
+      });
+      fail();
+    } catch (err) {
+      expect(err).toEqual('enforcePrivateUsers must be a boolean value');
+    }
+  });
+
+  it('user login with enforcePrivateUsers', async done => {
+    await reconfigureServer({ enforcePrivateUsers: true });
+    await Parse.User.signUp('asdf', 'zxcv');
+    const user = await Parse.User.logIn('asdf', 'zxcv');
+    equal(user.get('username'), 'asdf');
+    const ACL = user.getACL();
+    expect(ACL.getReadAccess(user)).toBe(true);
+    expect(ACL.getWriteAccess(user)).toBe(true);
+    expect(ACL.getPublicReadAccess()).toBe(false);
+    expect(ACL.getPublicWriteAccess()).toBe(false);
+    const perms = ACL.permissionsById;
+    expect(Object.keys(perms).length).toBe(1);
+    expect(perms[user.id].read).toBe(true);
+    expect(perms[user.id].write).toBe(true);
+    expect(perms['*']).toBeUndefined();
+    done();
   });
 
   describe('issue #4897', () => {

--- a/src/Config.js
+++ b/src/Config.js
@@ -75,6 +75,7 @@ export class Config {
     fileUpload,
     pages,
     security,
+    enforcePrivateUsers,
   }) {
     if (masterKey === readOnlyMasterKey) {
       throw new Error('masterKey and readOnlyMasterKey should be different');
@@ -111,6 +112,10 @@ export class Config {
     this.validateIdempotencyOptions(idempotencyOptions);
     this.validatePagesOptions(pages);
     this.validateSecurityOptions(security);
+
+    if (typeof enforcePrivateUsers !== 'boolean') {
+      throw 'enforcePrivateUsers must be a boolean value';
+    }
   }
 
   static validateSecurityOptions(security) {

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -11,4 +11,4 @@
  *
  * If there are no deprecations this must return an empty array anyway.
  */
-module.exports = [];
+module.exports = [{ optionKey: 'enforcePrivateUsers', changeNewDefault: true }];

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -153,6 +153,13 @@ module.exports.ParseServerOptions = {
     env: 'PARSE_SERVER_ENCRYPTION_KEY',
     help: 'Key for encrypting your files',
   },
+  enforcePrivateUsers: {
+    env: 'PARSE_SERVER_ENFORCE_PRIVATE_USERS',
+    help:
+      'Is true if Parse Server should set public read and write access on new Parse.Users to false',
+    action: parsers.booleanParser,
+    default: false,
+  },
   expireInactiveSessions: {
     env: 'PARSE_SERVER_EXPIRE_INACTIVE_SESSIONS',
     help: 'Sets wether we should expire the inactive sessions, defaults to true',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -28,6 +28,7 @@
  * @property {Boolean} enableAnonymousUsers Enable (or disable) anonymous users, defaults to true
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
  * @property {String} encryptionKey Key for encrypting your files
+ * @property {Boolean} enforcePrivateUsers Is true if Parse Server should set public read and write access on new Parse.Users to false
  * @property {Boolean} expireInactiveSessions Sets wether we should expire the inactive sessions, defaults to true
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -226,6 +226,10 @@ export interface ParseServerOptions {
   /* The security options to identify and report weak security settings.
   :DEFAULT: {} */
   security: ?SecurityOptions;
+  /* Is true if Parse Server should set public read and write access on new Parse.Users to false
+  :ENV: PARSE_SERVER_ENFORCE_PRIVATE_USERS
+  :DEFAULT: false */
+  enforcePrivateUsers: ?boolean;
 }
 
 export interface SecurityOptions {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1374,7 +1374,9 @@ RestWrite.prototype.runDatabaseOperation = function () {
       // default public r/w ACL
       if (!ACL) {
         ACL = {};
-        ACL['*'] = { read: true, write: false };
+        if (!this.config.enforcePrivateUsers) {
+          ACL['*'] = { read: true, write: false };
+        }
       }
       // make sure the user is not locked down
       ACL[this.data.objectId] = { read: true, write: true };

--- a/src/Security/CheckGroups/CheckGroupServerConfig.js
+++ b/src/Security/CheckGroups/CheckGroupServerConfig.js
@@ -8,9 +8,9 @@ import Config from '../../Config';
 import Parse from 'parse/node';
 
 /**
-* The security checks group for Parse Server configuration.
-* Checks common Parse Server parameters such as access keys.
-*/
+ * The security checks group for Parse Server configuration.
+ * Checks common Parse Server parameters such as access keys.
+ */
 class CheckGroupServerConfig extends CheckGroup {
   setName() {
     return 'Parse Server Configuration';
@@ -21,7 +21,8 @@ class CheckGroupServerConfig extends CheckGroup {
       new Check({
         title: 'Secure master key',
         warning: 'The Parse Server master key is insecure and vulnerable to brute force attacks.',
-        solution: 'Choose a longer and/or more complex master key with a combination of upper- and lowercase characters, numbers and special characters.',
+        solution:
+          'Choose a longer and/or more complex master key with a combination of upper- and lowercase characters, numbers and special characters.',
         check: () => {
           const masterKey = config.masterKey;
           const hasUpperCase = /[A-Z]/.test(masterKey);
@@ -41,7 +42,7 @@ class CheckGroupServerConfig extends CheckGroup {
       new Check({
         title: 'Security log disabled',
         warning: 'Security checks in logs may expose vulnerabilities to anyone access to logs.',
-        solution: 'Change Parse Server configuration to \'security.enableCheckLog: false\'.',
+        solution: "Change Parse Server configuration to 'security.enableCheckLog: false'.",
         check: () => {
           if (config.security && config.security.enableCheckLog) {
             throw 1;
@@ -50,10 +51,21 @@ class CheckGroupServerConfig extends CheckGroup {
       }),
       new Check({
         title: 'Client class creation disabled',
-        warning: 'Attackers are allowed to create new classes without restriction and flood the database.',
-        solution: 'Change Parse Server configuration to \'allowClientClassCreation: false\'.',
+        warning:
+          'Attackers are allowed to create new classes without restriction and flood the database.',
+        solution: "Change Parse Server configuration to 'allowClientClassCreation: false'.",
         check: () => {
           if (config.allowClientClassCreation || config.allowClientClassCreation == null) {
+            throw 1;
+          }
+        },
+      }),
+      new Check({
+        title: 'Public Users on signup',
+        warning: 'Users will be publicly readable on signup.',
+        solution: "Change Parse Server configuration to 'enforcePrivateUsers: true'.",
+        check: () => {
+          if (!config.enforcePrivateUsers) {
             throw 1;
           }
         },


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Improves default user security by adding `enforcePrivateUsers` that removes the default public read option on signup.

Related issue: #7292

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)