### PR TITLE
Add lock file version check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build docker image
         uses: docker/build-push-action@v2
+  check-lock-file-version:
+    name: NPM Lock File Version
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mansona/npm-lockfile-version@v1
+        with:
+          version: 1
   check-mongo:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,11 @@ jobs:
   check-lock-file-version:
     name: NPM Lock File Version
     timeout-minutes: 5
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: mansona/npm-lockfile-version@v1
+      - name: Check NPM lock file version
+        uses: mansona/npm-lockfile-version@v1
         with:
           version: 1
   check-mongo:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ ___
 - Use Node.js 15.13.0 in CI (Olle Jonsson) [#7312](https://github.com/parse-community/parse-server/pull/7312)
 - Fix file upload issue for S3 compatible storage (Linode, DigitalOcean) by avoiding empty tags property when creating a file (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
 - Add building Docker image as CI check (Manuel Trezza) [#7332](https://github.com/parse-community/parse-server/pull/7332)
+- Add NPM package-lock version check to CI (Manuel Trezza) [#7333](https://github.com/parse-community/parse-server/pull/7333)
 ___
 ## 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "parse-server",
   "version": "4.5.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "dependencies": {
     "@actions/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "parse-server",
   "version": "4.5.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@actions/core": {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Ci does not check NPM lock file version; from NPM 7 onwards the version changed.

Related issue: closes #7326

### Approach
Adds lock file version check to CI.

### TODOs before merging
none