### PR TITLE
Fix #7340 by correclty computing function name for push event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ ___
 - Fix file upload issue for S3 compatible storage (Linode, DigitalOcean) by avoiding empty tags property when creating a file (Ali Oguzhan Yildiz) [#7300](https://github.com/parse-community/parse-server/pull/7300)
 - Add building Docker image as CI check (Manuel Trezza) [#7332](https://github.com/parse-community/parse-server/pull/7332)
 - Add NPM package-lock version check to CI (Manuel Trezza) [#7333](https://github.com/parse-community/parse-server/pull/7333)
+- Fix incorrect LiveQuery events triggered for multiple subscriptions on the same class with different events [#7341](https://github.com/parse-community/parse-server/pull/7341)
 ___
 ## 4.5.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.4.0...4.5.0)

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -515,3 +515,5 @@ jasmine.restoreLibrary = function (library, name) {
   }
   require(library)[name] = libraryCache[library][name];
 };
+
+jasmine.timeout = t => new Promise(resolve => setTimeout(resolve, t));

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -298,7 +298,6 @@ class ParseLiveQueryServer {
             } else {
               return null;
             }
-            message.event = type;
             res = {
               event: type,
               sessionToken: client.sessionToken,
@@ -334,8 +333,7 @@ class ParseLiveQueryServer {
               originalParseObject = res.original.toJSON();
               originalParseObject.className = res.original.className || className;
             }
-            const functionName =
-              'push' + message.event.charAt(0).toUpperCase() + message.event.slice(1);
+            const functionName = 'push' + res.event.charAt(0).toUpperCase() + res.event.slice(1);
             if (client[functionName]) {
               client[functionName](requestId, currentParseObject, originalParseObject);
             }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7340 

### Approach
<!-- Add a description of the approach in this PR. -->
First create a failing test to demonstrate the issue described by #7340. Then simply replace the update of the argument `message` by the use of the newly created `res` object.


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog