### PR TITLE
More specific error codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6931,9 +6931,9 @@
       }
     },
     "idb-keyval": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.2.tgz",
-      "integrity": "sha512-1DYjY/nX2U9pkTkwFoAmKcK1ZWmkNgO32Oon9tp/9+HURizxUQ4fZRxMJZs093SldP7q6dotVj03kIkiqOILyA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.4.tgz",
+      "integrity": "sha512-qS0kplHuadZujoE90ze0NUkhW0/Fbfib7d+mYNMXNEn45NSh2NWY3fBewoX4GZUsKkGHBgc8JiAwMx0zrfL3LQ=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -10020,32 +10020,23 @@
       }
     },
     "parse": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-3.1.0.tgz",
-      "integrity": "sha512-oUDTiH2F9sRX1a+jvLTb/sJMBea6wIv3dUK/mTDJHw1lOA+r008B6ybjYCfqPu4/2CrSt1Hfe4mJNoa4Ic4dyg==",
+      "version": "github:parse-community/Parse-SDK-JS#52cd8d47fb3f9d42a9fea3b7feb7f02a309d40b9",
+      "from": "github:parse-community/Parse-SDK-JS#52cd8d47fb3f9d42a9fea3b7feb7f02a309d40b9",
       "requires": {
-        "@babel/runtime": "7.12.5",
-        "@babel/runtime-corejs3": "7.12.5",
+        "@babel/runtime": "7.13.10",
+        "@babel/runtime-corejs3": "7.13.10",
         "crypto-js": "4.0.0",
-        "idb-keyval": "5.0.2",
+        "idb-keyval": "5.0.4",
         "react-native-crypto-js": "1.0.0",
         "uuid": "3.4.0",
-        "ws": "7.4.3",
+        "ws": "7.4.4",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "@babel/runtime-corejs3": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-          "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+          "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
           "requires": {
             "core-js-pure": "^3.0.0",
             "regenerator-runtime": "^0.13.4"
@@ -10055,11 +10046,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime": "2.5.2",
     "mongodb": "3.6.6",
     "mustache": "4.1.0",
-    "parse": "3.1.0",
+    "parse": "github:parse-community/Parse-SDK-JS#52cd8d47fb3f9d42a9fea3b7feb7f02a309d40b9",
     "pg-monitor": "1.4.1",
     "pg-promise": "10.9.2",
     "pluralize": "8.0.0",

--- a/spec/ParseGeoPoint.spec.js
+++ b/spec/ParseGeoPoint.spec.js
@@ -554,7 +554,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.data.code).toEqual(1);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_VALUE);
         done();
       });
   });
@@ -588,7 +588,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INCORRECT_TYPE);
         done();
       });
   });
@@ -622,7 +622,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.data.code).toEqual(Parse.Error.INVALID_JSON);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_VALUE);
         done();
       });
   });
@@ -660,7 +660,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.data.code).toEqual(1);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_VALUE);
         done();
       });
   });
@@ -698,7 +698,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.data.code).toEqual(1);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_VALUE);
         done();
       });
   });
@@ -732,7 +732,7 @@ describe('Parse.GeoPoint testing', () => {
         done();
       })
       .catch(err => {
-        expect(err.data.code).toEqual(107);
+        expect(err.data.code).toEqual(Parse.Error.INVALID_VALUE);
         done();
       });
   });

--- a/spec/ParsePolygon.spec.js
+++ b/spec/ParsePolygon.spec.js
@@ -156,7 +156,10 @@ describe('Parse.Polygon testing', () => {
         const query = new Parse.Query(TestObject);
         return query.get(obj.id);
       })
-      .then(done.fail, () => done());
+      .then(done.fail, e => {
+        expect(e.code).toBe(Parse.Error.INVALID_VALUE);
+        done();
+      });
   });
 
   it('polygon three points minimum', done => {
@@ -164,7 +167,10 @@ describe('Parse.Polygon testing', () => {
     const obj = new TestObject();
     // use raw so we test the server validates properly
     obj.set('polygon', { __type: 'Polygon', coordinates: coords });
-    obj.save().then(done.fail, () => done());
+    obj.save().then(done.fail, e => {
+      expect(e.code).toBe(Parse.Error.INVALID_VALUE);
+      done();
+    });
   });
 
   it('polygon three different points minimum', done => {
@@ -175,7 +181,10 @@ describe('Parse.Polygon testing', () => {
     ];
     const obj = new TestObject();
     obj.set('polygon', new Parse.Polygon(coords));
-    obj.save().then(done.fail, () => done());
+    obj.save().then(done.fail, e => {
+      expect(e.code).toBe(Parse.Error.INVALID_VALUE);
+      done();
+    });
   });
 
   it('polygon counterclockwise', done => {
@@ -384,10 +393,15 @@ describe('Parse.Polygon testing', () => {
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
-        .then(done.fail, () => done());
+        .then(done.fail, e => {
+          e = JSON.parse(e.text);
+          expect(e.code).toBe(Parse.Error.INVALID_VALUE);
+          done();
+        });
     });
 
     it('polygonContain invalid geoPoint', done => {
@@ -416,10 +430,15 @@ describe('Parse.Polygon testing', () => {
             headers: {
               'X-Parse-Application-Id': Parse.applicationId,
               'X-Parse-Javascript-Key': Parse.javaScriptKey,
+              'Content-Type': 'application/json',
             },
           });
         })
-        .then(done.fail, () => done());
+        .then(done.fail, e => {
+          e = JSON.parse(e.text);
+          expect(e.code).toBe(Parse.Error.INVALID_VALUE);
+          done();
+        });
     });
   });
 });
@@ -532,6 +551,9 @@ describe_only_db('mongo')('Parse.Polygon testing', () => {
     ];
     const obj = new TestObject();
     obj.set('polygon', new Parse.Polygon(coords));
-    obj.save().then(done.fail, () => done());
+    obj.save().then(done.fail, e => {
+      expect(e.code).toBe(Parse.Error.INVALID_VALUE);
+      done();
+    });
   });
 });

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -472,6 +472,11 @@ export class MongoStorageAdapter implements StorageAdapter {
             }
           }
           throw err;
+        } else if (error.code === 16755 || error.code === 16756) {
+          // Can't extract geo keys
+          const err = new Parse.Error(Parse.Error.INVALID_VALUE, error.message);
+          err.underlyingError = error;
+          throw err;
         }
         throw error;
       })

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -29,7 +29,13 @@ export class ClassesRouter extends PromiseRouter {
       options.redirectClassNameForKey = String(body.redirectClassNameForKey);
     }
     if (typeof body.where === 'string') {
-      body.where = JSON.parse(body.where);
+      try {
+        body.where = JSON.parse(body.where);
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          throw new Parse.Error(Parse.Error.INVALID_JSON, "'where' constraint is not valid JSON");
+        } else throw e;
+      }
     }
     return rest
       .find(


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This PR makes certain error paths produce more specific error codes (e.g., `INVALID_VALUE` instead of `INVALID_JSON`, `INVALID_JSON` instead of `INTERNAL_SERVER_ERROR`)
It also fixes some unit tests, which previously did not test what they were meant to test.

Related issue: #7331 

### Approach
<!-- Add a description of the approach in this PR. -->
Error codes were made more specific where possible.
Geojson errors produced by Mongo are passed-through as `Parse.Error.INVALID_VALUE`, instead of causing `INTERNAL_SERVER_ERROR`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ x ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ x ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] Depend on a release of the js sdk, instead of a commit hash.