### PR TITLE
Forward Mongo geojson errors as Parse.Error.INVALID_VALUE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6931,9 +6931,9 @@
       }
     },
     "idb-keyval": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.2.tgz",
-      "integrity": "sha512-1DYjY/nX2U9pkTkwFoAmKcK1ZWmkNgO32Oon9tp/9+HURizxUQ4fZRxMJZs093SldP7q6dotVj03kIkiqOILyA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.4.tgz",
+      "integrity": "sha512-qS0kplHuadZujoE90ze0NUkhW0/Fbfib7d+mYNMXNEn45NSh2NWY3fBewoX4GZUsKkGHBgc8JiAwMx0zrfL3LQ=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -10020,32 +10020,23 @@
       }
     },
     "parse": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-3.1.0.tgz",
-      "integrity": "sha512-oUDTiH2F9sRX1a+jvLTb/sJMBea6wIv3dUK/mTDJHw1lOA+r008B6ybjYCfqPu4/2CrSt1Hfe4mJNoa4Ic4dyg==",
+      "version": "github:parse-community/Parse-SDK-JS#52cd8d47fb3f9d42a9fea3b7feb7f02a309d40b9",
+      "from": "github:parse-community/Parse-SDK-JS#52cd8d47fb3f9d42a9fea3b7feb7f02a309d40b9",
       "requires": {
-        "@babel/runtime": "7.12.5",
-        "@babel/runtime-corejs3": "7.12.5",
+        "@babel/runtime": "7.13.10",
+        "@babel/runtime-corejs3": "7.13.10",
         "crypto-js": "4.0.0",
-        "idb-keyval": "5.0.2",
+        "idb-keyval": "5.0.4",
         "react-native-crypto-js": "1.0.0",
         "uuid": "3.4.0",
-        "ws": "7.4.3",
+        "ws": "7.4.4",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "@babel/runtime-corejs3": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-          "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz",
+          "integrity": "sha512-x/XYVQ1h684pp1mJwOV4CyvqZXqbc8CMsMGUnAbuc82ZCdv1U63w5RSUzgDSXQHG5Rps/kiksH6g2D5BuaKyXg==",
           "requires": {
             "core-js-pure": "^3.0.0",
             "regenerator-runtime": "^0.13.4"
@@ -10055,11 +10046,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime": "2.5.2",
     "mongodb": "3.6.6",
     "mustache": "4.1.0",
-    "parse": "3.1.0",
+    "parse": "github:parse-community/Parse-SDK-JS#52cd8d47fb3f9d42a9fea3b7feb7f02a309d40b9",
     "pg-monitor": "1.4.1",
     "pg-promise": "10.9.2",
     "pluralize": "8.0.0",

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -24,6 +24,27 @@ const headers = {
 };
 
 describe_only_db('mongo')('miscellaneous', () => {
+  beforeEach(async () => {
+    await TestUtils.destroyAllDataPermanently(false);
+  });
+
+  it('invalid geometry on spatially indexed field fails', async () => {
+    const testSchema = new Parse.Schema('geojson_test');
+    testSchema.addObject('geometry');
+    testSchema.addIndex('geospatial_index', {
+      geometry: '2dsphere',
+    });
+    await testSchema.save();
+
+    const obj = new Parse.Object('geojson_test');
+    obj.set('geometry', { foo: 'bar' });
+    try {
+      await obj.save();
+      fail('Invalid geometry did not fail');
+    } catch (e) {
+      expect(e.code).toEqual(Parse.Error.INVALID_VALUE);
+    }
+  });
   it('db contains document after successful save', async () => {
     const obj = new Parse.Object('TestObject');
     obj.set('foo', 'bar');

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -472,6 +472,11 @@ export class MongoStorageAdapter implements StorageAdapter {
             }
           }
           throw err;
+        } else if (error.code === 16755 || error.code === 16756) {
+          // Can't extract geo keys
+          const err = new Parse.Error(Parse.Error.INVALID_VALUE, error.message);
+          err.underlyingError = error;
+          throw err;
         }
         throw error;
       })


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Creating an object in a collection with a spatially indexed field fails if that field of the new object does not contain valid geometry. This is not handled by Parse, causing an INTERNAL_SERVER_ERROR that makes it difficult to diagnose invalid geojsons.

Related issue: #7331

### Approach
<!-- Add a description of the approach in this PR. -->
Geojson errors produced by Mongo are cought and turned into Parse errors.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ x ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ x ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] Depend on a release of the js sdk, instead of a commit hash.