### PR TITLE
Support wildcard classname in cloud triggers

### DIFF
--- a/src/triggers.js
+++ b/src/triggers.js
@@ -165,7 +165,11 @@ export function getTrigger(className, triggerType, applicationId) {
   if (!applicationId) {
     throw 'Missing ApplicationID';
   }
-  return get(Category.Triggers, `${triggerType}.${className}`, applicationId);
+  const trigger = get(Category.Triggers, `${triggerType}.${className}`, applicationId);
+  if (trigger) {
+    return trigger;
+  }
+  return get(Category.Triggers, `${triggerType}.*`, applicationId);
 }
 
 export async function runTrigger(trigger, name, request, auth) {


### PR DESCRIPTION
### Issue Description
This pull request solves this problem
https://community.parseplatform.org/t/support-wildcard-classname-in-cloud-triggers/1584


### Approach
If user set trigger for class "*", that trigger will be called for every class unless class has its own trigger.

### TODOs before merging

- [ ] Add test cases
