### PR TITLE
Allow modify object key without addField permission

### DIFF
--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1779,6 +1779,34 @@ describe('schemas', () => {
     });
   });
 
+  describe('Nested documents', () => {
+    beforeAll(async () => {
+      const testSchema = new Parse.Schema('test_7371');
+      testSchema.setCLP({
+        create: { ['*']: true },
+        update: { ['*']: true },
+        addField: {},
+      });
+      testSchema.addObject('a');
+      await testSchema.save();
+    });
+
+    it('addField not required for adding a nested field (#7371)', async () => {
+      const obj = new Parse.Object('test_7371');
+      obj.set('a', {});
+      await obj.save();
+      obj.set('a.b', 2);
+      await obj.save();
+    });
+    it('addField not required for modifying a nested field (#7371)', async () => {
+      const obj = new Parse.Object('test_7371');
+      obj.set('a', { b: 1 });
+      await obj.save();
+      obj.set('a.b', 2);
+      await obj.save();
+    });
+  });
+
   it('should aceept class-level permission with userid of any length', async done => {
     await global.reconfigureServer({
       customIdSize: 11,

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -894,7 +894,7 @@ class DatabaseController {
       if (object[field] && object[field].__op && object[field].__op === 'Delete') {
         return false;
       }
-      return schemaFields.indexOf(field) < 0;
+      return schemaFields.indexOf(getRootFieldName(field)) < 0;
     });
     if (newKeys.length > 0) {
       // adds a marker that new field is being adding during update


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Modification on nested documents currently require the addField permission.

Related issue: closes #7371 

### Approach
<!-- Add a description of the approach in this PR. -->
DatabaseController checks that the root field exists, so if, e.g., the field `a` exists, a modification on the embedded key `a.b` will not be considered to be creating a new field.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...