### PR TITLE
Add unique fields only capability to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Jump directly to a version:
 
 | 4.x               |
 |-------------------|
-| [**4.5.0 (latest release)**](#450) |
+| [**4.5.1 (latest release)**](#450) |
+| [4.5.0](#450) |
 | [4.4.0](#440)     |
 | [4.3.0](#430)     |
 | [4.2.0](#420)     |
@@ -103,6 +104,7 @@ ___
 - Added Deprecation Policy to govern the introduction of braking changes in a phased pattern that is more predictable for developers (Manuel Trezza) [#7199](https://github.com/parse-community/parse-server/pull/7199)
 ### Other Changes
 - Fix error when a not yet inserted job is updated (Antonio Davi Macedo Coelho de Castro) [#7196](https://github.com/parse-community/parse-server/pull/7196)
+- Fix error when a not yet inserted job is updated (Antonio Davi Macedo Coelho de Castro) [#7196](https://github.com/parse-community/parse-server/pull/7196)
 - request.context for afterFind triggers (dblythy) [#7078](https://github.com/parse-community/parse-server/pull/7078)
 - Winston Logger interpolating stdout to console (dplewis) [#7114](https://github.com/parse-community/parse-server/pull/7114)
 - Move graphql-tag from devDependencies to dependencies (Antonio Davi Macedo Coelho de Castro) [#7183](https://github.com/parse-community/parse-server/pull/7183)
@@ -137,6 +139,7 @@ ___
 ### Breaking Changes
 - FIX: Consistent casing for afterLiveQueryEvent. The afterLiveQueryEvent was introduced in 4.4.0 with inconsistent casing for the event names, which was fixed in 4.5.0. [#7023](https://github.com/parse-community/parse-server/pull/7023). Thanks to [dblythy](https://github.com/dblythy).
 ### Other Changes
+- IMPROVE: Create schema request serialisation. [#6059](https://github.com/parse-community/parse-server/issues/6059).
 - FIX: Properly handle serverURL and publicServerUrl in Batch requests. [#7049](https://github.com/parse-community/parse-server/pull/7049). Thanks to [Zach Goldberg](https://github.com/ZachGoldberg).
 - IMPROVE: Prevent invalid column names (className and length). [#7053](https://github.com/parse-community/parse-server/pull/7053). Thanks to [Diamond Lewis](https://github.com/dplewis).
 - IMPROVE: GraphQL: Remove viewer from logout mutation. [#7029](https://github.com/parse-community/parse-server/pull/7029). Thanks to [Antoine Cormouls](https://github.com/Moumouls).

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1710,6 +1710,109 @@ describe('miscellaneous', function () {
   });
 });
 
+describe('FilterOptions', () => {
+  it('Should reject default fields without filter options', done => {
+    const headers = {
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Master-Key': 'test',
+      'Content-Type': 'application/json',
+    };
+    request({
+      method: 'POST',
+      headers,
+      url: 'http://localhost:8378/1/schemas/MyObject',
+      json: true,
+      body: {
+        className: 'MyObject',
+        fields: {
+          objectId: {
+            type: 'String',
+          },
+          name: {
+            type: 'String',
+          },
+        },
+      },
+    })
+      .catch(e => {
+        expect(e.status).toEqual(400);
+      })
+      .then(() => done());
+  });
+
+  it('Should ignore default fields with body filter options', done => {
+    const headers = {
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Master-Key': 'test',
+      'Content-Type': 'application/json',
+    };
+    request({
+      method: 'POST',
+      headers,
+      url: 'http://localhost:8378/1/schemas/MyObject',
+      json: true,
+      body: {
+        options: {
+          ignoreDefaultFields: true,
+        },
+        className: 'MyObject',
+        fields: {
+          objectId: {
+            type: 'Number',
+          },
+          name: {
+            type: 'String',
+          },
+        },
+      },
+    })
+      .then(response => {
+        expect(response).toBeDefined();
+        expect(response.data.fields.objectId.type).not.toBe('Number');
+        expect(response.data.fields.objectId.type).toBe('String');
+        expect(response.data.fields.name.type).toBe('String');
+      })
+      .catch(e => expect(e).not.toBeDefined())
+      .then(() => done());
+  });
+
+  it('Should ignore default fields with query filter options', done => {
+    const headers = {
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Master-Key': 'test',
+      'Content-Type': 'application/json',
+    };
+    request({
+      method: 'POST',
+      headers,
+      url: 'http://localhost:8378/1/schemas/MyObject',
+      params: {
+        ignoreDefaultFields: true,
+      },
+      json: true,
+      body: {
+        className: 'MyObject',
+        fields: {
+          objectId: {
+            type: 'Number',
+          },
+          name: {
+            type: 'String',
+          },
+        },
+      },
+    })
+      .then(response => {
+        expect(response).toBeDefined();
+        expect(response.data.fields.objectId.type).not.toBe('Number');
+        expect(response.data.fields.objectId.type).toBe('String');
+        expect(response.data.fields.name.type).toBe('String');
+      })
+      .catch(e => expect(e).not.toBeDefined())
+      .then(() => done());
+  });
+});
+
 describe_only_db('mongo')('legacy _acl', () => {
   it('should have _acl when locking down (regression for #2465)', done => {
     const headers = {

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -30,6 +30,22 @@ import type {
   LoadSchemaOptions,
 } from './types';
 
+const filterOptions: Array<{ label: string, type: string }> = [
+  {
+    label: 'ignoreDefaultFields',
+    defaultValue: false,
+    do: fields => {
+      const newFields = {};
+      Object.keys(fields)?.map(field => {
+        if (Object.keys(defaultColumns._Default).includes(field) === false) {
+          newFields[field] = fields[field];
+        }
+      });
+      return newFields;
+    },
+  },
+];
+
 const defaultColumns: { [string]: SchemaFields } = Object.freeze({
   // Contain the default columns for every parse object type (except _Join collection)
   _Default: {
@@ -1585,4 +1601,5 @@ export {
   convertSchemaToAdapterSchema,
   VolatileClassesSchemas,
   SchemaController,
+  filterOptions,
 };

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -88,7 +88,6 @@ function createSchema(req) {
 
   // handle options.
   const options = getOptionParamsFromRequest(req) || req.body.options;
-  console.log(options);
   if (options && typeof options === 'object') {
     requestSchema = handleSchemaOptions(options, requestSchema);
   }

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -5,6 +5,8 @@ var Parse = require('parse/node').Parse,
 
 import PromiseRouter from '../PromiseRouter';
 import * as middleware from '../middlewares';
+import { filterOptions } from '../Controllers/SchemaController';
+import Utils from '../Utils';
 
 function classNameMismatchResponse(bodyClass, pathClass) {
   throw new Parse.Error(
@@ -35,7 +37,38 @@ function getOneSchema(req) {
     });
 }
 
+function handleSchemaOptions(options, requestSchema) {
+  if (
+    options.ignoreDefaultFields &&
+    typeof options.ignoreDefaultFields === 'boolean' &&
+    options.ignoreDefaultFields === true
+  ) {
+    const filterOption = filterOptions.find(f => f.label === 'ignoreDefaultFields');
+    if (!filterOption) {
+      throw new Parse.Error(`ignoreDefaultFields not registered in filter options list`);
+    }
+    requestSchema.fields = filterOption.do(requestSchema.fields);
+  }
+  return requestSchema;
+}
+
+function getOptionParamsFromRequest(req) {
+  const options = new URLSearchParams(req.query);
+  const filtered = {};
+  for (let i = 0; i < filterOptions.length; i++) {
+    if (options.has(filterOptions[i].label)) {
+      filtered[filterOptions[i].label] = new Utils().convertType(
+        filterOptions[i].defaultValue,
+        options.get(filterOptions[i].label)
+      );
+    }
+  }
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
 function createSchema(req) {
+  let requestSchema = Object.assign({}, req.body);
+
   if (req.auth.isReadOnly) {
     throw new Parse.Error(
       Parse.Error.OPERATION_FORBIDDEN,
@@ -53,14 +86,21 @@ function createSchema(req) {
     throw new Parse.Error(135, `POST ${req.path} needs a class name.`);
   }
 
+  // handle options.
+  const options = getOptionParamsFromRequest(req) || req.body.options;
+  console.log(options);
+  if (options && typeof options === 'object') {
+    requestSchema = handleSchemaOptions(options, requestSchema);
+  }
+
   return req.config.database
     .loadSchema({ clearCache: true })
     .then(schema =>
       schema.addClassIfNotExists(
         className,
-        req.body.fields,
-        req.body.classLevelPermissions,
-        req.body.indexes
+        requestSchema.fields,
+        requestSchema.classLevelPermissions,
+        requestSchema.indexes
       )
     )
     .then(schema => ({ response: schema }));

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -200,6 +200,14 @@ class Utils {
       }
     }
   }
+
+  convertType(typedVar, ...args) {
+    return {
+      boolean: v => v == 'true',
+      number: Number,
+      string: String,
+    }[typeof typedVar](args);
+  }
 }
 
 module.exports = Utils;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue%206059).

### Issue Description
Add an option to ignore parse default fields while creating a schema.

### Approach
Add request object serialisation to the create schema endpoint such that when a transform option is provided either in the request body or params, parse server  performs the required serialisation before handing the object over to controller for saving.
For this issue, only one serialisation option has been added i.e. _ignoreDefaultFields_ . _ignoreDefaultFields_ option removes the default field from request object before saving schema and no error is sent to the requesting client app.

eg body options. 
{
    "options": {
        "ignoreDefaultFields": true
    },
    "className": "Another",
    "fields": {
        "objectId": {
            "type": "String"
        },
        "name": {
            "type": "String"
        }
    }
}

eg response.
{
    "className": "Another",
    "fields": {
        "objectId": {
            "type": "String"
        },
        "updatedAt": {
            "type": "Date"
        },
        "createdAt": {
            "type": "Date"
        },
        "name": {
            "type": "String"
        },
        "ACL": {
            "type": "ACL"
        }
    },
    "classLevelPermissions": {
        "find": {
            "*": true
        },
        "count": {
            "*": true
        },
        "get": {
            "*": true
        },
        "create": {
            "*": true
        },
        "update": {
            "*": true
        },
        "delete": {
            "*": true
        },
        "addField": {
            "*": true
        },
        "protectedFields": {
            "*": []
        }
    }
}

eg query params.
http://localhost:1337/parse/schemas/Another?ignoreDefaultFields=true

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog
- [] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...