### PR TITLE
Fixed a bug affecting updates to nested pointers

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -646,6 +646,28 @@ describe('miscellaneous', function () {
       });
   });
 
+  it('pointer reassign on nested fields is working properly', async () => {
+    const obj = new Parse.Object('GameScore'); // This object will include nested pointers
+    const ptr1 = new Parse.Object('GameScore');
+    await ptr1.save(); // Obtain a unique id
+    const ptr2 = new Parse.Object('GameScore');
+    await ptr2.save(); // Obtain a unique id
+    obj.set('data', { ptr: ptr1 });
+    await obj.save();
+
+    obj.set('data.ptr', ptr2);
+    await obj.save();
+
+    const obj2 = await new Parse.Query('GameScore').get(obj.id);
+    expect(obj2.get('data').ptr.id).toBe(ptr2.id);
+
+    const query = new Parse.Query('GameScore');
+    query.equalTo('data.ptr', ptr2);
+    const res = await query.find();
+    expect(res.length).toBe(1);
+    expect(res[0].get('data').ptr.id).toBe(ptr2.id);
+  });
+
   it('test afterSave get full object on create and update', function (done) {
     let triggerTime = 0;
     // Register a mock beforeSave hook

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -646,7 +646,7 @@ describe('miscellaneous', function () {
       });
   });
 
-  it('pointer reassign on nested fields is working properly', async () => {
+  it_only_db('mongo')('pointer reassign on nested fields is working properly (#7391)', async () => {
     const obj = new Parse.Object('GameScore'); // This object will include nested pointers
     const ptr1 = new Parse.Object('GameScore');
     await ptr1.save(); // Obtain a unique id

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -332,7 +332,7 @@ function transformQueryKeyValue(className, key, value, schema, count = false) {
   }
 
   // Handle atomic values
-  var transformRes = key.includes('.')
+  const transformRes = key.includes('.')
     ? transformInteriorAtom(value)
     : transformTopLevelAtom(value);
   if (transformRes !== CannotTransform) {


### PR DESCRIPTION
  Also created unit tests

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Updates to nested pointers don't work

Related issue: #7391 

### Approach
MongoTransform avoids prefixing nested keys with \_p\_, even if they contain the "__type: Pointer" field.
transformQueryKeyValue invokes transformInteriorAtom if the key is nested (contains a dot)

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...