### PR TITLE
Properly set "original" attribute in afterSave hook

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -509,6 +509,11 @@ RestWrite.prototype.handleAuthData = function (authData) {
             response: userResult,
             location: this.location(),
           };
+
+          // Set the query object so the afterSave hook gets called properly with the
+          // "original" attribute.
+          this.query = { objectId: userResult.objectId };
+
           // Run beforeLogin hook before storing any updates
           // to authData on the db; changes to userResult
           // will be ignored.


### PR DESCRIPTION
This PR will properly set the `original` attribute on the "afterSave" hook after a user logs in using GraphQL and the `logInWith` mutation.

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7433).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7433 

### Approach
In the "RestWrite.js" code, specifically the `runAfterSaveTrigger`, the `original`  attribute is set if a `query` was initially set the the class is instantiated. This flow is kicked off by issuing a "create" and because of that the `query` value is null. The `handleAuthData` function checks for an existing user and if found, sets the `response` as an escape hatch for the remaining Promise resolvers. At this point I set the `query` object so that the `original` attribute is set when running the `afterSave` hook.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)