### PR TITLE
Parse Server should return consistent error messages #7444

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -361,11 +361,11 @@ export function handleParseErrors(err, req, res, next) {
         httpStatus = 400;
     }
     res.status(httpStatus);
-    res.json({ code: err.code, error: err.message });
+    res.json({ code: err.code, message: err.message });
     log.error('Parse error: ', err);
   } else if (err.status && err.message) {
     res.status(err.status);
-    res.json({ error: err.message });
+    res.json({ message: err.message });
     if (!(process && process.env.TESTING)) {
       next(err);
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7444).

### Issue Description
The Parse Server should return consistent error messages.

### Approach
Update the error response to share the format `code` and `message`.

### Note
Making the error message consistent would cause breaks in the existing SDKs. I've opened this PR with the basic idea and maybe a workaround can be added for existing users but locally, this already breaks the dashboard which uses the JS SDK.

<img width="449" alt="Screenshot 2021-06-28 at 5 44 06 PM" src="https://user-images.githubusercontent.com/23558802/123646091-56c21a80-d840-11eb-8a03-4b8727136423.png">

<img width="410" alt="Screenshot 2021-06-28 at 5 43 45 PM" src="https://user-images.githubusercontent.com/23558802/123646143-617caf80-d840-11eb-92b5-3d37bfd44e60.png">


