### PR TITLE
chore(ci): Remove prettier quoted argument to fix issue on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "posttest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=4.4.8} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=wiredTiger} mongodb-runner stop",
     "coverage": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=4.4.8} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=wiredTiger} TESTING=1 nyc jasmine",
     "start": "node ./bin/parse-server",
-    "prettier": "prettier --write '{src,spec}/{**/*,*}.js'",
+    "prettier": "prettier --write {src,spec}/{**/*,*}.js",
     "prepare": "npm run build",
     "postinstall": "node -p 'require(\"./postinstall.js\")()'",
     "madge:circular": "node_modules/.bin/madge ./src --circular"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Windows doesn't like single quotes around prettier arguments.

```
> prettier --write '{src,spec}/{**/*,*}.js'
[error] No files matching the pattern were found: "'{src,spec}/{**/*,*}.js'".
```


Related issue: https://github.com/parse-community/parse-server/pull/7419#issuecomment-855927094

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

