### PR TITLE
Fail test for Login or Signup when LiveQuery server is set to watch for class _Session you will get the following error and won't be able to login or sign up  error: Uncaught internal server error. Cannot modify readonly attribute: sessionToken

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -104,6 +104,8 @@ const defaultConfiguration = {
     enableForAnonymousUser: true,
     enableForAuthenticatedUser: true,
   },
+  liveQuery: { classNames: ["_Session"] },
+   startLiveQueryServer: true,
   push: {
     android: {
       senderId: 'yolo',


### PR DESCRIPTION
…or class _Session you will get the following error and won't be able to login or sign up error: Uncaught internal server error. Cannot modify readonly attribute: sessionToken

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...