### PR TITLE
GQL format array results into elements from cloud functions

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -10262,22 +10262,6 @@ describe('ParseGraphQLServer', () => {
       });
 
       it('can resolve a custom query, that returns an array', async () => {
-        Parse.Cloud.define('helloArray', async () => {
-          return ['Hello', 'world!'];
-        });
-
-        const result = await apolloClient.query({
-          query: gql`
-            query HelloArray {
-              helloArray
-            }
-          `,
-        });
-
-        expect(result.data.helloArray).toEqual(['Hello', 'world!']);
-      });
-
-      fit('can resolve a custom query, that returns an array', async () => {
         const schemaController = await parseServer.config.databaseController.loadSchema();
 
         await schemaController.addClassIfNotExists('SuperCar', {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Parse does not convert arrays into arrays of elements for cloud functions.

TODO: We could perhaps adopt the relay, node edges architecture on cloud functions that return arrays of parse objects.

Related issue: https://github.com/parse-community/parse-server/issues/7197

### Approach
The initial commit just contains an example that shows the error. I need help to find the solution to the issue. 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [X] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...