### PR TITLE
Release 4.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 ### 4.10.1
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.10.0...4.10.1)
 
-- Updated to Parse 3.3.0 and other security fixes (Manuel Trezza) [#7508](https://github.com/parse-community/parse-server/pull/7508)
+- Updated to Parse JS SDK 3.3.0 and other security fixes (Manuel Trezza) [#7508](https://github.com/parse-community/parse-server/pull/7508)
+
+> ⚠️ This includes a security fix of the Parse JS SDK where `logIn` will default to `POST` instead of `GET` method. This may require changes in your deployment before you upgrade to this release, see the Parse JS SDK 3.0.0 [release notes](https://github.com/parse-community/Parse-SDK-JS/releases/tag/3.0.0).
 
 ### 4.10.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.5.2...4.10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Parse Server Changelog
 
 ### master
-[Full Changelog](https://github.com/parse-community/parse-server/compare/4.10.0...master)
+[Full Changelog](https://github.com/parse-community/parse-server/compare/4.10.1...master)
+
+### 4.10.1
+[Full Changelog](https://github.com/parse-community/parse-server/compare/4.10.0...4.10.1)
+
+- Updated to Parse 3.3.0 and other security fixes (Manuel Trezza) [#7508](https://github.com/parse-community/parse-server/pull/7508)
 
 ### 4.10.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.5.2...4.10.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3154,45 +3154,23 @@
       "dev": true
     },
     "@parse/node-apn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.0.0.tgz",
-      "integrity": "sha512-/Zhz7+AfwuMeBn9kpENF5qbWDG1+0xLBOlAb7O34BhR9R5BSjAKkMxqWmTz3R3nvlsod4XrZ8NuRMUOXVrCCFQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.1.1.tgz",
+      "integrity": "sha512-stWlQE95w5T0vkVYscoq/S3eXPQ1qzdQbKKQ8GAdw4CSNxRWLWgOH50byUR30thnQ93RshLCH5ROkvXMqzzLtw==",
       "requires": {
-        "debug": "3.1.0",
-        "jsonwebtoken": "8.1.0",
+        "debug": "4.3.2",
+        "jsonwebtoken": "8.5.1",
         "node-forge": "0.10.0",
         "verror": "1.10.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
-        },
-        "jsonwebtoken": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
-          "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
-          "requires": {
-            "jws": "^3.1.4",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -3207,49 +3185,14 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.0.tgz",
-      "integrity": "sha512-ZYf6DKQHpUoi806SIDiuVhstL3BRQC4brcCyTnoLih/u08Cg60Pbkz2B95JU+6xMcM211A2AvPDudEmsMahq7w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.1.tgz",
+      "integrity": "sha512-iev69kbwhXbez5nfEwB2GkCWBLUmRlImQTmHPpLnHBJfATYKyXf/H41WQhBPuwwScZBVp9ABsIsjjKy8iKg3fw==",
       "requires": {
-        "@parse/node-apn": "4.0.0",
+        "@parse/node-apn": "4.1.1",
         "@parse/node-gcm": "1.0.2",
         "npmlog": "4.1.2",
-        "parse": "2.17.0"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs3": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-          "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
-          "requires": {
-            "core-js-pure": "^3.0.0",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "parse": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-2.17.0.tgz",
-          "integrity": "sha512-1hWoMNW39LH5YV3xCds9LyD8SsKD6FUwlD1Kn8ZlXNosg6WgF+s3ZSQUzT5AJ/9YPUoC/y1PoCO79FumrBYftA==",
-          "requires": {
-            "@babel/runtime": "7.11.2",
-            "@babel/runtime-corejs3": "7.11.2",
-            "crypto-js": "4.0.0",
-            "react-native-crypto-js": "1.0.0",
-            "uuid": "3.4.0",
-            "ws": "7.3.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
-        }
+        "parse": "3.3.0"
       }
     },
     "@parse/s3-files-adapter": {
@@ -3422,9 +3365,9 @@
       }
     },
     "@types/express-unless": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
-      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.2.tgz",
+      "integrity": "sha512-Q74UyYRX/zIgl1HSp9tUX2PlG8glkVm+59r7aK4KGKzC5jqKIOX6rrVLRQrzpZUQ84VukHtRoeAuon2nIssHPQ==",
       "requires": {
         "@types/express": "*"
       }
@@ -4334,34 +4277,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-eslint": {
@@ -4667,8 +4587,7 @@
     "bson": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
-      "dev": true
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -5382,11 +5301,6 @@
         }
       }
     },
-    "core-js-pure": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.0.tgz",
-      "integrity": "sha512-fRjhg3NeouotRoIV0L1FdchA6CK7ZD+lyINyMoz19SyV+ROpC4noS1xItWHFtwZdlqfMfVPJEyEGdfri2bD1pA=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5772,9 +5686,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -8604,12 +8518,12 @@
       }
     },
     "jwks-rsa": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.11.0.tgz",
-      "integrity": "sha512-G7ZgXZ3dlGbOUBQwgF+U/SVzOlI9KxJ9Uzp61bue2S5TV0h7c+kJRCl3bEPkC5PVmeu7/h82B3uQALVJMjzt/Q==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.12.3.tgz",
+      "integrity": "sha512-cFipFDeYYaO9FhhYJcZWX/IyZgc0+g316rcHnDpT2dNRNIE/lMOmWKKqp09TkJoYlNFzrEVODsR4GgXJMgWhnA==",
       "requires": {
         "@types/express-jwt": "0.0.42",
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
         "debug": "^4.1.0",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -8629,9 +8543,9 @@
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -9332,9 +9246,9 @@
       }
     },
     "lru-memoizer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
-      "integrity": "sha512-N5L5xlnVcbIinNn/TJ17vHBZwBMt9t7aJDz2n97moWubjNl6VO9Ao2XuAGBBddkYdjrwR9HfzXbT6NfMZXAZ/A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"
@@ -9636,14 +9550,14 @@
       "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "mongodb": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
+      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       },
@@ -9656,11 +9570,6 @@
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
           }
-        },
-        "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         }
       }
     },
@@ -10344,6 +10253,14 @@
       "dev": true,
       "requires": {
         "@wry/context": "^0.4.0"
+      }
+    },
+    "optional-require": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.7.tgz",
+      "integrity": "sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==",
+      "requires": {
+        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -11217,6 +11134,11 @@
         }
       }
     },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11233,6 +11155,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -11241,7 +11164,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -11266,7 +11190,8 @@
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12944,9 +12869,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3365,9 +3365,9 @@
       }
     },
     "@types/express-unless": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
-      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.2.tgz",
+      "integrity": "sha512-Q74UyYRX/zIgl1HSp9tUX2PlG8glkVm+59r7aK4KGKzC5jqKIOX6rrVLRQrzpZUQ84VukHtRoeAuon2nIssHPQ==",
       "requires": {
         "@types/express": "*"
       }
@@ -4277,34 +4277,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-eslint": {
@@ -8542,12 +8519,12 @@
       }
     },
     "jwks-rsa": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.11.0.tgz",
-      "integrity": "sha512-G7ZgXZ3dlGbOUBQwgF+U/SVzOlI9KxJ9Uzp61bue2S5TV0h7c+kJRCl3bEPkC5PVmeu7/h82B3uQALVJMjzt/Q==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.12.3.tgz",
+      "integrity": "sha512-cFipFDeYYaO9FhhYJcZWX/IyZgc0+g316rcHnDpT2dNRNIE/lMOmWKKqp09TkJoYlNFzrEVODsR4GgXJMgWhnA==",
       "requires": {
         "@types/express-jwt": "0.0.42",
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
         "debug": "^4.1.0",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -8567,9 +8544,9 @@
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -9270,9 +9247,9 @@
       }
     },
     "lru-memoizer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
-      "integrity": "sha512-N5L5xlnVcbIinNn/TJ17vHBZwBMt9t7aJDz2n97moWubjNl6VO9Ao2XuAGBBddkYdjrwR9HfzXbT6NfMZXAZ/A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2740,12 +2740,19 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.6.tgz",
+      "integrity": "sha512-Xl8SPYtdjcMoCsIM4teyVRg7jIcgl8F2kRtoCcXuHzXswt9UxZCS6BzRo8fcnCuP6u2XtPgvyonmEPF57Kxo9Q==",
       "requires": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.14.0",
         "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "core-js-pure": {
+          "version": "3.16.2",
+          "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
+          "integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw=="
+        }
       }
     },
     "@babel/template": {
@@ -3587,6 +3594,7 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4321,9 +4329,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
       "version": "0.19.2",
@@ -6776,7 +6784,8 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -7441,12 +7450,30 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        }
       }
     },
     "has": {
@@ -7726,6 +7753,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb-keyval": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.6.tgz",
+      "integrity": "sha512-6lJuVbwyo82mKSH6Wq2eHkt9LcbwHAelMIcMe0tP4p20Pod7tTxq9zf0ge2n/YDfMOpDryerfmmYyuQiaFaKOg=="
     },
     "ieee754": {
       "version": "1.1.13",
@@ -9689,44 +9721,6 @@
         }
       }
     },
-    "mongodb-download-url": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-0.5.2.tgz",
-      "integrity": "sha512-hEwWEsJUh/XbY8yy7EfwF4a6Hres/v89EyMV5/l3dWh8zT2isIo9gt94RkLgvdgOliBw4jtGbViIOcvM6F1G/w==",
-      "dev": true,
-      "requires": {
-        "async": "^2.1.2",
-        "debug": "^2.2.0",
-        "lodash.defaults": "^4.0.0",
-        "minimist": "^1.2.0",
-        "mongodb-version-list": "^1.0.0",
-        "request": "^2.65.0",
-        "semver": "^5.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "mongodb-runner": {
       "version": "github:mongodb-js/runner#dfb9a520147de6e2537f7c1c21a5e7005d1905f8",
       "from": "github:mongodb-js/runner",
@@ -9762,6 +9756,100 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mongodb-download-url": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.1.1.tgz",
+          "integrity": "sha512-LTZcnD1By5G80DFgLEnCZhrl0TFINfcVT/iGgrjCNj7EYZjEvhtlE9Ik19Q5PebrULWqWA8cVwYtDOVBsLcPgw==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "minimist": "^1.2.3",
+            "node-fetch": "^2.6.1",
+            "semver": "^7.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "mongodb-version-manager": {
+          "version": "1.4.6",
+          "resolved": "https://registry.npmjs.org/mongodb-version-manager/-/mongodb-version-manager-1.4.6.tgz",
+          "integrity": "sha512-UxXZy7iqHUa039Bp8e1Y2tSLh/X/JtHRqnlcVkqNEWpX/5ETPaKwrT7QIVZc1Tk5tEkQXjRHd6nQtUjcemOHmA==",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^5.0.3",
+            "async": "^3.1.0",
+            "chalk": "^2.1.0",
+            "debug": ">= 2.6.9 < 3.0.0 || >= ^3.1.0",
+            "docopt": "^0.6.2",
+            "download": "^6.2.5",
+            "figures": "^3.2.0",
+            "fs-extra": "^8.1.0",
+            "get-mongodb-version": "^2.0.1",
+            "lodash.defaults": "^4.2.0",
+            "lodash.difference": "^4.1.1",
+            "mongodb-download-url": "^1.0.0",
+            "mongodb-version-list": "^1.0.0",
+            "semver": "^5.3.0",
+            "tildify": "^2.0.0",
+            "untildify": "^4.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "tildify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+          "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -9871,64 +9959,6 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
-    "mongodb-version-manager": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/mongodb-version-manager/-/mongodb-version-manager-1.4.3.tgz",
-      "integrity": "sha512-+zQdWHLdumqX4mNyqLP08LIa8Wsn52AyU8lEBRx4onlCN13AVNCvgHtCjBAquCYC/wm1rT1i7nAglSJq1LD81Q==",
-      "dev": true,
-      "requires": {
-        "ampersand-state": "^5.0.3",
-        "async": "^2.1.2",
-        "chalk": "^2.1.0",
-        "debug": ">= 2.6.9 < 3.0.0 || >= ^3.1.0",
-        "docopt": "^0.6.2",
-        "download": "^6.2.5",
-        "figures": "^2.0.0",
-        "fs-extra": "^4.0.2",
-        "get-mongodb-version": "^2.0.1",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.1.1",
-        "mongodb-download-url": "^0.5.2",
-        "mongodb-version-list": "^1.0.0",
-        "semver": "^5.3.0",
-        "tildify": "^1.2.0",
-        "untildify": "^3.0.2"
-      },
-      "dependencies": {
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "untildify": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
           "dev": true
         }
       }
@@ -10329,12 +10359,6 @@
         "word-wrap": "~1.2.3"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -10496,23 +10520,24 @@
       }
     },
     "parse": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-2.19.0.tgz",
-      "integrity": "sha512-twxq/Kzyd0c9exxK0jMEPISwDpFzukmexSa+VAFL4a6K+lqGeJ9TuysYhfR9Bkcd0mHGcMFM5gn4uycu1xykvA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-3.3.0.tgz",
+      "integrity": "sha512-SQkTDupU7JQBJpYFIpO8TlQjUtjboUdkXaak57pjoC1ZVbhaiNyLsdYbrlM0B+sNYhlvcMh7zwZW48u10+zm0A==",
       "requires": {
-        "@babel/runtime": "7.12.5",
-        "@babel/runtime-corejs3": "7.12.5",
+        "@babel/runtime": "7.14.6",
+        "@babel/runtime-corejs3": "7.14.6",
         "crypto-js": "4.0.0",
+        "idb-keyval": "5.0.6",
         "react-native-crypto-js": "1.0.0",
         "uuid": "3.4.0",
-        "ws": "7.4.0",
+        "ws": "7.5.0",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -10521,6 +10546,11 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+          "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw=="
         }
       }
     },
@@ -10889,9 +10919,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
-      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pump": {
       "version": "3.0.0",
@@ -12226,15 +12256,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
-    },
-    "tildify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
-      }
     },
     "timed-out": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4587,8 +4587,7 @@
     "bson": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
-      "dev": true
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -5687,9 +5686,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -9551,14 +9550,14 @@
       "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "mongodb": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
+      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       },
@@ -9571,11 +9570,6 @@
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
           }
-        },
-        "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         }
       }
     },
@@ -10259,6 +10253,14 @@
       "dev": true,
       "requires": {
         "@wry/context": "^0.4.0"
+      }
+    },
+    "optional-require": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.7.tgz",
+      "integrity": "sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==",
+      "requires": {
+        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -11132,6 +11134,11 @@
         }
       }
     },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11148,6 +11155,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -11156,7 +11164,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -11181,7 +11190,8 @@
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12869,9 +12869,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3154,23 +3154,45 @@
       "dev": true
     },
     "@parse/node-apn": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.1.1.tgz",
-      "integrity": "sha512-stWlQE95w5T0vkVYscoq/S3eXPQ1qzdQbKKQ8GAdw4CSNxRWLWgOH50byUR30thnQ93RshLCH5ROkvXMqzzLtw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.0.0.tgz",
+      "integrity": "sha512-/Zhz7+AfwuMeBn9kpENF5qbWDG1+0xLBOlAb7O34BhR9R5BSjAKkMxqWmTz3R3nvlsod4XrZ8NuRMUOXVrCCFQ==",
       "requires": {
-        "debug": "4.3.2",
-        "jsonwebtoken": "8.5.1",
+        "debug": "3.1.0",
+        "jsonwebtoken": "8.1.0",
         "node-forge": "0.10.0",
         "verror": "1.10.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "2.0.0"
           }
+        },
+        "jsonwebtoken": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
+          "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
+          "requires": {
+            "jws": "^3.1.4",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -3185,14 +3207,49 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.1.tgz",
-      "integrity": "sha512-iev69kbwhXbez5nfEwB2GkCWBLUmRlImQTmHPpLnHBJfATYKyXf/H41WQhBPuwwScZBVp9ABsIsjjKy8iKg3fw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.0.tgz",
+      "integrity": "sha512-ZYf6DKQHpUoi806SIDiuVhstL3BRQC4brcCyTnoLih/u08Cg60Pbkz2B95JU+6xMcM211A2AvPDudEmsMahq7w==",
       "requires": {
-        "@parse/node-apn": "4.1.1",
+        "@parse/node-apn": "4.0.0",
         "@parse/node-gcm": "1.0.2",
         "npmlog": "4.1.2",
-        "parse": "3.3.0"
+        "parse": "2.17.0"
+      },
+      "dependencies": {
+        "@babel/runtime-corejs3": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+          "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "parse": {
+          "version": "2.17.0",
+          "resolved": "https://registry.npmjs.org/parse/-/parse-2.17.0.tgz",
+          "integrity": "sha512-1hWoMNW39LH5YV3xCds9LyD8SsKD6FUwlD1Kn8ZlXNosg6WgF+s3ZSQUzT5AJ/9YPUoC/y1PoCO79FumrBYftA==",
+          "requires": {
+            "@babel/runtime": "7.11.2",
+            "@babel/runtime-corejs3": "7.11.2",
+            "crypto-js": "4.0.0",
+            "react-native-crypto-js": "1.0.0",
+            "uuid": "3.4.0",
+            "ws": "7.3.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+        }
       }
     },
     "@parse/s3-files-adapter": {
@@ -3365,9 +3422,9 @@
       }
     },
     "@types/express-unless": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.2.tgz",
-      "integrity": "sha512-Q74UyYRX/zIgl1HSp9tUX2PlG8glkVm+59r7aK4KGKzC5jqKIOX6rrVLRQrzpZUQ84VukHtRoeAuon2nIssHPQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
       "requires": {
         "@types/express": "*"
       }
@@ -4277,11 +4334,34 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "babel-eslint": {
@@ -4587,7 +4667,8 @@
     "bson": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+      "dev": true
     },
     "buffer": {
       "version": "4.9.2",
@@ -5301,6 +5382,11 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.0.tgz",
+      "integrity": "sha512-fRjhg3NeouotRoIV0L1FdchA6CK7ZD+lyINyMoz19SyV+ROpC4noS1xItWHFtwZdlqfMfVPJEyEGdfri2bD1pA=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5686,9 +5772,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -8518,12 +8604,12 @@
       }
     },
     "jwks-rsa": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.12.3.tgz",
-      "integrity": "sha512-cFipFDeYYaO9FhhYJcZWX/IyZgc0+g316rcHnDpT2dNRNIE/lMOmWKKqp09TkJoYlNFzrEVODsR4GgXJMgWhnA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.11.0.tgz",
+      "integrity": "sha512-G7ZgXZ3dlGbOUBQwgF+U/SVzOlI9KxJ9Uzp61bue2S5TV0h7c+kJRCl3bEPkC5PVmeu7/h82B3uQALVJMjzt/Q==",
       "requires": {
         "@types/express-jwt": "0.0.42",
-        "axios": "^0.21.1",
+        "axios": "^0.19.2",
         "debug": "^4.1.0",
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -8543,9 +8629,9 @@
           }
         },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -9246,9 +9332,9 @@
       }
     },
     "lru-memoizer": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
-      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
+      "integrity": "sha512-N5L5xlnVcbIinNn/TJ17vHBZwBMt9t7aJDz2n97moWubjNl6VO9Ao2XuAGBBddkYdjrwR9HfzXbT6NfMZXAZ/A==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"
@@ -9550,14 +9636,14 @@
       "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "mongodb": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.3",
+        "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       },
@@ -9570,6 +9656,11 @@
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
           }
+        },
+        "bson": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         }
       }
     },
@@ -10253,14 +10344,6 @@
       "dev": true,
       "requires": {
         "@wry/context": "^0.4.0"
-      }
-    },
-    "optional-require": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.7.tgz",
-      "integrity": "sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==",
-      "requires": {
-        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -11134,11 +11217,6 @@
         }
       }
     },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11155,7 +11233,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -11164,8 +11241,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -11190,8 +11266,7 @@
     "resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-      "dev": true
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12869,9 +12944,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3154,45 +3154,23 @@
       "dev": true
     },
     "@parse/node-apn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.0.0.tgz",
-      "integrity": "sha512-/Zhz7+AfwuMeBn9kpENF5qbWDG1+0xLBOlAb7O34BhR9R5BSjAKkMxqWmTz3R3nvlsod4XrZ8NuRMUOXVrCCFQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.1.1.tgz",
+      "integrity": "sha512-stWlQE95w5T0vkVYscoq/S3eXPQ1qzdQbKKQ8GAdw4CSNxRWLWgOH50byUR30thnQ93RshLCH5ROkvXMqzzLtw==",
       "requires": {
-        "debug": "3.1.0",
-        "jsonwebtoken": "8.1.0",
+        "debug": "4.3.2",
+        "jsonwebtoken": "8.5.1",
         "node-forge": "0.10.0",
         "verror": "1.10.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
-        },
-        "jsonwebtoken": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
-          "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
-          "requires": {
-            "jws": "^3.1.4",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -3207,49 +3185,14 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.0.tgz",
-      "integrity": "sha512-ZYf6DKQHpUoi806SIDiuVhstL3BRQC4brcCyTnoLih/u08Cg60Pbkz2B95JU+6xMcM211A2AvPDudEmsMahq7w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.1.tgz",
+      "integrity": "sha512-iev69kbwhXbez5nfEwB2GkCWBLUmRlImQTmHPpLnHBJfATYKyXf/H41WQhBPuwwScZBVp9ABsIsjjKy8iKg3fw==",
       "requires": {
-        "@parse/node-apn": "4.0.0",
+        "@parse/node-apn": "4.1.1",
         "@parse/node-gcm": "1.0.2",
         "npmlog": "4.1.2",
-        "parse": "2.17.0"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs3": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-          "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
-          "requires": {
-            "core-js-pure": "^3.0.0",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "parse": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-2.17.0.tgz",
-          "integrity": "sha512-1hWoMNW39LH5YV3xCds9LyD8SsKD6FUwlD1Kn8ZlXNosg6WgF+s3ZSQUzT5AJ/9YPUoC/y1PoCO79FumrBYftA==",
-          "requires": {
-            "@babel/runtime": "7.11.2",
-            "@babel/runtime-corejs3": "7.11.2",
-            "crypto-js": "4.0.0",
-            "react-native-crypto-js": "1.0.0",
-            "uuid": "3.4.0",
-            "ws": "7.3.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
-        }
+        "parse": "3.3.0"
       }
     },
     "@parse/s3-files-adapter": {
@@ -5381,11 +5324,6 @@
           "dev": true
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.0.tgz",
-      "integrity": "sha512-fRjhg3NeouotRoIV0L1FdchA6CK7ZD+lyINyMoz19SyV+ROpC4noS1xItWHFtwZdlqfMfVPJEyEGdfri2bD1pA=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "uuid": "8.3.1",
     "winston": "3.3.3",
     "winston-daily-rotate-file": "4.5.0",
-    "ws": "7.4.0"
+    "ws": "7.5.3"
   },
   "devDependencies": {
     "@babel/cli": "7.14.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lru-cache": "5.1.1",
     "mime": "2.4.6",
     "mongodb": "3.6.3",
-    "parse": "2.19.0",
+    "parse": "3.3.0",
     "pg-promise": "10.8.1",
     "pluralize": "8.0.0",
     "redis": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@graphql-tools/stitch": "6.2.4",
     "@graphql-tools/utils": "6.2.4",
     "@parse/fs-files-adapter": "1.2.0",
-    "@parse/push-adapter": "3.4.0",
+    "@parse/push-adapter": "3.4.1",
     "@parse/s3-files-adapter": "1.6.2",
     "@parse/simple-mailgun-adapter": "1.1.0",
     "apollo-server-express": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@graphql-tools/stitch": "6.2.4",
     "@graphql-tools/utils": "6.2.4",
     "@parse/fs-files-adapter": "1.2.0",
-    "@parse/push-adapter": "3.4.1",
+    "@parse/push-adapter": "3.4.0",
     "@parse/s3-files-adapter": "1.6.2",
     "@parse/simple-mailgun-adapter": "1.1.0",
     "apollo-server-express": "2.19.0",
@@ -41,12 +41,12 @@
     "graphql-upload": "11.0.0",
     "intersect": "1.0.1",
     "jsonwebtoken": "8.5.1",
-    "jwks-rsa": "1.12.3",
+    "jwks-rsa": "1.11.0",
     "ldapjs": "2.2.2",
     "lodash": "4.17.21",
     "lru-cache": "5.1.1",
     "mime": "2.4.6",
-    "mongodb": "3.6.11",
+    "mongodb": "3.6.3",
     "parse": "3.3.0",
     "pg-promise": "10.8.1",
     "pluralize": "8.0.0",
@@ -57,7 +57,7 @@
     "uuid": "8.3.1",
     "winston": "3.3.3",
     "winston-daily-rotate-file": "4.5.0",
-    "ws": "7.5.3"
+    "ws": "7.4.0"
   },
   "devDependencies": {
     "@babel/cli": "7.14.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@graphql-tools/stitch": "6.2.4",
     "@graphql-tools/utils": "6.2.4",
     "@parse/fs-files-adapter": "1.2.0",
-    "@parse/push-adapter": "3.4.0",
+    "@parse/push-adapter": "3.4.1",
     "@parse/s3-files-adapter": "1.6.2",
     "@parse/simple-mailgun-adapter": "1.1.0",
     "apollo-server-express": "2.19.0",
@@ -41,12 +41,12 @@
     "graphql-upload": "11.0.0",
     "intersect": "1.0.1",
     "jsonwebtoken": "8.5.1",
-    "jwks-rsa": "1.11.0",
+    "jwks-rsa": "1.12.3",
     "ldapjs": "2.2.2",
     "lodash": "4.17.21",
     "lru-cache": "5.1.1",
     "mime": "2.4.6",
-    "mongodb": "3.6.3",
+    "mongodb": "3.6.11",
     "parse": "3.3.0",
     "pg-promise": "10.8.1",
     "pluralize": "8.0.0",
@@ -57,7 +57,7 @@
     "uuid": "8.3.1",
     "winston": "3.3.3",
     "winston-daily-rotate-file": "4.5.0",
-    "ws": "7.4.0"
+    "ws": "7.5.3"
   },
   "devDependencies": {
     "@babel/cli": "7.14.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "4.17.21",
     "lru-cache": "5.1.1",
     "mime": "2.4.6",
-    "mongodb": "3.6.3",
+    "mongodb": "3.6.11",
     "parse": "3.3.0",
     "pg-promise": "10.8.1",
     "pluralize": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "graphql-upload": "11.0.0",
     "intersect": "1.0.1",
     "jsonwebtoken": "8.5.1",
-    "jwks-rsa": "1.11.0",
+    "jwks-rsa": "1.12.3",
     "ldapjs": "2.2.2",
     "lodash": "4.17.21",
     "lru-cache": "5.1.1",

--- a/spec/OAuth1.spec.js
+++ b/spec/OAuth1.spec.js
@@ -87,13 +87,17 @@ describe('OAuth', function () {
     done();
   }
 
-  it('Should fail a GET request', done => {
+  it('GET request for a resource that requires OAuth should fail with invalid credentials', done => {
+    /*
+      This endpoint has been chosen to make a request to an endpoint that requires OAuth which fails due to missing authentication.
+      Any other endpoint from the Twitter API that requires OAuth can be used instead in case the currently used endpoint deprecates.
+    */
     const options = {
       host: 'api.twitter.com',
-      consumer_key: 'XXXXXXXXXXXXXXXXXXXXXXXXX',
-      consumer_secret: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      consumer_key: 'invalid_consumer_key',
+      consumer_secret: 'invalid_consumer_secret',
     };
-    const path = '/1.1/help/configuration.json';
+    const path = '/1.1/favorites/list.json';
     const params = { lang: 'en' };
     const oauthClient = new OAuth(options);
     oauthClient.get(path, params).then(function (data) {
@@ -101,11 +105,15 @@ describe('OAuth', function () {
     });
   });
 
-  it('Should fail a POST request', done => {
+  it('POST request for a resource that requires OAuth should fail with invalid credentials', done => {
+    /*
+      This endpoint has been chosen to make a request to an endpoint that requires OAuth which fails due to missing authentication.
+      Any other endpoint from the Twitter API that requires OAuth can be used instead in case the currently used endpoint deprecates.
+    */
     const options = {
       host: 'api.twitter.com',
-      consumer_key: 'XXXXXXXXXXXXXXXXXXXXXXXXX',
-      consumer_secret: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      consumer_key: 'invalid_consumer_key',
+      consumer_secret: 'invalid_consumer_secret',
     };
     const body = {
       lang: 'en',

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -791,7 +791,7 @@ describe('Parse.User testing', () => {
 
     user.set('username', 'test');
     await user.save();
-    equal(Object.keys(user.attributes).length, 6);
+    equal(Object.keys(user.attributes).length, 5);
     ok(user.attributes['username']);
     ok(user.attributes['email']);
     await user.destroy();

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -2,6 +2,7 @@ import { loadAdapter } from '../Adapters/AdapterLoader';
 import { WSAdapter } from '../Adapters/WebSocketServer/WSAdapter';
 import logger from '../logger';
 import events from 'events';
+import { inspect } from 'util';
 
 export class ParseWebSocketServer {
   server: Object;
@@ -15,7 +16,7 @@ export class ParseWebSocketServer {
     wss.onConnection = ws => {
       ws.on('error', error => {
         logger.error(error.message);
-        logger.error(JSON.stringify(ws));
+        logger.error(inspect(ws, false));
       });
       onConnect(new ParseWebSocket(ws));
       // Send ping to client periodically


### PR DESCRIPTION
## Release 4.10.1

The objective of this release is to reduce the vulnerabilities from `1 low, 6 moderate, 2 high` in 4.10.0 to `1 low, 1 high`.

The remaining high vulnerability is due to the now deprecated `@parse/simple-mailgun-adapter`. This can easily be fixed by the developer by not using the adapter. There is an up-to-date mailgun adapter as replacement, but it works differently.

- [x] Bump to parse 3.3.0 to fix security vulnerabilities
- [x] Bump to [parse-push-adapter 3.4.1](https://github.com/parse-community/parse-server-push-adapter/pull/193) to fix security vulnerabilities
- [x] Bump non-Parse dependencies

The bump from Parse 2.x to 3.x contains a breaking change:
> For security purposes, logIn will default to POST instead of GET method. (#1284)
> If you need to use GET set the usePost option to false.
> Parse.User.logIn('username', 'password', { usePost: false })

This change prevents the plain text username and password from being in URLs and log files, a significant security issue.

If we argue that a security issue is usually not considered a braking change, because it doesn't "break" anything, but "fixes" something that is currently broken, we could release a parse server 4.10.1 that is free of any significant vulnerabilities. I think that approach is required once we move to Long Term Support, otherwise we could never fix vulnerabilities in a 4.x release while maintaining a 5.x release at the same time. In that sense, the fix in Parse would probably not have justified the major version bump from 2.x to 3.x.

Bottom line, this will make Parse Server 4.x usable again without any significant vulnerability until we release Parse Server 5.0.

## Note

- When merging: merge this into branch `release-4.x.x` and don't delete that branch, it is the LTS branch for 4.x.x, a good exercise for our LTS trial to come.

## TODO
- [ ] Cherry pick dependency bumps into master branch
