### PR TITLE
ci(changelog): add changelog reminder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: CI Self-Check
         run: npm run ci:check
   check-changelog:
-    name: Changelog Entry
+    name: Changelog
     timeout-minutes: 5
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
         run: npm ci
       - name: CI Self-Check
         run: npm run ci:check
+  check-changelog-update:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2
   check-lint:
      name: Lint
      timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
         run: npm ci
       - name: CI Self-Check
         run: npm run ci:check
-  check-changelog-update:
-    runs-on: ubuntu-18.04
+  check-changelog:
+    name: Changelog Entry
     timeout-minutes: 5
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - uses: dangoslen/changelog-enforcer@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ ___
 - Fix LiveQuery server crash when using $all query operator on a missing object key (Jason Posthuma) [#7421](https://github.com/parse-community/parse-server/pull/7421)
 - Added runtime deprecation warnings (Manuel Trezza) [#7451](https://github.com/parse-community/parse-server/pull/7451)
 - Add ability to pass context of an object via a header, X-Parse-Cloud-Context, for Cloud Code triggers. The header addition allows client SDK's to add context without injecting _context in the body of JSON objects (Corey Baker) [#7437](https://github.com/parse-community/parse-server/pull/7437)
+- Add CI check to add changelog entry (Manuel Trezza) [#7512](https://github.com/parse-community/parse-server/pull/7512)
 
 ## 4.10.0
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.5.2...4.10.0)


### PR DESCRIPTION
Ensures a PR modifies the CHANGELOG.md file:
![image](https://user-images.githubusercontent.com/5673677/130494689-63220d95-da54-4e35-9cdb-9d1ece2c26e3.png)

Transitional solution until we move to automated releases which will generate the changelog entry.

TODO:

- [ ] Add check to required tests for merge in repo settings