### PR TITLE
security(query): deprecate explain without master key

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -6,6 +6,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 |-------------------------------------------------|----------------------------------------------------------------------|---------------------------------|---------------------------------|-----------------------|-------|
 | Native MongoDB syntax in aggregation pipeline   | [#7338](https://github.com/parse-community/parse-server/issues/7338) | 5.0.0 (2022)                    | 6.0.0 (2023)                    | deprecated            | -     |
 | Config option `directAccess` defaults to `true` | [#6636](https://github.com/parse-community/parse-server/pull/6636)   | 5.0.0 (2022)                    | 6.0.0 (2023)                    | deprecated            | -     |
+| Config option `nonMasterExplain` defaults to `false` | [#7519](https://github.com/parse-community/parse-server/issues/7519)   | XXX                    | XXX | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_removal]: ## "The version and date of the planned removal."

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -22,4 +22,9 @@ module.exports = [
     solution:
       "Additionally, the environment variable 'PARSE_SERVER_ENABLE_EXPERIMENTAL_DIRECT_ACCESS' will be deprecated and renamed to 'PARSE_SERVER_DIRECT_ACCESS' in a future version; it is currently possible to use either one.",
   },
+  {
+    optionKey: 'nonMasterExplain',
+    envKey: 'PARSE_SERVER_NON_MASTER_EXPLAIN',
+    changeNewDefault: 'false',
+  },
 ];

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -277,6 +277,12 @@ module.exports.ParseServerOptions = {
     action: parsers.booleanParser,
     default: false,
   },
+  nonMasterExplain: {
+    env: 'PARSE_SERVER_NON_MASTER_EXPLAIN',
+    help: 'Allow non-master users to use the `explain` query parameter.',
+    action: parsers.booleanParser,
+    default: true,
+  },
   objectIdSize: {
     env: 'PARSE_SERVER_OBJECT_ID_SIZE',
     help: "Sets the number of characters in generated object id's, default 10",

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -52,6 +52,7 @@
  * @property {Boolean} mountGraphQL Mounts the GraphQL endpoint
  * @property {String} mountPath Mount path for the server, defaults to /parse
  * @property {Boolean} mountPlayground Mounts the GraphQL Playground - never use this option in production
+ * @property {Boolean} nonMasterExplain Allow non-master users to use the `explain` query parameter, defaults to true
  * @property {Number} objectIdSize Sets the number of characters in generated object id's, default 10
  * @property {PagesOptions} pages The options for pages such as password reset and email verification. Caution, this is an experimental feature that may not be appropriate for production.
  * @property {PasswordPolicyOptions} passwordPolicy The password policy for enforcing password related rules.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -209,6 +209,7 @@ export interface ParseServerOptions {
   cluster: ?NumberOrBoolean;
   /* middleware for express server, can be string or function */
   middleware: ?((() => void) | string);
+
   /* Starts the liveQuery server */
   startLiveQueryServer: ?boolean;
   /* Live query server configuration options (will start the liveQuery server) */
@@ -239,6 +240,9 @@ export interface ParseServerOptions {
   :ENV: PARSE_SERVER_PLAYGROUND_PATH
   :DEFAULT: /playground */
   playgroundPath: ?string;
+  /* Allow non-master users to use the `explain` query parameter.
+  :DEFAULT: true */
+  nonMasterExplain: ?boolean;
   /* Callback when server has started */
   serverStartComplete: ?(error: ?Error) => void;
   /* Callback when server has closed */

--- a/src/rest.js
+++ b/src/rest.js
@@ -26,6 +26,9 @@ function checkLiveQuery(className, config) {
 // Returns a promise for an object with optional keys 'results' and 'count'.
 function find(config, auth, className, restWhere, restOptions, clientSDK, context) {
   enforceRoleSecurity('find', className, auth);
+  if (!config.nonMasterExplain && restOptions.explain && !auth.isMaster) {
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'Cannot explain');
+  }
   return triggers
     .maybeRunQueryTrigger(
       triggers.Types.beforeFind,
@@ -57,6 +60,9 @@ function find(config, auth, className, restWhere, restOptions, clientSDK, contex
 const get = (config, auth, className, objectId, restOptions, clientSDK, context) => {
   var restWhere = { objectId };
   enforceRoleSecurity('get', className, auth);
+  if (!config.nonMasterExplain && restOptions.explain && !auth.isMaster) {
+    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, 'Cannot explain');
+  }
   return triggers
     .maybeRunQueryTrigger(
       triggers.Types.beforeFind,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Currently, any user is able to run a query with the explain parameter and obtain the raw result returned by MongoDB. This discloses too much information to the clients, nor is it of great utility to them.

Related issue: #7519 

### Approach
rest.js now checks whether the user is allowed to use the `explain` option.
The PR uses the [depreactor](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#deprecation-policy) to deprecate the current default, which is to allow even non-master users to use `explain`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->