### PR TITLE
refactor: remove restricted session field

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -1,6 +1,7 @@
 name: Issue Bot
 on:
   issues:
+    types: [opened, reopened, edited]
   pull_request:
     types: [opened, reopened, edited]
 jobs:

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -1,5 +1,8 @@
 name: Issue Bot
-on: [issues]
+on:
+  issues:
+  pull_request:
+    types: [opened, reopened, edited]
 jobs:
   issue-bot:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ ___
 - Remove support for MongoDB 3.6 which has reached its End-of-Life date and PostgreSQL 10 (Manuel Trezza) [#7315](https://github.com/parse-community/parse-server/pull/7315)
 - Remove support for Node 10 which has reached its End-of-Life date (Manuel Trezza) [#7314](https://github.com/parse-community/parse-server/pull/7314)
 - Remove S3 Files Adapter from Parse Server, instead install separately as `@parse/s3-files-adapter` (Manuel Trezza) [#7324](https://github.com/parse-community/parse-server/pull/7324)
+- Remove Session field `restricted`; the field was a code artifact from a feature that never existed in Open Source Parse Server; if you have been using this field for custom purposes, consider that its default value `false` will not be set anymore when creating a new session (Manuel Trezza) [#7543](https://github.com/parse-community/parse-server/pull/7543)
 
 ### Notable Changes
 - Added Parse Server Security Check to report weak security settings (Manuel Trezza, dblythy) [#7247](https://github.com/parse-community/parse-server/issues/7247)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ ___
 - Remove support for MongoDB 3.6 which has reached its End-of-Life date and PostgreSQL 10 (Manuel Trezza) [#7315](https://github.com/parse-community/parse-server/pull/7315)
 - Remove support for Node 10 which has reached its End-of-Life date (Manuel Trezza) [#7314](https://github.com/parse-community/parse-server/pull/7314)
 - Remove S3 Files Adapter from Parse Server, instead install separately as `@parse/s3-files-adapter` (Manuel Trezza) [#7324](https://github.com/parse-community/parse-server/pull/7324)
-- Remove Session field `restricted`; the field was a code artifact from a feature that never existed in Open Source Parse Server; if you have been using this field for custom purposes, consider that its default value `false` will not be set anymore when creating a new session (Manuel Trezza) [#7543](https://github.com/parse-community/parse-server/pull/7543)
+- Remove Session field `restricted`; the field was a code artifact from a feature that never existed in Open Source Parse Server; if you have been using this field for custom purposes, consider that for new Parse Server installations the field does not exist anymore in the schema, and for existing installations the field default value `false` will not be set anymore when creating a new session (Manuel Trezza) [#7543](https://github.com/parse-community/parse-server/pull/7543)
 
 ### Notable Changes
 - Added Parse Server Security Check to report weak security settings (Manuel Trezza, dblythy) [#7247](https://github.com/parse-community/parse-server/issues/7247)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ ___
 - Add ability to pass context of an object via a header, X-Parse-Cloud-Context, for Cloud Code triggers. The header addition allows client SDK's to add context without injecting _context in the body of JSON objects (Corey Baker) [#7437](https://github.com/parse-community/parse-server/pull/7437)
 - Add CI check to add changelog entry (Manuel Trezza) [#7512](https://github.com/parse-community/parse-server/pull/7512)
 - Refactor: uniform issue templates across repos (Manuel Trezza) [#7528](https://github.com/parse-community/parse-server/pull/7528)
+- ci: add Issue Bot for PRs (Manuel Trezza) [#7530](https://github.com/parse-community/parse-server/pull/7530)
 
 ## 4.10.2
 [Full Changelog](https://github.com/parse-community/parse-server/compare/4.10.1...4.10.2)

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -892,7 +892,6 @@ describe('SchemaController', () => {
             objectId: { type: 'String' },
             updatedAt: { type: 'Date' },
             createdAt: { type: 'Date' },
-            restricted: { type: 'Boolean' },
             user: { type: 'Pointer', targetClass: '_User' },
             installationId: { type: 'String' },
             sessionToken: { type: 'String' },

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -70,7 +70,6 @@ const defaultColumns: { [string]: SchemaFields } = Object.freeze({
   },
   // The additional default columns for the _Session collection (in addition to DefaultCols)
   _Session: {
-    restricted: { type: 'Boolean' },
     user: { type: 'Pointer', targetClass: '_User' },
     installationId: { type: 'String' },
     sessionToken: { type: 'String' },

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -891,7 +891,6 @@ RestWrite.createSession = function (
       objectId: userId,
     },
     createdWith,
-    restricted: false,
     expiresAt: Parse._encode(expiresAt),
   };
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
The `_Session` field `restricted` for the feature of restricted sessions is not in use by Parse Server internally. It is a code artifact of a feature that according to [comments](https://github.com/parse-community/parse-server/issues/5047#issuecomment-420112122) has not been ported from Parse.com to Open Source Parse Server.

This is a Parse Server internal field without any internal logic attached to it. The field is unlikely to be used by developers, so instead of deprecating it, we'll remove the field as a sudden breaking change with Parse Server 5.0. If a developer was using the field, the change for a developer would simply be setting the field `false` in the `Session.beforeSave` trigger.

See
- https://github.com/parse-community/parse-server/issues/5047
- https://github.com/parse-community/parse-server/issues/6612

Related issue: 6612

### Approach
- Remove `_Session` field `restricted` from schema
- Remove logic that sets `restricted` to `false` by default when creating a new session

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)