### PR TITLE
Remove some hardcoded error codes

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -1750,7 +1750,7 @@ describe('microsoft graph auth adapter', () => {
       access_token: 'very.long.bad.token',
     };
     microsoft.validateAuthData(authData).then(done.fail, err => {
-      expect(err.code).toBe(101);
+      expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
       expect(err.message).toBe('Microsoft Graph auth is invalid for this user.');
       done();
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -67,7 +67,7 @@ describe('Cloud Code', () => {
 
   it('is cleared cleared after the previous test', done => {
     Parse.Cloud.run('hello', {}).catch(error => {
-      expect(error.code).toEqual(141);
+      expect(error.code).toEqual(Parse.Error.SCRIPT_FAILED);
       done();
     });
   });
@@ -101,7 +101,7 @@ describe('Cloud Code', () => {
     Parse.Cloud.run('cloudCodeWithError').then(
       () => done.fail('should not succeed'),
       e => {
-        expect(e).toEqual(new Parse.Error(141, 'foo is not defined'));
+        expect(e).toEqual(new Parse.Error(Parse.Error.SCRIPT_FAILED, 'foo is not defined'));
         done();
       }
     );
@@ -115,7 +115,7 @@ describe('Cloud Code', () => {
     Parse.Cloud.run('cloudCodeWithError').then(
       () => done.fail('should not succeed'),
       e => {
-        expect(e.code).toEqual(141);
+        expect(e.code).toEqual(Parse.Error.SCRIPT_FAILED);
         expect(e.message).toEqual('Script failed.');
         done();
       }
@@ -134,7 +134,7 @@ describe('Cloud Code', () => {
       const query = new Parse.Query('beforeFind');
       await query.first();
     } catch (e) {
-      expect(e.code).toBe(141);
+      expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
       expect(e.message).toBe('throw beforeFind');
       done();
     }
@@ -2011,7 +2011,7 @@ describe('beforeFind hooks', () => {
         done();
       },
       err => {
-        expect(err.code).toBe(141);
+        expect(err.code).toBe(Parse.Error.SCRIPT_FAILED);
         expect(err.message).toEqual('Do not run that query');
         done();
       }

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -459,7 +459,7 @@ describe('Cloud Code', () => {
       });
     } catch (e) {
       catched = true;
-      expect(e.code).toBe(101);
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
     }
     expect(catched).toBe(true);
     expect(called).toBe(7);
@@ -471,7 +471,7 @@ describe('Cloud Code', () => {
       });
     } catch (e) {
       catched = true;
-      expect(e.code).toBe(101);
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
     }
     expect(catched).toBe(true);
     expect(called).toBe(7);
@@ -483,7 +483,7 @@ describe('Cloud Code', () => {
       });
     } catch (e) {
       catched = true;
-      expect(e.code).toBe(101);
+      expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
     }
     expect(catched).toBe(true);
     expect(called).toBe(7);
@@ -1734,7 +1734,7 @@ describe('Cloud Code', () => {
 
     it('should set the failure message on the job error', async () => {
       Parse.Cloud.job('myJobError', () => {
-        throw new Parse.Error(101, 'Something went wrong');
+        throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Something went wrong');
       });
       const job = await Parse.Cloud.startJob('myJobError');
       let jobStatus, status;

--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -161,7 +161,7 @@ describe('Cloud Code Logger', () => {
         expect(log[0]).toEqual('error');
         const error = log[2].error;
         expect(error instanceof Parse.Error).toBeTruthy();
-        expect(error.code).toBe(141);
+        expect(error.code).toBe(Parse.Error.SCRIPT_FAILED);
         expect(error.message).toBe('uh oh!');
         done();
       });
@@ -199,7 +199,9 @@ describe('Cloud Code Logger', () => {
         expect(log[1]).toMatch(
           /Failed running cloud function aFunction for user [^ ]* with:\n {2}Input: {"foo":"bar"}\n {2}Error:/
         );
-        const errorString = JSON.stringify(new Parse.Error(141, 'it failed!'));
+        const errorString = JSON.stringify(
+          new Parse.Error(Parse.Error.SCRIPT_FAILED, 'it failed!')
+        );
         expect(log[1].indexOf(errorString)).toBeGreaterThan(0);
         done();
       })

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1015,7 +1015,7 @@ describe('miscellaneous', function () {
         done();
       },
       e => {
-        expect(e.code).toEqual(141);
+        expect(e.code).toEqual(Parse.Error.SCRIPT_FAILED);
         expect(e.message).toEqual('noway');
         done();
       }

--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -464,7 +464,7 @@ describe('Hooks', () => {
           expect(err).not.toBe(undefined);
           expect(err).not.toBe(null);
           if (err) {
-            expect(err.code).toBe(141);
+            expect(err.code).toBe(Parse.Error.SCRIPT_FAILED);
             expect(err.message.code).toEqual(1337);
             expect(err.message.error).toEqual('hacking that one!');
           }
@@ -536,7 +536,7 @@ describe('Hooks', () => {
             expect(err).not.toBe(undefined);
             expect(err).not.toBe(null);
             if (err) {
-              expect(err.code).toBe(141);
+              expect(err.code).toBe(Parse.Error.SCRIPT_FAILED);
               expect(err.message).toEqual('incorrect key provided');
             }
             done();

--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -428,7 +428,7 @@ describe('Parse Role testing', () => {
         },
         e => {
           if (e) {
-            expect(e.code).toEqual(101);
+            expect(e.code).toEqual(Parse.Error.OBJECT_NOT_FOUND);
           } else {
             fail('should return an error');
           }

--- a/spec/PointerPermissions.spec.js
+++ b/spec/PointerPermissions.spec.js
@@ -99,7 +99,7 @@ describe('Pointer Permissions', () => {
           },
           err => {
             // User 1 should not be able to update obj2
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             return Promise.resolve();
           }
         )
@@ -203,7 +203,7 @@ describe('Pointer Permissions', () => {
             fail('User 2 should not get the obj1 object');
           },
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             expect(err.message).toBe('Object not found.');
             return Promise.resolve();
           }
@@ -530,7 +530,7 @@ describe('Pointer Permissions', () => {
             done();
           },
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             done();
           }
         );
@@ -583,7 +583,7 @@ describe('Pointer Permissions', () => {
             done();
           },
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             done();
           }
         );
@@ -695,7 +695,7 @@ describe('Pointer Permissions', () => {
             done();
           },
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             done();
           }
         );
@@ -819,7 +819,7 @@ describe('Pointer Permissions', () => {
             done();
           },
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             done();
           }
         );
@@ -848,7 +848,7 @@ describe('Pointer Permissions', () => {
         .then(
           () => {},
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             return Promise.resolve();
           }
         )
@@ -891,7 +891,7 @@ describe('Pointer Permissions', () => {
         .then(
           () => {},
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             return Promise.resolve();
           }
         )
@@ -934,7 +934,7 @@ describe('Pointer Permissions', () => {
         .then(
           () => {},
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             return Promise.resolve();
           }
         )
@@ -977,7 +977,7 @@ describe('Pointer Permissions', () => {
             fail();
           },
           err => {
-            expect(err.code).toBe(101);
+            expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
             return Promise.resolve();
           }
         )
@@ -1111,7 +1111,7 @@ describe('Pointer Permissions', () => {
         done.fail('User should not be able to update obj2');
       } catch (err) {
         // User 1 should not be able to update obj2
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
       }
 
       obj.set('hello', 'world');
@@ -1186,7 +1186,7 @@ describe('Pointer Permissions', () => {
         await q.get(obj.id);
         done.fail('User 3 should not get the obj1 object');
       } catch (err) {
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         expect(err.message).toBe('Object not found.');
       }
 
@@ -1541,7 +1541,7 @@ describe('Pointer Permissions', () => {
         await obj.save({ key: 'value' });
         done.fail('Should not succeed saving');
       } catch (err) {
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         done();
       }
     });
@@ -1590,7 +1590,7 @@ describe('Pointer Permissions', () => {
           await obj.save({ key: 'value' });
           done.fail('Should not succeed saving');
         } catch (err) {
-          expect(err.code).toBe(101);
+          expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         }
       }
       done();
@@ -1692,7 +1692,7 @@ describe('Pointer Permissions', () => {
         await obj.fetch();
         done.fail('Should not succeed fetching');
       } catch (err) {
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         done();
       }
       done();
@@ -1811,7 +1811,7 @@ describe('Pointer Permissions', () => {
           await obj.fetch();
           done.fail('Should not succeed fetching');
         } catch (err) {
-          expect(err.code).toBe(101);
+          expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         }
       }
       done();
@@ -1863,7 +1863,7 @@ describe('Pointer Permissions', () => {
         await q.get(object.id);
         done.fail();
       } catch (err) {
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
       }
 
       try {
@@ -1894,7 +1894,7 @@ describe('Pointer Permissions', () => {
         await object.save({ hello: 'bar' });
         done.fail();
       } catch (err) {
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
       }
 
       try {
@@ -1925,7 +1925,7 @@ describe('Pointer Permissions', () => {
         await object.destroy();
         done.fail();
       } catch (err) {
-        expect(err.code).toBe(101);
+        expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
       }
       try {
         await object.destroy({ useMasterKey: true });

--- a/spec/PushWorker.spec.js
+++ b/spec/PushWorker.spec.js
@@ -249,7 +249,7 @@ describe('PushWorker', () => {
             // should not be deleted
             transmitted: false,
             device: {
-              deviceToken: 101,
+              deviceToken: Parse.Error.OBJECT_NOT_FOUND,
               deviceType: 'ios',
             },
             response: { error: 'invalid error...' },

--- a/spec/RegexVulnerabilities.spec.js
+++ b/spec/RegexVulnerabilities.spec.js
@@ -147,7 +147,7 @@ describe('Regex Vulnerabilities', function () {
         await Parse.User.logIn('someemail@somedomain.com', 'newpassword');
         fail('should not work');
       } catch (e) {
-        expect(e.code).toEqual(101);
+        expect(e.code).toEqual(Parse.Error.OBJECT_NOT_FOUND);
         expect(e.message).toEqual('Invalid username/password.');
       }
     });

--- a/src/AccountLockout.js
+++ b/src/AccountLockout.js
@@ -91,7 +91,7 @@ export class AccountLockout {
         err &&
         err.code &&
         err.message &&
-        err.code === 101 &&
+        err.code === Parse.Error.OBJECT_NOT_FOUND &&
         err.message === 'Object not found.'
       ) {
         return; // nothing to update so we are good

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -190,7 +190,7 @@ class ParseLiveQueryServer {
           } catch (error) {
             Client.pushError(
               client.parseWebSocket,
-              error.code || 141,
+              error.code || Parse.Error.SCRIPT_FAILED,
               error.message || error,
               false,
               requestId
@@ -344,7 +344,7 @@ class ParseLiveQueryServer {
           } catch (error) {
             Client.pushError(
               client.parseWebSocket,
-              error.code || 141,
+              error.code || Parse.Error.SCRIPT_FAILED,
               error.message || error,
               false,
               requestId
@@ -665,7 +665,12 @@ class ParseLiveQueryServer {
       client.pushConnect();
       runLiveQueryEventHandlers(req);
     } catch (error) {
-      Client.pushError(parseWebsocket, error.code || 141, error.message || error, false);
+      Client.pushError(
+        parseWebsocket,
+        error.code || Parse.Error.SCRIPT_FAILED,
+        error.message || error,
+        false
+      );
       logger.error(
         `Failed running beforeConnect for session ${request.sessionToken} with:\n Error: ` +
           JSON.stringify(error)
@@ -779,7 +784,13 @@ class ParseLiveQueryServer {
         installationId: client.installationId,
       });
     } catch (e) {
-      Client.pushError(parseWebsocket, e.code || 141, e.message || e, false, request.requestId);
+      Client.pushError(
+        parseWebsocket,
+        e.code || Parse.Error.SCRIPT_FAILED,
+        e.message || e,
+        false,
+        request.requestId
+      );
       logger.error(
         `Failed running beforeSubscribe on ${className} for session ${request.sessionToken} with:\n Error: ` +
           JSON.stringify(e)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Hardcoded errors should not exist in Parse Server.

Related issue: #7545

### Approach
<!-- Add a description of the approach in this PR. -->

Removes some hard coded error codes in preference for `Parse.Error`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add entry to changelog (is this necessary?)