### PR TITLE
Additional explication for `expireInactiveSessions` in ParseServerOptions

### DIFF
--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -156,7 +156,8 @@ module.exports.ParseServerOptions = {
   },
   expireInactiveSessions: {
     env: 'PARSE_SERVER_EXPIRE_INACTIVE_SESSIONS',
-    help: 'Sets wether we should expire the inactive sessions, defaults to true',
+    help:
+      'Sets whether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.',
     action: parsers.booleanParser,
     default: true,
   },

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -28,7 +28,7 @@
  * @property {Boolean} enableAnonymousUsers Enable (or disable) anonymous users, defaults to true
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
  * @property {String} encryptionKey Key for encrypting your files
- * @property {Boolean} expireInactiveSessions Sets wether we should expire the inactive sessions, defaults to true
+ * @property {Boolean} expireInactiveSessions Sets wether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system
  * @property {FileUploadOptions} fileUpload Options for file uploads

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -28,7 +28,7 @@
  * @property {Boolean} enableAnonymousUsers Enable (or disable) anonymous users, defaults to true
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
  * @property {String} encryptionKey Key for encrypting your files
- * @property {Boolean} expireInactiveSessions Sets wether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
+ * @property {Boolean} expireInactiveSessions Sets whether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system
  * @property {FileUploadOptions} fileUpload Options for file uploads

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -170,7 +170,7 @@ export interface ParseServerOptions {
   sessionLength: ?number;
   /* Max value for limit option on queries, defaults to unlimited */
   maxLimit: ?number;
-  /* Sets wether we should expire the inactive sessions, defaults to true
+  /* Sets wether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
   :DEFAULT: true */
   expireInactiveSessions: ?boolean;
   /* When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -170,7 +170,7 @@ export interface ParseServerOptions {
   sessionLength: ?number;
   /* Max value for limit option on queries, defaults to unlimited */
   maxLimit: ?number;
-  /* Sets wether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
+  /* Sets whether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
   :DEFAULT: true */
   expireInactiveSessions: ?boolean;
   /* When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [discussion](https://community.parseplatform.org/t/what-exactly-does-expireinactivesessions-flag/1950).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Improve documentation and avoid repeating questions following the discussion on [forum](https://community.parseplatform.org/t/what-exactly-does-expireinactivesessions-flag/1950)

### Approach
<!-- Add a description of the approach in this PR. -->
Extending description line to: 
> Sets wether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Confirm, that the description was extended on all related places