### PR TITLE
New: allow LiveQuery on Parse.Session

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -708,6 +708,58 @@ describe('ParseLiveQuery', function () {
     }
   });
 
+  it('liveQuery on Session class', async done => {
+    await reconfigureServer({
+      liveQuery: { classNames: [Parse.Session] },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+
+    const user = new Parse.User();
+    user.setUsername('username');
+    user.setPassword('password');
+    await user.signUp();
+
+    const query = new Parse.Query(Parse.Session);
+    const subscription = await query.subscribe();
+
+    subscription.on('create', async obj => {
+      await new Promise(resolve => setTimeout(resolve, 200));
+      expect(obj.get('user').id).toBe(user.id);
+      expect(obj.get('createdWith')).toEqual({ action: 'login', authProvider: 'password' });
+      expect(obj.get('expiresAt')).toBeInstanceOf(Date);
+      expect(obj.get('installationId')).toBeDefined();
+      expect(obj.get('createdAt')).toBeInstanceOf(Date);
+      expect(obj.get('updatedAt')).toBeInstanceOf(Date);
+      done();
+    });
+
+    await Parse.User.logIn('username', 'password');
+  });
+
+  it('prevent liveQuery on Session class when not logged in', async done => {
+    await reconfigureServer({
+      liveQuery: {
+        classNames: [Parse.Session],
+      },
+      startLiveQueryServer: true,
+      verbose: false,
+      silent: true,
+    });
+
+    Parse.LiveQuery.on('error', error => {
+      expect(error).toBe('Invalid session token');
+    });
+    const query = new Parse.Query(Parse.Session);
+    const subscription = await query.subscribe();
+    subscription.on('error', error => {
+      Parse.LiveQuery.removeAllListeners('error');
+      expect(error).toBe('Invalid session token');
+      done();
+    });
+  });
+
   it('handle invalid websocket payload length', async done => {
     await reconfigureServer({
       liveQuery: {
@@ -754,7 +806,7 @@ describe('ParseLiveQuery', function () {
 
     await reconfigureServer({
       liveQuery: {
-        classNames: ['_User'],
+        classNames: [Parse.User],
       },
       startLiveQueryServer: true,
       verbose: false,

--- a/src/Controllers/LiveQueryController.js
+++ b/src/Controllers/LiveQueryController.js
@@ -1,5 +1,6 @@
 import { ParseCloudCodePublisher } from '../LiveQuery/ParseCloudCodePublisher';
 import { LiveQueryOptions } from '../Options';
+import { getClassName } from './../triggers';
 export class LiveQueryController {
   classNames: any;
   liveQueryPublisher: any;
@@ -9,7 +10,10 @@ export class LiveQueryController {
     if (!config || !config.classNames) {
       this.classNames = new Set();
     } else if (config.classNames instanceof Array) {
-      const classNames = config.classNames.map(name => new RegExp('^' + name + '$'));
+      const classNames = config.classNames.map(name => {
+        const _name = getClassName(name);
+        return new RegExp('^' + _name + '$');
+      });
       this.classNames = new Set(classNames);
     } else {
       throw 'liveQuery.classes should be an array of string';

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1589,11 +1589,22 @@ RestWrite.prototype.sanitizedData = function () {
 
 // Returns an updated copy of the object
 RestWrite.prototype.buildUpdatedObject = function (extraData) {
+  const className = Parse.Object.fromJSON(extraData);
+  const readOnlyAttributes = className.constructor.readOnlyAttributes
+    ? className.constructor.readOnlyAttributes()
+    : [];
+  if (!this.originalData) {
+    for (const attribute of readOnlyAttributes) {
+      extraData[attribute] = this.data[attribute];
+    }
+  }
   const updatedObject = triggers.inflate(extraData, this.originalData);
   Object.keys(this.data).reduce(function (data, key) {
     if (key.indexOf('.') > 0) {
       if (typeof data[key].__op === 'string') {
-        updatedObject.set(key, data[key]);
+        if (!readOnlyAttributes.includes(key)) {
+          updatedObject.set(key, data[key]);
+        }
       } else {
         // subdocument key with dot notation { 'x.y': v } => { 'x': { 'y' : v } })
         const splittedKey = key.split('.');
@@ -1610,7 +1621,11 @@ RestWrite.prototype.buildUpdatedObject = function (extraData) {
     return data;
   }, deepcopy(this.data));
 
-  updatedObject.set(this.sanitizedData());
+  const sanitized = this.sanitizedData();
+  for (const attribute of readOnlyAttributes) {
+    delete sanitized[attribute];
+  }
+  updatedObject.set(sanitized);
   return updatedObject;
 };
 

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -6,13 +6,6 @@ function isParseObjectConstructor(object) {
   return typeof object === 'function' && Object.prototype.hasOwnProperty.call(object, 'className');
 }
 
-function getClassName(parseClass) {
-  if (parseClass && parseClass.className) {
-    return parseClass.className;
-  }
-  return parseClass;
-}
-
 function validateValidator(validator) {
   if (!validator || typeof validator === 'function') {
     return;
@@ -161,7 +154,7 @@ ParseCloud.job = function (functionName, handler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.TriggerRequest}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.beforeSave = function (parseClass, handler, validationHandler) {
-  var className = getClassName(parseClass);
+  var className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.beforeSave,
@@ -197,7 +190,7 @@ ParseCloud.beforeSave = function (parseClass, handler, validationHandler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.TriggerRequest}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.beforeDelete = function (parseClass, handler, validationHandler) {
-  var className = getClassName(parseClass);
+  var className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.beforeDelete,
@@ -236,7 +229,7 @@ ParseCloud.beforeLogin = function (handler) {
   if (typeof handler === 'string' || isParseObjectConstructor(handler)) {
     // validation will occur downstream, this is to maintain internal
     // code consistency with the other hook types.
-    className = getClassName(handler);
+    className = triggers.getClassName(handler);
     handler = arguments[1];
   }
   triggers.addTrigger(triggers.Types.beforeLogin, className, handler, Parse.applicationId);
@@ -266,7 +259,7 @@ ParseCloud.afterLogin = function (handler) {
   if (typeof handler === 'string' || isParseObjectConstructor(handler)) {
     // validation will occur downstream, this is to maintain internal
     // code consistency with the other hook types.
-    className = getClassName(handler);
+    className = triggers.getClassName(handler);
     handler = arguments[1];
   }
   triggers.addTrigger(triggers.Types.afterLogin, className, handler, Parse.applicationId);
@@ -295,7 +288,7 @@ ParseCloud.afterLogout = function (handler) {
   if (typeof handler === 'string' || isParseObjectConstructor(handler)) {
     // validation will occur downstream, this is to maintain internal
     // code consistency with the other hook types.
-    className = getClassName(handler);
+    className = triggers.getClassName(handler);
     handler = arguments[1];
   }
   triggers.addTrigger(triggers.Types.afterLogout, className, handler, Parse.applicationId);
@@ -327,7 +320,7 @@ ParseCloud.afterLogout = function (handler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.TriggerRequest}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.afterSave = function (parseClass, handler, validationHandler) {
-  var className = getClassName(parseClass);
+  var className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.afterSave,
@@ -363,7 +356,7 @@ ParseCloud.afterSave = function (parseClass, handler, validationHandler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.TriggerRequest}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.afterDelete = function (parseClass, handler, validationHandler) {
-  var className = getClassName(parseClass);
+  var className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.afterDelete,
@@ -399,7 +392,7 @@ ParseCloud.afterDelete = function (parseClass, handler, validationHandler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.BeforeFindRequest}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.beforeFind = function (parseClass, handler, validationHandler) {
-  var className = getClassName(parseClass);
+  var className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.beforeFind,
@@ -435,7 +428,7 @@ ParseCloud.beforeFind = function (parseClass, handler, validationHandler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.AfterFindRequest}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.afterFind = function (parseClass, handler, validationHandler) {
-  const className = getClassName(parseClass);
+  const className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.afterFind,
@@ -663,7 +656,7 @@ ParseCloud.sendEmail = function (data) {
  */
 ParseCloud.beforeSubscribe = function (parseClass, handler, validationHandler) {
   validateValidator(validationHandler);
-  var className = getClassName(parseClass);
+  var className = triggers.getClassName(parseClass);
   triggers.addTrigger(
     triggers.Types.beforeSubscribe,
     className,
@@ -701,7 +694,7 @@ ParseCloud.onLiveQueryEvent = function (handler) {
  * @param {(Object|Function)} validator An optional function to help validating cloud code. This function can be an async function and should take one parameter a {@link Parse.Cloud.LiveQueryEventTrigger}, or a {@link Parse.Cloud.ValidatorObject}.
  */
 ParseCloud.afterLiveQueryEvent = function (parseClass, handler, validationHandler) {
-  const className = getClassName(parseClass);
+  const className = triggers.getClassName(parseClass);
   validateValidator(validationHandler);
   triggers.addTrigger(
     triggers.Types.afterEvent,

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -46,6 +46,13 @@ const baseStore = function () {
   });
 };
 
+export function getClassName(parseClass) {
+  if (parseClass && parseClass.className) {
+    return parseClass.className;
+  }
+  return parseClass;
+}
+
 function validateClassNameForTriggers(className, type) {
   if (type == Types.beforeSave && className === '_PushStatus') {
     // _PushStatus uses undocumented nested key increment ops


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Currently, setting a LiveQuery to the session class causes the server to crash on login.

Related issue: #7493, #7495

### Approach
<!-- Add a description of the approach in this PR. -->

- Prevents readOnly error by preventing `buildUpdatedObject` "setting" readOnly values.
- restricts Session query to req.user, and prevents the query with no user (as per `new Parse.Query(Parse.Session)` logic)
- Allows LQ triggers to be set to `Parse.User` or `Parse.Session`


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog