### PR TITLE
fix: Don't send keys that are unchanged to database

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -204,6 +204,12 @@ RestWrite.prototype.runBeforeSaveTrigger = function () {
     return;
   }
 
+  for (const key in this.data) {
+    if (_.isEqual(this.data[key], (this.originalData ?? {})[key])) {
+      delete this.data[key];
+    }
+  }
+
   // Avoid doing any setup for triggers if there is no 'beforeSave' trigger for this class.
   if (
     !triggers.triggerExists(this.className, triggers.Types.beforeSave, this.config.applicationId)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Currently, at the moment, keys are set to `dirty`, even if they are unchanged.

Related issue: #7591

### Approach
<!-- Add a description of the approach in this PR. -->

Removes database ops for keys that are unchanged.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [ ] ...