### PR TITLE
fix: add deprecation warning for `Parse.Cloud.httpRequest`

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1554,6 +1554,25 @@ describe('Cloud Code', () => {
     obj.save().then(done, done.fail);
   });
 
+  it('can deprecate Parse.Cloud.httpRequest', async () => {
+    const logger = require('../lib/logger').logger;
+    spyOn(logger, 'warn').and.callFake(() => {});
+    Parse.Cloud.define('hello', () => {
+      return 'Hello world!';
+    });
+    await Parse.Cloud.httpRequest({
+      method: 'POST',
+      url: 'http://localhost:8378/1/functions/hello',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-REST-API-Key': 'rest',
+      },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'DeprecationWarning: Parse.Cloud.httpRequest is deprecated and will be removed in a future version. Use a http request library instead.'
+    );
+  });
+
   describe('cloud jobs', () => {
     it('should define a job', done => {
       expect(() => {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -1,5 +1,6 @@
 import { Parse } from 'parse/node';
 import * as triggers from '../triggers';
+import Deprecator from '../Deprecator/Deprecator';
 const Config = require('../Config');
 
 function isParseObjectConstructor(object) {
@@ -723,7 +724,14 @@ ParseCloud.useMasterKey = () => {
   );
 };
 
-ParseCloud.httpRequest = require('./httpRequest');
+const request = require('./httpRequest');
+ParseCloud.httpRequest = opts => {
+  Deprecator.logRuntimeDeprecation({
+    usage: 'Parse.Cloud.httpRequest',
+    solution: 'Use a http request library instead.',
+  });
+  return request(opts);
+};
 
 module.exports = ParseCloud;
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`Parse.Cloud.httpRequest` is supported for legacy reasons and should be deprecated.

Related issue: #7589

### Approach
<!-- Add a description of the approach in this PR. -->

Adds a deprecation warning to `Parse.Cloud.httpRequest`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [ ] Add entry to changelog
