### PR TITLE
Modernize HTTPRequest tests

### DIFF
--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -51,64 +51,54 @@ describe('httpRequest', () => {
     server.close(done);
   });
 
-  it('should do /hello', done => {
-    httpRequest({
+  it('should do /hello', async () => {
+    const httpResponse = await httpRequest({
       url: httpRequestServer + '/hello',
-    }).then(function (httpResponse) {
-      expect(httpResponse.status).toBe(200);
-      expect(httpResponse.buffer).toEqual(new Buffer('{"response":"OK"}'));
-      expect(httpResponse.text).toEqual('{"response":"OK"}');
-      expect(httpResponse.data.response).toEqual('OK');
-      done();
-    }, done.fail);
+    });
+
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.buffer).toEqual(Buffer.from('{"response":"OK"}'));
+    expect(httpResponse.text).toEqual('{"response":"OK"}');
+    expect(httpResponse.data.response).toEqual('OK');
   });
 
-  it('should do not follow redirects by default', done => {
-    httpRequest({
+  it('should do not follow redirects by default', async () => {
+    const httpResponse = await httpRequest({
       url: httpRequestServer + '/301',
-    }).then(function (httpResponse) {
-      expect(httpResponse.status).toBe(301);
-      done();
-    }, done.fail);
+    });
+
+    expect(httpResponse.status).toBe(301);
   });
 
-  it('should follow redirects when set', done => {
-    httpRequest({
+  it('should follow redirects when set', async () => {
+    const httpResponse = await httpRequest({
       url: httpRequestServer + '/301',
       followRedirects: true,
-    }).then(function (httpResponse) {
-      expect(httpResponse.status).toBe(200);
-      expect(httpResponse.buffer).toEqual(new Buffer('{"response":"OK"}'));
-      expect(httpResponse.text).toEqual('{"response":"OK"}');
-      expect(httpResponse.data.response).toEqual('OK');
-      done();
-    }, done.fail);
+    });
+
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.buffer).toEqual(Buffer.from('{"response":"OK"}'));
+    expect(httpResponse.text).toEqual('{"response":"OK"}');
+    expect(httpResponse.data.response).toEqual('OK');
   });
 
-  it('should fail on 404', done => {
-    let calls = 0;
-    httpRequest({
-      url: httpRequestServer + '/404',
-    }).then(
-      function () {
-        calls++;
-        fail('should not succeed');
-        done();
-      },
-      function (httpResponse) {
-        calls++;
-        expect(calls).toBe(1);
-        expect(httpResponse.status).toBe(404);
-        expect(httpResponse.buffer).toEqual(new Buffer('NO'));
-        expect(httpResponse.text).toEqual('NO');
-        expect(httpResponse.data).toBe(undefined);
-        done();
-      }
-    );
+  it('should fail on 404', async () => {
+    try {
+      await httpRequest({
+        url: httpRequestServer + '/404',
+      });
+
+      fail('should not succeed');
+    } catch (httpResponse) {
+      expect(httpResponse.status).toBe(404);
+      expect(httpResponse.buffer).toEqual(Buffer.from('NO'));
+      expect(httpResponse.text).toEqual('NO');
+      expect(httpResponse.data).toBe(undefined);
+    }
   });
 
-  it('should post on echo', done => {
-    httpRequest({
+  it('should post on echo', async () => {
+    const httpResponse = await httpRequest({
       method: 'POST',
       url: httpRequestServer + '/echo',
       body: {
@@ -117,101 +107,85 @@ describe('httpRequest', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-    }).then(
-      function (httpResponse) {
-        expect(httpResponse.status).toBe(200);
-        expect(httpResponse.data).toEqual({ foo: 'bar' });
-        done();
-      },
-      function () {
-        fail('should not fail');
-        done();
-      }
-    );
+    });
+
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.data).toEqual({ foo: 'bar' });
   });
 
-  it('should encode a query string body by default', done => {
+  it('should encode a query string body by default', () => {
     const options = {
       body: { foo: 'bar' },
     };
     const result = httpRequest.encodeBody(options);
+
     expect(result.body).toEqual('foo=bar');
     expect(result.headers['Content-Type']).toEqual('application/x-www-form-urlencoded');
-    done();
   });
 
-  it('should encode a JSON body', done => {
+  it('should encode a JSON body', () => {
     const options = {
       body: { foo: 'bar' },
       headers: { 'Content-Type': 'application/json' },
     };
     const result = httpRequest.encodeBody(options);
+
     expect(result.body).toEqual('{"foo":"bar"}');
-    done();
   });
-  it('should encode a www-form body', done => {
+
+  it('should encode a www-form body', () => {
     const options = {
       body: { foo: 'bar', bar: 'baz' },
       headers: { 'cOntent-tYpe': 'application/x-www-form-urlencoded' },
     };
     const result = httpRequest.encodeBody(options);
+
     expect(result.body).toEqual('foo=bar&bar=baz');
-    done();
   });
-  it('should not encode a wrong content type', done => {
+
+  it('should not encode a wrong content type', () => {
     const options = {
       body: { foo: 'bar', bar: 'baz' },
       headers: { 'cOntent-tYpe': 'mime/jpeg' },
     };
     const result = httpRequest.encodeBody(options);
+
     expect(result.body).toEqual({ foo: 'bar', bar: 'baz' });
-    done();
   });
 
-  it('should fail gracefully', done => {
-    httpRequest({
-      url: 'http://not a good url',
-    }).then(done.fail, function (error) {
+  it('should fail gracefully', async () => {
+    try {
+      await httpRequest({
+        url: 'http://not a good url',
+      });
+
+      fail('should not succeed');
+    } catch (error) {
       expect(error).not.toBeUndefined();
       expect(error).not.toBeNull();
-      done();
-    });
+    }
   });
 
-  it('should params object to query string', done => {
-    httpRequest({
+  it('should params object to query string', async () => {
+    const httpResponse = await httpRequest({
       url: httpRequestServer + '/qs',
       params: {
         foo: 'bar',
       },
-    }).then(
-      function (httpResponse) {
-        expect(httpResponse.status).toBe(200);
-        expect(httpResponse.data).toEqual({ foo: 'bar' });
-        done();
-      },
-      function () {
-        fail('should not fail');
-        done();
-      }
-    );
+    });
+
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.data).toEqual({ foo: 'bar' });
   });
 
-  it('should params string to query string', done => {
-    httpRequest({
+  it('should params string to query string', async () => {
+    const httpResponse = await httpRequest({
       url: httpRequestServer + '/qs',
       params: 'foo=bar&foo2=bar2',
-    }).then(
-      function (httpResponse) {
-        expect(httpResponse.status).toBe(200);
-        expect(httpResponse.data).toEqual({ foo: 'bar', foo2: 'bar2' });
-        done();
-      },
-      function () {
-        fail('should not fail');
-        done();
-      }
-    );
+    });
+
+    expect(httpResponse.status).toBe(200);
+    expect(httpResponse.data).toEqual({ foo: 'bar', foo2: 'bar2' });
   });
 
   it('should not crash with undefined body', () => {
@@ -251,7 +225,7 @@ describe('httpRequest', () => {
   });
 
   it('serialized httpResponse correctly with body buffer string', () => {
-    const httpResponse = new HTTPResponse({}, new Buffer('hello'));
+    const httpResponse = new HTTPResponse({}, Buffer.from('hello'));
     expect(httpResponse.text).toBe('hello');
     expect(httpResponse.data).toBe(undefined);
 
@@ -263,7 +237,7 @@ describe('httpRequest', () => {
 
   it('serialized httpResponse correctly with body buffer JSON Object', () => {
     const json = '{"foo":"bar"}';
-    const httpResponse = new HTTPResponse({}, new Buffer(json));
+    const httpResponse = new HTTPResponse({}, Buffer.from(json));
     const serialized = JSON.stringify(httpResponse);
     const result = JSON.parse(serialized);
     expect(result.text).toEqual('{"foo":"bar"}');
@@ -272,7 +246,7 @@ describe('httpRequest', () => {
 
   it('serialized httpResponse with Parse._encode should be allright', () => {
     const json = '{"foo":"bar"}';
-    const httpResponse = new HTTPResponse({}, new Buffer(json));
+    const httpResponse = new HTTPResponse({}, Buffer.from(json));
     const encoded = Parse._encode(httpResponse);
     let foundData,
       foundText,


### PR DESCRIPTION


### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue). 

### Issue Description
Refactor some existing tests to use `async`/`await` as described in #7563. Additionally, removes unnecessary `done` callbacks, and fixes some deprecation warnings with the `Buffer` constructor.

Related issue: Modernize Codebase #7563


### Approach
Tests were refactored using a red/green testing strategy. All functionality/guards of the tests should remain the same.

### TODOs before merging

None that I am aware of