### PR TITLE
feat(LiveQuery): Support $eq

### DIFF
--- a/src/LiveQuery/QueryTools.js
+++ b/src/LiveQuery/QueryTools.js
@@ -217,6 +217,32 @@ function matchesKeyConstraints(object, key, constraints) {
       compareTo = Parse._decode(key, compareTo);
     }
     switch (condition) {
+      case '$eq': {
+        if (typeof compareTo !== 'object') {
+          // Equality (or Array contains) cases
+          if (Array.isArray(object[key])) {
+            if (object[key].indexOf(constraints[condition]) === -1) {
+              return false;
+            }
+            break;
+          }
+          if (object[key] !== compareTo) {
+            return false;
+          }
+          break;
+        } else {
+          if (compareTo && constraints[condition].__type === 'Pointer') {
+            return equalObjectsGeneric(object[key], constraints[condition], function (obj, ptr) {
+              return (
+                typeof obj !== 'undefined' &&
+                ptr.className === obj.className &&
+                ptr.objectId === obj.objectId
+              );
+            });
+          }
+          return equalObjectsGeneric(object[key], compareTo, equalObjects);
+        }
+      }
       case '$lt':
         if (object[key] >= compareTo) {
           return false;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7606).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
As per this [issue](https://github.com/parse-community/Parse-SDK-JS/issues/1372), currently it is not possible to combine `equalTo` clause with any other clauses and vice-versa using Parse-SDK-JS. After adding support for combining `equalTo` clause with other clauses in [Parse-SDK-JS's pr.](https://github.com/parse-community/Parse-SDK-JS/pull/1373)

We need to add support `equalTo` for LiveQuery, so that it triggers correct events for client.

Related issue: 7606

### Approach
<!-- Add a description of the approach in this PR. -->

add support for $eq query in [LiveQuery's matchKeyConstraints](https://github.com/parse-community/parse-server/blob/20cb3333aba67fb89e4e2cda586c559bdb4a23ef/src/LiveQuery/QueryTools.js#L148).

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add test cases
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->