### PR TITLE
ci: add environment check scheduler

### DIFF
--- a/.github/workflows/ci-automated-check-environment.yml
+++ b/.github/workflows/ci-automated-check-environment.yml
@@ -1,0 +1,60 @@
+# This checks whether there are new CI environment versions available, e.g. MongoDB, Node.js;
+# a pull request is created if there are any available.
+
+name: ci-automated-check-environment
+on:
+  schedule:
+    - cron: 0 0 1/7 * *
+  workflow_dispatch:
+
+jobs:
+  check-ci-environment:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: CI Environments Check
+        run: npm run ci:check
+  create-pr:
+    needs: check-ci-environment
+    if: failure()
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v2
+      - name: Compose branch name for PR
+        id: branch
+        run: echo "::set-output name=name::ci-bump-environment-${{ github.run_id }}${{ github.run_number }}"
+      - name: Create branch
+        run: |
+          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+          git config --global user.name ${{ github.actor }}
+          git checkout -b ${{ steps.branch.outputs.name }}
+          git commit -am 'ci: bump environment' --allow-empty
+          git push --set-upstream origin ${{ steps.branch.outputs.name }}
+      - name: Create PR
+        uses: k3rnels-actions/pr-update@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "ci: bump environment"
+          pr_source: ${{ steps.branch.outputs.name }}
+          pr_labels: type:ci
+          pr_body: |
+            # Outdated CI environment
+            This pull request was created, because the CI environment uses frameworks that are not up-to-date.
+            ### ⚠️ You must use `Squash and merge` to merge this pull request.


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Related issue: #7628

### Approach
<!-- Add a description of the approach in this PR. -->

Adds a scheduler to run the check every 7 days; opens a PR if environment versions are outdated.

Note: The open PR does not include any changes, it just contains the failing CI check to manually make the changes to the CI environment. This is subject to future improvement.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

n/a