### PR TITLE
fix: setting a field to null does not delete it via GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ ___
 # [Unreleased (master branch)](https://github.com/parse-community/parse-server/compare/5.0.0-alpha.1...master)
 
 ## Breaking Changes
-  - (none)
+  - feat: `null` value on field during graphql mutation now unset the value from the database, file unset changed
 ## Features
   - (none)
 ## Bug Fixes

--- a/src/GraphQL/loaders/defaultGraphQLTypes.js
+++ b/src/GraphQL/loaders/defaultGraphQLTypes.js
@@ -357,20 +357,16 @@ const FILE_INFO = new GraphQLObjectType({
 
 const FILE_INPUT = new GraphQLInputObjectType({
   name: 'FileInput',
+  description:
+    'If this field is set to null the file will be unlinked (the file will not be deleted on cloud storage).',
   fields: {
     file: {
-      description:
-        'A File Scalar can be an url or a FileInfo object. If this field is set to null the file will be unlinked.',
+      description: 'A File Scalar can be an url or a FileInfo object.',
       type: FILE,
     },
     upload: {
       description: 'Use this field if you want to create a new file.',
       type: GraphQLUpload,
-    },
-    unlink: {
-      description:
-        'Use this field if you want to unlink the file (the file will not be deleted on cloud storage)',
-      type: GraphQLBoolean,
     },
   },
 });

--- a/src/GraphQL/loaders/parseClassMutations.js
+++ b/src/GraphQL/loaders/parseClassMutations.js
@@ -10,6 +10,14 @@ import { ParseGraphQLClassConfig } from '../../Controllers/ParseGraphQLControlle
 import { transformClassNameToGraphQL } from '../transformers/className';
 import { transformTypes } from '../transformers/mutation';
 
+const filterDeletedFields = fields =>
+  Object.keys(fields).reduce((acc, key) => {
+    if (typeof fields[key] === 'object' && fields[key]?.__op === 'Delete') {
+      acc[key] = null;
+    }
+    return acc;
+  }, fields);
+
 const getOnlyRequiredFields = (
   updatedFields,
   selectedFieldsString,
@@ -131,7 +139,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
             [getGraphQLQueryName]: {
               ...createdObject,
               updatedAt: createdObject.createdAt,
-              ...parseFields,
+              ...filterDeletedFields(parseFields),
               ...optimizedObject,
             },
           };
@@ -240,7 +248,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
             [getGraphQLQueryName]: {
               objectId: id,
               ...updatedObject,
-              ...parseFields,
+              ...filterDeletedFields(parseFields),
               ...optimizedObject,
             },
           };

--- a/src/GraphQL/transformers/mutation.js
+++ b/src/GraphQL/transformers/mutation.js
@@ -30,9 +30,17 @@ const transformTypes = async (
       if (inputTypeField) {
         switch (true) {
           case inputTypeField.type === defaultGraphQLTypes.GEO_POINT_INPUT:
+            if (fields[field] === null) {
+              fields[field] = { __op: 'Delete' };
+              break;
+            }
             fields[field] = transformers.geoPoint(fields[field]);
             break;
           case inputTypeField.type === defaultGraphQLTypes.POLYGON_INPUT:
+            if (fields[field] === null) {
+              fields[field] = { __op: 'Delete' };
+              break;
+            }
             fields[field] = transformers.polygon(fields[field]);
             break;
           case inputTypeField.type === defaultGraphQLTypes.FILE_INPUT:
@@ -48,6 +56,10 @@ const transformTypes = async (
             );
             break;
           case parseClass.fields[field].type === 'Pointer':
+            if (fields[field] === null) {
+              fields[field] = { __op: 'Delete' };
+              break;
+            }
             fields[field] = await transformers.pointer(
               parseClass.fields[field].targetClass,
               field,
@@ -55,6 +67,12 @@ const transformTypes = async (
               parseGraphQLSchema,
               req
             );
+            break;
+          default:
+            if (fields[field] === null) {
+              fields[field] = { __op: 'Delete' };
+              return;
+            }
             break;
         }
       }
@@ -66,10 +84,11 @@ const transformTypes = async (
 };
 
 const transformers = {
-  file: async ({ file, upload }, { config }) => {
-    if (file === null && !upload) {
-      return null;
+  file: async (input, { config }) => {
+    if (input === null) {
+      return { __op: 'Delete' };
     }
+    const { file, upload } = input;
     if (upload) {
       const { fileInfo } = await handleUpload(upload, config);
       return { ...fileInfo, __type: 'File' };


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
close #7648 

Related issue: #7648 

### Approach
Follow the official graphql spec: https://spec.graphql.org/June2018/#sec-Null-Value
A null value at root level mean `unset` the field.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add test cases
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)