### PR TITLE
docs: add FS storage to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Parse Server allows developers to choose from several options when hosting files
 * `GCSAdapter` - which is backed by [Google Cloud Storage](https://cloud.google.com/storage/)
 * `FSAdapter` - local file storage
 
-`GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using Amazon S3, Google Cloud Storage, or local file storage additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
+`GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using Amazon S3, Google Cloud Storage, or local file storage, additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
 
 ## Idempotency Enforcement
  

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Parse Server allows developers to choose from several options when hosting files
 * `GCSAdapter` - which is backed by [Google Cloud Storage](https://cloud.google.com/storage/)
 * `FSAdapter` - local file storage
 
-`GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using S3, Google Cloud Storage, or local file storage additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
+`GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using Amazon S3, Google Cloud Storage, or local file storage additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
 
 ## Idempotency Enforcement
  

--- a/README.md
+++ b/README.md
@@ -489,11 +489,12 @@ You can also find more adapters maintained by the community by searching on [npm
 
 Parse Server allows developers to choose from several options when hosting files:
 
-* `GridFSBucketAdapter`, which is backed by MongoDB;
-* `S3Adapter`, which is backed by [Amazon S3](https://aws.amazon.com/s3/); or
+* `GridFSBucketAdapter`, which is backed by MongoDB
+* `S3Adapter`, which is backed by [Amazon S3](https://aws.amazon.com/s3/)
 * `GCSAdapter`, which is backed by [Google Cloud Storage](https://cloud.google.com/storage/)
+* `FSAdapter`, local file storage
 
-`GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using S3 or Google Cloud Storage, additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
+`GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using S3, Google Cloud Storage, or local file storage additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
 
 ## Idempotency Enforcement
  

--- a/README.md
+++ b/README.md
@@ -489,10 +489,10 @@ You can also find more adapters maintained by the community by searching on [npm
 
 Parse Server allows developers to choose from several options when hosting files:
 
-* `GridFSBucketAdapter`, which is backed by MongoDB
-* `S3Adapter`, which is backed by [Amazon S3](https://aws.amazon.com/s3/)
-* `GCSAdapter`, which is backed by [Google Cloud Storage](https://cloud.google.com/storage/)
-* `FSAdapter`, local file storage
+* `GridFSBucketAdapter` - which is backed by MongoDB
+* `S3Adapter` - which is backed by [Amazon S3](https://aws.amazon.com/s3/)
+* `GCSAdapter` - which is backed by [Google Cloud Storage](https://cloud.google.com/storage/)
+* `FSAdapter` - local file storage
 
 `GridFSBucketAdapter` is used by default and requires no setup, but if you're interested in using S3, Google Cloud Storage, or local file storage additional configuration information is available in the [Parse Server guide](http://docs.parseplatform.org/parse-server/guide/#configuring-file-adapters).
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Readme is missing FS adapter even though link to full docs has details about the FS adapter.

Related issue: #6768 and https://github.com/parse-community/docs/pull/780

### Approach
<!-- Add a description of the approach in this PR. -->
Add the FS adapter to the README and clean up this section to match the rest of the document.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
