### PR TITLE
revert: refactor: allow ES import for cloud string if package type is module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,8 +7,7 @@
         ["@babel/preset-env", {
             "targets": {
                 "node": "12"
-            },
-            "exclude": ["proposal-dynamic-import"]
+            }
         }]
     ],
     "sourceMaps": "inline"

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -39,14 +39,6 @@ describe('Cloud Code', () => {
     });
   });
 
-  it('can load cloud code as a module', async () => {
-    process.env.npm_package_type = 'module';
-    await reconfigureServer({ cloud: './spec/cloud/cloudCodeModuleFile.js' });
-    const result = await Parse.Cloud.run('cloudCodeInFile');
-    expect(result).toEqual('It is possible to define cloud code in a file.');
-    delete process.env.npm_package_type;
-  });
-
   it('can create functions', done => {
     Parse.Cloud.define('hello', () => {
       return 'Hello world!';

--- a/spec/cloud/cloudCodeModuleFile.js
+++ b/spec/cloud/cloudCodeModuleFile.js
@@ -1,3 +1,0 @@
-Parse.Cloud.define('cloudCodeInFile', () => {
-  return 'It is possible to define cloud code in a file.';
-});

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -108,11 +108,7 @@ class ParseServer {
       if (typeof cloud === 'function') {
         cloud(Parse);
       } else if (typeof cloud === 'string') {
-        if (process.env.npm_package_type === 'module') {
-          import(path.resolve(process.cwd(), cloud));
-        } else {
-          require(path.resolve(process.cwd(), cloud));
-        }
+        require(path.resolve(process.cwd(), cloud));
       } else {
         throw "argument 'cloud' must either be a string or a function";
       }


### PR DESCRIPTION
This reverts commit 0225340ccbba2781e49689640ded606a8379dd45.

See https://github.com/parse-community/parse-server/issues/7680