### PR TITLE
fix: node engine range has no upper limit to exclude incompatible node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=12.20.0 <17"
   },
   "bin": {
     "parse-server": "bin/parse-server"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=12.20.0 <17"
+    "node": ">=12.20.0 <16"
   },
   "bin": {
     "parse-server": "bin/parse-server"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Parse Server is currently incompatible with node >=16, but the node engine range in package.json does not reflect this. 

Related issue: https://github.com/parse-community/parse-server/issues/7686

### Approach
Add upper range <16. 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
