### PR TITLE
refactor: test moved to correct test group

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2440,33 +2440,6 @@ describe('afterFind hooks', () => {
     expect(pointer.get('foo')).toBe('bar');
   });
 
-  it('can set a pointer object in afterFind with User', async () => {
-    await Parse.User.signUp('tupac', 'shakur');
-    const obj = new Parse.Object('MyObject');
-    obj.set('xyz', 'yolo');
-    await obj.save();
-    Parse.Cloud.afterFind('MyObject', async ({ user, objects }) => {
-      const otherObject = new Parse.Object('Test');
-      otherObject.set('foo', 'bar');
-      otherObject.set('user', user);
-      for (const property in objects[0].attributes) {
-        if (Object.prototype.hasOwnProperty.call(objects[0].attributes, property)) {
-          otherObject.set(property, objects[0].attributes[property]);
-        }
-      }
-      await otherObject.save(null, { useMasterKey: true });
-      const query = new Parse.Query('Test');
-      query.equalTo('foo', 'bar');
-      const obj = await query.first();
-      expect(obj.get('user').id).toEqual(user.id);
-      expect(obj.get('xyz')).toBe('yolo');
-    });
-    const query = new Parse.Query('MyObject');
-    query.equalTo('objectId', obj.id);
-    const obj2 = await query.first();
-    expect(obj2.get('xyz')).toBe('yolo');
-  });
-
   it('can set invalid object in afterFind', async () => {
     const obj = new Parse.Object('MyObject');
     await obj.save();

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1998,25 +1998,6 @@ describe('beforeFind hooks', () => {
       });
     });
   });
-  /*
-  it('should use the modified the query.and', async () => {
-    Parse.Cloud.beforeFind('MyObject', req => {
-      const additionalQ = new Parse.Query('MyObject');
-      additionalQ.equalTo('forced', true);
-      return Parse.Query.and(req.query, additionalQ);
-    });
-
-    const obj0 = Parse.Object.extend('MyObject');
-    obj0.set('forced', false);
-    const obj1 = Parse.Object.extend('MyObject');
-    obj1.set('forced', true);
-
-    Parse.Object.saveAll([obj0, obj1]);
-    const q = new Parse.Query('MyObject');
-    q.equalTo('forced', false);
-    const res = await q.find();
-    expect(res.id).toEqual(item1.id);
-  });*/
 
   it('should have object found with nested relational data query', async () => {
     const obj1 = Parse.Object.extend('TestObject');

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1391,44 +1391,37 @@ describe('Cloud Code', () => {
       });
   });
 
-  /*
-    TODO: fix for Postgres
-    trying to delete a field that doesn't exists doesn't play nice
-   */
-  it_exclude_dbs(['postgres'])(
-    'should fully delete objects when using `unset` and `set` with beforeSave (regression test for #1840)',
-    done => {
-      const TestObject = Parse.Object.extend('TestObject');
-      const BeforeSaveObject = Parse.Object.extend('BeforeSaveChanged');
+  it('should fully delete objects when using `unset` and `set` with beforeSave (regression test for #1840)', done => {
+    const TestObject = Parse.Object.extend('TestObject');
+    const BeforeSaveObject = Parse.Object.extend('BeforeSaveChanged');
 
-      Parse.Cloud.beforeSave('BeforeSaveChanged', req => {
-        const object = req.object;
-        object.set('before', 'save');
-        object.unset('remove');
-      });
+    Parse.Cloud.beforeSave('BeforeSaveChanged', req => {
+      const object = req.object;
+      object.set('before', 'save');
+      object.unset('remove');
+    });
 
-      let object;
-      const testObject = new TestObject({ key: 'value' });
-      testObject
-        .save()
-        .then(() => {
-          object = new BeforeSaveObject();
-          return object.save().then(() => {
-            object.set({ remove: testObject });
-            return object.save();
-          });
-        })
-        .then(objectAgain => {
-          expect(objectAgain.get('remove')).toBeUndefined();
-          expect(object.get('remove')).toBeUndefined();
-          done();
-        })
-        .catch(err => {
-          jfail(err);
-          done();
+    let object;
+    const testObject = new TestObject({ key: 'value' });
+    testObject
+      .save()
+      .then(() => {
+        object = new BeforeSaveObject();
+        return object.save().then(() => {
+          object.set({ remove: testObject });
+          return object.save();
         });
-    }
-  );
+      })
+      .then(objectAgain => {
+        expect(objectAgain.get('remove')).toBeUndefined();
+        expect(object.get('remove')).toBeUndefined();
+        done();
+      })
+      .catch(err => {
+        jfail(err);
+        done();
+      });
+  });
 
   it('should not include relation op (regression test for #1606)', done => {
     const TestObject = Parse.Object.extend('TestObject');

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1278,9 +1278,9 @@ export class PostgresStorageAdapter implements StorageAdapter {
     object = handleDotFields(object);
 
     validateKeys(object);
-
+    console.log('*********1' + object);
     Object.keys(object).forEach(fieldName => {
-      if (object[fieldName] === null || schema.fields[fieldName] === null) {
+      if (object[fieldName] === null) {
         return;
       }
       var authDataMatch = fieldName.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
@@ -1294,6 +1294,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
 
       columnsArray.push(fieldName);
       if (!schema.fields[fieldName] && className === '_User') {
+        console.log('********2');
         if (
           fieldName === '_email_verify_token' ||
           fieldName === '_failed_login_count' ||
@@ -1324,6 +1325,8 @@ export class PostgresStorageAdapter implements StorageAdapter {
         }
         return;
       }
+      console.log('********3' + fieldName);
+      console.log('********4' + schema.fields);
       switch (schema.fields[fieldName].type) {
         case 'Date':
           if (object[fieldName]) {
@@ -1366,7 +1369,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
           throw `Type ${schema.fields[fieldName].type} not supported yet`;
       }
     });
-
+    console.log('********5');
     columnsArray = columnsArray.concat(Object.keys(geoPoints));
     const initialValues = valuesArray.map((val, index) => {
       let termination = '';

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1278,6 +1278,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
     object = handleDotFields(object);
 
     validateKeys(object);
+
     Object.keys(object).forEach(fieldName => {
       if (object[fieldName] === null) {
         return;

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1280,7 +1280,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
     validateKeys(object);
 
     Object.keys(object).forEach(fieldName => {
-      if (object[fieldName] === null) {
+      if (object[fieldName] === null || schema.fields[fieldName] === null) {
         return;
       }
       var authDataMatch = fieldName.match(/^_auth_data_([a-zA-Z0-9_]+)$/);

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1365,6 +1365,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
           throw `Type ${schema.fields[fieldName].type} not supported yet`;
       }
     });
+
     columnsArray = columnsArray.concat(Object.keys(geoPoints));
     const initialValues = valuesArray.map((val, index) => {
       let termination = '';

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1278,7 +1278,6 @@ export class PostgresStorageAdapter implements StorageAdapter {
     object = handleDotFields(object);
 
     validateKeys(object);
-    console.log('*********1' + object);
     Object.keys(object).forEach(fieldName => {
       if (object[fieldName] === null) {
         return;
@@ -1294,7 +1293,6 @@ export class PostgresStorageAdapter implements StorageAdapter {
 
       columnsArray.push(fieldName);
       if (!schema.fields[fieldName] && className === '_User') {
-        console.log('********2');
         if (
           fieldName === '_email_verify_token' ||
           fieldName === '_failed_login_count' ||
@@ -1325,8 +1323,6 @@ export class PostgresStorageAdapter implements StorageAdapter {
         }
         return;
       }
-      console.log('********3' + fieldName);
-      console.log('********4' + schema.fields);
       switch (schema.fields[fieldName].type) {
         case 'Date':
           if (object[fieldName]) {
@@ -1369,7 +1365,6 @@ export class PostgresStorageAdapter implements StorageAdapter {
           throw `Type ${schema.fields[fieldName].type} not supported yet`;
       }
     });
-    console.log('********5');
     columnsArray = columnsArray.concat(Object.keys(geoPoints));
     const initialValues = valuesArray.map((val, index) => {
       let termination = '';

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -972,9 +972,9 @@ class DatabaseController {
       });
     }
     if (query['$and']) {
-      const ors = query['$and'];
+      const ands = query['$and'];
       return Promise.all(
-        ors.map((aQuery, index) => {
+        ands.map((aQuery, index) => {
           return this.reduceInRelation(className, aQuery, schema).then(aQuery => {
             query['$and'][index] = aQuery;
           });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
A variable named `ors` is used in #7593 which should probably be named `ands` to better represent what it's used for. In addition, the test case added is placed under the `sendEmail` tests which it should be placed under other `beforeFind` tests.

Related issue: #7714 

### Approach
<!-- Add a description of the approach in this PR. -->
Move the added test in the same category as other `beforeFind` tests. This will make debugging failures in the future easier. Replace variable names.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Update tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
