### PR TITLE
fix: node engine compatibility did not include node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=12.20.0 <16"
+    "node": ">=12.20.0 <17"
   },
   "bin": {
     "parse-server": "bin/parse-server"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Node engine upper range did not reflect Node 16 compatibility, which was added in https://github.com/parse-community/parse-server/issues/7669.

Related issue: #7738 

### Approach
Set upper engine limit to <17

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
