### PR TITLE
feat: support `postgresql` protocol in database URI

### DIFF
--- a/spec/PostgresInitOptions.spec.js
+++ b/spec/PostgresInitOptions.spec.js
@@ -4,8 +4,7 @@ const PostgresStorageAdapter = require('../lib/Adapters/Storage/Postgres/Postgre
 const postgresURI =
   process.env.PARSE_SERVER_TEST_DATABASE_URI ||
   'postgres://localhost:5432/parse_server_postgres_adapter_test_database';
-const ParseServer = require('../lib/index');
-const express = require('express');
+
 //public schema
 const databaseOptions1 = {
   initOptions: {
@@ -24,72 +23,57 @@ const GameScore = Parse.Object.extend({
   className: 'GameScore',
 });
 
-function createParseServer(options) {
-  return new Promise((resolve, reject) => {
-    const parseServer = new ParseServer.default(
-      Object.assign({}, defaultConfiguration, options, {
-        serverURL: 'http://localhost:12668/parse',
-        serverStartComplete: error => {
-          if (error) {
-            reject(error);
-          } else {
-            expect(Parse.applicationId).toEqual('test');
-            const app = express();
-            app.use('/parse', parseServer.app);
-
-            const server = app.listen(12668);
-            Parse.serverURL = 'http://localhost:12668/parse';
-            resolve(server);
-          }
-        },
-      })
-    );
-  });
-}
-
 describe_only_db('postgres')('Postgres database init options', () => {
-  let server;
 
-  afterAll(done => {
-    if (server) {
-      Parse.serverURL = 'http://localhost:8378/1';
-      server.close(done);
-    }
-  });
-
-  it('should create server with public schema databaseOptions', done => {
+  it('should create server with public schema databaseOptions', async () => {
     const adapter = new PostgresStorageAdapter({
       uri: postgresURI,
       collectionPrefix: 'test_',
       databaseOptions: databaseOptions1,
     });
-
-    createParseServer({ databaseAdapter: adapter })
-      .then(newServer => {
-        server = newServer;
-        const score = new GameScore({
-          score: 1337,
-          playerName: 'Sean Plott',
-          cheatMode: false,
-        });
-        return score.save();
-      })
-      .then(async () => {
-        await reconfigureServer();
-        done();
-      }, done.fail);
+    await reconfigureServer({
+      databaseAdapter: adapter,
+    });
+    const score = new GameScore({
+      score: 1337,
+      playerName: 'Sean Plott',
+      cheatMode: false,
+    });
+    await score.save();
   });
 
-  it('should fail to create server if schema databaseOptions does not exist', done => {
+  it('should create server using postgresql uri with public schema databaseOptions', async () => {
+    const postgresURI2 = new URL(postgresURI);
+    postgresURI2.protocol = 'postgresql:';
+    const adapter = new PostgresStorageAdapter({
+      uri: postgresURI2.toString(),
+      collectionPrefix: 'test_',
+      databaseOptions: databaseOptions1,
+    });
+    await reconfigureServer({
+      databaseAdapter: adapter,
+    });
+    const score = new GameScore({
+      score: 1337,
+      playerName: 'Sean Plott',
+      cheatMode: false,
+    });
+    await score.save();
+  });
+
+  it('should fail to create server if schema databaseOptions does not exist', async () => {
     const adapter = new PostgresStorageAdapter({
       uri: postgresURI,
       collectionPrefix: 'test_',
       databaseOptions: databaseOptions2,
     });
-
-    createParseServer({ databaseAdapter: adapter }).then(done.fail, async () => {
-      await reconfigureServer();
-      done();
-    });
+    try {
+      await reconfigureServer({
+        databaseAdapter: adapter,
+      });
+      fail("Should have thrown error");
+    } catch(error) {
+      expect(error).toBeDefined();
+    }
   });
 });

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -555,7 +555,7 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
       },
       classLevelPermissions: undefined,
     });
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await new Promise(resolve => setTimeout(resolve, 2000));
     expect(adapter._onchange).toHaveBeenCalled();
   });
 });
@@ -563,6 +563,15 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
 describe_only_db('postgres')('PostgresStorageAdapter shutdown', () => {
   it('handleShutdown, close connection', () => {
     const adapter = new PostgresStorageAdapter({ uri: databaseURI });
+    expect(adapter._client.$pool.ending).toEqual(false);
+    adapter.handleShutdown();
+    expect(adapter._client.$pool.ending).toEqual(true);
+  });
+
+  it('handleShutdown, close connection of postgresql uri', () => {
+    const databaseURI2 = new URL(databaseURI);
+    databaseURI2.protocol = 'postgresql:';
+    const adapter = new PostgresStorageAdapter({ uri: databaseURI2.toString() });
     expect(adapter._client.$pool.ending).toEqual(false);
     adapter.handleShutdown();
     expect(adapter._client.$pool.ending).toEqual(true);

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -227,6 +227,7 @@ export function getDatabaseAdapter(databaseURI, collectionPrefix, databaseOption
   }
   switch (protocol) {
     case 'postgres:':
+    case 'postgresql:':
       return new PostgresStorageAdapter({
         uri: databaseURI,
         collectionPrefix,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Developers using PostgreSQL can only use a URI with the prefix "postgres:" when "postgresql:" is also commonly used. Close #7687.

Related issue: #7687 

### Approach
<!-- Add a description of the approach in this PR. -->
Add support for `postgresql://`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Fixed some of the flakiness in the Postgres testcases that caused connection time outs. This is due tests needed the server reconfigured before they began and previous test not cleaning up it's connection (PostgresInitOptions.spec.js)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
