### PR TITLE
test: make GraphQL server test more reliable

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -2600,11 +2600,19 @@ describe('ParseGraphQLServer', () => {
               // "SecondaryObject:bBRgmzIRRM" < "SecondaryObject:nTMcuVbATY" true
               // base64("SecondaryObject:bBRgmzIRRM"") < base64(""SecondaryObject:nTMcuVbATY"") false
               // "U2Vjb25kYXJ5T2JqZWN0OmJCUmdteklSUk0=" < "U2Vjb25kYXJ5T2JqZWN0Om5UTWN1VmJBVFk=" false
+              const originalIds = [getSecondaryObjectsResult.data.secondaryObject2.objectId,
+                getSecondaryObjectsResult.data.secondaryObject4.objectId];
               expect(
                 findSecondaryObjectsResult.data.secondaryObjects.edges[0].node.objectId
-              ).toBeLessThan(
+              ).not.toBe(
                 findSecondaryObjectsResult.data.secondaryObjects.edges[1].node.objectId
               );
+              expect(
+                originalIds.includes(findSecondaryObjectsResult.data.secondaryObjects.edges[0].node.objectId)
+              ).toBeTrue();
+              expect(
+                originalIds.includes(findSecondaryObjectsResult.data.secondaryObjects.edges[1].node.objectId)
+              ).toBeTrue();
 
               const createPrimaryObjectResult = await apolloClient.mutate({
                 mutation: gql`


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This test randomly fails and has a comment attached to it mentioning the relevant issue.

Related issue: #7180

### Approach
<!-- Add a description of the approach in this PR. -->
Instead of removing the test, adapt to functions current behavior to ensure it passes, but ensures the code it's testing always behaves the way it currently behaves. The modification will still detect if an added feature breaks.

 I attempted to remove the random failure in the graph tests by changing: https://github.com/parse-community/parse-server/blob/191d80b6677f8ee6f6a0ccd3bde2bf6bb50f9a20/spec/ParseGraphQLServer.spec.js#L2597-L2607

to:

```javascript
// NOTE: Here @davimacedo tried to test RelayID order, but the test is wrong since
// "objectId1" < "objectId2" do not always keep the order when objectId is transformed
// to base64 by Relay
// "SecondaryObject:bBRgmzIRRM" < "SecondaryObject:nTMcuVbATY" true
// base64("SecondaryObject:bBRgmzIRRM"") < base64(""SecondaryObject:nTMcuVbATY"") false
// "U2Vjb25kYXJ5T2JqZWN0OmJCUmdteklSUk0=" < "U2Vjb25kYXJ5T2JqZWN0Om5UTWN1VmJBVFk=" false
 const originalIds = [getSecondaryObjectsResult.data.secondaryObject2.objectId,
      getSecondaryObjectsResult.data.secondaryObject4.objectId];
 expect(
                findSecondaryObjectsResult.data.secondaryObjects.edges[0].node.objectId
 ).not.toBe(
                findSecondaryObjectsResult.data.secondaryObjects.edges[1].node.objectId
 );
 expect(
                originalIds.includes(findSecondaryObjectsResult.data.secondaryObjects.edges[0].node.objectId)
 ).toBeTrue();
 expect(
                originalIds.includes(findSecondaryObjectsResult.data.secondaryObjects.edges[1].node.objectId)
 ).toBeTrue();
```

The change doesn't check for order, but it seems from your comment that's something you want to fix in the future.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
