### PR TITLE
feat: add Cloud Code context to `ParseObject.fetch`

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3225,10 +3225,10 @@ describe('afterLogin hook', () => {
     await query.find({ context: { a: 'a' } });
   });
 
-  it('beforeFine and afterFind should have access to context while making fetch call', async () => {
+  it('beforeFind and afterFind should have access to context while making fetch call', async () => {
     Parse.Cloud.beforeFind('TestObject', req => {
       expect(req.context.a).toEqual('a');
-      expect(req.context.b).to.not.exist;
+      expect(req.context.b).toBeUndefined();
       req.context.b = 'b';
     });
     Parse.Cloud.afterFind('TestObject', req => {

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3225,9 +3225,15 @@ describe('afterLogin hook', () => {
     await query.find({ context: { a: 'a' } });
   });
 
-  it('afterFind should have access to context while making fetch call', async () => {
+  it('beforeFine and afterFind should have access to context while making fetch call', async () => {
+    Parse.Cloud.beforeFind('TestObject', req => {
+      expect(req.context.a).toEqual('a');
+      expect(req.context.b).to.not.exist;
+      req.context.b = 'b';
+    });
     Parse.Cloud.afterFind('TestObject', req => {
       expect(req.context.a).toEqual('a');
+      expect(req.context.b).toEqual('b');
     });
     const obj = new TestObject();
     await obj.save();

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3224,6 +3224,15 @@ describe('afterLogin hook', () => {
     const query = new Parse.Query(TestObject);
     await query.find({ context: { a: 'a' } });
   });
+
+  it('afterFind should have access to context while making fetch call', async () => {
+    Parse.Cloud.afterFind('TestObject', req => {
+      expect(req.context.a).toEqual('a');
+    });
+    const obj = new TestObject();
+    await obj.save();
+    await obj.fetch({ context: { a: 'a' } });
+  });
 });
 
 describe('saveFile hooks', () => {

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -83,7 +83,8 @@ export class ClassesRouter extends PromiseRouter {
         this.className(req),
         req.params.objectId,
         options,
-        req.info.clientSDK
+        req.info.clientSDK,
+        req.info.context
       )
       .then(response => {
         if (!response.results || response.results.length == 0) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

This extension the of the https://github.com/parse-community/parse-server/pull/6626. To pass context while making fetch call.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
