### PR TITLE
ci: add manual docker release workflow

### DIFF
--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -1,0 +1,57 @@
+# Trigger this workflow only to manually create a Docker release; this should only be used
+# in extraordinary circumstances, as Docker releases are normally created automatically as
+# part of the automated release workflow.
+
+name: release-manual-docker
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        default: ''
+        description: 'Reference (tag / SHA):'  
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: parseplatform/parse-server
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Determine branch name
+        id: branch
+        run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Log into Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ steps.branch.outputs.branch_name == 'release' && github.event.inputs.ref == '' }}
+          tags: |
+            type=semver,enable=true,pattern={{version}},value=${{ github.event.inputs.ref }}
+            type=raw,enable=${{ github.event.inputs.ref == '' }},value=latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,30 @@
+############################################################
 # Build stage
+############################################################
 FROM node:lts-alpine as build
 
 RUN apk update; \
   apk add git;
 WORKDIR /tmp
+
+# Copy package.json first to benefit from layer caching
 COPY package*.json ./
-RUN npm ci
+
+# Copy src to have config files for install
 COPY . .
+
+# Clean npm cache; added to fix an issue with the install process
+RUN npm cache clean --force
+
+# Install all dependencies
+RUN npm ci
+
+# Run build steps
 RUN npm run build
 
+############################################################
 # Release stage
+############################################################
 FROM node:lts-alpine as release
 
 RUN apk update; \
@@ -21,6 +36,8 @@ WORKDIR /parse-server
 
 COPY package*.json ./
 
+# Clean npm cache; added to fix an issue with the install process
+RUN npm cache clean --force
 RUN npm ci --production --ignore-scripts
 
 COPY bin bin


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
1. Adds a GitHub workflow to manually trigger a docker release of a specific version tag.
2. Fixes docker file