### PR TITLE
feat: bump required node engine to >=12.22.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=12.20.0 <17"
+    "node": ">=12.22.10 <17"
   },
   "bin": {
     "parse-server": "bin/parse-server"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Some dependencies require a higher min node engine.

Related issue: #n/a

### Approach
To add some room before the next required node bump, this bump to the latest node 12 LTS versions 12.22.10 instead of just 12.22.0.

BREAKING CHANGE: This requires Node.js version >=12.22.10.

### TODOs before merging
n/a