### PR TITLE
ci: add branch name change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - release
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
CI does not run for PRs because the branch name has changed from `master` to `release`.

Related issue: #n/a

### Approach
Rename branch name is CI workflow from `master` to `release`.

### TODOs before merging
n/a