### PR TITLE
ci: temporarily disable breaking change detection

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -64,7 +64,7 @@ async function config() {
       ['@semantic-release/release-notes-generator', {
         preset: 'angular',
         parserOpts: {
-          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING']
+          noteKeywords: ['BREAKING CHANGE DETECTION DISABLED'] //['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING']
         },
         writerOpts: {
           commitsSort: ['subject', 'scope'],


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
Parse Server 5.0 has been released without some "breaking changes of low importance" that should have been included in the 5.0 stable release. These changes are:
- Remove support for Node 15; only removes the Node 15 CI tests (of low importance because Node 15 reached its End-of-Life anyway and is not a Long-Term-Support version)
- Remove MongoDB GridStore adapter support (of low importance because Parse Server uses GridFSBucketAdapter instead of GridStore adapter by default since 2018; also there seems to be no manual migration effort necessary to switch to GridFSBucketAdapter).

Related issue: #n/a

### Approach
Merge changes without triggering a major release increment. The changes will be released as a feature / minor increment instead. After release, this PR needs to be reverted to correctly trigger a major release in case of merging a breaking change into the `release` branch.

### TODOs before merging
n/a