### PR TITLE
fix: sensitive keyword detection may produce false positives

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -280,4 +280,18 @@ describe('Vulnerabilities', () => {
       expect(text.error).toBe('Prohibited keyword in request data: {"value":"aValue[123]*"}.');
     });
   });
+
+  describe('Ignore non-matches', () => {
+    it('ignores write request that contains only fraction of denied keyword', async () => {
+      await reconfigureServer({
+        requestKeywordDenylist: [{ key: 'abc' }],
+      });
+      // Initially saving an object executes the keyword detection in RestWrite.js
+      const obj = new TestObject({ a: { b: { c: 0 } } });
+      await expectAsync(obj.save()).toBeResolved();
+      // Modifying a nested key executes the keyword detection in DatabaseController.js
+      obj.increment('a.b.c');
+      await expectAsync(obj.save()).toBeResolved();
+    });
+  });
 });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1763,7 +1763,7 @@ class DatabaseController {
     if (this.options && this.options.requestKeywordDenylist) {
       // Scan request data for denied keywords
       for (const keyword of this.options.requestKeywordDenylist) {
-        const isMatch = (a, b) => (typeof a === 'string' && new RegExp(a).test(b)) || a === b;
+        const isMatch = (a, b) => (typeof a === 'string' && new RegExp(b).test(a)) || a === b;
         if (isMatch(firstKey, keyword.key)) {
           throw new Parse.Error(
             Parse.Error.INVALID_KEY_NAME,

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -11,6 +11,7 @@ import intersect from 'intersect';
 // @flow-disable-next
 import deepcopy from 'deepcopy';
 import logger from '../logger';
+import Utils from '../Utils';
 import * as SchemaController from './SchemaController';
 import { StorageAdapter } from '../Adapters/Storage/StorageAdapter';
 import MongoStorageAdapter from '../Adapters/Storage/Mongo/MongoStorageAdapter';
@@ -1763,8 +1764,8 @@ class DatabaseController {
     if (this.options && this.options.requestKeywordDenylist) {
       // Scan request data for denied keywords
       for (const keyword of this.options.requestKeywordDenylist) {
-        const isMatch = (a, b) => (typeof a === 'string' && new RegExp(b).test(a)) || a === b;
-        if (isMatch(firstKey, keyword.key)) {
+        const match = Utils.objectContainsKeyValue({ firstKey: undefined }, keyword.key, undefined);
+        if (match) {
           throw new Parse.Error(
             Parse.Error.INVALID_KEY_NAME,
             `Prohibited keyword in request data: ${JSON.stringify(keyword)}.`

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -342,8 +342,8 @@ class Utils {
    */
   static objectContainsKeyValue(obj, key, value) {
     const isMatch = (a, b) => (typeof a === 'string' && new RegExp(b).test(a)) || a === b;
-    const isKeyMatch = k => isMatch(key, k);
-    const isValueMatch = v => isMatch(value, v);
+    const isKeyMatch = k => isMatch(k, key);
+    const isValueMatch = v => isMatch(v, value);
     for (const [k, v] of Object.entries(obj)) {
       if (key !== undefined && value === undefined && isKeyMatch(k)) {
         return true;

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -341,7 +341,7 @@ class Utils {
    * @returns {Boolean} True if a match was found, false otherwise.
    */
   static objectContainsKeyValue(obj, key, value) {
-    const isMatch = (a, b) => (typeof a === 'string' && new RegExp(a).test(b)) || a === b;
+    const isMatch = (a, b) => (typeof a === 'string' && new RegExp(b).test(a)) || a === b;
     const isKeyMatch = k => isMatch(key, k);
     const isValueMatch = v => isMatch(value, v);
     for (const [k, v] of Object.entries(obj)) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Keyword detection algorithm produces false positives.
Related issue: https://github.com/parse-community/parse-server/issues/7882.

### Approach
Fix keyword detection algorithm.

### TODOs before merging
n/a