### PR TITLE
perf: reduce database operations when using the `constant` parameter in Cloud Function validation

### DIFF
--- a/src/triggers.js
+++ b/src/triggers.js
@@ -738,7 +738,7 @@ async function builtInTriggerValidator(options, request, auth) {
         }
         if (opt.constant && request.object) {
           if (request.original) {
-            request.object.set(key, request.original.get(key));
+            request.object.revert(key);
           } else if (opt.default != null) {
             request.object.set(key, opt.default);
           }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

When using the `constant` param for the inbuilt validator, the cloud code runs `req.object.set(key, req.original.get(key))`, which causes unnecessary database OPs as it thinks that `key` needs to be updated.

Related issue: #7534

### Approach
<!-- Add a description of the approach in this PR. -->

Uses the preferred JS method `.revert`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
