### PR TITLE
fix: peer dependency mismatch for GraphQL dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7507,9 +7507,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.1.tgz",
-      "integrity": "sha512-x34S6gC0/peBZnlK60zCJox/d45A7p6At9oN9EPA3qhoIAlR4LNZmXRLkICBckwwTMJzVdA8cx3QIQZMOl606A=="
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
     "graphql-executor": {
       "version": "0.0.18",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "deepcopy": "2.1.0",
     "express": "4.17.2",
     "follow-redirects": "1.14.8",
-    "graphql": "15.7.1",
+    "graphql": "15.8.0",
     "graphql-list-fields": "2.0.2",
     "graphql-relay": "0.7.0",
     "graphql-tag": "2.12.6",


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #7933

### Approach
<!-- Add a description of the approach in this PR. -->
This is a simple update of the `graphql` dependency to solve peer dependency issues.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
