### PR TITLE
test: enable GraphQL file upload tests

### DIFF
--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -18,10 +18,13 @@
       "it_only_db": true,
       "it_only_mongodb_version": true,
       "it_only_postgres_version": true,
+      "it_only_node_version": true,
       "fit_only_mongodb_version": true,
+      "fit_only_node_version": true,
       "it_exclude_mongodb_version": true,
       "it_exclude_postgres_version": true,
       "fit_exclude_mongodb_version": true,
+      "fit_exclude_node_version": true,
       "it_exclude_dbs": true,
       "describe_only_db": true,
       "describe_only": true,
@@ -31,11 +34,10 @@
       "jequal": true,
       "create": true,
       "arrayContains": true,
-      "expectAsync": true,
-      "databaseAdapter": true
+      "databaseAdapter": true,
     },
     "rules": {
       "no-console": [0],
-      "no-var": "error"
+      "no-var": "error",
     }
 }

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -34,10 +34,10 @@
       "jequal": true,
       "create": true,
       "arrayContains": true,
-      "databaseAdapter": true,
+      "databaseAdapter": true
     },
     "rules": {
       "no-console": [0],
-      "no-var": "error",
+      "no-var": "error"
     }
 }

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -6793,7 +6793,7 @@ describe('ParseGraphQLServer', () => {
 
       describe('Files Mutations', () => {
         describe('Create', () => {
-          xit('should return File object', async () => {
+          it_only_node_version('<17')('should return File object', async () => {
             const clientMutationId = uuidv4();
 
             parseServer = await global.reconfigureServer({
@@ -9096,7 +9096,7 @@ describe('ParseGraphQLServer', () => {
           expect(result6[0].node.name).toEqual('imACountry3');
         });
 
-        xit('should support files', async () => {
+        it_only_node_version('<17')('should support files', async () => {
           try {
             parseServer = await global.reconfigureServer({
               publicServerURL: 'http://localhost:13377/parse',

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -461,8 +461,26 @@ global.it_only_postgres_version = version => {
   }
 };
 
+global.it_only_node_version = version => {
+  const envVersion = process.env.NODE_VERSION;
+  if (!envVersion || semver.satisfies(envVersion, version)) {
+    return it;
+  } else {
+    return xit;
+  }
+};
+
 global.fit_only_mongodb_version = version => {
   const envVersion = process.env.MONGODB_VERSION;
+  if (!envVersion || semver.satisfies(envVersion, version)) {
+    return fit;
+  } else {
+    return xit;
+  }
+};
+
+global.fit_only_node_version = version => {
+  const envVersion = process.env.NODE_VERSION;
   if (!envVersion || semver.satisfies(envVersion, version)) {
     return fit;
   } else {
@@ -488,8 +506,26 @@ global.it_exclude_postgres_version = version => {
   }
 };
 
+global.it_exclude_node_version = version => {
+  const envVersion = process.env.NODE_VERSION;
+  if (!envVersion || !semver.satisfies(envVersion, version)) {
+    return it;
+  } else {
+    return xit;
+  }
+};
+
 global.fit_exclude_mongodb_version = version => {
   const envVersion = process.env.MONGODB_VERSION;
+  if (!envVersion || !semver.satisfies(envVersion, version)) {
+    return fit;
+  } else {
+    return xit;
+  }
+};
+
+global.fit_exclude_node_version = version => {
+  const envVersion = process.env.NODE_VERSION;
   if (!envVersion || !semver.satisfies(envVersion, version)) {
     return fit;
   } else {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
GraphQL file upload tests are temp. disabled due to Node >=17 incompatibility.

Related issue: https://github.com/parse-community/parse-server/issues/7978

### Approach
Enable tests for Node <17

This PR does not fully close the referenced issue, as the tests should run on higher Node versions too, but that requires more investigation.

### TODOs before merging
n/a
