### PR TITLE
docs: fix incorrect deprecation date of `allowClientClassCreation` option

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -8,7 +8,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS2 | Config option `directAccess` defaults to `true` | [#6636](https://github.com/parse-community/parse-server/pull/6636)   | 5.0.0 (2022)                    | 6.0.0 (2023)                    | deprecated            | -     |
 | DEPPS3 | Config option `enforcePrivateUsers` defaults to `true` | [#7319](https://github.com/parse-community/parse-server/pull/7319)   | 5.0.0 (2022)                    | 6.0.0 (2023)                    | deprecated            | -     |
 | DEPPS4 | Remove convenience method for http request `Parse.Cloud.httpRequest` | [#7589](https://github.com/parse-community/parse-server/pull/7589)   | 5.0.0 (2022)                    | 6.0.0 (2023)                    | deprecated            | -     |
-| DEPPS5 | Config option `allowClientClassCreation` defaults to `false` | [#7925](https://github.com/parse-community/parse-server/pull/7925)   | 5.3.0 (2023)                    | 7.0.0 (2024)                    | deprecated            | -     |
+| DEPPS5 | Config option `allowClientClassCreation` defaults to `false` | [#7925](https://github.com/parse-community/parse-server/pull/7925)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_removal]: ## "The version and date of the planned removal."


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

The incorrect date was used in #7925 to deprecate allowClientClassCreation.

Related issue: #7925

### Approach
<!-- Add a description of the approach in this PR. -->

Fix date

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
