### PR TITLE
feat: add client socket ID to LiveQuery `ws_disconnect`, `ws_connect` , `connect` and `subscribe` event

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -6,7 +6,7 @@ const validatorFail = () => {
 };
 
 describe('ParseLiveQuery', function () {
-  it('access user on onLiveQueryEvent disconnect', async done => {
+  fit('access user on onLiveQueryEvent disconnect', async done => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['TestObject'],
@@ -20,20 +20,54 @@ describe('ParseLiveQuery', function () {
     requestedUser.setUsername('username');
     requestedUser.setPassword('password');
     Parse.Cloud.onLiveQueryEvent(req => {
-      const { event, sessionToken, clientId } = req;
+      const {
+        event,
+        clientId,
+        clients,
+        installationId,
+        sessionToken,
+        subscriptions,
+        useMasterKey,
+      } = req;
       if (event === 'ws_disconnect') {
         Parse.Cloud._removeAllHooks();
-        expect(sessionToken).toBeDefined();
         expect(clientId).toBeDefined();
+        expect(clients).toBeDefined();
+        expect(installationId).toBeDefined();
         expect(sessionToken).toBe(requestedUser.getSessionToken());
+        expect(useMasterKey).toBeDefined();
         done();
+      }
+      if (event === 'ws_connect') {
+        expect(clients).toBeDefined();
+        expect(subscriptions).toBeDefined();
+      }
+      if (event === 'connect') {
+        expect(client).toBeDefined();
+        expect(clientId).toBeDefined();
+        expect(event).toBeDefined();
+        expect(clients).toBeDefined();
+        expect(subscriptions).toBeDefined();
+        expect(sessionToken).toBeDefined();
+        expect(useMasterKey).toBeDefined();
+        expect(installationId).toBeDefined();
+      }
+      if (event === 'subscribe') {
+        expect(client).toBeDefined();
+        expect(clientId).toBeDefined();
+        expect(event).toBeDefined();
+        expect(clients).toBeDefined();
+        expect(subscriptions).toBeDefined();
+        expect(sessionToken).toBeDefined();
+        expect(useMasterKey).toBeDefined();
+        expect(installationId).toBeDefined();
       }
     });
     await requestedUser.signUp();
     const query = new Parse.Query(TestObject);
     await query.subscribe();
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
-    client.close();
+    await client.close();
   });
 
   it('can subscribe to query', async done => {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -6,7 +6,7 @@ const validatorFail = () => {
 };
 
 describe('ParseLiveQuery', function () {
-  fit('access user on onLiveQueryEvent disconnect', async done => {
+  it('access user on onLiveQueryEvent disconnect', async done => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['TestObject'],

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -67,7 +67,7 @@ describe('ParseLiveQuery', function () {
     const query = new Parse.Query(TestObject);
     await query.subscribe();
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
-    await client.close();
+    client.close();
   });
 
   it('can subscribe to query', async done => {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -20,10 +20,11 @@ describe('ParseLiveQuery', function () {
     requestedUser.setUsername('username');
     requestedUser.setPassword('password');
     Parse.Cloud.onLiveQueryEvent(req => {
-      const { event, sessionToken } = req;
+      const { event, sessionToken, clientId } = req;
       if (event === 'ws_disconnect') {
         Parse.Cloud._removeAllHooks();
         expect(sessionToken).toBeDefined();
+        expect(clientId).toBeDefined();
         expect(sessionToken).toBe(requestedUser.getSessionToken());
         done();
       }

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -445,7 +445,7 @@ class ParseLiveQueryServer {
       logger.verbose('Current subscriptions %d', this.subscriptions.size);
       runLiveQueryEventHandlers({
         event: 'ws_disconnect',
-        client,
+        clientId,
         clients: this.clients.size,
         subscriptions: this.subscriptions.size,
         useMasterKey: client.hasMasterKey,

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -419,6 +419,7 @@ class ParseLiveQueryServer {
       if (!this.clients.has(clientId)) {
         runLiveQueryEventHandlers({
           event: 'ws_disconnect_error',
+          clientId,
           clients: this.clients.size,
           subscriptions: this.subscriptions.size,
           error: `Unable to find client ${clientId}`,
@@ -451,7 +452,7 @@ class ParseLiveQueryServer {
       logger.verbose('Current subscriptions %d', this.subscriptions.size);
       runLiveQueryEventHandlers({
         event: 'ws_disconnect',
-        client,
+        clientId,
         clients: this.clients.size,
         subscriptions: this.subscriptions.size,
         useMasterKey: client.hasMasterKey,
@@ -812,6 +813,7 @@ class ParseLiveQueryServer {
       logger.verbose('Current client number: %d', this.clients.size);
       runLiveQueryEventHandlers({
         client,
+        clientId: parseWebsocket.clientId,
         event: 'subscribe',
         clients: this.clients.size,
         subscriptions: this.subscriptions.size,

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -10,13 +10,7 @@ import { ParsePubSub } from './ParsePubSub';
 import SchemaController from '../Controllers/SchemaController';
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import {
-  runLiveQueryEventHandlers,
-  getTrigger,
-  runTrigger,
-  resolveError,
-  toJSONwithObjects,
-} from '../triggers';
+import { runLiveQueryEventHandlers, getTrigger, runTrigger, resolveError, toJSONwithObjects } from '../triggers';
 import { getAuthForSessionToken, Auth } from '../Auth';
 import { getCacheController } from '../Controllers';
 import LRU from 'lru-cache';

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -10,7 +10,13 @@ import { ParsePubSub } from './ParsePubSub';
 import SchemaController from '../Controllers/SchemaController';
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { runLiveQueryEventHandlers, getTrigger, runTrigger, resolveError, toJSONwithObjects } from '../triggers';
+import {
+  runLiveQueryEventHandlers,
+  getTrigger,
+  runTrigger,
+  resolveError,
+  toJSONwithObjects,
+} from '../triggers';
 import { getAuthForSessionToken, Auth } from '../Auth';
 import { getCacheController } from '../Controllers';
 import LRU from 'lru-cache';
@@ -445,6 +451,7 @@ class ParseLiveQueryServer {
       logger.verbose('Current subscriptions %d', this.subscriptions.size);
       runLiveQueryEventHandlers({
         event: 'ws_disconnect',
+        client,
         clients: this.clients.size,
         subscriptions: this.subscriptions.size,
         useMasterKey: client.hasMasterKey,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/1906#issuecomment-616805834).

### Issue Description

In order to create a Online/offline functionality with ParseLiveQuery socket protocol, i'd like to add client's socket Id to 'ws_disconnect' event, in order to know which socket is disconnecting.

### Approach

Just add existing client ID, to ws_disconnect Object.

### TODOs before merging


- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)


This is my first ever contribution on Github, so sorry if not totally well done.