### PR TITLE
fix: interrupted WebSocket connection not closed by LiveQuery server

### DIFF
--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -76,7 +76,7 @@ describe('ParseWebSocketServer', function () {
     expect(wssError).toBe('Invalid Packet');
   });
 
-  it('closes interrupted connection', function (done) {
+  it('closes interrupted connection', async () => {
     const onConnectCallback = jasmine.createSpy('onConnectCallback');
     const http = require('http');
     const server = http.createServer();
@@ -93,16 +93,13 @@ describe('ParseWebSocketServer', function () {
 
     // Make sure callback is called
     expect(onConnectCallback).toHaveBeenCalled();
+    await new Promise(resolve => setTimeout(resolve, 10));
     // Make sure we ping to the client
-    setTimeout(function () {
-      expect(ws.ping).toHaveBeenCalled();
-      setTimeout(function () {
-        //make sure we close the connection after timeout cause we don't answer the ping
-        expect(ws.terminate).toHaveBeenCalled();
-        server.close();
-        done();
-      }, 10);
-    }, 10);
+    expect(ws.ping).toHaveBeenCalled();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    // make sure connection close after we didn't answer the ping on time
+    expect(ws.terminate).toHaveBeenCalled();
+    server.close();
   });
 
   afterEach(function () {

--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -94,10 +94,8 @@ describe('ParseWebSocketServer', function () {
     // Make sure callback is called
     expect(onConnectCallback).toHaveBeenCalled();
     await new Promise(resolve => setTimeout(resolve, 10));
-    // Make sure we ping to the client
     expect(ws.ping).toHaveBeenCalled();
     await new Promise(resolve => setTimeout(resolve, 10));
-    // make sure connection close after we didn't answer the ping on time
     expect(ws.terminate).toHaveBeenCalled();
     server.close();
   });

--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -76,7 +76,7 @@ describe('ParseWebSocketServer', function () {
     expect(wssError).toBe('Invalid Packet');
   });
 
-  fit('can handle broken connection', function (done) {
+  it('can handle broken connection', function (done) {
     const onConnectCallback = jasmine.createSpy('onConnectCallback');
     const http = require('http');
     const server = http.createServer();

--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -76,7 +76,7 @@ describe('ParseWebSocketServer', function () {
     expect(wssError).toBe('Invalid Packet');
   });
 
-  it('can handle broken connection', function (done) {
+  it('closes interrupted connection', function (done) {
     const onConnectCallback = jasmine.createSpy('onConnectCallback');
     const http = require('http');
     const server = http.createServer();

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -14,6 +14,10 @@ export class ParseWebSocketServer {
       logger.info('Parse LiveQuery Server started running');
     };
     wss.onConnection = ws => {
+      ws.isAlive = true;
+      ws.on('pong', () => {
+        this.isAlive = true;
+      });
       ws.on('error', error => {
         logger.error(error.message);
         logger.error(inspect(ws, false));
@@ -21,10 +25,12 @@ export class ParseWebSocketServer {
       onConnect(new ParseWebSocket(ws));
       // Send ping to client periodically
       const pingIntervalId = setInterval(() => {
-        if (ws.readyState == ws.OPEN) {
+        if (ws.isAlive) {
           ws.ping();
+          ws.isAlive = false;
         } else {
           clearInterval(pingIntervalId);
+          ws.terminate();
         }
       }, config.websocketTimeout || 10 * 1000);
     };

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -14,9 +14,9 @@ export class ParseWebSocketServer {
       logger.info('Parse LiveQuery Server started running');
     };
     wss.onConnection = ws => {
-      ws.waitingForPong = true;
+      ws.waitingForPong = false;
       ws.on('pong', () => {
-        this.waitingForPong = true;
+        this.waitingForPong = false;
       });
       ws.on('error', error => {
         logger.error(error.message);
@@ -25,9 +25,9 @@ export class ParseWebSocketServer {
       onConnect(new ParseWebSocket(ws));
       // Send ping to client periodically
       const pingIntervalId = setInterval(() => {
-        if (ws.waitingForPong) {
+        if (!ws.waitingForPong) {
           ws.ping();
-          ws.waitingForPong = false;
+          ws.waitingForPong = true;
         } else {
           clearInterval(pingIntervalId);
           ws.terminate();

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -14,9 +14,9 @@ export class ParseWebSocketServer {
       logger.info('Parse LiveQuery Server started running');
     };
     wss.onConnection = ws => {
-      ws.isAlive = true;
+      ws.waitingForPong = true;
       ws.on('pong', () => {
-        this.isAlive = true;
+        this.waitingForPong = true;
       });
       ws.on('error', error => {
         logger.error(error.message);
@@ -25,9 +25,9 @@ export class ParseWebSocketServer {
       onConnect(new ParseWebSocket(ws));
       // Send ping to client periodically
       const pingIntervalId = setInterval(() => {
-        if (ws.isAlive) {
+        if (ws.waitingForPong) {
           ws.ping();
-          ws.isAlive = false;
+          ws.waitingForPong = false;
         } else {
           clearInterval(pingIntervalId);
           ws.terminate();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/8010).

### Issue Description
parse live query WebSocket server not closing broken connection!

Related issue: https://github.com/parse-community/parse-server/issues/8010

### Approach
<!-- Add a description of the approach in this PR. -->
I add a property to ws object (isAlive) and make isAlive false on ping message and make that true if got pong message.
If I didn't get a pong message on the next sending ping message, terminaing connection and clear interval

### TODOs before merging
I don't have any idea how to write a test for this, I need help to complete this

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
