### PR TITLE
fix: graphQL query ignores condition `equalTo` with value `false`

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -91,6 +91,22 @@ const toPostgresValue = value => {
   return value;
 };
 
+const toPostgresValueCastType = value => {
+  const postgresValue = toPostgresValue(value);
+  let castType;
+  switch (typeof postgresValue) {
+    case 'number':
+      castType = 'double precision';
+      break;
+    case 'boolean':
+      castType = 'boolean';
+      break;
+    default:
+      castType = undefined;
+  }
+  return castType;
+};
+
 const transformValue = value => {
   if (typeof value === 'object' && value.__type === 'Pointer') {
     return value.objectId;
@@ -191,6 +207,10 @@ const transformDotFieldToComponents = fieldName => {
     if (index === 0) {
       return `"${cmpt}"`;
     }
+    if (parseInt(cmpt).toString() === cmpt) {
+      return `${cmpt}`;
+    }
+
     return `'${cmpt}'`;
   });
 };
@@ -369,9 +389,12 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
             );
           } else {
             if (fieldName.indexOf('.') >= 0) {
-              const constraintFieldName = transformDotField(fieldName);
+              const castType = toPostgresValueCastType(fieldValue.$ne);
+              const constraintFieldName = castType
+                ? `CAST ((${transformDotField(fieldName)}) AS ${castType})`
+                : transformDotField(fieldName);
               patterns.push(
-                `(${constraintFieldName} <> $${index} OR ${constraintFieldName} IS NULL)`
+                `(${constraintFieldName} <> $${index + 1} OR ${constraintFieldName} IS NULL)`
               );
             } else if (typeof fieldValue.$ne === 'object' && fieldValue.$ne.$relativeTime) {
               throw new Parse.Error(
@@ -401,8 +424,12 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
         index += 1;
       } else {
         if (fieldName.indexOf('.') >= 0) {
+          const castType = toPostgresValueCastType(fieldValue.$eq);
+          const constraintFieldName = castType
+            ? `CAST ((${transformDotField(fieldName)}) AS ${castType})`
+            : transformDotField(fieldName);
           values.push(fieldValue.$eq);
-          patterns.push(`${transformDotField(fieldName)} = $${index++}`);
+          patterns.push(`${constraintFieldName} = $${index++}`);
         } else if (typeof fieldValue.$eq === 'object' && fieldValue.$eq.$relativeTime) {
           throw new Parse.Error(
             Parse.Error.INVALID_JSON,
@@ -771,20 +798,11 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
     Object.keys(ParseToPosgresComparator).forEach(cmp => {
       if (fieldValue[cmp] || fieldValue[cmp] === 0) {
         const pgComparator = ParseToPosgresComparator[cmp];
-        let postgresValue = toPostgresValue(fieldValue[cmp]);
         let constraintFieldName;
+        let postgresValue = toPostgresValue(fieldValue[cmp]);
+
         if (fieldName.indexOf('.') >= 0) {
-          let castType;
-          switch (typeof postgresValue) {
-            case 'number':
-              castType = 'double precision';
-              break;
-            case 'boolean':
-              castType = 'boolean';
-              break;
-            default:
-              castType = undefined;
-          }
+          const castType = toPostgresValueCastType(fieldValue[cmp]);
           constraintFieldName = castType
             ? `CAST ((${transformDotField(fieldName)}) AS ${castType})`
             : transformDotField(fieldName);
@@ -823,6 +841,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
     }
   }
   values = values.map(transformValue);
+
   return { pattern: patterns.join(' AND '), values, sorts };
 };
 

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -207,10 +207,6 @@ const transformDotFieldToComponents = fieldName => {
     if (index === 0) {
       return `"${cmpt}"`;
     }
-    if (parseInt(cmpt).toString() === cmpt) {
-      return `${cmpt}`;
-    }
-
     return `'${cmpt}'`;
   });
 };
@@ -841,7 +837,6 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
     }
   }
   values = values.map(transformValue);
-
   return { pattern: patterns.join(' AND '), values, sorts };
 };
 

--- a/src/GraphQL/transformers/query.js
+++ b/src/GraphQL/transformers/query.js
@@ -108,7 +108,7 @@ const transformQueryConstraintInputToParse = (
      *      }
      *   }
      */
-    if (fieldValue.key && fieldValue.value && parentConstraints && parentFieldName) {
+    if (fieldValue.key && fieldValue.value !== undefined && parentConstraints && parentFieldName) {
       delete parentConstraints[parentFieldName];
       parentConstraints[`${parentFieldName}.${fieldValue.key}`] = {
         ...parentConstraints[`${parentFieldName}.${fieldValue.key}`],


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/8031).

### Issue Description
Related issue: https://github.com/parse-community/parse-server/issues/8031

### Approach
Ignore only the value is `undefined`.

### TODOs before merging
- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
