### PR TITLE
fix: errors in GraphQL do not show the original error but a general `Unexpected Error`

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -10646,6 +10646,12 @@ describe('ParseGraphQLServer', () => {
                     },
                     resolve: (p, { message }) => message,
                   },
+                  errorQuery: {
+                    type: new GraphQLNonNull(GraphQLString),
+                    resolve: () => {
+                      throw new Error('A test error');
+                    },
+                  },
                   customQueryWithAutoTypeReturn: {
                     type: SomeClassType,
                     args: {
@@ -10732,6 +10738,18 @@ describe('ParseGraphQLServer', () => {
           `,
         });
         expect(result.data.customQuery).toEqual('hello');
+      });
+
+      it('can forward original error of a custom query', async () => {
+        await expectAsync(
+          apolloClient.query({
+            query: gql`
+              query ErrorQuery {
+                errorQuery
+              }
+            `,
+          })
+        ).toBeRejectedWithError('A test error');
       });
 
       it('can resolve a custom query with auto type return', async () => {

--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -38,6 +38,7 @@ class ParseGraphQLServer {
           config,
           auth,
         }),
+        maskedErrors: false,
         multipart: {
           fileSize: this._transformMaxUploadSizeToBytes(
             this.parseServer.config.maxUploadSize || '20mb'


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #8044

### Approach
Disable error masking on Yoga

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
