### PR TITLE
fix: websocket connection of LiveQuery interrupts frequently

### DIFF
--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -76,6 +76,37 @@ describe('ParseWebSocketServer', function () {
     expect(wssError).toBe('Invalid Packet');
   });
 
+  it('can handle ping/pong', async () => {
+    const onConnectCallback = jasmine.createSpy('onConnectCallback');
+    const http = require('http');
+    const server = http.createServer();
+    const parseWebSocketServer = new ParseWebSocketServer(server, onConnectCallback, {
+      websocketTimeout: 10,
+    }).server;
+
+    const ws = new EventEmitter();
+    ws.readyState = 0;
+    ws.OPEN = 0;
+    ws.ping = jasmine.createSpy('ping');
+    ws.terminate = jasmine.createSpy('terminate');
+
+    parseWebSocketServer.onConnection(ws);
+
+    // Make sure callback is called
+    expect(onConnectCallback).toHaveBeenCalled();
+    // Check that `waitingForPong` toggles
+    expect(ws.waitingForPong).toBe(false);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(ws.ping).toHaveBeenCalled();
+    expect(ws.waitingForPong).toBe(true);
+    ws.emit('pong');
+    expect(ws.waitingForPong).toBe(false);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(ws.waitingForPong).toBe(true);
+    expect(ws.terminate).not.toHaveBeenCalled();
+    server.close();
+  });
+
   it('closes interrupted connection', async () => {
     const onConnectCallback = jasmine.createSpy('onConnectCallback');
     const http = require('http');
@@ -93,8 +124,10 @@ describe('ParseWebSocketServer', function () {
 
     // Make sure callback is called
     expect(onConnectCallback).toHaveBeenCalled();
+    expect(ws.waitingForPong).toBe(false);
     await new Promise(resolve => setTimeout(resolve, 10));
     expect(ws.ping).toHaveBeenCalled();
+    expect(ws.waitingForPong).toBe(true);
     await new Promise(resolve => setTimeout(resolve, 10));
     expect(ws.terminate).toHaveBeenCalled();
     server.close();

--- a/spec/ParseWebSocketServer.spec.js
+++ b/spec/ParseWebSocketServer.spec.js
@@ -92,9 +92,7 @@ describe('ParseWebSocketServer', function () {
 
     parseWebSocketServer.onConnection(ws);
 
-    // Make sure callback is called
     expect(onConnectCallback).toHaveBeenCalled();
-    // Check that `waitingForPong` toggles
     expect(ws.waitingForPong).toBe(false);
     await new Promise(resolve => setTimeout(resolve, 10));
     expect(ws.ping).toHaveBeenCalled();

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -16,7 +16,7 @@ export class ParseWebSocketServer {
     wss.onConnection = ws => {
       ws.waitingForPong = false;
       ws.on('pong', () => {
-        this.waitingForPong = false;
+        ws.waitingForPong = false;
       });
       ws.on('error', error => {
         logger.error(error.message);


### PR DESCRIPTION
Signed-off-by: Layne Bernardo <lmbernar@uark.edu>

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

PR #8012 implemented heartbeats using the websocket ping/pong system, however when it receives the 'pong' it sets the `waitingForPong` flag on a nonexistent `this` instead of the `ws` object. This results in repeated LiveQuery disconnections.

Related issue: #8047

### Approach

Set `waitingForPong` to `false` on `ws` instead of `this`.

### TODOs before merging

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
