### PR TITLE
fix: auto-release process may fail if optional back-merging task fails

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -83,21 +83,21 @@ async function config() {
       ['@semantic-release/git', {
         assets: [changelogFile, 'package.json', 'package-lock.json', 'npm-shrinkwrap.json'],
       }],
+      ['@semantic-release/github', {
+        successComment: getReleaseComment(),
+        labels: ['type:ci'],
+        releasedLabels: ['state:released<%= nextRelease.channel ? `-\${nextRelease.channel}` : "" %>']
+      }],
+      // Back-merge module runs last because if it fails it should not impede the release process
       [
         "@saithodev/semantic-release-backmerge",
         {
           "branches": [
             { from: "beta", to: "alpha" },
             { from: "release", to: "beta" },
-            { from: "release", to: "alpha" },
           ]
         }
       ],
-      ['@semantic-release/github', {
-        successComment: getReleaseComment(),
-        labels: ['type:ci'],
-        releasedLabels: ['state:released<%= nextRelease.channel ? `-\${nextRelease.channel}` : "" %>']
-      }],
     ],
   };
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
If back-merging fails in the auto-release process, labels are not applies to GitHub issues that are closed by the the auto-release process.

Related issue: #n/a

### Approach
Move the back-merge task as last in line; this PR would normally be merged with `ci:` prefix, but in this case requires a release trigger.

### TODOs before merging
n/a