### PR TITLE
fix: Update GraphQL to return correct HTTP response code for file size limit upload errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1123,30 +1123,30 @@
       }
     },
     "@envelop/core": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-2.3.2.tgz",
-      "integrity": "sha512-NTVY7bajznZyE0S/yzwIu5aimcM8JLqdeWkWUmwmrAHZdE6zjrvOuVCwq1kMIHzgV3bmLdPg2F7534Nxad/HLg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-ZA8d3sg69+IrZH0seB/HxHi+IYaOOu5OLzZBAHw7MrT2mBI0RyboM6QZv0gGvYJjQIUeJ1I2Zz4bqjOKNmgpxA==",
       "requires": {
-        "@envelop/types": "2.2.0"
+        "@envelop/types": "2.3.0"
       }
     },
     "@envelop/parser-cache": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@envelop/parser-cache/-/parser-cache-4.3.2.tgz",
-      "integrity": "sha512-gdi814GdJ8PazYBGtWcpKdqtbBbxhbdXBKhSpTjt1kNmgzBsKV1VV2J674/9UqwFjhpuk2POXouIwF0t3z6mXg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@envelop/parser-cache/-/parser-cache-4.4.0.tgz",
+      "integrity": "sha512-m/RhbWlkKmRftqytWfBGLJCtiUqSOb3gxXsk4/TOlABZZ8KPeI4Yiq5SwZh6UrFOaup00QZK+fWmfjdniLi/sA==",
       "requires": {
         "tiny-lru": "7.0.6"
       }
     },
     "@envelop/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-Lghvfs0kh53G5mUKpCMlB/FhHh3O8SSR4hewB7JyE9hOEu/9h/6u+GHH/OEgdaRHky1Sae5Jf4grO+h21ka4ig=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-2.3.0.tgz",
+      "integrity": "sha512-K20KxpGlY+HKenms4Kccuh/YcCm0ytj1Zk0Ak6b6hKA68JI4YQ2GwGMq7A7gSOb1MxlbKqrnVdeQdXaDpQfCmA=="
     },
     "@envelop/validation-cache": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@envelop/validation-cache/-/validation-cache-4.3.2.tgz",
-      "integrity": "sha512-dihBgqbwm52u69QQeyOZQyDeIz/GIlLuSmgVJcsrKbbevX6pqiuZAs7Vbaj8EraIkuhAqPInzKrtWqYRgePIOA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@envelop/validation-cache/-/validation-cache-4.4.0.tgz",
+      "integrity": "sha512-mvKc1GU9xtQC1yKYYoEbkmjXXEGB7U/ESqlFO33oaMB7z3ctoQpvldBSJj+xj3hF9OchMb1nQKKSYf0GYpF/Gw==",
       "requires": {
         "tiny-lru": "7.0.6"
       }
@@ -1214,104 +1214,82 @@
       "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg=="
     },
     "@graphql-yoga/common": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/common/-/common-2.6.0.tgz",
-      "integrity": "sha512-iG33wMQlBujB1+Q2D/CLEVDW3xTeBVhHKsbaUmVSHV4zpmGRRQMg/YROJ2mU1lONOyZDPIC+9j3AR7+x0dSzoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/common/-/common-2.10.0.tgz",
+      "integrity": "sha512-Ugrj5FbhCmogSn2Ji0qG2kMkYEbCAha60qAIw+c6StYZBRxuE25RnRAw+2mEM1PqEE/UHMZ2bh/UvormAKJGoQ==",
       "requires": {
-        "@envelop/core": "^2.0.0",
-        "@envelop/parser-cache": "^4.0.0",
-        "@envelop/validation-cache": "^4.0.0",
-        "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.6.0",
+        "@envelop/core": "^2.4.0",
+        "@envelop/parser-cache": "^4.4.0",
+        "@envelop/validation-cache": "^4.4.0",
+        "@graphql-tools/schema": "^8.5.0",
+        "@graphql-tools/utils": "^8.8.0",
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@graphql-yoga/subscription": "2.0.0",
+        "@graphql-yoga/subscription": "^2.1.0",
         "cross-undici-fetch": "^0.4.2",
         "dset": "^3.1.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
         "@graphql-tools/merge": {
-          "version": "8.2.11",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.11.tgz",
-          "integrity": "sha512-fsjJVdsk9GV1jj1Ed2AKLlHYlsf0ZadTK8X5KxFRE1ZSnKqh56BLVX93JrtOIAnsiHkwOK2TC43HGhApF1swpQ==",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.0.tgz",
+          "integrity": "sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==",
           "requires": {
-            "@graphql-tools/utils": "8.6.10",
-            "tslib": "~2.4.0"
+            "@graphql-tools/utils": "8.8.0",
+            "tslib": "^2.4.0"
           }
         },
         "@graphql-tools/schema": {
-          "version": "8.3.11",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.11.tgz",
-          "integrity": "sha512-esMEnbyXbp8B5VEI4o395+x0G7Qmz3JSX5onFBF8HeLYcqWJasY5vBuWkO18VxrZpEnvnryodP6Y00bVag9O3Q==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.0.tgz",
+          "integrity": "sha512-VeFtKjM3SA9/hCJJfr95aEdC3G0xIKM9z0Qdz4i+eC1g2fdZYnfWFt2ucW4IME+2TDd0enHlKzaV0qk2SLVUww==",
           "requires": {
-            "@graphql-tools/merge": "8.2.11",
-            "@graphql-tools/utils": "8.6.10",
-            "tslib": "~2.4.0",
+            "@graphql-tools/merge": "8.3.0",
+            "@graphql-tools/utils": "8.8.0",
+            "tslib": "^2.4.0",
             "value-or-promise": "1.0.11"
           }
         },
         "@graphql-tools/utils": {
-          "version": "8.6.10",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.10.tgz",
-          "integrity": "sha512-bJH9qwuyM3BP0PTU6/lvBDkk6jdEIOn+dbyk4pHMVNnvbJ1gZQwo62To8SHxxaUTus8OMhhVPSh9ApWXREURcg==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
+          "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
           "requires": {
-            "tslib": "~2.4.0"
+            "tslib": "^2.4.0"
           }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        },
-        "value-or-promise": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-          "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
         }
       }
     },
     "@graphql-yoga/node": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/node/-/node-2.6.0.tgz",
-      "integrity": "sha512-VkHaiIwDYx+WJI/NnT2x+mGknk1YoNTP/auweDvKzPXdsWR5Za8rEYUloKZX4TxHTpyqbBLMtCt+4TDITriVbA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/node/-/node-2.11.1.tgz",
+      "integrity": "sha512-GLA+wuM4YK4pGKhvbA/VhCEy1aCsKf6TBqs6EdDlhuKOY3Pdcw2D5lyanU/k9PuUQVH1x5t2uHf186Ok4kivWw==",
       "requires": {
-        "@envelop/core": "^2.0.0",
-        "@graphql-tools/utils": "^8.6.0",
-        "@graphql-yoga/common": "2.6.0",
-        "@graphql-yoga/subscription": "2.0.0",
+        "@envelop/core": "^2.4.0",
+        "@graphql-tools/utils": "^8.8.0",
+        "@graphql-yoga/common": "^2.10.0",
+        "@graphql-yoga/subscription": "^2.1.0",
         "cross-undici-fetch": "^0.4.2",
         "tslib": "^2.3.1"
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "8.6.10",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.10.tgz",
-          "integrity": "sha512-bJH9qwuyM3BP0PTU6/lvBDkk6jdEIOn+dbyk4pHMVNnvbJ1gZQwo62To8SHxxaUTus8OMhhVPSh9ApWXREURcg==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
+          "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
           "requires": {
-            "tslib": "~2.4.0"
+            "tslib": "^2.4.0"
           }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@graphql-yoga/subscription": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-2.0.0.tgz",
-      "integrity": "sha512-HlG+gIddjIP3/BDrMZymdzmzDjNdYuSGMxx6+1JA83gAEVRDR4yOoT4QeNKYqRhLK9xca/Hxp1PfBpquSa244Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-2.1.0.tgz",
+      "integrity": "sha512-MXqYYGVx3xOQ2DeDEKIMx4ZEkSZm8IvLnT+/IEXgqLrEdn4wGVODddtDDkR9C4d8aQU1pB1eyr7yoj8JjYXKAQ==",
       "requires": {
         "@repeaterjs/repeater": "^3.0.4",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -4405,9 +4383,9 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.4.3.tgz",
-      "integrity": "sha512-mv1jusEQsFnBHEBkpFaYROKAzAWyuW8ZyN48NcyqkjLGRrscMKuFRmUigUrkE/pdprQZjNTQQ/aWJKe6F4tzTA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.4.8.tgz",
+      "integrity": "sha512-qQbw1GHZaW56ETnNL7nWn5wdsjnZsmPkPImTM3+ymUPwREkzihxgwqESaVF+X2IZ2hkZCxVOTfEOp28xtL/+pw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "busboy": "^1.6.0",
@@ -6599,9 +6577,9 @@
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
     },
     "formdata-node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.2.tgz",
-      "integrity": "sha512-k7lYJyzDOSL6h917favP8j1L0/wNyylzU+x+1w4p5haGVHNlP58dbpdJhiCUsDbWsa9HwEtLp89obQgXl2e0qg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.3.tgz",
+      "integrity": "sha512-coTew7WODO2vF+XhpUdmYz4UBvlsiTMSNaFYZlrXIqYbFd4W7bMwnoALNLE6uvNgzTg2j1JDF0ZImEfF06VPAA==",
       "requires": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.1"
@@ -15736,9 +15714,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.2.0.tgz",
-      "integrity": "sha512-XY6+NS3WH9b3TKOHeNz2CjR+qrVz/k4fO9g3etPpLozRvULoQmZ1+dk9JbIz40ehn27xzFk4jYVU2MU3Nle62A=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@graphql-yoga/node": "2.6.0",
+    "@graphql-yoga/node": "2.11.1",
     "@graphql-tools/utils": "8.6.12",
     "@graphql-tools/merge": "8.2.13",
     "@graphql-tools/schema": "8.3.14",

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -9419,7 +9419,6 @@ describe('ParseGraphQLServer', () => {
           });
 
           const result = JSON.parse(await res.text());
-          // Server should return 413 https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413
           expect(res.status).toEqual(413);
           expect(result.errors[0].message).toEqual('File size limit exceeded: 1024 bytes');
         });

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -9419,7 +9419,8 @@ describe('ParseGraphQLServer', () => {
           });
 
           const result = JSON.parse(await res.text());
-          expect(res.status).toEqual(500);
+          // Server should return 413 https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413
+          expect(res.status).toEqual(413);
           expect(result.errors[0].message).toEqual('File size limit exceeded: 1024 bytes');
         });
 


### PR DESCRIPTION

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [X ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/pull/8043#issuecomment-1155742360).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Previously GraphQL Yoga was returning 500 but in the latest version it returns 400 which also not 100% correct. 
It should be 413 which indicates that user sends a request over the specified limit per HTTP spec.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413

https://github.com/dotansimha/graphql-yoga/pull/1270
With the PR above on GraphQL Yoga repo, the behavior is fixed per spec. But Parse Server tests need to be updated since it was expecting the wrong status code (500) which indicates a misleading internal server error that isn't related to the user.

Related issue: https://github.com/parse-community/parse-server/pull/8043#issuecomment-1155742360

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
