### PR TITLE
fix: internal indices for classes `_Idempotency` and `_Role` are not protected in defined schema

### DIFF
--- a/spec/DefinedSchemas.spec.js
+++ b/spec/DefinedSchemas.spec.js
@@ -447,6 +447,7 @@ describe('DefinedSchemas', () => {
       expect(definedSchema.isProtectedIndex('_Role', 'name_1')).toEqual(true);
       expect(definedSchema.isProtectedIndex('_Role', 'test')).toEqual(false);
     });
+
     it('should detect protected indexes for _Idempotency class', () => {
       const definedSchema = new DefinedSchemas({}, {});
       expect(definedSchema.isProtectedIndex('_Idempotency', 'reqId_1')).toEqual(true);

--- a/spec/DefinedSchemas.spec.js
+++ b/spec/DefinedSchemas.spec.js
@@ -432,6 +432,40 @@ describe('DefinedSchemas', () => {
       expect(testSchema.indexes).toBeUndefined();
       expect(userSchema.indexes).toEqual(expectedIndexes);
     });
+
+    it('should detect protected indexes for _User class', () => {
+      const definedSchema = new DefinedSchemas({}, {});
+      const protectedUserIndexes = ['_id_', 'case_insensitive_email', 'username_1', 'email_1'];
+      protectedUserIndexes.forEach(field => {
+        expect(definedSchema.isProtectedIndex('_User', field)).toEqual(true);
+      });
+      expect(definedSchema.isProtectedIndex('_User', 'test')).toEqual(false);
+    });
+    it('should detect protected indexes for _Role class', () => {
+      const definedSchema = new DefinedSchemas({}, {});
+      expect(definedSchema.isProtectedIndex('_Role', 'name_1')).toEqual(true);
+      expect(definedSchema.isProtectedIndex('_Role', 'test')).toEqual(false);
+    });
+    it('should detect protected indexes for _Idempotency class', () => {
+      const definedSchema = new DefinedSchemas({}, {});
+      expect(definedSchema.isProtectedIndex('_Idempotency', 'reqId_1')).toEqual(true);
+      expect(definedSchema.isProtectedIndex('_Idempotency', 'test')).toEqual(false);
+    });
+
+    it('should not detect protected indexes on user defined class', () => {
+      const definedSchema = new DefinedSchemas({}, {});
+      const protectedIndexes = [
+        'case_insensitive_email',
+        'username_1',
+        'email_1',
+        'reqId_1',
+        'name_1',
+      ];
+      protectedIndexes.forEach(field => {
+        expect(definedSchema.isProtectedIndex('ExampleClass', field)).toEqual(false);
+      });
+      expect(definedSchema.isProtectedIndex('ExampleClass', '_id_')).toEqual(true);
+    });
   });
 
   describe('ClassLevelPermissions', () => {

--- a/spec/DefinedSchemas.spec.js
+++ b/spec/DefinedSchemas.spec.js
@@ -441,6 +441,7 @@ describe('DefinedSchemas', () => {
       });
       expect(definedSchema.isProtectedIndex('_User', 'test')).toEqual(false);
     });
+
     it('should detect protected indexes for _Role class', () => {
       const definedSchema = new DefinedSchemas({}, {});
       expect(definedSchema.isProtectedIndex('_Role', 'name_1')).toEqual(true);

--- a/src/SchemaMigrations/DefinedSchemas.js
+++ b/src/SchemaMigrations/DefinedSchemas.js
@@ -399,15 +399,23 @@ export class DefinedSchemas {
   }
 
   isProtectedIndex(className: string, indexName: string) {
-    let indexes = ['_id_'];
-    if (className === '_User') {
-      indexes = [
-        ...indexes,
-        'case_insensitive_username',
-        'case_insensitive_email',
-        'username_1',
-        'email_1',
-      ];
+    const indexes = ['_id_'];
+    switch (className) {
+      case '_User':
+        indexes.push(
+          'case_insensitive_username',
+          'case_insensitive_email',
+          'username_1',
+          'email_1'
+        );
+        break;
+      case '_Role':
+        indexes.push('name_1');
+        break;
+
+      case '_Idempotency':
+        indexes.push('reqId_1');
+        break;
     }
 
     return indexes.indexOf(indexName) !== -1;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Missing protected indexes detection on _Role and _Idempotency class

Related issue: NONE

### Approach

Fix and cover with unit tests

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
