### PR TITLE
fix: `Parse.Query` with `count` option throws error

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -383,6 +383,28 @@ describe('miscellaneous', function () {
       );
   });
 
+  it('query with count', async () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': Parse.applicationId,
+      'X-Parse-Master-Key': Parse.masterKey,
+    };
+    await Parse.Object.saveAll([new TestObject({ x: true }), new TestObject({ x: false })]);
+    const res = await request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject',
+      body: {
+        where: { x: false },
+        count: 1,
+        limit: 0,
+        _method: 'GET',
+      },
+      json: true,
+    });
+    expect(res.data.count).toEqual(1);
+  });
+
   it('basic saveAll', function (done) {
     const alpha = new TestObject({ letter: 'alpha' });
     const beta = new TestObject({ letter: 'beta' });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Related issue: https://github.com/parse-community/parse-server/issues/8127

### Approach

Trying to reproduce issue with failing test.

### TODOs before merging
n/a