### PR TITLE
fix: sorting by non-existing value throws `INVALID_SERVER_ERROR` on Postgres

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1715,6 +1715,16 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  it('order by non-existing string', async () => {
+    const strings = ['a', 'b', 'c', 'd'];
+    const makeBoxedNumber = function (num, i) {
+      return new BoxedNumber({ number: num, string: strings[i] });
+    };
+    await Parse.Object.saveAll([3, 1, 3, 2].map(makeBoxedNumber));
+    const results = await new Parse.Query(BoxedNumber).ascending('foo').find();
+    expect(results.length).toBe(4);
+  });
+
   it('order by descending number then ascending string', function (done) {
     const strings = ['a', 'b', 'c', 'd'];
     const makeBoxedNumber = function (num, i) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1207,7 +1207,7 @@ class DatabaseController {
                 `Invalid field name: ${fieldName}.`
               );
             }
-            if (!schema.fields[fieldName.split('.')[0]]) {
+            if (!schema.fields[fieldName.split('.')[0]] && fieldName.charAt(0) !== '$') {
               delete sort[fieldName];
             }
           });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1207,6 +1207,9 @@ class DatabaseController {
                 `Invalid field name: ${fieldName}.`
               );
             }
+            if (!schema.fields[fieldName]) {
+              delete sort[fieldName];
+            }
           });
           return (isMaster
             ? Promise.resolve()

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1207,7 +1207,7 @@ class DatabaseController {
                 `Invalid field name: ${fieldName}.`
               );
             }
-            if (this.adapter instanceof PostgresStorageAdapter && !schema.fields[fieldName]) {
+            if (!schema.fields[fieldName.split('.')[0]]) {
               delete sort[fieldName];
             }
           });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1207,7 +1207,7 @@ class DatabaseController {
                 `Invalid field name: ${fieldName}.`
               );
             }
-            if (!schema.fields[fieldName.split('.')[0]] && fieldName.charAt(0) !== '$') {
+            if (!schema.fields[fieldName.split('.')[0]] && fieldName !== 'score') {
               delete sort[fieldName];
             }
           });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1207,7 +1207,7 @@ class DatabaseController {
                 `Invalid field name: ${fieldName}.`
               );
             }
-            if (!schema.fields[fieldName]) {
+            if (this.adapter instanceof PostgresStorageAdapter && !schema.fields[fieldName]) {
               delete sort[fieldName];
             }
           });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Sorting by a non-existent string throws on postgres.

Closes #8072

### Approach
<!-- Add a description of the approach in this PR. -->

Checks if the sort key exists in `SCHEMA`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
