### PR TITLE
fix: push notifications `badge` doesn't update with Installation beforeSave trigger

### DIFF
--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -1239,6 +1239,57 @@ describe('Installations', () => {
     });
   });
 
+  it('can use  push with beforeSave', async () => {
+    const input = {
+      deviceToken: '11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306',
+      deviceType: 'ios',
+    };
+    await rest.create(config, auth.nobody(config), '_Installation', input)
+    const functions = {
+      beforeSave() {},
+      afterSave() {}
+    }
+    spyOn(functions, 'beforeSave').and.callThrough();
+    spyOn(functions, 'afterSave').and.callThrough();
+    Parse.Cloud.beforeSave(Parse.Installation, functions.beforeSave);
+    Parse.Cloud.afterSave(Parse.Installation, functions.afterSave);
+    await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
+      },
+      data: {
+        badge: 'increment',
+        alert: 'Hello world!',
+      },
+    });
+
+    await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
+      },
+      data: {
+        badge: 'increment',
+        alert: 'Hello world!',
+      },
+    });
+
+    await Parse.Push.send({
+      where: {
+        deviceType: 'ios',
+      },
+      data: {
+        badge: 'increment',
+        alert: 'Hello world!',
+      },
+    });
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const installation = await new Parse.Query(Parse.Installation).first({useMasterKey: true});
+    expect(installation.get('badge')).toEqual(3);
+    expect(functions.beforeSave).not.toHaveBeenCalled();
+    expect(functions.afterSave).not.toHaveBeenCalled();
+
+  });
+
   // TODO: Look at additional tests from installation_collection_test.go:882
   // TODO: Do we need to support _tombstone disabling of installations?
   // TODO: Test deletion, badge increments

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -1287,7 +1287,6 @@ describe('Installations', () => {
     expect(installation.get('badge')).toEqual(3);
     expect(functions.beforeSave).not.toHaveBeenCalled();
     expect(functions.afterSave).not.toHaveBeenCalled();
-
   });
 
   // TODO: Look at additional tests from installation_collection_test.go:882

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -1239,7 +1239,7 @@ describe('Installations', () => {
     });
   });
 
-  it('can use  push with beforeSave', async () => {
+  it('can use push with beforeSave', async () => {
     const input = {
       deviceToken: '11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306',
       deviceType: 'ios',

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -217,7 +217,7 @@ RestWrite.prototype.validateSchema = function () {
 // Runs any beforeSave triggers against this operation.
 // Any change leads to our data being mutated.
 RestWrite.prototype.runBeforeSaveTrigger = function () {
-  if (this.response) {
+  if (this.response || this.runOptions.many) {
     return;
   }
 
@@ -1522,7 +1522,7 @@ RestWrite.prototype.runDatabaseOperation = function () {
 
 // Returns nothing - doesn't wait for the trigger.
 RestWrite.prototype.runAfterSaveTrigger = function () {
-  if (!this.response || !this.response.response) {
+  if (!this.response || !this.response.response || this.runOptions.many) {
     return;
   }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

beforeSave triggers on the `Installation` class prevent `badge` being tracked.

Related issue: #8118

### Approach
<!-- Add a description of the approach in this PR. -->

If `this.runOptions.many`, do not run the triggers. `many` is used to run `updateMany`, which is used internally to update `badge` in pushes.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
