### PR TITLE
fix: invalid json logs incorrectly

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -5247,4 +5247,14 @@ describe('Parse.Query testing', () => {
     // Validate
     expect(result.executionStats).not.toBeUndefined();
   });
+  it_only_db('mongo')('should correctly throw on invalid transform', async () => {
+    await expectAsync(
+      new Parse.Query('SomeObject').equalTo('users', new Parse.Query(Parse.User)).first()
+    ).toBeRejectedWith(
+      new Parse.Error(
+        Parse.Error.INVALID_JSON,
+        `You cannot use {"className":"_User","_where":{},"_include":[],"_exclude":[],"_count":false,"_limit":-1,"_skip":0,"_readPreference":null,"_includeReadPreference":null,"_subqueryReadPreference":null,"_queriesLocalDatastore":false,"_localDatastorePinName":null,"_extraOptions":{},"_xhrRequest":{"task":null}} as a query parameter.`
+      )
+    );
+  });
 });

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -341,7 +341,7 @@ function transformQueryKeyValue(className, key, value, schema, count = false) {
   } else {
     throw new Parse.Error(
       Parse.Error.INVALID_JSON,
-      `You cannot use ${value} as a query parameter.`
+      `You cannot use ${JSON.stringify(value)} as a query parameter.`
     );
   }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Invalid JSON is currently logged as a string, which converts to `[object Object]`

Related issue: n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Stringifies error for easier debugging

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
