### PR TITLE
fix: query aggregation pipeline cannot handle value of type `Date` when `directAccess: true`

### DIFF
--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -666,6 +666,23 @@ describe('Parse.Query Aggregate testing', () => {
       });
   });
 
+  it('should aggregate with Date object (directAccess)', async () => {
+    const rest = require('../lib/rest');
+    const auth = require('../lib/Auth');
+    const TestObject = Parse.Object.extend('TestObject');
+    const date = new Date();
+    await new TestObject({ date: date }).save(null, { useMasterKey: true });
+    const config = Config.get(Parse.applicationId);
+    const resp = await rest.find(
+      config,
+      auth.master(config),
+      'TestObject',
+      {},
+      { pipeline: [{ $match: { date: { $lte: new Date() } } }] }
+    );
+    expect(resp.results.length).toBe(1);
+  });
+
   it('match comparison query', done => {
     const options = Object.assign({}, masterKeyOptions, {
       body: {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -952,6 +952,9 @@ export class MongoStorageAdapter implements StorageAdapter {
   // an operator in it (like $gt, $lt, etc). Because of this I felt it was easier to make this a
   // recursive method to traverse down to the "leaf node" which is going to be the string.
   _convertToDate(value: any): any {
+    if (value instanceof Date) {
+      return value;
+    }
     if (typeof value === 'string') {
       return new Date(value);
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Aggregation pipeline with dates do not work with `directAccess`

Related issue: #7748

Closes #7748

### Approach
<!-- Add a description of the approach in this PR. -->

If a date is already a date in an aggregate pipeline, it should stay as a date. It is currently converted to `{}`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
