### PR TITLE
ci: upgrade Postgres versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,13 +146,8 @@ jobs:
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 16.14.2
-          - name: MongoDB 4.0, ReplicaSet, WiredTiger
-            MONGODB_VERSION: 4.0.28
-            MONGODB_TOPOLOGY: replicaset
-            MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 16.14.2
-          - name: MongoDB 4.0, Standalone, MMAPv1
-            MONGODB_VERSION: 4.0.28
+          - name: MongoDB 4.2, Standalone, MMAPv1
+            MONGODB_VERSION: 4.2.19
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: mmapv1
             NODE_VERSION: 16.14.2
@@ -162,11 +157,6 @@ jobs:
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 16.14.2
-          - name: Node 12
-            MONGODB_VERSION: 4.4.13
-            MONGODB_TOPOLOGY: standalone
-            MONGODB_STORAGE_ENGINE: wiredTiger
-            NODE_VERSION: 12.22.11
           - name: Node 14
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
@@ -223,23 +213,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: PostgreSQL 11, PostGIS 3.0
-            POSTGRES_IMAGE: postgis/postgis:11-3.0
-            NODE_VERSION: 16.14.2
-          - name: PostgreSQL 11, PostGIS 3.1
-            POSTGRES_IMAGE: postgis/postgis:11-3.1
-            NODE_VERSION: 16.14.2
-          - name: PostgreSQL 11, PostGIS 3.2
-            POSTGRES_IMAGE: postgis/postgis:11-3.2
+          - name: PostgreSQL 12, PostGIS 3.1
+            POSTGRES_IMAGE: postgis/postgis:12-3.1
             NODE_VERSION: 16.14.2
           - name: PostgreSQL 12, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:12-3.2
             NODE_VERSION: 16.14.2
-          - name: PostgreSQL 13, PostGIS 3.2
-            POSTGRES_IMAGE: postgis/postgis:13-3.2
+          - name: PostgreSQL 12, PostGIS 3.3
+            POSTGRES_IMAGE: postgis/postgis:12-3.3
             NODE_VERSION: 16.14.2
-          - name: PostgreSQL 14, PostGIS 3.2
-            POSTGRES_IMAGE: postgis/postgis:14-3.2
+          - name: PostgreSQL 13, PostGIS 3.3
+            POSTGRES_IMAGE: postgis/postgis:13-3.3
+            NODE_VERSION: 16.14.2
+          - name: PostgreSQL 14, PostGIS 3.3
+            POSTGRES_IMAGE: postgis/postgis:14-3.3
             NODE_VERSION: 16.14.2
       fail-fast: false
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,27 @@ jobs:
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 16.14.2
+          - name: MongoDB 4.0, ReplicaSet, WiredTiger
+            MONGODB_VERSION: 4.0.28
+            MONGODB_TOPOLOGY: replicaset
+            MONGODB_STORAGE_ENGINE: wiredTiger
+            NODE_VERSION: 16.14.2
+          - name: MongoDB 4.0, Standalone, MMAPv1
+            MONGODB_VERSION: 4.0.28
+            MONGODB_TOPOLOGY: standalone
+            MONGODB_STORAGE_ENGINE: mmapv1
+            NODE_VERSION: 16.14.2
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 16.14.2
+          - name: Node 12
+            MONGODB_VERSION: 4.4.13
+            MONGODB_TOPOLOGY: standalone
+            MONGODB_STORAGE_ENGINE: wiredTiger
+            NODE_VERSION: 12.22.11
           - name: Node 14
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
@@ -208,11 +223,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: PostgreSQL 12, PostGIS 3.1
-            POSTGRES_IMAGE: postgis/postgis:12-3.1
+          - name: PostgreSQL 11, PostGIS 3.0
+            POSTGRES_IMAGE: postgis/postgis:11-3.0
             NODE_VERSION: 16.14.2
-          - name: PostgreSQL 12, PostGIS 3.2
-            POSTGRES_IMAGE: postgis/postgis:12-3.2
+          - name: PostgreSQL 11, PostGIS 3.1
+            POSTGRES_IMAGE: postgis/postgis:11-3.1
+            NODE_VERSION: 16.14.2
+          - name: PostgreSQL 11, PostGIS 3.2
+            POSTGRES_IMAGE: postgis/postgis:11-3.2
+            NODE_VERSION: 16.14.2
+          - name: PostgreSQL 11, PostGIS 3.3
+            POSTGRES_IMAGE: postgis/postgis:11-3.3
             NODE_VERSION: 16.14.2
           - name: PostgreSQL 12, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:12-3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,6 @@ jobs:
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 16.14.2
-          - name: MongoDB 4.2, Standalone, MMAPv1
-            MONGODB_VERSION: 4.2.19
-            MONGODB_TOPOLOGY: standalone
-            MONGODB_STORAGE_ENGINE: mmapv1
-            NODE_VERSION: 16.14.2
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 4.4.13

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Parse Server is continuously tested with the most recent releases of PostgreSQL 
 | Version     | PostGIS Version | End-of-Life   | Parse Server Support End | Compatible |
 |-------------|-----------------|---------------|--------------------------|------------|
 | Postgres 12 | 3.1, 3.2, 3.3   | November 2024 | April 2023               | ✅ Yes      |
-| Postgres 13 | 3.2             | November 2025 | April 2024               | ✅ Yes      |
-| Postgres 14 | 3.2             | November 2026 | April 2025               | ✅ Yes      |
+| Postgres 13 | 3.3             | November 2025 | April 2024               | ✅ Yes      |
+| Postgres 14 | 3.3             | November 2026 | April 2025               | ✅ Yes      |
 
 ### Locally
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Coverage](https://img.shields.io/codecov/c/github/parse-community/parse-server/alpha.svg)](https://codecov.io/github/parse-community/parse-server?branch=alpha)
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
-[![Node Version](https://img.shields.io/badge/nodejs-12,_14,_16,_17,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
-[![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5.0,_5.1,_5.2-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
-[![Postgres Version](https://img.shields.io/badge/postgresql-11,_12,_13,_14-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
+[![Node Version](https://img.shields.io/badge/nodejs-14,_16,_17,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
+[![MongoDB Version](https://img.shields.io/badge/mongodb-4.2,_4.4,_5.0,_5.1,_5.2-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
+[![Postgres Version](https://img.shields.io/badge/postgresql-12,_13,_14-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
 [![npm latest version](https://img.shields.io/npm/v/parse-server/latest.svg)](https://www.npmjs.com/package/parse-server)
 [![npm beta version](https://img.shields.io/npm/v/parse-server/beta.svg)](https://www.npmjs.com/package/parse-server)
@@ -126,7 +126,6 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
-| Node.js 12 | 12.22.11       | April 2022  | ✅ Yes      |
 | Node.js 14 | 14.19.1        | April 2023  | ✅ Yes      |
 | Node.js 16 | 16.14.2        | April 2024  | ✅ Yes      |
 | Node.js 17 | 17.9.0         | June 2022   | ✅ Yes      |
@@ -138,7 +137,6 @@ Parse Server is continuously tested with the most recent releases of MongoDB to 
 
 | Version     | Latest Version | End-of-Life | Compatible |
 |-------------|----------------|-------------|------------|
-| MongoDB 4.0 | 4.0.28         | April 2022  | ✅ Yes      |
 | MongoDB 4.2 | 4.2.19         | TBD         | ✅ Yes      |
 | MongoDB 4.4 | 4.4.13         | TBD         | ✅ Yes      |
 | MongoDB 5.0 | 5.0.6          | TBD         | ✅ Yes      |
@@ -151,8 +149,7 @@ Parse Server is continuously tested with the most recent releases of PostgreSQL 
 
 | Version     | PostGIS Version | End-of-Life   | Parse Server Support End | Compatible |
 |-------------|-----------------|---------------|--------------------------|------------|
-| Postgres 11 | 3.0, 3.1, 3.2   | November 2023 | April 2022               | ✅ Yes      |
-| Postgres 12 | 3.2             | November 2024 | April 2023               | ✅ Yes      |
+| Postgres 12 | 3.1, 3.2, 3.3   | November 2024 | April 2023               | ✅ Yes      |
 | Postgres 13 | 3.2             | November 2025 | April 2024               | ✅ Yes      |
 | Postgres 14 | 3.2             | November 2026 | April 2025               | ✅ Yes      |
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Coverage](https://img.shields.io/codecov/c/github/parse-community/parse-server/alpha.svg)](https://codecov.io/github/parse-community/parse-server?branch=alpha)
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
-[![Node Version](https://img.shields.io/badge/nodejs-14,_16,_17,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
-[![MongoDB Version](https://img.shields.io/badge/mongodb-4.2,_4.4,_5.0,_5.1,_5.2-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
-[![Postgres Version](https://img.shields.io/badge/postgresql-12,_13,_14-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
+[![Node Version](https://img.shields.io/badge/nodejs-12,_14,_16,_17,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
+[![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5.0,_5.1,_5.2-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
+[![Postgres Version](https://img.shields.io/badge/postgresql-11,_12,_13,_14-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
 [![npm latest version](https://img.shields.io/npm/v/parse-server/latest.svg)](https://www.npmjs.com/package/parse-server)
 [![npm beta version](https://img.shields.io/npm/v/parse-server/beta.svg)](https://www.npmjs.com/package/parse-server)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
+| Node.js 12 | 12.22.11       | April 2022  | ✅ Yes      |
 | Node.js 14 | 14.19.1        | April 2023  | ✅ Yes      |
 | Node.js 16 | 16.14.2        | April 2024  | ✅ Yes      |
 | Node.js 17 | 17.9.0         | June 2022   | ✅ Yes      |
@@ -137,6 +138,7 @@ Parse Server is continuously tested with the most recent releases of MongoDB to 
 
 | Version     | Latest Version | End-of-Life | Compatible |
 |-------------|----------------|-------------|------------|
+| MongoDB 4.0 | 4.0.28         | April 2022  | ✅ Yes      |
 | MongoDB 4.2 | 4.2.19         | TBD         | ✅ Yes      |
 | MongoDB 4.4 | 4.4.13         | TBD         | ✅ Yes      |
 | MongoDB 5.0 | 5.0.6          | TBD         | ✅ Yes      |


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The CI isn't testing against the current latest versions of dependencies (e.g. Postgis 3.3) and still testing against dependencies that has reached the Parse EOL (e.g. Postges 11, Node 12, Mongo 4.0). This prevents the CI from determining if there are issues with the latest versions along with running unnecessary tests for each PR.

Closes: #8192

### Approach
<!-- Add a description of the approach in this PR. -->
Update versions of Postgis, remove versions that have reached EOL: Postres 11, Postgis 3.0, Node 12, Mongo 4.0, Mongo MMAPv1. 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Someone with access to the repo settings will need to update the branch requirements
- [x] Ensure CI passes
- [x] Update README badges and descriptions to represent latest EOL's 
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
