### PR TITLE
ci: reduce timeout after idempotency tests

### DIFF
--- a/spec/Idempotency.spec.js
+++ b/spec/Idempotency.spec.js
@@ -45,6 +45,10 @@ describe('Idempotency', () => {
     });
   });
 
+  afterAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.PARSE_SERVER_TEST_TIMEOUT || 10000;
+  });
+
   // Tests
   it('should enforce idempotency for cloud code function', async () => {
     let counter = 0;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Idempotency tests mutate `DEFAULT_TIMEOUT_INTERVAL` to 3 and a half minutes, so any tests thereafter will maintain that timeout. This means that if 3-5 tests timeout, the whole test suite will stop (as it's limited to 15 minutes).

This PR sets the timeout back to the default after the Idempotency tests.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
