### PR TITLE
feat: allow master key to bypass email verification

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -732,9 +732,11 @@ RestWrite.prototype._validateEmail = function () {
         (Object.keys(this.data.authData).length === 1 &&
           Object.keys(this.data.authData)[0] === 'anonymous')
       ) {
-        // We updated the email, send a new validation
-        this.storage['sendVerificationEmail'] = true;
-        this.config.userController.setEmailVerifyToken(this.data);
+        // We updated the email, send a new verification unless the master key explicitly suppresses it
+        if (!this.auth.isMaster || !this.data['emailVerified']) {
+          this.storage['sendVerificationEmail'] = true;
+          this.config.userController.setEmailVerifyToken(this.data);
+        }
       }
     });
 };
@@ -862,8 +864,10 @@ RestWrite.prototype.createSessionTokenIfNeeded = function () {
     this.config.preventLoginWithUnverifiedEmail && // no login without verification
     this.config.verifyUserEmails
   ) {
-    // verification is on
-    return; // do not create the session token in that case!
+    // verification is on and the master key has not explicitly suppressed verification
+    if (!this.auth.isMaster || !this.data['emailVerified']) {
+      return; // do not create the session token in that case!
+    }
   }
   return this.createSessionToken();
 };


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This PR allows the master key to bypass email verification.

Related issue: #8230

### Approach
<!-- Add a description of the approach in this PR. -->
Modified RestWrite to avoid triggering the verification sequence and create a session token if the request was initiated by the master key and the request sets `emailVerified` to true.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
