### PR TITLE
feat: add support for MongoDB 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,11 @@ jobs:
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 18.1.0
+          - name: MongoDB 6, ReplicaSet, WiredTiger
+            MONGODB_VERSION: 6.0.2
+            MONGODB_TOPOLOGY: replicaset
+            MONGODB_STORAGE_ENGINE: wiredTiger
+            NODE_VERSION: 18.1.0
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 4.4.13

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
 [![Node Version](https://img.shields.io/badge/nodejs-12,_14,_16,_17,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
-[![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5.0,_5.1,_5.2-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
+[![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5.0,_5.1,_5.2,_6-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
 [![Postgres Version](https://img.shields.io/badge/postgresql-11,_12,_13,_14,_15-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
 [![npm latest version](https://img.shields.io/npm/v/parse-server/latest.svg)](https://www.npmjs.com/package/parse-server)
@@ -142,7 +142,7 @@ Parse Server is continuously tested with the most recent releases of MongoDB to 
 | MongoDB 4.2 | 4.2.19         | April 2023    | ✅ Yes        |
 | MongoDB 4.4 | 4.4.13         | February 2024 | ✅ Yes        |
 | MongoDB 5.3 | 5.3.2          | October 2024  | ✅ Yes        |
-| MongoDB 6.0 | -              | July 2025     | ❌ Not tested |
+| MongoDB 6   | 6.0.2          | July 2025     | ✅ Yes        |
 
 #### PostgreSQL
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "test:mongodb:4.2.19": "npm run test:mongodb --dbversion=4.2.19",
     "test:mongodb:4.4.13": "npm run test:mongodb --dbversion=4.4.13",
     "test:mongodb:5.3.2": "npm run test:mongodb --dbversion=5.3.2",
+    "test:mongodb:6.0.2": "npm run test:mongodb --dbversion=6.0.2",
     "posttest:mongodb": "mongodb-runner stop",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=5.3.2} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=wiredTiger} mongodb-runner start",
     "testonly": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=5.3.2} MONGODB_TOPOLOGY=${MONGODB_TOPOLOGY:=standalone} MONGODB_STORAGE_ENGINE=${MONGODB_STORAGE_ENGINE:=wiredTiger} TESTING=1 jasmine",

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -308,7 +308,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     await expectAsync(adapter.getClass('UnknownClass')).toBeRejectedWith(undefined);
   });
 
-  it_only_mongodb_version('<5.1')('should use index for caseInsensitive query', async () => {
+  it_only_mongodb_version('<5.1>=6')('should use index for caseInsensitive query', async () => {
     const user = new Parse.User();
     user.set('username', 'Bugs');
     user.set('password', 'Bunny');
@@ -342,7 +342,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     expect(postIndexPlan.executionStats.executionStages.stage).toBe('FETCH');
   });
 
-  it_only_mongodb_version('>=5.1')('should use index for caseInsensitive query', async () => {
+  it_only_mongodb_version('>=5.1<6')('should use index for caseInsensitive query', async () => {
     const user = new Parse.User();
     user.set('username', 'Bugs');
     user.set('password', 'Bunny');

--- a/spec/ParseQuery.hint.spec.js
+++ b/spec/ParseQuery.hint.spec.js
@@ -27,7 +27,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     await TestUtils.destroyAllDataPermanently(false);
   });
 
-  it_only_mongodb_version('<5.1')('query find with hint string', async () => {
+  it_only_mongodb_version('<5.1>=6')('query find with hint string', async () => {
     const object = new TestObject();
     await object.save();
 
@@ -39,7 +39,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(explain.queryPlanner.winningPlan.inputStage.indexName).toBe('_id_');
   });
 
-  it_only_mongodb_version('>=5.1')('query find with hint string', async () => {
+  it_only_mongodb_version('>=5.1<6')('query find with hint string', async () => {
     const object = new TestObject();
     await object.save();
 
@@ -50,7 +50,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(explain.queryPlanner.winningPlan.queryPlan.inputStage.indexName).toBe('_id_');
   });
 
-  it_only_mongodb_version('<5.1')('query find with hint object', async () => {
+  it_only_mongodb_version('<5.1>=6')('query find with hint object', async () => {
     const object = new TestObject();
     await object.save();
 
@@ -64,7 +64,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     });
   });
 
-  it_only_mongodb_version('>=5.1')('query find with hint object', async () => {
+  it_only_mongodb_version('>=5.1<6')('query find with hint object', async () => {
     const object = new TestObject();
     await object.save();
 
@@ -265,7 +265,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(queryPlanner.winningPlan.queryPlan.inputStage.inputStage.keyPattern).toEqual({ _id: 1 });
   });
 
-  it_only_mongodb_version('<5.1')('query find with hint (rest)', async () => {
+  it_only_mongodb_version('<5.1>=6')('query find with hint (rest)', async () => {
     const object = new TestObject();
     await object.save();
     let options = Object.assign({}, masterKeyOptions, {
@@ -290,7 +290,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(explain.queryPlanner.winningPlan.inputStage.inputStage.indexName).toBe('_id_');
   });
 
-  it_only_mongodb_version('>=5.1')('query find with hint (rest)', async () => {
+  it_only_mongodb_version('>=5.1<6')('query find with hint (rest)', async () => {
     const object = new TestObject();
     await object.save();
     let options = Object.assign({}, masterKeyOptions, {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

Adds support for MongoDB 6

Related issue: #8217 
Closes: #8217 

### Approach

Due to the new versioning system of MongoDB, this will be the first version we'll only refer to as "MongoDB 6". Any patch or minor release will be bumped accordingly without adding any new CI job.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add required CI test for MongoDB 6 in repo settings
