### PR TITLE
docs: remove differentiation between MongoDB 5.x versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger
             NODE_VERSION: 18.1.0
-          - name: MongoDB 5.3, ReplicaSet, WiredTiger
+          - name: MongoDB 5, ReplicaSet, WiredTiger
             MONGODB_VERSION: 5.3.2
             MONGODB_TOPOLOGY: replicaset
             MONGODB_STORAGE_ENGINE: wiredTiger

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
 [![Node Version](https://img.shields.io/badge/nodejs-12,_14,_16,_17,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
-[![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5.0,_5.1,_5.2,_6-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
+[![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5,_6-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
 [![Postgres Version](https://img.shields.io/badge/postgresql-11,_12,_13,_14,_15-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
 [![npm latest version](https://img.shields.io/npm/v/parse-server/latest.svg)](https://www.npmjs.com/package/parse-server)
@@ -141,7 +141,7 @@ Parse Server is continuously tested with the most recent releases of MongoDB to 
 | MongoDB 4.0 | 4.0.28         | April 2022    | ✅ Yes        |
 | MongoDB 4.2 | 4.2.19         | April 2023    | ✅ Yes        |
 | MongoDB 4.4 | 4.4.13         | February 2024 | ✅ Yes        |
-| MongoDB 5.3 | 5.3.2          | October 2024  | ✅ Yes        |
+| MongoDB 5   | 5.3.2          | October 2024  | ✅ Yes        |
 | MongoDB 6   | 6.0.2          | July 2025     | ✅ Yes        |
 
 #### PostgreSQL


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

The README differentiates between different MongoDB 5.x versions, also the CI test title. That is unnecessary with the new [versioning](https://www.mongodb.com/docs/v5.0/reference/versioning/#std-label-release-version-numbers) of MongoDB. Parse Server will always test against the latest major version from MongoDB 5 onwards.

Related issue: #n/a

### Approach

Fixed:
- README compatibility table
- CI workflow job title that specifies MongoDB minor version

### TODOs before merging
n/a