### PR TITLE
refactor: replace deprecated LRU cache methods

### DIFF
--- a/src/Adapters/Cache/LRUCache.js
+++ b/src/Adapters/Cache/LRUCache.js
@@ -18,11 +18,11 @@ export class LRUCache {
   }
 
   del(key) {
-    this.cache.del(key);
+    this.cache.delete(key);
   }
 
   clear() {
-    this.cache.reset();
+    this.cache.clear();
   }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

LRU `.del()` and `.reset()` are deprecated and generate a huge amount of warning logs.

Related issue: None

### Approach
<!-- Add a description of the approach in this PR. -->

Use recommanded methods

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
