### PR TITLE
fix: Parse Server option `requestKeywordDenylist` can be bypassed via Cloud Code Webhooks or Triggers

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -109,6 +109,56 @@ describe('Vulnerabilities', () => {
       );
     });
 
+    it('denies creating a cloud trigger with polluted data', async () => {
+      Parse.Cloud.beforeSave('TestObject', ({ object }) => {
+        object.set('obj', {
+          constructor: {
+            prototype: {
+              dummy: 0,
+            },
+          },
+        });
+      });
+      await expectAsync(new Parse.Object('TestObject').save()).toBeRejectedWith(
+        new Parse.Error(
+          Parse.Error.INVALID_KEY_NAME,
+          'Prohibited keyword in request data: {"key":"constructor"}.'
+        )
+      );
+    });
+
+    it('denies creating a hook with polluted data', async () => {
+      const express = require('express');
+      const bodyParser = require('body-parser');
+      const port = 34567;
+      const hookServerURL = 'http://localhost:' + port;
+      const app = express();
+      app.use(bodyParser.json({ type: '*/*' }));
+      const server = await new Promise(resolve => {
+        const res = app.listen(port, undefined, () => resolve(res));
+      });
+      app.post('/BeforeSave', function (req, res) {
+        const object = Parse.Object.fromJSON(req.body.object);
+        object.set('hello', 'world');
+        object.set('obj', {
+          constructor: {
+            prototype: {
+              dummy: 0,
+            },
+          },
+        });
+        res.json({ success: object });
+      });
+      await Parse.Hooks.createTrigger('TestObject', 'beforeSave', hookServerURL + '/BeforeSave');
+      await expectAsync(new Parse.Object('TestObject').save()).toBeRejectedWith(
+        new Parse.Error(
+          Parse.Error.INVALID_KEY_NAME,
+          'Prohibited keyword in request data: {"key":"constructor"}.'
+        )
+      );
+      await new Promise(resolve => server.close(resolve));
+    });
+
     it('allows BSON type code data in write request with custom denylist', async () => {
       await reconfigureServer({
         requestKeywordDenylist: [],

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -62,18 +62,7 @@ function RestWrite(config, auth, className, query, data, originalData, clientSDK
     }
   }
 
-  if (this.config.requestKeywordDenylist) {
-    // Scan request data for denied keywords
-    for (const keyword of this.config.requestKeywordDenylist) {
-      const match = Utils.objectContainsKeyValue(data, keyword.key, keyword.value);
-      if (match) {
-        throw new Parse.Error(
-          Parse.Error.INVALID_KEY_NAME,
-          `Prohibited keyword in request data: ${JSON.stringify(keyword)}.`
-        );
-      }
-    }
-  }
+  this.checkProhibitedKeywords(data);
 
   // When the operation is complete, this.response may have several
   // fields.
@@ -296,6 +285,7 @@ RestWrite.prototype.runBeforeSaveTrigger = function () {
           delete this.data.objectId;
         }
       }
+      this.checkProhibitedKeywords(this.data);
     });
 };
 
@@ -1649,6 +1639,21 @@ RestWrite.prototype._updateResponseWithData = function (response, data) {
     }
   });
   return response;
+};
+
+RestWrite.prototype.checkProhibitedKeywords = function (data) {
+  if (this.config.requestKeywordDenylist) {
+    // Scan request data for denied keywords
+    for (const keyword of this.config.requestKeywordDenylist) {
+      const match = Utils.objectContainsKeyValue(data, keyword.key, keyword.value);
+      if (match) {
+        throw new Parse.Error(
+          Parse.Error.INVALID_KEY_NAME,
+          `Prohibited keyword in request data: ${JSON.stringify(keyword)}.`
+        );
+      }
+    }
+  }
 };
 
 export default RestWrite;


### PR DESCRIPTION
Fixes security vulnerability [GHSA-xprv-wvh7-qqqx](https://github.com/parse-community/parse-server/security/advisories/GHSA-xprv-wvh7-qqqx)