### PR TITLE
refactor: Improve incorrect deprecation log message for auth adapter

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -590,7 +590,7 @@ describe('AuthenticationProviders', function () {
     );
   });
 
-  it('can depreciate', async () => {
+  it('can deprecate', async () => {
     await reconfigureServer();
     const Deprecator = require('../lib/Deprecator/Deprecator');
     const spy = spyOn(Deprecator, 'logRuntimeDeprecation').and.callFake(() => {});
@@ -598,8 +598,9 @@ describe('AuthenticationProviders', function () {
     Parse.User._registerAuthenticationProvider(provider);
     await Parse.User._logInWith('myoauth');
     expect(spy).toHaveBeenCalledWith({
-      usage: 'auth.myoauth',
-      solution: 'auth.myoauth.enabled: true',
+      usage: 'Using the authentication adapter "myoauth" without explicitly enabling it',
+      solution:
+        'Enable the authentication adapter by setting the Parse Server option "auth.myoauth.enabled: true".',
     });
   });
 });

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -435,8 +435,8 @@ const handleAuthDataValidation = async (authData, req, foundUser) => {
       const authProvider = (req.config.auth || {})[provider] || {};
       if (authProvider.enabled == null) {
         Deprecator.logRuntimeDeprecation({
-          usage: `auth.${provider}`,
-          solution: `auth.${provider}.enabled: true`,
+          usage: `Using the authentication adapter "${provider}" without explicitly enabling it`,
+          solution: `Enable the authentication adapter by setting the Parse Server option "auth.${provider}.enabled: true".`,
         });
       }
       if (!validator || authProvider.enabled === false) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description

PR https://github.com/parse-community/parse-server/pull/7953 introduced an incorrect / unclear deprecation message that logs:

> DeprecationWarning: auth.facebook is deprecated and will be removed in a future version. auth.facebook.enabled: true

The log message should be improved. I think what the message intends to say is that the auth adapter is not enabled but a future version will require to explicitly enable it for it to work.

Closes: #n/a

### Approach

Improve log message.

### TODOs before merging
n/a