### PR TITLE
Uffizzi Integration

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,98 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, review_requested]
+
+jobs:
+  build-parse-server:
+    name: Build and push `Parse-Server`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: |
+            type=raw,value=60d
+
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-parse-server
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          PARSE_SERVER_IMAGE=${{ needs.build-parse-server.outputs.tags }}
+          export PARSE_SERVER_IMAGE
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,86 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,75 @@
+version: '3'
+
+# uffizzi integration
+x-uffizzi:
+  ingress:
+    service: nginx
+    port: 8081
+
+services:
+
+  postgres:
+      image: postgres
+      environment:
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=password
+        - POSTGRES_DB=postgres
+      ports:
+        - "5432:5432"
+      deploy:
+            resources:
+              limits:
+                memory: 1000M
+      volumes:
+        - postgres_data:/var/lib/postgresql
+
+  parse:
+        image: "${PARSE_SERVER_IMAGE}"
+        environment:
+        - PARSE_SERVER_APPLICATION_ID=parse
+        - PARSE_SERVER_MASTER_KEY=parse@master123!
+        - PARSE_SERVER_DATABASE_URI=postgresql://postgres:password@localhost:5432/postgres
+        - PARSE_SERVER_MOUNT_PATH=/parse
+        - PORT=1337
+        ports:
+          - '1337:1337'
+        deploy:
+          resources:
+            limits:
+              memory: 1000M
+        #entrypoint: ["/bin/sh", "-c", "sleep 5;  node ./bin/parse-server; export UFFIZZI_URL"] #sleep few seconds for postgres to come up
+  dashboard:
+        image: parseplatform/parse-dashboard:latest
+        ports:
+            - "4040:4040"
+        environment:
+        # - PARSE_DASHBOARD_SERVER_URL=https://pr-1-deployment-8540-parse-server.app.uffizzi.com/parse
+        - PARSE_DASHBOARD_MASTER_KEY=parse@master123!
+        - PARSE_DASHBOARD_APP_ID=parse
+        - PARSE_DASHBOARD_APP_NAME=MyParseApp
+        - PARSE_DASHBOARD_USER_ID=admin
+        - PARSE_DASHBOARD_USER_PASSWORD=password
+        - MOUNT_PATH=/dashboard
+        # - PARSE_DASHBOARD_ALLOW_INSECURE_HTTP=1
+        - PARSE_DASHBOARD_TRUST_PROXY=1
+        #- PARSE_DASHBOARD_COOKIE_SESSION_SECRET=AB8849B6-D725-4A75-AA73-AB7103F0363F
+        #command: parse-dashboard --dev
+        entrypoint: /bin/sh
+        command:
+         - "-c"
+         - "PARSE_DASHBOARD_SERVER_URL=$$UFFIZZI_URL/parse node Parse-Dashboard/index.js"
+        deploy:
+          resources:
+            limits:
+              memory: 1000M
+        # volumes:
+        # -  ./dashboard/parse-dashboard-config.json:/src/Parse-Dashboard/parse-dashboard-config.json
+
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx:/etc/nginx
+
+volumes:
+  postgres_data:
+

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,33 @@
+events {
+    worker_connections 1024; #default
+}
+http {
+    server {
+        listen 8081;
+
+        location / {
+            default_type text/html;
+            return 200 "<!DOCTYPE html><h2>Visit /dashboard/ to log into parse-dashboard</h2>\n";
+        }
+
+        location /dashboard {
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header X-NginX-Proxy true;
+         proxy_pass http://localhost:4040/dashboard/;
+         proxy_ssl_session_reuse off;
+         proxy_set_header Host $http_host;
+         proxy_redirect off;
+        }
+
+        location /parse {
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            keepalive_requests 10;
+            keepalive_timeout 75s;
+            proxy_pass http://localhost:1337/parse/;
+            proxy_http_version 1.1;
+        }
+    }
+    }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This PR addresses the challenges maintainers and contributors face testing and verifying changes on PRs. The idea behind the PR is to _**merge with confidence**_. Test environments are often polluted; testing changes on a _dev_ branch also requires a significant amount of effort — solving merge conflicts before testing being one of them.  

Preview Environments, built by [Ufffizzi](https://www.uffizzi.com/), solve these challenges elegantly. With these preview environments, contributors and maintainers will be able to approve contributions in half the time with live previews for every pull request. The PR will allow testing branches in isolation, and merging with confidence.

Closes: https://github.com/parse-community/parse-server/issues/8258

### Approach
<!-- Add a description of the approach in this PR. -->
This PR extends parse-server's GHA workflows and utilizes parse-server's dockerfile to build a docker-compose, which is then used to spin up containers containing the services we are testing parse-server with. This PR uses Postgres, parse-dashboard, and parse-server. Parse-server image is built from the source, which allows changes to reflect in the preview environment. The services are put behind a proxy for internal routing. No change has been made in the source code itself.

When a PR event is triggered on parse-server (PR opened, sync'd, etc), Uffizzi workflows will be triggered and either deploy a new Uffizzi Preview or update an existing one. Once the preview is deployed, a comment will be posted on the PR containing the URL of the preview environment, allowing easy navigation. 

[Here is a PoC](https://github.com/ShrutiC-git/parse-server/pull/1) for Parse-Server preview on Uffizzi - a PR opened against the main in my fork of Parse-Server. Here is the [comment](https://github.com/ShrutiC-git/parse-server/pull/1#issuecomment-1336191493) on that PR.
This is what the [preview](https://pr-1-deployment-8540-parse-server.app.uffizzi.com/) looks like.

To log into the preview, use the following credentials: 

- username: admin
- password: password


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->

cc @waveywaves 