### PR TITLE
feat: Adapt `verifyServerUrl` for new asynchronous Parse Server start-up states

### DIFF
--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -29,27 +29,20 @@ describe('Server Url Checks', () => {
     server.close(done);
   });
 
-  it('validate good server url', done => {
+  it('validate good server url', async () => {
     Parse.serverURL = 'http://localhost:13376';
-    ParseServer.verifyServerUrl(async result => {
-      if (!result) {
-        done.fail('Did not pass valid url');
-      }
-      await reconfigureServer();
-      done();
-    });
+    const response = await ParseServer.verifyServerUrl();
+    expect(response).toBeTrue();
   });
 
-  it('mark bad server url', done => {
+  it('mark bad server url', async () => {
     spyOn(console, 'warn').and.callFake(() => {});
     Parse.serverURL = 'notavalidurl';
-    ParseServer.verifyServerUrl(async result => {
-      if (result) {
-        done.fail('Did not mark invalid url');
-      }
-      await reconfigureServer();
-      done();
-    });
+    const response = await ParseServer.verifyServerUrl();
+    expect(response).not.toBeTrue();
+    expect(console.warn).toHaveBeenCalledWith(
+      `\nWARNING, Unable to connect to 'notavalidurl' as the URL is invalid. Cloud code and push notifications may be unavailable!\n`
+    );
   });
 
   xit('handleShutdown, close connection', done => {

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -546,6 +546,12 @@ describe('server', () => {
     const health = await request({
       url: 'http://localhost:12701/parse/health',
     }).catch(e => e);
+    spyOn(console, 'warn').and.callFake(() => {});
+    const verify = await ParseServer.default.verifyServerUrl();
+    expect(verify).not.toBeTrue();
+    expect(console.warn).toHaveBeenCalledWith(
+      `\nWARNING, Unable to connect to 'http://localhost:12701/parse'. Cloud code and push notifications may be unavailable!\n`
+    );
     expect(health.data.status).toBe('initialized');
     expect(health.status).toBe(503);
     await new Promise(resolve => server.close(resolve));
@@ -572,7 +578,9 @@ describe('server', () => {
     }).catch(e => e);
     expect(health.data.status).toBe('starting');
     expect(health.status).toBe(503);
-    expect(health.headers['retry-after']).toBe('1');
+    expect(health.headers['retry-after']).toBe('100');
+    const response = await ParseServer.default.verifyServerUrl();
+    expect(response).toBeTrue();
     await startingPromise;
     await new Promise(resolve => server.close(resolve));
   });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -578,7 +578,7 @@ describe('server', () => {
     }).catch(e => e);
     expect(health.data.status).toBe('starting');
     expect(health.status).toBe(503);
-    expect(health.headers['retry-after']).toBe('100');
+    expect(health.headers['retry-after']).toBe('1');
     const response = await ParseServer.default.verifyServerUrl();
     expect(response).toBeTrue();
     await startingPromise;

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -196,7 +196,7 @@ class ParseServer {
     api.use('/health', function (req, res) {
       res.status(options.state === 'ok' ? 200 : 503);
       if (options.state === 'starting') {
-        res.set('Retry-After', 1);
+        res.set('Retry-After', 100);
       }
       res.json({
         status: options.state,
@@ -384,30 +384,45 @@ class ParseServer {
     return server;
   }
 
-  static verifyServerUrl(callback) {
+  static async verifyServerUrl() {
     // perform a health check on the serverURL value
     if (Parse.serverURL) {
+      const isValidHttpUrl = string => {
+        let url;
+        try {
+          url = new URL(string);
+        } catch (_) {
+          return false;
+        }
+        return url.protocol === 'http:' || url.protocol === 'https:';
+      };
+      const url = `${Parse.serverURL.replace(/\/$/, '')}/health`;
+      if (!isValidHttpUrl(url)) {
+        console.warn(
+          `\nWARNING, Unable to connect to '${Parse.serverURL}' as the URL is invalid.` +
+            ` Cloud code and push notifications may be unavailable!\n`
+        );
+        return;
+      }
       const request = require('./request');
-      request({ url: Parse.serverURL.replace(/\/$/, '') + '/health' })
-        .catch(response => response)
-        .then(response => {
-          const json = response.data || null;
-          if (response.status !== 200 || !json || (json && json.status !== 'ok')) {
-            /* eslint-disable no-console */
-            console.warn(
-              `\nWARNING, Unable to connect to '${Parse.serverURL}'.` +
-                ` Cloud code and push notifications may be unavailable!\n`
-            );
-            /* eslint-enable no-console */
-            if (callback) {
-              callback(false);
-            }
-          } else {
-            if (callback) {
-              callback(true);
-            }
-          }
-        });
+      const response = await request({ url }).catch(response => response);
+      const json = response.data || null;
+      console.log(response.status, { json });
+      const retry = response.headers['retry-after'];
+      if (retry) {
+        await new Promise(resolve => setTimeout(resolve, retry));
+        return this.verifyServerUrl();
+      }
+      if (response.status !== 200 || json?.status !== 'ok') {
+        /* eslint-disable no-console */
+        console.warn(
+          `\nWARNING, Unable to connect to '${Parse.serverURL}'.` +
+            ` Cloud code and push notifications may be unavailable!\n`
+        );
+        /* eslint-enable no-console */
+        return;
+      }
+      return true;
     }
   }
 }

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -196,7 +196,7 @@ class ParseServer {
     api.use('/health', function (req, res) {
       res.status(options.state === 'ok' ? 200 : 503);
       if (options.state === 'starting') {
-        res.set('Retry-After', 100);
+        res.set('Retry-After', 1);
       }
       res.json({
         status: options.state,
@@ -410,7 +410,7 @@ class ParseServer {
       console.log(response.status, { json });
       const retry = response.headers['retry-after'];
       if (retry) {
-        await new Promise(resolve => setTimeout(resolve, retry));
+        await new Promise(resolve => setTimeout(resolve, retry * 1000));
         return this.verifyServerUrl();
       }
       if (response.status !== 200 || json?.status !== 'ok') {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`verifyServerUrl` uses callback syntax, and does not consider the `retry-after` header. This is a breaking change, as `verifyServerUrl` will no longer have a callback.

Closes: #8380

### Approach
<!-- Add a description of the approach in this PR. -->

- Refactor `verifyServerUrl`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests

