### PR TITLE
ci: Fix failing Node 14 workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11997,7 +11997,7 @@
     },
     "node_modules/mongodb-tools": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/mongodb-js/mongodb-tools.git#0d1a90f49796c41f6d47c7c7999fe384014a16a0",
+      "resolved": "https://github.com/mongodb-js/mongodb-tools.git#0d1a90f49796c41f6d47c7c7999fe384014a16a0",
       "integrity": "sha512-DNJJQYg1/VcE4gNP7zpKeWGIezwcpkI8XzG4YFL3WybY6cuKWMz3d1CIp3uKKEpva1qOHk2LI8mKWJX1Vpw4Sg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -29837,7 +29837,7 @@
       }
     },
     "mongodb-tools": {
-      "version": "git+ssh://git@github.com/mongodb-js/mongodb-tools.git#0d1a90f49796c41f6d47c7c7999fe384014a16a0",
+      "version": "https://github.com/mongodb-js/mongodb-tools.git#0d1a90f49796c41f6d47c7c7999fe384014a16a0",
       "integrity": "sha512-DNJJQYg1/VcE4gNP7zpKeWGIezwcpkI8XzG4YFL3WybY6cuKWMz3d1CIp3uKKEpva1qOHk2LI8mKWJX1Vpw4Sg==",
       "dev": true,
       "from": "mongodb-tools@github:mongodb-js/mongodb-tools#0d1a90f49796c41f6d47c7c7999fe384014a16a0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,9 +1,14 @@
 const pkg = require('./package.json');
+const fs = require('fs').promises;
 
 const version = parseFloat(process.version.substr(1));
 const minimum = parseFloat(pkg.engines.node.match(/\d+/g).join('.'));
 
-module.exports = function () {
+module.exports = async function () {
+  // support node 14
+  const lockFile = await fs.readFile('./package-lock.json').then(res => res.toString());
+  const file = lockFile.split('git+ssh://git@github.com/mongodb-js/mongodb-tools.git').join('https://github.com/mongodb-js/mongodb-tools.git');
+  await fs.writeFile('./package-lock.json', file);
   const openCollective = `
                   1111111111
                1111111111111111


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Currently the CI fails on Node 14. When we updated to lockfile v2, there were some manual changes to make it compatible with Node 14. These changes get reverted whenever `npm i` is ran in another PR.

Closes: `n/a`

### Approach
<!-- Add a description of the approach in this PR. -->

Adds script to allow `npm ci` to work on node 14. Can be removed once node 14 is no longer supported.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
