### PR TITLE
fix: `ParseServer.verifyServerUrl` may fail if server response headers are missing; remove unnecessary logging

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -240,7 +240,8 @@ class ParseServer {
       });
       // verify the server url after a 'mount' event is received
       /* istanbul ignore next */
-      api.on('mount', function () {
+      api.on('mount', async function () {
+        await new Promise(resolve => setTimeout(resolve, 1000));
         ParseServer.verifyServerUrl();
       });
     }
@@ -415,8 +416,7 @@ class ParseServer {
       const request = require('./request');
       const response = await request({ url }).catch(response => response);
       const json = response.data || null;
-      console.log(response.status, { json });
-      const retry = response.headers['retry-after'];
+      const retry = response.headers?.['retry-after'];
       if (retry) {
         await new Promise(resolve => setTimeout(resolve, retry * 1000));
         return this.verifyServerUrl();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

#8366 left some console code in. Also, if `request.headers` is undefined, it can throw an error.

Closes: `n/a`

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)

