### PR TITLE
fix: Schema without class level permissions may cause error

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,3 +8,4 @@
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\@flow-disable-next
+esproposal.optional_chaining=enable

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -220,8 +220,8 @@ const filterSensitiveData = (
     protectedFields && protectedFields.forEach(k => delete object[k]);
 
     // fields not requested by client (excluded),
-    //but were needed to apply protecttedFields
-    perms.protectedFields &&
+    // but were needed to apply protectedFields
+    perms && perms.protectedFields &&
       perms.protectedFields.temporaryKeys &&
       perms.protectedFields.temporaryKeys.forEach(k => delete object[k]);
   }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -221,9 +221,7 @@ const filterSensitiveData = (
 
     // fields not requested by client (excluded),
     // but were needed to apply protectedFields
-    perms && perms.protectedFields &&
-      perms.protectedFields.temporaryKeys &&
-      perms.protectedFields.temporaryKeys.forEach(k => delete object[k]);
+    perms?.protectedFields?.temporaryKeys?.forEach(k => delete object[k]);
   }
 
   for (const key in object) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

If the schema doesn't have classLevelPermissions for a class an error might occur. I've only seen this happen in very rare edge cases. 

Closes: https://github.com/parse-community/parse-server/issues/8406

