### PR TITLE
refactor: Upgrade to latest Parse JS SDK dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "parse-server",
       "version": "6.0.0-alpha.30",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/eslint-parser": "7.19.1",
         "@graphql-tools/merge": "8.3.6",
@@ -39,7 +39,7 @@
         "mime": "3.0.0",
         "mongodb": "4.10.0",
         "mustache": "4.2.0",
-        "parse": "4.0.0",
+        "parse": "4.0.1",
         "path-to-regexp": "0.1.7",
         "pg-monitor": "1.5.0",
         "pg-promise": "10.12.1",
@@ -16116,9 +16116,9 @@
       }
     },
     "node_modules/parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-4.0.0.tgz",
-      "integrity": "sha512-LKaHHqSLulEv1f76Cg3eJlDQL8FtK+mn6XehVbjY7uUGwm2B3LyzYjBH6iX0BXOFwfABcDRtq+8KCpuHXiIQ3g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-4.0.1.tgz",
+      "integrity": "sha512-ctv7zaVKlQIBSbarorB7TH3yacDzCvgWBP4ccpLKxlpe21QlaY88kv9V7ca7JdG/Txb3qWug4MwepQoPogXB6Q==",
       "dependencies": {
         "@babel/runtime": "7.18.0",
         "@babel/runtime-corejs3": "7.17.8",
@@ -32874,9 +32874,9 @@
       }
     },
     "parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-4.0.0.tgz",
-      "integrity": "sha512-LKaHHqSLulEv1f76Cg3eJlDQL8FtK+mn6XehVbjY7uUGwm2B3LyzYjBH6iX0BXOFwfABcDRtq+8KCpuHXiIQ3g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-4.0.1.tgz",
+      "integrity": "sha512-ctv7zaVKlQIBSbarorB7TH3yacDzCvgWBP4ccpLKxlpe21QlaY88kv9V7ca7JdG/Txb3qWug4MwepQoPogXB6Q==",
       "requires": {
         "@babel/runtime": "7.18.0",
         "@babel/runtime-corejs3": "7.17.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mime": "3.0.0",
     "mongodb": "4.10.0",
     "mustache": "4.2.0",
-    "parse": "4.0.0",
+    "parse": "4.0.1",
     "path-to-regexp": "0.1.7",
     "pg-monitor": "1.5.0",
     "pg-promise": "10.12.1",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Upgrading Parse JS SDK before Parse Server 6 release as it contains an important performance fix.

Closes: #8412 

## Approach

Upgrade Parse JS SDK

## Tasks
n/a