### PR TITLE
ci: Fix CI not running for certain branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches: [ release*, alpha, beta ]
   pull_request:
-    branches: [ release*, alpha, beta ]
+    branches:
+      - '**'
 env:
   NODE_VERSION: 19.3.0
   PARSE_SERVER_TEST_TIMEOUT: 20000


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

CI doesn't run when merging from alpha to beta, beta to release branch.

## Approach

Fix CI PR filter in workflow

## Tasks
<!-- Delete tasks that don't apply. -->

n/a