### PR TITLE
fix: Parameters missing in `afterFind` trigger of authentication adapters

### DIFF
--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -354,8 +354,9 @@ describe('Auth Adapter features', () => {
     await user.fetch({ sessionToken: user.getSessionToken() });
     const authData = user.get('authData').modernAdapter3;
     expect(authData).toEqual({ foo: 'bar' });
+    user._objCount = 3;
     expect(afterSpy).toHaveBeenCalledWith(
-      { ip: '127.0.0.1', user: undefined, master: true },
+      { ip: '127.0.0.1', user, master: false },
       { id: 'modernAdapter3Data' },
       undefined
     );

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -347,12 +347,18 @@ describe('Auth Adapter features', () => {
 
   it('should strip out authData if required', async () => {
     const spy = spyOn(modernAdapter3, 'validateOptions').and.callThrough();
+    const afterSpy = spyOn(modernAdapter3, 'afterFind').and.callThrough();
     await reconfigureServer({ auth: { modernAdapter3 }, silent: false });
     const user = new Parse.User();
     await user.save({ authData: { modernAdapter3: { id: 'modernAdapter3Data' } } });
     await user.fetch({ sessionToken: user.getSessionToken() });
     const authData = user.get('authData').modernAdapter3;
     expect(authData).toEqual({ foo: 'bar' });
+    expect(afterSpy).toHaveBeenCalledWith(
+      { ip: '127.0.0.1', user: undefined, master: true },
+      { id: 'modernAdapter3Data' },
+      undefined
+    );
     expect(spy).toHaveBeenCalled();
   });
 

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -354,7 +354,13 @@ describe('Auth Adapter features', () => {
     await user.fetch({ sessionToken: user.getSessionToken() });
     const authData = user.get('authData').modernAdapter3;
     expect(authData).toEqual({ foo: 'bar' });
-    user._objCount = 3;
+    for (const call of afterSpy.calls.all()) {
+      const args = call.args[0];
+      if (args.user) {
+        user._objCount = args.user._objCount;
+        break;
+      }
+    }
     expect(afterSpy).toHaveBeenCalledWith(
       { ip: '127.0.0.1', user, master: false },
       { id: 'modernAdapter3Data' },

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -214,7 +214,7 @@ module.exports = function (authOptions = {}, enableAnonymousUsers = true) {
     return { validator: authDataValidator(provider, adapter, appIds, providerOptions), adapter };
   };
 
-  const runAfterFind = async authData => {
+  const runAfterFind = async (req, authData) => {
     if (!authData) {
       return;
     }
@@ -230,7 +230,12 @@ module.exports = function (authOptions = {}, enableAnonymousUsers = true) {
           providerOptions,
         } = authAdapter;
         if (afterFind && typeof afterFind === 'function') {
-          const result = afterFind(authData[provider], providerOptions);
+          const requestObject = {
+            ip: req.config.ip,
+            user: req.auth.user,
+            master: req.auth.isMaster,
+          };
+          const result = afterFind(requestObject, authData[provider], providerOptions);
           if (result) {
             authData[provider] = result;
           }

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -850,7 +850,12 @@ RestQuery.prototype.handleAuthAdapters = async function () {
     return;
   }
   await Promise.all(
-    this.response.results.map(result => this.config.authDataManager.runAfterFind(result.authData))
+    this.response.results.map(result =>
+      this.config.authDataManager.runAfterFind(
+        { config: this.config, auth: this.auth },
+        result.authData
+      )
+    )
   );
 };
 

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -292,7 +292,7 @@ export class UsersRouter extends ClassesRouter {
     if (authDataResponse) {
       user.authDataResponse = authDataResponse;
     }
-    await req.config.authDataManager.runAfterFind(user.authData);
+    await req.config.authDataManager.runAfterFind(req, user.authData);
 
     return { response: user };
   }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Added in #8444, authentication adapters can change the save response, however there is no way to change behavior depending on `master`, `user`, `ip`, etc.

Closes: #8444

## Approach
<!-- Describe the changes in this PR. -->

Add request parameter to auth `afterFind` trigger

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests

