### PR TITLE
feat: Improve facebook adapter

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -489,6 +489,19 @@ describe('Parse.User testing', () => {
       );
   });
 
+  it('cannot connect to unconfigured adapter', async () => {
+    await reconfigureServer({
+      auth: {},
+    });
+    const provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    const user = new Parse.User();
+    user.set('foo', 'bar');
+    await expectAsync(user._linkWith('facebook', {})).toBeRejectedWith(
+      new Parse.Error(Parse.Error.UNSUPPORTED_SERVICE, 'This authentication method is unsupported.')
+    );
+  });
+
   it('should not call beforeLogin with become', async done => {
     const provider = getMockFacebookProvider();
     Parse.User._registerAuthenticationProvider(provider);

--- a/src/Adapters/Auth/facebook.js
+++ b/src/Adapters/Auth/facebook.js
@@ -1,143 +1,148 @@
 // Helper functions for accessing the Facebook Graph API.
-const Parse = require('parse/node').Parse;
-const crypto = require('crypto');
-const jwksClient = require('jwks-rsa');
-const util = require('util');
-const jwt = require('jsonwebtoken');
-const httpsRequest = require('./httpsRequest');
-const authUtils = require('./utils');
+import { Parse } from 'parse/node';
+import crypto from 'crypto';
+import jwksClient from 'jwks-rsa';
+import util from 'util';
+import jwt from 'jsonwebtoken';
+import httpsRequest from './httpsRequest';
+import authUtils from './utils';
+import AuthAdapter from './AuthAdapter';
 
-const TOKEN_ISSUER = 'https://facebook.com';
-
-function getAppSecretPath(authData, options = {}) {
-  const appSecret = options.appSecret;
-  if (!appSecret) {
-    return '';
+class FacebookAdapter extends AuthAdapter {
+  constructor() {
+    super();
+    this._TOKEN_ISSUER = 'https://facebook.com';
   }
-  const appsecret_proof = crypto
-    .createHmac('sha256', appSecret)
-    .update(authData.access_token)
-    .digest('hex');
+  validateAuthData(authData, options) {
+    if (authData.token) {
+      return this.verifyIdToken(authData, options);
+    }
+    return this.validateGraphToken(authData);
+  }
 
-  return `&appsecret_proof=${appsecret_proof}`;
-}
+  validateAppId(_, authData) {
+    if (authData.token) {
+      return Promise.resolve();
+    }
+    return this.validateGraphAppId(authData);
+  }
 
-function validateGraphToken(authData, options) {
-  return graphRequest(
-    'me?fields=id&access_token=' + authData.access_token + getAppSecretPath(authData, options)
-  ).then(data => {
-    if ((data && data.id == authData.id) || (process.env.TESTING && authData.id === 'test')) {
+  validateOptions(opts) {
+    const appIds = opts?.appIds;
+    if (!Array.isArray(appIds)) {
+      throw 'facebook.appIds must be an array.';
+    }
+    if (!appIds.length) {
+      throw 'facebook.appIds must have at least one appId.';
+    }
+    this.appIds = appIds;
+    this.appSecret = opts?.appSecret;
+  }
+
+  graphRequest(path) {
+    return httpsRequest.get(`https://graph.facebook.com/${path}`);
+  }
+
+  getAppSecretPath(authData) {
+    const appSecret = this.appSecret;
+    if (!appSecret) {
+      return '';
+    }
+    const appsecret_proof = crypto
+      .createHmac('sha256', appSecret)
+      .update(authData.access_token)
+      .digest('hex');
+
+    return `&appsecret_proof=${appsecret_proof}`;
+  }
+
+  async validateGraphToken(authData) {
+    const data = await this.graphRequest(
+      `me?fields=id&access_token=${authData.access_token}${this.getAppSecretPath(authData)}`
+    );
+    if (data?.id === authData.id || (process.env.TESTING && authData.id === 'test')) {
       return;
     }
     throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Facebook auth is invalid for this user.');
-  });
-}
-
-async function validateGraphAppId(appIds, authData, options) {
-  var access_token = authData.access_token;
-  if (process.env.TESTING && access_token === 'test') {
-    return;
   }
-  if (!Array.isArray(appIds)) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'appIds must be an array.');
-  }
-  if (!appIds.length) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Facebook auth is not configured.');
-  }
-  const data = await graphRequest(
-    `app?access_token=${access_token}${getAppSecretPath(authData, options)}`
-  );
-  if (!data || !appIds.includes(data.id)) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Facebook auth is invalid for this user.');
-  }
-}
 
-const getFacebookKeyByKeyId = async (keyId, cacheMaxEntries, cacheMaxAge) => {
-  const client = jwksClient({
-    jwksUri: `${TOKEN_ISSUER}/.well-known/oauth/openid/jwks/`,
-    cache: true,
-    cacheMaxEntries,
-    cacheMaxAge,
-  });
-
-  const asyncGetSigningKeyFunction = util.promisify(client.getSigningKey);
-
-  let key;
-  try {
-    key = await asyncGetSigningKeyFunction(keyId);
-  } catch (error) {
-    throw new Parse.Error(
-      Parse.Error.OBJECT_NOT_FOUND,
-      `Unable to find matching key for Key ID: ${keyId}`
+  async validateGraphAppId(authData) {
+    const access_token = authData.access_token;
+    if (process.env.TESTING && access_token === 'test') {
+      return;
+    }
+    const data = await this.graphRequest(
+      `app?access_token=${access_token}${this.getAppSecretPath(authData)}`
     );
+    if (!data || !this.appIds.includes(data.id)) {
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Facebook auth is invalid for this user.'
+      );
+    }
   }
-  return key;
-};
 
-const verifyIdToken = async ({ token, id }, { clientId, cacheMaxEntries, cacheMaxAge }) => {
-  if (!token) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'id token is invalid for this user.');
-  }
-
-  const { kid: keyId, alg: algorithm } = authUtils.getHeaderFromToken(token);
-  const ONE_HOUR_IN_MS = 3600000;
-  let jwtClaims;
-
-  cacheMaxAge = cacheMaxAge || ONE_HOUR_IN_MS;
-  cacheMaxEntries = cacheMaxEntries || 5;
-
-  const facebookKey = await getFacebookKeyByKeyId(keyId, cacheMaxEntries, cacheMaxAge);
-  const signingKey = facebookKey.publicKey || facebookKey.rsaPublicKey;
-
-  try {
-    jwtClaims = jwt.verify(token, signingKey, {
-      algorithms: algorithm,
-      // the audience can be checked against a string, a regular expression or a list of strings and/or regular expressions.
-      audience: clientId,
+  async getFacebookKeyByKeyId(keyId, cacheMaxEntries, cacheMaxAge) {
+    const client = jwksClient({
+      jwksUri: `${this._TOKEN_ISSUER}/.well-known/oauth/openid/jwks/`,
+      cache: true,
+      cacheMaxEntries,
+      cacheMaxAge,
     });
-  } catch (exception) {
-    const message = exception.message;
 
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, `${message}`);
+    const asyncGetSigningKeyFunction = util.promisify(client.getSigningKey);
+
+    let key;
+    try {
+      key = await asyncGetSigningKeyFunction(keyId);
+    } catch (error) {
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        `Unable to find matching key for Key ID: ${keyId}`
+      );
+    }
+    return key;
   }
 
-  if (jwtClaims.iss !== TOKEN_ISSUER) {
-    throw new Parse.Error(
-      Parse.Error.OBJECT_NOT_FOUND,
-      `id token not issued by correct OpenID provider - expected: ${TOKEN_ISSUER} | from: ${jwtClaims.iss}`
-    );
-  }
+  async verifyIdToken({ token, id }, { clientId, cacheMaxEntries, cacheMaxAge }) {
+    if (!token) {
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'id token is invalid for this user.');
+    }
 
-  if (jwtClaims.sub !== id) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'auth data is invalid for this user.');
-  }
-  return jwtClaims;
-};
+    const { kid: keyId, alg: algorithm } = authUtils.getHeaderFromToken(token);
+    const ONE_HOUR_IN_MS = 3600000;
+    let jwtClaims;
 
-// Returns a promise that fulfills iff this user id is valid.
-function validateAuthData(authData, options) {
-  if (authData.token) {
-    return verifyIdToken(authData, options);
-  } else {
-    return validateGraphToken(authData, options);
+    cacheMaxAge = cacheMaxAge || ONE_HOUR_IN_MS;
+    cacheMaxEntries = cacheMaxEntries || 5;
+
+    const facebookKey = await this.getFacebookKeyByKeyId(keyId, cacheMaxEntries, cacheMaxAge);
+    const signingKey = facebookKey.publicKey || facebookKey.rsaPublicKey;
+
+    try {
+      jwtClaims = jwt.verify(token, signingKey, {
+        algorithms: algorithm,
+        // the audience can be checked against a string, a regular expression or a list of strings and/or regular expressions.
+        audience: clientId,
+      });
+    } catch (exception) {
+      const message = exception.message;
+
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, `${message}`);
+    }
+
+    if (jwtClaims.iss !== this._TOKEN_ISSUER) {
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        `id token not issued by correct OpenID provider - expected: ${this._TOKEN_ISSUER} | from: ${jwtClaims.iss}`
+      );
+    }
+
+    if (jwtClaims.sub !== id) {
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'auth data is invalid for this user.');
+    }
+    return jwtClaims;
   }
 }
 
-// Returns a promise that fulfills iff this app id is valid.
-function validateAppId(appIds, authData, options) {
-  if (authData.token) {
-    return Promise.resolve();
-  } else {
-    return validateGraphAppId(appIds, authData, options);
-  }
-}
-
-// A promisey wrapper for FB graph requests.
-function graphRequest(path) {
-  return httpsRequest.get('https://graph.facebook.com/' + path);
-}
-
-module.exports = {
-  validateAppId: validateAppId,
-  validateAuthData: validateAuthData,
-};
+export default new FacebookAdapter();

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -441,19 +441,19 @@ const handleAuthDataValidation = async (authData, req, foundUser) => {
         acc.authData[provider] = null;
         continue;
       }
-      const { validator } = req.config.authDataManager.getValidatorForProvider(provider);
+      const { validator, adapter } = req.config.authDataManager.getValidatorForProvider(provider);
       const authProvider = (req.config.auth || {})[provider] || {};
+      if (!validator || authProvider.enabled === false || adapter.enabled === false) {
+        throw new Parse.Error(
+          Parse.Error.UNSUPPORTED_SERVICE,
+          'This authentication method is unsupported.'
+        );
+      }
       if (authProvider.enabled == null) {
         Deprecator.logRuntimeDeprecation({
           usage: `Using the authentication adapter "${provider}" without explicitly enabling it`,
           solution: `Enable the authentication adapter by setting the Parse Server option "auth.${provider}.enabled: true".`,
         });
-      }
-      if (!validator || authProvider.enabled === false) {
-        throw new Parse.Error(
-          Parse.Error.UNSUPPORTED_SERVICE,
-          'This authentication method is unsupported.'
-        );
       }
       let validationResult = await validator(authData[provider], req, user, requestObject);
       method = validationResult && validationResult.method;

--- a/src/Config.js
+++ b/src/Config.js
@@ -7,6 +7,7 @@ import net from 'net';
 import AppCache from './cache';
 import DatabaseController from './Controllers/DatabaseController';
 import { logLevels as validLogLevels } from './Controllers/LoggerController';
+import AuthAdapter from './Adapters/Auth';
 import {
   AccountLockoutOptions,
   DatabaseOptions,
@@ -86,6 +87,7 @@ export class Config {
     logLevels,
     rateLimit,
     databaseOptions,
+    auth,
   }) {
     if (masterKey === readOnlyMasterKey) {
       throw new Error('masterKey and readOnlyMasterKey should be different');
@@ -124,6 +126,9 @@ export class Config {
     this.validateRateLimit(rateLimit);
     this.validateLogLevels(logLevels);
     this.validateDatabaseOptions(databaseOptions);
+    if (auth) {
+      AuthAdapter.validateAuthConfig(auth);
+    }
   }
 
   static validateControllers({


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Currently, the facebook adapter does not validate it's config via `validateOptions`, meaning that a developer can set an invalid configuration and is not aware of it until a user attempts to log in via facebook.

Closes: #8461

## Approach
<!-- Describe the changes in this PR. -->

Improves facebook adapter to modern `AuthAdapter` syntax, some minor other changes necessary to validate inbuilt auth adapters.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
