### PR TITLE
fix: GridFS file storage doesn't work with certain `enableSchemaHooks` settings

### DIFF
--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -55,6 +55,8 @@ describe('FilesController', () => {
     const config = Config.get(Parse.applicationId);
     expect(config.database.adapter._mongoOptions.retryWrites).toBeTrue();
     expect(config.filesController.adapter._mongoOptions.retryWrites).toBeTrue();
+    expect(config.filesController.adapter._mongoOptions.enableSchemaHooks).toBeUndefined();
+    expect(config.filesController.adapter._mongoOptions.schemaCacheTtl).toBeUndefined();
   });
 
   it('should create a server log on failure', done => {

--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -20,6 +20,22 @@ describe_only_db('mongo')('GridFSBucket', () => {
     await db.dropDatabase();
   });
 
+  it('should connect to mongo with the supported database options', async () => {
+    const databaseURI = 'mongodb://localhost:27017/parse';
+    const gfsAdapter = new GridFSBucketAdapter(databaseURI, {
+      retryWrites: true,
+      // these are not supported by the mongo client
+      enableSchemaHooks: true,
+      schemaCacheTtl: 5000,
+      maxTimeMS: 30000,
+    });
+
+    const db = await gfsAdapter._connect();
+    const status = await db.admin().serverStatus();
+    expect(status.connections.current > 0).toEqual(true);
+    expect(db.options?.retryWrites).toEqual(true);
+  });
+
   it('should save an encrypted file that can only be decrypted by a GridFS adapter with the encryptionKey', async () => {
     const unencryptedAdapter = new GridFSBucketAdapter(databaseURI);
     const encryptedAdapter = new GridFSBucketAdapter(

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -34,7 +34,11 @@ export class GridFSBucketAdapter extends FilesAdapter {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     };
-    this._mongoOptions = Object.assign(defaultMongoOptions, mongoOptions);
+    const _mongoOptions = Object.assign(defaultMongoOptions, mongoOptions);
+    for (const key of ['enableSchemaHooks', 'schemaCacheTtl', 'maxTimeMS']) {
+      delete _mongoOptions[key];
+    }
+    this._mongoOptions = _mongoOptions;
   }
 
   _connect() {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

GridFS does not work on alpha due to `enableSchemaHooks` is not supported

Closes: #8466

## Approach
<!-- Describe the changes in this PR. -->

Strips out invalid options

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests

