### PR TITLE
fix: Unable to create new role if `beforeSave` hook exists

### DIFF
--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -601,4 +601,12 @@ describe('Parse Role testing', () => {
       });
     });
   });
+
+  it('should save role when beforeSave hook for _Role is present.', async done => {
+    Parse.Cloud.beforeSave('_Role', () => {});
+    const role = new Parse.Role('roleName', new Parse.ACL());
+    await role.save({}, { useMasterKey: true });
+    expect(role.id).toBeDefined();
+    done();
+  });
 });


### PR DESCRIPTION
Unable to save role when before save hook is present on role.

Closes: #8473 

- [X] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
