### PR TITLE
fix: Operations in `afterSave` triggers aren't decoded

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1666,6 +1666,72 @@ describe('Cloud Code', () => {
     expect(obj.get('count')).toBe(0);
   });
 
+  it('operations in beforeSave should return to client', async () => {
+    Parse.Cloud.afterSave('MyObject', ({ object }) => {
+      object.unset('foo');
+      object.increment('count');
+      object.addUnique('unique', 2);
+      object.add('array', 2);
+      object.remove('remove', 2);
+    });
+    const saveResponse = await request({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Installation-Id': 'yolo',
+      },
+      url: 'http://localhost:8378/1/classes/MyObject',
+      body: JSON.stringify({
+        unique: [2],
+        remove: [2],
+      }),
+    }).catch(e => {
+      console.log({ e });
+    });
+    console.log(saveResponse.data);
+    const { array, count, foo, unique, remove } = saveResponse.data;
+    expect(array).toEqual([2]);
+    expect(count).toEqual(1);
+    expect(foo).toEqual(null);
+    expect(unique).toBeUndefined();
+    expect(remove).toEqual([]);
+  });
+
+  it('operations in afterSave should return to client', async () => {
+    Parse.Cloud.afterSave('MyObject', ({ object }) => {
+      object.unset('foo');
+      object.increment('count');
+      object.addUnique('unique', 2);
+      object.add('array', 2);
+      object.remove('remove', 2);
+    });
+    const saveResponse = await request({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Installation-Id': 'yolo',
+      },
+      url: 'http://localhost:8378/1/classes/MyObject',
+      body: JSON.stringify({
+        unique: [2],
+        remove: [2],
+      }),
+    }).catch(e => {
+      console.log({ e });
+    });
+    console.log(saveResponse.data);
+    const { array, count, foo, unique, remove } = saveResponse.data;
+    expect(array).toEqual([2]);
+    expect(count).toEqual(1);
+    expect(foo).toEqual(null);
+    expect(unique).toBeUndefined();
+    expect(remove).toEqual([]);
+  });
+
   it('pointer should not be cleared by triggers', async () => {
     Parse.Cloud.afterSave('MyObject', () => {});
     const foo = await new Parse.Object('Test', { foo: 'bar' }).save();

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -11,7 +11,6 @@ var cryptoUtils = require('./cryptoUtils');
 var passwordCrypto = require('./password');
 var Parse = require('parse/node');
 var triggers = require('./triggers');
-var ClientSDK = require('./ClientSDK');
 const util = require('util');
 import RestQuery from './RestQuery';
 import _ from 'lodash';
@@ -38,7 +37,9 @@ function RestWrite(config, auth, className, query, data, originalData, clientSDK
   this.auth = auth;
   this.className = className;
   this.clientSDK = clientSDK;
-  this.storage = {};
+  this.storage = {
+    fieldsChangedByTrigger: [],
+  };
   this.runOptions = {};
   this.context = context || {};
 
@@ -281,9 +282,9 @@ RestWrite.prototype.runBeforeSaveTrigger = function () {
       );
     })
     .then(response => {
-      if (response && response.object) {
-        this.storage.fieldsChangedByTrigger = _.reduce(
-          response.object,
+      this.storage.fieldsChangedByTrigger.push(
+        ..._.reduce(
+          response?.object || updatedObject.toJSON(),
           (result, value, key) => {
             if (!_.isEqual(this.data[key], value)) {
               result.push(key);
@@ -291,7 +292,9 @@ RestWrite.prototype.runBeforeSaveTrigger = function () {
             return result;
           },
           []
-        );
+        )
+      );
+      if (response && response.object) {
         this.data = response.object;
         // We should delete the objectId for an update write
         if (this.query && this.query.objectId) {
@@ -349,7 +352,6 @@ RestWrite.prototype.setRequiredFieldsIfNeeded = function () {
               (typeof this.data[fieldName] === 'object' && this.data[fieldName].__op === 'Delete'))
           ) {
             this.data[fieldName] = schema.fields[fieldName].defaultValue;
-            this.storage.fieldsChangedByTrigger = this.storage.fieldsChangedByTrigger || [];
             if (this.storage.fieldsChangedByTrigger.indexOf(fieldName) < 0) {
               this.storage.fieldsChangedByTrigger.push(fieldName);
             }
@@ -1599,6 +1601,18 @@ RestWrite.prototype.runAfterSaveTrigger = function () {
       this.context
     )
     .then(result => {
+      this.storage.fieldsChangedByTrigger.push(
+        ..._.reduce(
+          updatedObject.toJSON(),
+          (result, value, key) => {
+            if (!_.isEqual(this.data[key], value)) {
+              result.push(key);
+            }
+            return result;
+          },
+          []
+        )
+      );
       const jsonReturned = result && !result._toFullJSON;
       if (jsonReturned) {
         this.pendingOps.operations = {};
@@ -1737,18 +1751,62 @@ RestWrite.prototype._updateResponseWithData = function (response, data) {
   if (_.isEmpty(this.storage.fieldsChangedByTrigger)) {
     return response;
   }
-  const clientSupportsDelete = ClientSDK.supportsForwardDelete(this.clientSDK);
   this.storage.fieldsChangedByTrigger.forEach(fieldName => {
-    const dataValue = data[fieldName];
+    let dataValue = deepcopy(data[fieldName]);
 
     if (!Object.prototype.hasOwnProperty.call(response, fieldName)) {
       response[fieldName] = dataValue;
     }
 
     // Strips operations from responses
-    if (response[fieldName] && response[fieldName].__op) {
-      delete response[fieldName];
-      if (clientSupportsDelete && dataValue.__op == 'Delete') {
+    const value = response[fieldName];
+    const op = value?.__op;
+    if (op) {
+      switch (op) {
+        case 'Increment': {
+          if (!dataValue) {
+            dataValue = 0;
+          }
+          dataValue += value.amount;
+          break;
+        }
+        case 'Delete': {
+          dataValue = null;
+          break;
+        }
+        case 'AddUnique':
+        case 'Add': {
+          if (!dataValue) {
+            dataValue = [];
+          }
+          for (const obj of value.objects) {
+            if (op === 'AddUnique' && dataValue.includes(obj)) {
+              continue;
+            }
+            dataValue.push(obj);
+          }
+          break;
+        }
+        case 'Remove': {
+          if (!dataValue) {
+            dataValue = [];
+          }
+          for (const obj of value.objects) {
+            let i = dataValue.length;
+            while (i--) {
+              const current = dataValue[i];
+              if (current === obj) {
+                dataValue.splice(i, 1);
+              }
+            }
+          }
+          break;
+        }
+        default:
+      }
+      if (util.isDeepStrictEqual(dataValue, this.data[fieldName])) {
+        delete response[fieldName];
+      } else {
         response[fieldName] = dataValue;
       }
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

When using operations in an afterSave trigger, they are returned directly to the client, which can break serilazation.

Closes: #8386

## Approach
<!-- Describe the changes in this PR. -->

Clear ops

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
