### PR TITLE
feat: Skip indexes for Azure Cosmos DB for MongoDB

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -85,7 +85,6 @@ export class Config {
     allowExpiredAuthDataToken,
     logLevels,
     rateLimit,
-    azureCosmosMongoDbCompatibleMode,
     databaseOptions,
   }) {
     if (masterKey === readOnlyMasterKey) {
@@ -121,7 +120,6 @@ export class Config {
     this.validateSchemaOptions(schema);
     this.validateEnforcePrivateUsers(enforcePrivateUsers);
     this.validateAllowExpiredAuthDataToken(allowExpiredAuthDataToken);
-    this.validateAzureCosmosMongoDbCompatibleMode(azureCosmosMongoDbCompatibleMode);
     this.validateRequestKeywordDenylist(requestKeywordDenylist);
     this.validateRateLimit(rateLimit);
     this.validateLogLevels(logLevels);
@@ -165,12 +163,6 @@ export class Config {
   static validateAllowExpiredAuthDataToken(allowExpiredAuthDataToken) {
     if (typeof allowExpiredAuthDataToken !== 'boolean') {
       throw 'Parse Server option allowExpiredAuthDataToken must be a boolean.';
-    }
-  }
-
-  static validateAzureCosmosMongoDbCompatibleMode(azureCosmosMongoDbCompatibleMode) {
-    if (typeof azureCosmosMongoDbCompatibleMode !== 'boolean') {
-      throw 'Parse Server option azureCosmosMongoDbCompatibleMode must be a boolean.';
     }
   }
 
@@ -565,6 +557,24 @@ export class Config {
       databaseOptions.schemaCacheTtl = DatabaseOptions.schemaCacheTtl.default;
     } else if (typeof databaseOptions.schemaCacheTtl !== 'number') {
       throw `databaseOptions.schemaCacheTtl must be a number`;
+    }
+    if (databaseOptions.disableEnsureUsernameCaseInsensitiveIndex === undefined) {
+      databaseOptions.disableEnsureUsernameCaseInsensitiveIndex =
+        DatabaseOptions.disableEnsureUsernameCaseInsensitiveIndex.default;
+    } else if (typeof databaseOptions.disableEnsureUsernameCaseInsensitiveIndex !== 'boolean') {
+      throw `databaseOptions.disableEnsureUsernameCaseInsensitiveIndex must be a boolean`;
+    }
+    if (databaseOptions.disableEnsureEmailCaseInsensitiveIndex === undefined) {
+      databaseOptions.disableEnsureEmailCaseInsensitiveIndex =
+        DatabaseOptions.disableEnsureEmailCaseInsensitiveIndex.default;
+    } else if (typeof databaseOptions.disableEnsureEmailCaseInsensitiveIndex !== 'boolean') {
+      throw `databaseOptions.disableEnsureEmailCaseInsensitiveIndex must be a boolean`;
+    }
+    if (databaseOptions.disableEnsureIdempotencyExpireIndex === undefined) {
+      databaseOptions.disableEnsureIdempotencyExpireIndex =
+        DatabaseOptions.disableEnsureIdempotencyExpireIndex.default;
+    } else if (typeof databaseOptions.disableEnsureIdempotencyExpireIndex !== 'boolean') {
+      throw `databaseOptions.disableEnsureIdempotencyExpireIndex must be a boolean`;
     }
   }
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -85,6 +85,7 @@ export class Config {
     allowExpiredAuthDataToken,
     logLevels,
     rateLimit,
+    azureCosmosMongoDbCompatibleMode,
     databaseOptions,
   }) {
     if (masterKey === readOnlyMasterKey) {
@@ -120,6 +121,7 @@ export class Config {
     this.validateSchemaOptions(schema);
     this.validateEnforcePrivateUsers(enforcePrivateUsers);
     this.validateAllowExpiredAuthDataToken(allowExpiredAuthDataToken);
+    this.validateAzureCosmosMongoDbCompatibleMode(azureCosmosMongoDbCompatibleMode);
     this.validateRequestKeywordDenylist(requestKeywordDenylist);
     this.validateRateLimit(rateLimit);
     this.validateLogLevels(logLevels);
@@ -163,6 +165,12 @@ export class Config {
   static validateAllowExpiredAuthDataToken(allowExpiredAuthDataToken) {
     if (typeof allowExpiredAuthDataToken !== 'boolean') {
       throw 'Parse Server option allowExpiredAuthDataToken must be a boolean.';
+    }
+  }
+
+  static validateAzureCosmosMongoDbCompatibleMode(azureCosmosMongoDbCompatibleMode) {
+    if (typeof azureCosmosMongoDbCompatibleMode !== 'boolean') {
+      throw 'Parse Server option azureCosmosMongoDbCompatibleMode must be a boolean.';
     }
   }
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1706,7 +1706,7 @@ class DatabaseController {
       throw error;
     });
 
-    if (!this.options.azureCosmosMongoDbCompatibleMode) {
+    if (!this.options.databaseOptions?.disableEnsureUsernameCaseInsensitiveIndex) {
       await this.adapter
         .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
         .catch(error => {
@@ -1725,7 +1725,7 @@ class DatabaseController {
       throw error;
     });
 
-    if (!this.options.azureCosmosMongoDbCompatibleMode) {
+    if (!this.options.databaseOptions?.disableEnsureEmailCaseInsensitiveIndex) {
       await this.adapter
         .ensureIndex('_User', requiredUserFields, ['email'], 'case_insensitive_email', true)
         .catch(error => {
@@ -1758,7 +1758,7 @@ class DatabaseController {
         options = this.idempotencyOptions;
         options.setIdempotencyFunction = true;
       }
-      if (!this.options.azureCosmosMongoDbCompatibleMode) {
+      if (!this.options.databaseOptions.disableEnsureIdempotencyExpireIndex) {
         await this.adapter
           .ensureIndex('_Idempotency', requiredIdempotencyFields, ['expire'], 'ttl', false, options)
           .catch(error => {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1706,30 +1706,33 @@ class DatabaseController {
       throw error;
     });
 
-    await this.adapter
-      .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
-      .catch(error => {
-        logger.warn('Unable to create case insensitive username index: ', error);
-        throw error;
-      });
-    await this.adapter
-      .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
-      .catch(error => {
-        logger.warn('Unable to create case insensitive username index: ', error);
-        throw error;
-      });
-
+    if (!this.options.azureCosmosMongoDbCompatibleMode) {
+      await this.adapter
+        .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
+        .catch(error => {
+          logger.warn('Unable to create case insensitive username index: ', error);
+          throw error;
+        });
+      await this.adapter
+        .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
+        .catch(error => {
+          logger.warn('Unable to create case insensitive username index: ', error);
+          throw error;
+        });
+    }
     await this.adapter.ensureUniqueness('_User', requiredUserFields, ['email']).catch(error => {
       logger.warn('Unable to ensure uniqueness for user email addresses: ', error);
       throw error;
     });
 
-    await this.adapter
-      .ensureIndex('_User', requiredUserFields, ['email'], 'case_insensitive_email', true)
-      .catch(error => {
-        logger.warn('Unable to create case insensitive email index: ', error);
-        throw error;
-      });
+    if (!this.options.azureCosmosMongoDbCompatibleMode) {
+      await this.adapter
+        .ensureIndex('_User', requiredUserFields, ['email'], 'case_insensitive_email', true)
+        .catch(error => {
+          logger.warn('Unable to create case insensitive email index: ', error);
+          throw error;
+        });
+    }
 
     await this.adapter.ensureUniqueness('_Role', requiredRoleFields, ['name']).catch(error => {
       logger.warn('Unable to ensure uniqueness for role name: ', error);
@@ -1755,12 +1758,14 @@ class DatabaseController {
         options = this.idempotencyOptions;
         options.setIdempotencyFunction = true;
       }
-      await this.adapter
-        .ensureIndex('_Idempotency', requiredIdempotencyFields, ['expire'], 'ttl', false, options)
-        .catch(error => {
-          logger.warn('Unable to create TTL index for idempotency expire date: ', error);
-          throw error;
-        });
+      if (!this.options.azureCosmosMongoDbCompatibleMode) {
+        await this.adapter
+          .ensureIndex('_Idempotency', requiredIdempotencyFields, ['expire'], 'ttl', false, options)
+          .catch(error => {
+            logger.warn('Unable to create TTL index for idempotency expire date: ', error);
+            throw error;
+          });
+      }
     }
     await this.adapter.updateSchemaWithIndexes();
   }

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -103,13 +103,6 @@ module.exports.ParseServerOptions = {
       'Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication',
     action: parsers.arrayParser,
   },
-  azureCosmosMongoDbCompatibleMode: {
-    env: 'PARSE_SERVER_AZURE_COSMOS_MONGO_DB_COMPATIBLE_MODE',
-    help:
-      'Set to true for running against Azure Cosmos for Mongo DB. This can bring some performance loss.',
-    action: parsers.booleanParser,
-    default: false,
-  },
   cacheAdapter: {
     env: 'PARSE_SERVER_CACHE_ADAPTER',
     help: 'Adapter module for the cache',
@@ -976,6 +969,27 @@ module.exports.FileUploadOptions = {
   },
 };
 module.exports.DatabaseOptions = {
+  disableEnsureEmailCaseInsensitiveIndex: {
+    env: 'PARSE_SERVER_DATABASE_DISABLE_ENSURE_EMAIL_CASE_INSENSITIVE_INDEX',
+    help:
+      'Disables behavior to ensure case-insensitive index on field email on _User collection. Set to `true` if using a database not supporting case-insensitive indexes.',
+    action: parsers.booleanParser,
+    default: false,
+  },
+  disableEnsureIdempotencyExpireIndex: {
+    env: 'PARSE_SERVER_DATABASE_DISABLE_ENSURE_IDEMPOTENCY_EXPIRE_INDEX',
+    help:
+      'Disables behavior to ensure time to live index on field expire on _Idempotency collection. Set to `true` if using a database not supporting TTL index on this field.',
+    action: parsers.booleanParser,
+    default: false,
+  },
+  disableEnsureUsernameCaseInsensitiveIndex: {
+    env: 'PARSE_SERVER_DATABASE_DISABLE_ENSURE_USERNAME_CASE_INSENSITIVE_INDEX',
+    help:
+      'Disables behavior to ensure case-insensitive index on field username on _User collection. Set to `true` if using a database not supporting case-insensitive indexes.',
+    action: parsers.booleanParser,
+    default: false,
+  },
   enableSchemaHooks: {
     env: 'PARSE_SERVER_DATABASE_ENABLE_SCHEMA_HOOKS',
     help:

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -103,6 +103,13 @@ module.exports.ParseServerOptions = {
       'Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication',
     action: parsers.arrayParser,
   },
+  azureCosmosMongoDbCompatibleMode: {
+    env: 'PARSE_SERVER_AZURE_COSMOS_MONGO_DB_COMPATIBLE_MODE',
+    help:
+      'Set to true for running against Azure Cosmos for Mongo DB. This can bring some performance loss.',
+    action: parsers.booleanParser,
+    default: false,
+  },
   cacheAdapter: {
     env: 'PARSE_SERVER_CACHE_ADAPTER',
     help: 'Adapter module for the cache',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -21,7 +21,6 @@
  * @property {String} appId Your Parse Application ID
  * @property {String} appName Sets the app name
  * @property {AuthAdapter[]} auth Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
- * @property {Boolean} azureCosmosMongoDbCompatibleMode Set to true for running against Azure Cosmos for Mongo DB. This can bring some performance loss.
  * @property {Adapter<CacheAdapter>} cacheAdapter Adapter module for the cache
  * @property {Number} cacheMaxSize Sets the maximum size for the in memory cache, defaults to 10000
  * @property {Number} cacheTTL Sets the TTL for the in memory cache (in ms), defaults to 5000 (5 seconds)
@@ -226,6 +225,9 @@
 
 /**
  * @interface DatabaseOptions
+ * @property {Boolean} disableEnsureEmailCaseInsensitiveIndex Disables behavior to ensure case-insensitive index on field email on _User collection. Set to `true` if using a database not supporting case-insensitive indexes.
+ * @property {Boolean} disableEnsureIdempotencyExpireIndex Disables behavior to ensure time to live index on field expire on _Idempotency collection. Set to `true` if using a database not supporting TTL index on this field.
+ * @property {Boolean} disableEnsureUsernameCaseInsensitiveIndex Disables behavior to ensure case-insensitive index on field username on _User collection. Set to `true` if using a database not supporting case-insensitive indexes.
  * @property {Boolean} enableSchemaHooks Enables database real-time hooks to update single schema cache. Set to `true` if using multiple Parse Servers instances connected to the same database. Failing to do so will cause a schema change to not propagate to all instances and re-syncing will only happen when the instances restart. To use this feature with MongoDB, a replica set cluster with [change stream](https://docs.mongodb.com/manual/changeStreams/#availability) support is required.
  * @property {Number} schemaCacheTtl The duration in seconds after which the schema cache expires and will be refetched from the database. Use this option if using multiple Parse Servers instances connected to the same database. A low duration will cause the schema cache to be updated too often, causing unnecessary database reads. A high duration will cause the schema to be updated too rarely, increasing the time required until schema changes propagate to all server instances. This feature can be used as an alternative or in conjunction with the option `enableSchemaHooks`. Default is infinite which means the schema cache never expires.
  */

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -21,6 +21,7 @@
  * @property {String} appId Your Parse Application ID
  * @property {String} appName Sets the app name
  * @property {AuthAdapter[]} auth Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
+ * @property {Boolean} azureCosmosMongoDbCompatibleMode Set to true for running against Azure Cosmos for Mongo DB. This can bring some performance loss.
  * @property {Adapter<CacheAdapter>} cacheAdapter Adapter module for the cache
  * @property {Number} cacheMaxSize Sets the maximum size for the in memory cache, defaults to 10000
  * @property {Number} cacheTTL Sets the TTL for the in memory cache (in ms), defaults to 5000 (5 seconds)

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -300,9 +300,6 @@ export interface ParseServerOptions {
   /* Options to limit repeated requests to Parse Server APIs. This can be used to protect sensitive endpoints such as `/requestPasswordReset` from brute-force attacks or Parse Server as a whole from denial-of-service (DoS) attacks.<br><br>ℹ️ Mind the following limitations:<br>- rate limits applied per IP address; this limits protection against distributed denial-of-service (DDoS) attacks where many requests are coming from various IP addresses<br>- if multiple Parse Server instances are behind a load balancer or ran in a cluster, each instance will calculate it's own request rates, independent from other instances; this limits the applicability of this feature when using a load balancer and another rate limiting solution that takes requests across all instances into account may be more suitable<br>- this feature provides basic protection against denial-of-service attacks, but a more sophisticated solution works earlier in the request flow and prevents a malicious requests to even reach a server instance; it's therefore recommended to implement a solution according to architecture and user case.
   :DEFAULT: [] */
   rateLimit: ?(RateLimitOptions[]);
-  /* Set to true for running against Azure Cosmos for Mongo DB. This can bring some performance loss.
-  :DEFAULT: false */
-  azureCosmosMongoDbCompatibleMode: ?boolean;
 }
 
 export interface RateLimitOptions {
@@ -556,6 +553,15 @@ export interface DatabaseOptions {
   enableSchemaHooks: ?boolean;
   /* The duration in seconds after which the schema cache expires and will be refetched from the database. Use this option if using multiple Parse Servers instances connected to the same database. A low duration will cause the schema cache to be updated too often, causing unnecessary database reads. A high duration will cause the schema to be updated too rarely, increasing the time required until schema changes propagate to all server instances. This feature can be used as an alternative or in conjunction with the option `enableSchemaHooks`. Default is infinite which means the schema cache never expires. */
   schemaCacheTtl: ?number;
+  /* Disables behavior to ensure case-insensitive index on field username on _User collection. Set to `true` if using a database not supporting case-insensitive indexes.
+  :DEFAULT: false */
+  disableEnsureUsernameCaseInsensitiveIndex: ?boolean;
+  /* Disables behavior to ensure case-insensitive index on field email on _User collection. Set to `true` if using a database not supporting case-insensitive indexes.
+  :DEFAULT: false */
+  disableEnsureEmailCaseInsensitiveIndex: ?boolean;
+  /* Disables behavior to ensure time to live index on field expire on _Idempotency collection. Set to `true` if using a database not supporting TTL index on this field.
+  :DEFAULT: false */
+  disableEnsureIdempotencyExpireIndex: ?boolean;
 }
 
 export interface AuthAdapter {

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -300,6 +300,9 @@ export interface ParseServerOptions {
   /* Options to limit repeated requests to Parse Server APIs. This can be used to protect sensitive endpoints such as `/requestPasswordReset` from brute-force attacks or Parse Server as a whole from denial-of-service (DoS) attacks.<br><br>ℹ️ Mind the following limitations:<br>- rate limits applied per IP address; this limits protection against distributed denial-of-service (DDoS) attacks where many requests are coming from various IP addresses<br>- if multiple Parse Server instances are behind a load balancer or ran in a cluster, each instance will calculate it's own request rates, independent from other instances; this limits the applicability of this feature when using a load balancer and another rate limiting solution that takes requests across all instances into account may be more suitable<br>- this feature provides basic protection against denial-of-service attacks, but a more sophisticated solution works earlier in the request flow and prevents a malicious requests to even reach a server instance; it's therefore recommended to implement a solution according to architecture and user case.
   :DEFAULT: [] */
   rateLimit: ?(RateLimitOptions[]);
+  /* Set to true for running against Azure Cosmos for Mongo DB. This can bring some performance loss.
+  :DEFAULT: false */
+  azureCosmosMongoDbCompatibleMode: ?boolean;
 }
 
 export interface RateLimitOptions {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Closes: #8492 

## Approach
<!-- Describe the changes in this PR. -->

By adding a switch in options called "azureCosmosMongoDbCompatibleMode". Setting it to true would bypass some indexes to be created when you would like to use Azure Cosmos DB for MongoDB as the database.

Normally, by default, this is off, and there should not be any impact on existing behaviors.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add changes to documentation (guides, repository pages, code comments)
