### PR TITLE
fix: Cloud Code Trigger `afterSave` executes even if not set

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1577,17 +1577,21 @@ RestWrite.prototype.runAfterSaveTrigger = function () {
   const { originalObject, updatedObject } = this.buildParseObjects();
   updatedObject._handleSaveResponse(this.response.response, this.response.status || 200);
 
-  this.config.database.loadSchema().then(schemaController => {
-    // Notifiy LiveQueryServer if possible
-    const perms = schemaController.getClassLevelPermissions(updatedObject.className);
-    this.config.liveQueryController.onAfterSave(
-      updatedObject.className,
-      updatedObject,
-      originalObject,
-      perms
-    );
-  });
-
+  if (hasLiveQuery) {
+    this.config.database.loadSchema().then(schemaController => {
+      // Notify LiveQueryServer if possible
+      const perms = schemaController.getClassLevelPermissions(updatedObject.className);
+      this.config.liveQueryController.onAfterSave(
+        updatedObject.className,
+        updatedObject,
+        originalObject,
+        perms
+      );
+    });
+  }
+  if (!hasAfterSaveHook) {
+    return Promise.resolve();
+  }
   // Run afterSave trigger
   return triggers
     .maybeRunTrigger(


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
AfterSave triggers will run when the triggers don't exist. This can cause major issues when trying to merge an afterSave result that is undefined with an object. This PR will also reduce overhead on afterSave calls

Closes: https://github.com/parse-community/parse-php-sdk/issues/502
