### PR TITLE
ci: Fix CI workflow not running on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 on:
   push:
-    branches: [ release*, alpha, beta ]
+    branches: [ release, alpha, beta, next-major, 'release-[0-9]+.x.x' ]
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

CI workflow not running on release branches due to apparently incorrect branch name `release*`

Closes: #n/a

## Approach

Fix branch name syntax

