### PR TITLE
docs: Fix missing logo in API docs

### DIFF
--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -29,7 +29,7 @@
     "template": "./node_modules/clean-jsdoc-theme",
     "theme_opts": {
       "default_theme": "dark",
-      "title": "<img src='../.github/parse-server-logo.png' class='logo'/>",
+      "title": "Parse Server",
       "create_style": "header, .sidebar-section-title, .sidebar-title { color: #139cee !important } .logo { margin-left : 40px; margin-right: 40px }"
     }
   },


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Closes:  #8017 

## Approach

Fix the incorrect path of the logo 
<img width="1713" alt="image" src="https://user-images.githubusercontent.com/73360179/235751635-1e9686ee-4150-49c0-a7b5-7420c343e578.png">


## Tasks

- [x] Add changes to documentation (guides, repository pages, code comments)

