### PR TITLE
feat: Add option to change the log level of logs emitted by Cloud Functions

### DIFF
--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -182,6 +182,29 @@ describe('Cloud Code Logger', () => {
     });
   });
 
+  it('should log cloud function ran using the custom log level', async done => {
+    await reconfigureServer({
+      silent: true,
+      logLevels: {
+        cloudFunctionRan: 'warn',
+      },
+    });
+
+    Parse.Cloud.define('aFunction', () => {
+      return 'it worked!';
+    });
+
+    spy = spyOn(Config.get('test').loggerController.adapter, 'log').and.callThrough();
+
+    Parse.Cloud.run('aFunction', { foo: 'bar' }).then(() => {
+      const log = spy.calls.allArgs().find(log => log[1].startsWith('Ran cloud function '))?.[0];
+
+      expect(log).toEqual('warn');
+
+      done();
+    });
+  });
+
   it('should log cloud function triggers using the custom log level', async () => {
     Parse.Cloud.beforeSave('TestClass', () => {});
     Parse.Cloud.afterSave('TestClass', () => {});

--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -182,7 +182,7 @@ describe('Cloud Code Logger', () => {
     });
   });
 
-  it('should log cloud function ran using the custom log level', async done => {
+  it('should log cloud function execution using the custom log level', async done => {
     await reconfigureServer({
       silent: true,
       logLevels: {

--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -198,9 +198,7 @@ describe('Cloud Code Logger', () => {
 
     Parse.Cloud.run('aFunction', { foo: 'bar' }).then(() => {
       const log = spy.calls.allArgs().find(log => log[1].startsWith('Ran cloud function '))?.[0];
-
       expect(log).toEqual('warn');
-
       done();
     });
   });

--- a/spec/CloudCodeLogger.spec.js
+++ b/spec/CloudCodeLogger.spec.js
@@ -183,24 +183,39 @@ describe('Cloud Code Logger', () => {
   });
 
   it('should log cloud function execution using the custom log level', async done => {
-    await reconfigureServer({
-      silent: true,
-      logLevels: {
-        cloudFunctionRan: 'warn',
-      },
-    });
-
     Parse.Cloud.define('aFunction', () => {
       return 'it worked!';
     });
 
+    Parse.Cloud.define('bFunction', () => {
+      throw new Error('Failed');
+    });
+
+    await Parse.Cloud.run('aFunction', { foo: 'bar' }).then(() => {
+      const log = spy.calls.allArgs().find(log => log[1].startsWith('Ran cloud function '))?.[0];
+      expect(log).toEqual('info');
+    });
+
+    await reconfigureServer({
+      silent: true,
+      logLevels: {
+        cloudFunctionSuccess: 'warn',
+        cloudFunctionError: 'info',
+      },
+    });
+
     spy = spyOn(Config.get('test').loggerController.adapter, 'log').and.callThrough();
 
-    Parse.Cloud.run('aFunction', { foo: 'bar' }).then(() => {
-      const log = spy.calls.allArgs().find(log => log[1].startsWith('Ran cloud function '))?.[0];
-      expect(log).toEqual('warn');
+    try {
+      await Parse.Cloud.run('bFunction', { foo: 'bar' });
+      throw new Error('bFunction should have failed');
+    } catch {
+      const log = spy.calls
+        .allArgs()
+        .find(log => log[1].startsWith('Failed running cloud function bFunction for '))?.[0];
+      expect(log).toEqual('info');
       done();
-    });
+    }
   });
 
   it('should log cloud function triggers using the custom log level', async () => {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -993,9 +993,14 @@ module.exports.AuthAdapter = {
   },
 };
 module.exports.LogLevels = {
-  cloudFunctionRan: {
-    env: 'PARSE_SERVER_LOG_LEVELS_CLOUD_FUNCTION_RAN',
-    help: 'Log level used by the Cloud Code Functions. Default is `info`.',
+  cloudFunctionError: {
+    env: 'PARSE_SERVER_LOG_LEVELS_CLOUD_FUNCTION_ERROR',
+    help: 'Log level used by the Cloud Code Functions on error. Default is `error`.',
+    default: 'error',
+  },
+  cloudFunctionSuccess: {
+    env: 'PARSE_SERVER_LOG_LEVELS_CLOUD_FUNCTION_SUCCESS',
+    help: 'Log level used by the Cloud Code Functions on success. Default is `info`.',
     default: 'info',
   },
   triggerAfter: {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -993,6 +993,11 @@ module.exports.AuthAdapter = {
   },
 };
 module.exports.LogLevels = {
+  cloudFunctionRan: {
+    env: 'PARSE_SERVER_LOG_LEVELS_CLOUD_FUNCTION_RAN',
+    help: 'Log level used by the Cloud Code Functions. Default is `info`.',
+    default: 'info',
+  },
   triggerAfter: {
     env: 'PARSE_SERVER_LOG_LEVELS_TRIGGER_AFTER',
     help:

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -236,7 +236,8 @@
 
 /**
  * @interface LogLevels
- * @property {String} cloudFunctionRan Log level used by the Cloud Code Functions. Default is `info`.
+ * @property {String} cloudFunctionError Log level used by the Cloud Code Functions on error. Default is `error`.
+ * @property {String} cloudFunctionSuccess Log level used by the Cloud Code Functions on success. Default is `info`.
  * @property {String} triggerAfter Log level used by the Cloud Code Triggers `afterSave`, `afterDelete`, `afterSaveFile`, `afterDeleteFile`, `afterFind`, `afterLogout`. Default is `info`.
  * @property {String} triggerBeforeError Log level used by the Cloud Code Triggers `beforeSave`, `beforeSaveFile`, `beforeDeleteFile`, `beforeFind`, `beforeLogin` on error. Default is `error `.
  * @property {String} triggerBeforeSuccess Log level used by the Cloud Code Triggers `beforeSave`, `beforeSaveFile`, `beforeDeleteFile`, `beforeFind`, `beforeLogin` on success. Default is `info`.

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -236,6 +236,7 @@
 
 /**
  * @interface LogLevels
+ * @property {String} cloudFunctionRan Log level used by the Cloud Code Functions. Default is `info`.
  * @property {String} triggerAfter Log level used by the Cloud Code Triggers `afterSave`, `afterDelete`, `afterSaveFile`, `afterDeleteFile`, `afterFind`, `afterLogout`. Default is `info`.
  * @property {String} triggerBeforeError Log level used by the Cloud Code Triggers `beforeSave`, `beforeSaveFile`, `beforeDeleteFile`, `beforeFind`, `beforeLogin` on error. Default is `error `.
  * @property {String} triggerBeforeSuccess Log level used by the Cloud Code Triggers `beforeSave`, `beforeSaveFile`, `beforeDeleteFile`, `beforeFind`, `beforeLogin` on success. Default is `info`.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -580,5 +580,5 @@ export interface LogLevels {
   /* Log level used by the Cloud Code Functions. Default is `info`.
   :DEFAULT: info
   */
-  cloudFunctionRan: ?string;
+  cloudFunctionSuccess: ?string;
 }

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -577,8 +577,12 @@ export interface LogLevels {
   :DEFAULT: error
   */
   triggerBeforeError: ?string;
-  /* Log level used by the Cloud Code Functions. Default is `info`.
+  /* Log level used by the Cloud Code Functions on success. Default is `info`.
   :DEFAULT: info
   */
   cloudFunctionSuccess: ?string;
+  /* Log level used by the Cloud Code Functions on error. Default is `error`.
+  :DEFAULT: error
+  */
+  cloudFunctionError: ?string;
 }

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -577,4 +577,8 @@ export interface LogLevels {
   :DEFAULT: error
   */
   triggerBeforeError: ?string;
+  /* Log level used by the Cloud Code Functions. Default is `info`.
+  :DEFAULT: info
+  */
+  cloudFunctionRan: ?string;
 }

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -140,7 +140,7 @@ export class FunctionsRouter extends PromiseRouter {
         result => {
           try {
             const cleanResult = logger.truncateLogMessage(JSON.stringify(result.response.result));
-            logger.info(
+            logger[req.config.logLevels.cloudFunctionRan](
               `Ran cloud function ${functionName} for user ${userString} with:\n  Input: ${cleanInput}\n  Result: ${cleanResult}`,
               {
                 functionName,

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -140,7 +140,7 @@ export class FunctionsRouter extends PromiseRouter {
         result => {
           try {
             const cleanResult = logger.truncateLogMessage(JSON.stringify(result.response.result));
-            logger[req.config.logLevels.cloudFunctionRan](
+            logger[req.config.logLevels.cloudFunctionSuccess](
               `Ran cloud function ${functionName} for user ${userString} with:\n  Input: ${cleanInput}\n  Result: ${cleanResult}`,
               {
                 functionName,
@@ -155,7 +155,7 @@ export class FunctionsRouter extends PromiseRouter {
         },
         error => {
           try {
-            logger.error(
+            logger[req.config.logLevels.cloudFunctionError](
               `Failed running cloud function ${functionName} for user ${userString} with:\n  Input: ${cleanInput}\n  Error: ` +
                 JSON.stringify(error),
               {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
[#8529](https://github.com/parse-community/parse-server/issues/8529)

Closes: [#8529](https://github.com/parse-community/parse-server/issues/8529)

## Approach
<!-- Describe the changes in this PR. -->
Version 6.0.0 of Parse Server introduced a feature to customize log level for triggers in Parse Server Options : 
logLevels: { triggerAfter: 'debug', triggerBeforeError: 'error', triggerBeforeSuccess: 'info' }

This PR add an option to also customize log level for cloud functions :
logLevels: { triggerAfter: 'silly', triggerBeforeError: 'silly', triggerBeforeSuccess: 'silly', cloudFunction: 'info' }

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
