### PR TITLE
refactor: Upgrade path-to-regexp from 0.1.7 to 6.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "mongodb": "4.10.0",
         "mustache": "4.2.0",
         "parse": "4.0.1",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "^6.2.1",
         "pg-monitor": "2.0.0",
         "pg-promise": "11.3.0",
         "pluralize": "8.0.0",
@@ -75,7 +75,7 @@
         "all-node-versions": "11.3.0",
         "apollo-upload-client": "17.0.0",
         "bcrypt-nodejs": "0.0.3",
-        "clean-jsdoc-theme": "^4.2.7",
+        "clean-jsdoc-theme": "4.2.7",
         "cross-env": "7.0.2",
         "deep-diff": "1.0.2",
         "eslint": "8.26.0",
@@ -7290,6 +7290,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/ext": {
       "version": "1.7.0",
@@ -16183,9 +16188,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -26104,6 +26109,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
         }
       }
     },
@@ -32811,9 +32821,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "mongodb": "4.10.0",
         "mustache": "4.2.0",
         "parse": "4.0.1",
-        "path-to-regexp": "^6.2.1",
+        "path-to-regexp": "6.2.1",
         "pg-monitor": "2.0.0",
         "pg-promise": "11.3.0",
         "pluralize": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mongodb": "4.10.0",
     "mustache": "4.2.0",
     "parse": "4.0.1",
-    "path-to-regexp": "0.1.7",
+    "path-to-regexp": "6.2.1",
     "pg-monitor": "2.0.0",
     "pg-promise": "11.3.0",
     "pluralize": "8.0.0",

--- a/spec/RateLimit.spec.js
+++ b/spec/RateLimit.spec.js
@@ -1,5 +1,5 @@
 const RedisCacheAdapter = require('../lib/Adapters/Cache/RedisCacheAdapter').default;
-describe('rate limit', () => {
+fdescribe('rate limit', () => {
   it('can limit cloud functions', async () => {
     Parse.Cloud.define('test', () => 'Abc');
     await reconfigureServer({

--- a/spec/RateLimit.spec.js
+++ b/spec/RateLimit.spec.js
@@ -1,5 +1,5 @@
 const RedisCacheAdapter = require('../lib/Adapters/Cache/RedisCacheAdapter').default;
-fdescribe('rate limit', () => {
+describe('rate limit', () => {
   it('can limit cloud functions', async () => {
     Parse.Cloud.define('test', () => 'Abc');
     await reconfigureServer({

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -82,9 +82,9 @@ const getRoute = parseClass => {
       '@File': 'files',
     }[parseClass] || 'classes';
   if (parseClass === '@File') {
-    return `/${route}/:id?*`;
+    return `/${route}/:id?(.*)`;
   }
-  return `/${route}/${parseClass}/:id?*`;
+  return `/${route}/${parseClass}/:id?(.*)`;
 };
 /** @namespace
  * @name Parse

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -9,7 +9,7 @@ import MongoStorageAdapter from './Adapters/Storage/Mongo/MongoStorageAdapter';
 import PostgresStorageAdapter from './Adapters/Storage/Postgres/PostgresStorageAdapter';
 import rateLimit from 'express-rate-limit';
 import { RateLimitOptions } from './Options/Definitions';
-import pathToRegexp from 'path-to-regexp';
+import { pathToRegexp } from 'path-to-regexp';
 import ipRangeCheck from 'ip-range-check';
 import RedisStore from 'rate-limit-redis';
 import { createClient } from 'redis';
@@ -512,8 +512,12 @@ export const addRateLimit = (route, config, cloud) => {
       },
     });
   }
+  let transformPath = route.requestPath.replaceAll('/*', '/(.*)');
+  if (transformPath === '*') {
+    transformPath = '(.*)';
+  }
   config.rateLimits.push({
-    path: pathToRegexp(route.requestPath),
+    path: pathToRegexp(transformPath),
     handler: rateLimit({
       windowMs: route.requestTimeWindow,
       max: route.requestCount,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8546

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
