### PR TITLE
fix: Rate limit feature is incompatible with Node 14

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -512,7 +512,7 @@ export const addRateLimit = (route, config, cloud) => {
       },
     });
   }
-  let transformPath = route.requestPath.replaceAll('/*', '/(.*)');
+  let transformPath = route.requestPath.split('/*').join('/(.*)');
   if (transformPath === '*') {
     transformPath = '(.*)';
   }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Code used to update path-to-regex is not supported on Node 14

Closes: #8577

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
