### PR TITLE
ci: Skip CI for changes in MD files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - '**'
+    paths-ignore:
+      - '**/**.md'
 env:
   NODE_VERSION: 19.3.0
   PARSE_SERVER_TEST_TIMEOUT: 20000


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #n/a

The CI currently runs also for changes in MD files, like the README.md. This is unnecessary as these files have no code impact.

## Approach

Ignore CI workflow for *.md file changes.

