### PR TITLE
docs: Add code ownership section to CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
   - [Review Feedback](#review-feedback)
   - [Merge Readiness](#merge-readiness)
   - [Review Validity](#review-validity)
+  - [Code Ownership](#code-ownership)
 - [Environment Setup](#environment-setup)
   - [Recommended Tools](#recommended-tools)
   - [Setting up your local machine](#setting-up-your-local-machine)
@@ -34,6 +35,8 @@
   - [Breaking Change](#breaking-change-1)
   - [Reverting](#reverting)
   - [Security Vulnerability](#security-vulnerability)
+    - [Local Testing](#local-testing)
+    - [Merging](#merging-1)
 - [Releasing](#releasing)
   - [General Considerations](#general-considerations)
   - [Major Release / Long-Term-Support](#major-release--long-term-support)
@@ -142,6 +145,12 @@ It's contrary to an open, collaborative environment to expect others to be invol
 > *The reviewer doesn't have any expertise in that matter, why would I care about their opinion?*
 
 Your arguments must focus on the issue, not on your assumption of someone else's personal experience. We will take immediate and appropriate action in case of personal attacks, regardless of your previous contributions. Personal attacks are not permissible. If you became a victim of personal attacks, you can privately [report](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam) the GitHub comment to the Parse Platform PMC.
+
+### Code Ownership
+
+> *Can I open a new pull request based on another author's pull request?*
+
+If your pull request contains work from someone else then you are required to get their permission to use their work in your pull request. Please make sure to observe the [license](LICENSE) for more details. In addition, as an appreciative gesture you should clearly mention that your pull request is based on another pull request with a link in the top-most comment of your pull request. To avoid this issue we encourage contributors to collaborate on a single pull request to preserve the commit history and clearly identify each author's contribution. To do so, you can review the other author's pull request and submit your code suggestions, or ask the original author to grant you write access to their repository to also be able to make commits directly to their pull request.
 
 ## Environment Setup
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #n/a

While the license regulates the topic of using foreign work in a pull request, contributors may not be aware of this topic.

## Approach

Add topic of collaborating on PRs to CONTRIBUTING guide.
