### PR TITLE
refactor: Incorrect spelling in hooks error message

### DIFF
--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -208,7 +208,7 @@ describe('Hooks', () => {
           expect(err).not.toBe(null);
           if (err) {
             expect(err.code).toBe(143);
-            expect(err.message).toBe('function name: my_new_function already exits');
+            expect(err.message).toBe('function name: my_new_function already exists');
           }
           return Parse.Hooks.removeFunction('my_new_function');
         }

--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -144,7 +144,7 @@ export class HooksController {
     if (aHook.functionName) {
       return this.getFunction(aHook.functionName).then(result => {
         if (result) {
-          throw new Parse.Error(143, `function name: ${aHook.functionName} already exits`);
+          throw new Parse.Error(143, `function name: ${aHook.functionName} already exists`);
         } else {
           return this.createOrUpdateHook(aHook);
         }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The word `exits` should be `exists` when a Hook error is thrown.

Closes: n/a

## Approach
<!-- Describe the changes in this PR. -->
Fix spelling

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Update tests
