### PR TITLE
refactor: Upgrade pg-promise from 11.3.0 to 11.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11646,14 +11646,12 @@
       }
     },
     "node_modules/mock-files-adapter": {
-      "version": "1.0.0",
-      "resolved": "file:spec/dependencies/mock-files-adapter",
-      "dev": true
+      "resolved": "spec/dependencies/mock-files-adapter",
+      "link": true
     },
     "node_modules/mock-mail-adapter": {
-      "version": "1.0.0",
-      "resolved": "file:spec/dependencies/mock-mail-adapter",
-      "dev": true
+      "resolved": "spec/dependencies/mock-mail-adapter",
+      "link": true
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -20655,6 +20653,14 @@
       "dependencies": {
         "zen-observable": "0.8.15"
       }
+    },
+    "spec/dependencies/mock-files-adapter": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "spec/dependencies/mock-mail-adapter": {
+      "version": "1.0.0",
+      "dev": true
     }
   },
   "dependencies": {
@@ -29493,12 +29499,10 @@
       }
     },
     "mock-files-adapter": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "file:spec/dependencies/mock-files-adapter"
     },
     "mock-mail-adapter": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "file:spec/dependencies/mock-mail-adapter"
     },
     "modify-values": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@graphql-tools/utils": "8.12.0",
         "@graphql-yoga/node": "2.6.0",
         "@parse/fs-files-adapter": "1.2.2",
-        "@parse/push-adapter": "^4.1.3",
+        "@parse/push-adapter": "4.1.3",
         "bcryptjs": "2.4.3",
         "body-parser": "1.20.1",
         "commander": "10.0.1",
@@ -42,7 +42,7 @@
         "parse": "4.0.1",
         "path-to-regexp": "6.2.1",
         "pg-monitor": "2.0.0",
-        "pg-promise": "11.3.0",
+        "pg-promise": "11.5.0",
         "pluralize": "8.0.0",
         "rate-limit-redis": "3.0.1",
         "redis": "4.6.6",
@@ -4090,9 +4090,9 @@
       }
     },
     "node_modules/assert-options": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.0.tgz",
-      "integrity": "sha512-qSELrEaEz4sGwTs4Qh+swQkjiHAysC4rot21+jzXU86dJzNG+FDqBzyS3ohSoTRf4ZLA3FSwxQdiuNl5NXUtvA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
+      "integrity": "sha512-5lNGRB5g5i2bGIzb+J1QQE1iKU/WEMVBReFIc5pPDWjcPj23otPL0eI6PB2v7QPi0qU6Mhym5D3y0ZiSIOf3GA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -15175,11 +15175,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16245,20 +16240,23 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/pg": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.9.0.tgz",
-      "integrity": "sha512-ZJM+qkEbtOHRuXjmvBtOgNOXOtLSbxiMiUVMgE4rV6Zwocy03RicCVvDXgx8l4Biwo8/qORUnEqn2fdQzV7KCg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.2",
+        "pg-connection-string": "^2.6.0",
+        "pg-pool": "^3.6.0",
         "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -16269,10 +16267,16 @@
         }
       }
     },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.0.tgz",
+      "integrity": "sha512-tGM8/s6frwuAIyRcJ6nWcIvd3+3NmUKIs6OjviIm1HPPFEt5MzQDOTBQyhPWg/m0kCl95M6gA1JaIXtS8KovOA==",
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
+      "integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -16283,11 +16287,11 @@
       }
     },
     "node_modules/pg-minify": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.2.tgz",
-      "integrity": "sha512-1KdmFGGTP6jplJoI8MfvRlfvMiyBivMRP7/ffh4a11RUFJ7kC2J0ZHlipoKiH/1hz+DVgceon9U2qbaHpPeyPg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.3.tgz",
+      "integrity": "sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ==",
       "engines": {
-        "node": ">=8.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pg-monitor": {
@@ -16357,22 +16361,22 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/pg-pool": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
-      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.0.tgz",
+      "integrity": "sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-promise": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.3.0.tgz",
-      "integrity": "sha512-A2CYmax5gsqVAO2N0ET9oPRCPX3kpKymj9qLVK7+jszlJL6l8uJDq/DGqLpxNi5VHwK7Dmm2WNRdrwkh1xuaxQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.5.0.tgz",
+      "integrity": "sha512-ZfhntV6Yoc3S0hQWOlEodk5fEmF9ADxKl0vNvBnZgzvLt73uY29wVaNBz2AZK2J0gVmm/zhO51RXPtI4MgKkSQ==",
       "dependencies": {
-        "assert-options": "0.8.0",
-        "pg": "8.9.0",
-        "pg-minify": "1.6.2",
-        "spex": "3.2.0"
+        "assert-options": "0.8.1",
+        "pg": "8.11.0",
+        "pg-minify": "1.6.3",
+        "spex": "3.3.0"
       },
       "engines": {
         "node": ">=14.0"
@@ -16407,9 +16411,9 @@
       }
     },
     "node_modules/pgpass/node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "engines": {
         "node": ">= 10.x"
       }
@@ -18771,11 +18775,11 @@
       "dev": true
     },
     "node_modules/spex": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-3.2.0.tgz",
-      "integrity": "sha512-9srjJM7NaymrpwMHvSmpDeIK5GoRMX/Tq0E8aOlDPS54dDnDUIp30DrP9SphMPEETDLzEM9+4qo+KipmbtPecg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.3.0.tgz",
+      "integrity": "sha512-VNiXjFp6R4ldPbVRYbpxlD35yRHceecVXlct1J4/X80KuuPnW2AXMq3sGwhnJOhKkUsOxAT6nRGfGE5pocVw5w==",
       "engines": {
-        "node": ">=4.5"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/split": {
@@ -23617,9 +23621,9 @@
       }
     },
     "assert-options": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.0.tgz",
-      "integrity": "sha512-qSELrEaEz4sGwTs4Qh+swQkjiHAysC4rot21+jzXU86dJzNG+FDqBzyS3ohSoTRf4ZLA3FSwxQdiuNl5NXUtvA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
+      "integrity": "sha512-5lNGRB5g5i2bGIzb+J1QQE1iKU/WEMVBReFIc5pPDWjcPj23otPL0eI6PB2v7QPi0qU6Mhym5D3y0ZiSIOf3GA=="
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -32883,23 +32887,30 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "pg": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.9.0.tgz",
-      "integrity": "sha512-ZJM+qkEbtOHRuXjmvBtOgNOXOtLSbxiMiUVMgE4rV6Zwocy03RicCVvDXgx8l4Biwo8/qORUnEqn2fdQzV7KCg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.2",
+        "pg-cloudflare": "^1.1.0",
+        "pg-connection-string": "^2.6.0",
+        "pg-pool": "^3.6.0",
         "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
     },
+    "pg-cloudflare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.0.tgz",
+      "integrity": "sha512-tGM8/s6frwuAIyRcJ6nWcIvd3+3NmUKIs6OjviIm1HPPFEt5MzQDOTBQyhPWg/m0kCl95M6gA1JaIXtS8KovOA==",
+      "optional": true
+    },
     "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
+      "integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -32907,9 +32918,9 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.2.tgz",
-      "integrity": "sha512-1KdmFGGTP6jplJoI8MfvRlfvMiyBivMRP7/ffh4a11RUFJ7kC2J0ZHlipoKiH/1hz+DVgceon9U2qbaHpPeyPg=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.3.tgz",
+      "integrity": "sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ=="
     },
     "pg-monitor": {
       "version": "2.0.0",
@@ -32974,20 +32985,20 @@
       }
     },
     "pg-pool": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
-      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.0.tgz",
+      "integrity": "sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==",
       "requires": {}
     },
     "pg-promise": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.3.0.tgz",
-      "integrity": "sha512-A2CYmax5gsqVAO2N0ET9oPRCPX3kpKymj9qLVK7+jszlJL6l8uJDq/DGqLpxNi5VHwK7Dmm2WNRdrwkh1xuaxQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.5.0.tgz",
+      "integrity": "sha512-ZfhntV6Yoc3S0hQWOlEodk5fEmF9ADxKl0vNvBnZgzvLt73uY29wVaNBz2AZK2J0gVmm/zhO51RXPtI4MgKkSQ==",
       "requires": {
-        "assert-options": "0.8.0",
-        "pg": "8.9.0",
-        "pg-minify": "1.6.2",
-        "spex": "3.2.0"
+        "assert-options": "0.8.1",
+        "pg": "8.11.0",
+        "pg-minify": "1.6.3",
+        "spex": "3.3.0"
       }
     },
     "pg-protocol": {
@@ -33016,9 +33027,9 @@
       },
       "dependencies": {
         "split2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
         }
       }
     },
@@ -34853,9 +34864,9 @@
       "dev": true
     },
     "spex": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-3.2.0.tgz",
-      "integrity": "sha512-9srjJM7NaymrpwMHvSmpDeIK5GoRMX/Tq0E8aOlDPS54dDnDUIp30DrP9SphMPEETDLzEM9+4qo+KipmbtPecg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.3.0.tgz",
+      "integrity": "sha512-VNiXjFp6R4ldPbVRYbpxlD35yRHceecVXlct1J4/X80KuuPnW2AXMq3sGwhnJOhKkUsOxAT6nRGfGE5pocVw5w=="
     },
     "split": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11646,12 +11646,14 @@
       }
     },
     "node_modules/mock-files-adapter": {
-      "resolved": "spec/dependencies/mock-files-adapter",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:spec/dependencies/mock-files-adapter",
+      "dev": true
     },
     "node_modules/mock-mail-adapter": {
-      "resolved": "spec/dependencies/mock-mail-adapter",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:spec/dependencies/mock-mail-adapter",
+      "dev": true
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -20653,14 +20655,6 @@
       "dependencies": {
         "zen-observable": "0.8.15"
       }
-    },
-    "spec/dependencies/mock-files-adapter": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "spec/dependencies/mock-mail-adapter": {
-      "version": "1.0.0",
-      "dev": true
     }
   },
   "dependencies": {
@@ -29499,10 +29493,12 @@
       }
     },
     "mock-files-adapter": {
-      "version": "file:spec/dependencies/mock-files-adapter"
+      "version": "1.0.0",
+      "dev": true
     },
     "mock-mail-adapter": {
-      "version": "file:spec/dependencies/mock-mail-adapter"
+      "version": "1.0.0",
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "parse": "4.0.1",
     "path-to-regexp": "6.2.1",
     "pg-monitor": "2.0.0",
-    "pg-promise": "11.3.0",
+    "pg-promise": "11.5.0",
     "pluralize": "8.0.0",
     "rate-limit-redis": "3.0.1",
     "redis": "4.6.6",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The dependencies pg-promise is not up-to-date and the node-postgres driver pg-promise depends on is out-of-date. For some reason, these are not being updated by the dependency bot or the snyk bot

Closes: #8587 

## Approach
<!-- Describe the changes in this PR. -->
Update the dependencies using `npm i -E pg-promise@11.5.0`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Ensure tests pass
