### PR TITLE
revert: Fix: Inaccurate table total row count for PostgreSQL

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -2040,7 +2040,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
     if (where.pattern.length > 0 || !estimate) {
       qs = `SELECT count(*) FROM $1:name ${wherePattern}`;
     } else {
-      qs = 'SELECT n_live_tup AS approximate_row_count FROM pg_stat_all_tables WHERE relname = $1;';
+      qs = 'SELECT reltuples AS approximate_row_count FROM pg_class WHERE relname = $1';
     }
 
     return this._client


### PR DESCRIPTION
This reverts commit 0823a02fbf80bc88dc403bc47e9f5c6597ea78b4.

See https://github.com/parse-community/parse-server/issues/8502#issuecomment-1566219530.