### PR TITLE
fix: Auth adapter VKontakte not working with new API

### DIFF
--- a/src/Adapters/Auth/vkontakte.js
+++ b/src/Adapters/Auth/vkontakte.js
@@ -7,56 +7,23 @@ var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, params) {
-  return vkOAuth2Request(params).then(function (response) {
-    if (response && response.access_token) {
-      return request(
-        'api.vk.com',
-        'method/users.get?access_token=' + authData.access_token + '&v=' + params.apiVersion
-      ).then(function (response) {
-        if (
-          response &&
-          response.response &&
-          response.response.length &&
-          response.response[0].id == authData.id
-        ) {
-          return;
-        }
-        throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
-      });
-    }
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk appIds or appSecret is incorrect.');
-  });
-}
+  if (!params.apiVersion) {
+    params.apiVersion = '5.131';
+  }
 
-function vkOAuth2Request(params) {
-  return new Promise(function (resolve) {
+  return request(
+    'api.vk.com',
+    'method/users.get?access_token=' + authData.access_token + '&v=' + params.apiVersion
+  ).then(function (response) {
     if (
-      !params ||
-      !params.appIds ||
-      !params.appIds.length ||
-      !params.appSecret ||
-      !params.appSecret.length
+      response &&
+      response.response &&
+      response.response.length &&
+      response.response[0].id == authData.id
     ) {
-      throw new Parse.Error(
-        Parse.Error.OBJECT_NOT_FOUND,
-        'Vk auth is not configured. Missing appIds or appSecret.'
-      );
+      return;
     }
-    if (!params.apiVersion) {
-      params.apiVersion = '5.124';
-    }
-    resolve();
-  }).then(function () {
-    return request(
-      'oauth.vk.com',
-      'access_token?client_id=' +
-        params.appIds +
-        '&client_secret=' +
-        params.appSecret +
-        '&v=' +
-        params.apiVersion +
-        '&grant_type=client_credentials'
-    );
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
   });
 }
 


### PR DESCRIPTION
## Pull Request

## Issue
https://github.com/parse-community/parse-server/issues/8626

Closes: https://github.com/parse-community/parse-server/issues/8626

## Approach
Remove previously unnecessary API call that now fails. Bump the api version for good practice.


