### PR TITLE
docs: Fix broken logo link in API docs

### DIFF
--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -29,7 +29,7 @@
     "template": "./node_modules/clean-jsdoc-theme",
     "theme_opts": {
       "default_theme": "dark",
-      "title": "Parse Server",
+      "title": "<img src='../.github/parse-server-logo.png' class='logo'/>",
       "create_style": "header, .sidebar-section-title, .sidebar-title { color: #139cee !important } .logo { margin-left : 40px; margin-right: 40px }"
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "pluralize": "8.0.0",
         "rate-limit-redis": "3.0.2",
         "redis": "4.6.6",
-        "semver": "^7.5.1",
+        "semver": "7.5.1",
         "subscriptions-transport-ws": "0.11.0",
         "tv4": "1.3.0",
         "uuid": "9.0.0",
@@ -15212,6 +15212,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/release_docs.sh
+++ b/release_docs.sh
@@ -27,3 +27,8 @@ npm run docs
 
 mkdir -p "docs/api/${DEST}"
 cp -R out/* "docs/api/${DEST}"
+
+# Copy other resources
+RESOURCE_DIR=".github"
+mkdir -p "docs/${RESOURCE_DIR}"
+cp "./.github/parse-server-logo.png" "docs/${RESOURCE_DIR}/"


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8528 

## Approach

Copy image resource during docs generation to make it available on deployed gh_pages.

