### PR TITLE
refactor: Replace deprecated `substr` with `substring`

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,6 +1,6 @@
 const pkg = require('./package.json');
 
-const version = parseFloat(process.version.substr(1));
+const version = parseFloat(process.version.substring(1));
 const minimum = parseFloat(pkg.engines.node.match(/\d+/g).join('.'));
 
 module.exports = function () {

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -28,7 +28,11 @@ export class GridFSBucketAdapter extends FilesAdapter {
     this._algorithm = 'aes-256-gcm';
     this._encryptionKey =
       encryptionKey !== undefined
-        ? crypto.createHash('sha256').update(String(encryptionKey)).digest('base64').substr(0, 32)
+        ? crypto
+          .createHash('sha256')
+          .update(String(encryptionKey))
+          .digest('base64')
+          .substring(0, 32)
         : null;
     const defaultMongoOptions = {
       useNewUrlParser: true,
@@ -138,8 +142,8 @@ export class GridFSBucketAdapter extends FilesAdapter {
   }
 
   async rotateEncryptionKey(options = {}) {
-    var fileNames = [];
-    var oldKeyFileAdapter = {};
+    let fileNames = [];
+    let oldKeyFileAdapter = {};
     const bucket = await this._getBucket();
     if (options.oldKey !== undefined) {
       oldKeyFileAdapter = new GridFSBucketAdapter(
@@ -158,51 +162,22 @@ export class GridFSBucketAdapter extends FilesAdapter {
         fileNames.push(file.filename);
       });
     }
-    return new Promise(resolve => {
-      var fileNamesNotRotated = fileNames;
-      var fileNamesRotated = [];
-      var fileNameTotal = fileNames.length;
-      var fileNameIndex = 0;
-      fileNames.forEach(fileName => {
-        oldKeyFileAdapter
-          .getFileData(fileName)
-          .then(plainTextData => {
-            //Overwrite file with data encrypted with new key
-            this.createFile(fileName, plainTextData)
-              .then(() => {
-                fileNamesRotated.push(fileName);
-                fileNamesNotRotated = fileNamesNotRotated.filter(function (value) {
-                  return value !== fileName;
-                });
-                fileNameIndex += 1;
-                if (fileNameIndex == fileNameTotal) {
-                  resolve({
-                    rotated: fileNamesRotated,
-                    notRotated: fileNamesNotRotated,
-                  });
-                }
-              })
-              .catch(() => {
-                fileNameIndex += 1;
-                if (fileNameIndex == fileNameTotal) {
-                  resolve({
-                    rotated: fileNamesRotated,
-                    notRotated: fileNamesNotRotated,
-                  });
-                }
-              });
-          })
-          .catch(() => {
-            fileNameIndex += 1;
-            if (fileNameIndex == fileNameTotal) {
-              resolve({
-                rotated: fileNamesRotated,
-                notRotated: fileNamesNotRotated,
-              });
-            }
-          });
-      });
-    });
+    let fileNamesNotRotated = fileNames;
+    const fileNamesRotated = [];
+    for (const fileName of fileNames) {
+      try {
+        const plainTextData = await oldKeyFileAdapter.getFileData(fileName);
+        // Overwrite file with data encrypted with new key
+        await this.createFile(fileName, plainTextData);
+        fileNamesRotated.push(fileName);
+        fileNamesNotRotated = fileNamesNotRotated.filter(function (value) {
+          return value !== fileName;
+        });
+      } catch (err) {
+        continue;
+      }
+    }
+    return { rotated: fileNamesRotated, notRotated: fileNamesNotRotated };
   }
 
   getFileLocation(config, filename) {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -231,7 +231,7 @@ const transformAggregateField = fieldName => {
   if (fieldName === '$_updated_at') {
     return 'updatedAt';
   }
-  return fieldName.substr(1);
+  return fieldName.substring(1);
 };
 
 const validateKeys = object => {
@@ -1922,7 +1922,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
       }
       if (object[fieldName] && schema.fields[fieldName].type === 'Polygon') {
         let coords = object[fieldName];
-        coords = coords.substr(2, coords.length - 4).split('),(');
+        coords = coords.substring(2, coords.length - 4).split('),(');
         coords = coords.map(point => {
           return [parseFloat(point.split(',')[1]), parseFloat(point.split(',')[0])];
         });
@@ -2634,7 +2634,7 @@ function literalizeRegexPart(s: string) {
   const result1: any = s.match(matcher1);
   if (result1 && result1.length > 1 && result1.index > -1) {
     // process regex that has a beginning and an end specified for the literal text
-    const prefix = s.substr(0, result1.index);
+    const prefix = s.substring(0, result1.index);
     const remaining = result1[1];
 
     return literalizeRegexPart(prefix) + createLiteralRegex(remaining);
@@ -2644,7 +2644,7 @@ function literalizeRegexPart(s: string) {
   const matcher2 = /\\Q((?!\\E).*)$/;
   const result2: any = s.match(matcher2);
   if (result2 && result2.length > 1 && result2.index > -1) {
-    const prefix = s.substr(0, result2.index);
+    const prefix = s.substring(0, result2.index);
     const remaining = result2[1];
 
     return literalizeRegexPart(prefix) + createLiteralRegex(remaining);

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1921,14 +1921,14 @@ export class PostgresStorageAdapter implements StorageAdapter {
         };
       }
       if (object[fieldName] && schema.fields[fieldName].type === 'Polygon') {
-        let coords = object[fieldName];
-        coords = coords.substr(2, coords.length - 4).split('),(');
-        coords = coords.map(point => {
+        let coords = new String(object[fieldName]);
+        coords = coords.substring(2, coords.length - 2).split('),(');
+        const updatedCoords = coords.map(point => {
           return [parseFloat(point.split(',')[1]), parseFloat(point.split(',')[0])];
         });
         object[fieldName] = {
           __type: 'Polygon',
-          coordinates: coords,
+          coordinates: updatedCoords,
         };
       }
       if (object[fieldName] && schema.fields[fieldName].type === 'File') {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1922,7 +1922,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
       }
       if (object[fieldName] && schema.fields[fieldName].type === 'Polygon') {
         let coords = object[fieldName];
-        coords = coords.substring(2, coords.length - 4).split('),(');
+        coords = coords.substr(2, coords.length - 4).split('),(');
         coords = coords.map(point => {
           return [parseFloat(point.split(',')[1]), parseFloat(point.split(',')[0])];
         });

--- a/src/Config.js
+++ b/src/Config.js
@@ -25,7 +25,7 @@ function removeTrailingSlash(str) {
     return str;
   }
   if (str.endsWith('/')) {
-    str = str.substr(0, str.length - 1);
+    str = str.substring(0, str.length - 1);
   }
   return str;
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
`substr()` has been deprecated.

Closes: #8645

## Approach
<!-- Describe the changes in this PR. -->
- [x] Use `substring()` instead and fix issues where needed
- [x] Refactor `rotateEncryptionKey()` in `GridFSBucketAdapter.js` to use async/await since already refactoring `substr()` in the same file 

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Ensure tests pass
