### PR TITLE
docs: Fix deprecation date

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -13,7 +13,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS7 | Remove file trigger syntax `Parse.Cloud.beforeSaveFile((request) => {})` | [#7966](https://github.com/parse-community/parse-server/pull/7966)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | deprecated            | -     |
 | DEPPS8 | Login with expired 3rd party authentication token defaults to `false` | [#7079](https://github.com/parse-community/parse-server/pull/7079)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | deprecated            | -     |
 | DEPPS9 | Rename LiveQuery `fields` option to `keys` | [#8389](https://github.com/parse-community/parse-server/issues/8389)   | 6.0.0 (2023)                    | 7.0.0 (2024)                    | deprecated            | -     |
-| DEPPS10 | Config option `encodeParseObjectInCloudFunction` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 7.0.0 (2024)                    | deprecated            | -     |
+| DEPPS10 | Config option `encodeParseObjectInCloudFunction` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_removal]: ## "The version and date of the planned removal."


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue


Deprecation date of https://github.com/parse-community/parse-server/pull/8646 is incorrect. It should be Parse Server 8 (2025) according to our policy to give developers >= 1 year time for breaking changes.

Closes: #n/a

## Approach

Fix date.

