### PR TITLE
refactor: Change response types of TOTP adapter to match existing adapters

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -2473,7 +2473,9 @@ describe('OTP TOTP auth adatper', () => {
         username: 'username',
         password: 'password',
         authData: {
-          mfa: totp.generate(),
+          mfa: {
+            token: totp.generate(),
+          },
         },
       }),
     }).then(res => res.data);
@@ -2608,7 +2610,9 @@ describe('OTP TOTP auth adatper', () => {
           username: 'username',
           password: 'password',
           authData: {
-            mfa: 'abcd',
+            mfa: {
+              token: 'abcd',
+            },
           },
         }),
       }).catch(e => {
@@ -2694,7 +2698,9 @@ describe('OTP SMS auth adatper', () => {
         username: 'username',
         password: 'password',
         authData: {
-          mfa: true,
+          mfa: {
+            token: 'request',
+          },
         },
       }),
     }).catch(e => e.data);
@@ -2708,7 +2714,9 @@ describe('OTP SMS auth adatper', () => {
         username: 'username',
         password: 'password',
         authData: {
-          mfa: code,
+          mfa: {
+            token: code,
+          },
         },
       }),
     }).then(res => res.data);

--- a/src/Adapters/Auth/mfa.js
+++ b/src/Adapters/Auth/mfa.js
@@ -96,7 +96,7 @@ class MFAAdapter extends AuthAdapter {
     }
     return saveResponse;
   }
-  validateUpdate(authData, _, req) {
+  async validateUpdate(authData, _, req) {
     if (req.master) {
       return;
     }
@@ -107,7 +107,7 @@ class MFAAdapter extends AuthAdapter {
       return this.confirmSMSOTP(authData, req.original.get('authData')?.mfa || {});
     }
     if (this.totp) {
-      this.validateLogin(authData.old, null, req);
+      await this.validateLogin(authData.old, null, req);
       return this.validateSetUp(authData);
     }
     throw 'Invalid MFA data';
@@ -118,16 +118,16 @@ class MFAAdapter extends AuthAdapter {
     }
     if (this.totp && authData.secret) {
       return {
-        enabled: true,
+        status: 'enabled',
       };
     }
     if (this.sms && authData.mobile) {
       return {
-        enabled: true,
+        status: 'enabled',
       };
     }
     return {
-      enabled: false,
+      status: 'disabled',
     };
   }
 
@@ -204,7 +204,7 @@ class MFAAdapter extends AuthAdapter {
     }
     const recovery = [randomString(30), randomString(30)];
     return {
-      response: { recovery },
+      response: { recovery: recovery.join(', ') },
       save: { secret, recovery },
     };
   }

--- a/src/Adapters/Auth/mfa.js
+++ b/src/Adapters/Auth/mfa.js
@@ -44,14 +44,15 @@ class MFAAdapter extends AuthAdapter {
     }
     throw 'Invalid MFA data';
   }
-  async validateLogin(token, _, req) {
+  async validateLogin(loginData, _, req) {
     const saveResponse = {
       doNotSave: true,
     };
+    const token = loginData.token;
     const auth = req.original.get('authData') || {};
     const { secret, recovery, mobile, token: saved, expiry } = auth.mfa || {};
     if (this.sms && mobile) {
-      if (typeof token === 'boolean') {
+      if (token === 'request') {
         const { token: sendToken, expiry } = await this.sendSMS(mobile);
         auth.mfa.token = sendToken;
         auth.mfa.expiry = expiry;
@@ -107,7 +108,7 @@ class MFAAdapter extends AuthAdapter {
       return this.confirmSMSOTP(authData, req.original.get('authData')?.mfa || {});
     }
     if (this.totp) {
-      await this.validateLogin(authData.old, null, req);
+      await this.validateLogin({ token: authData.old }, null, req);
       return this.validateSetUp(authData);
     }
     throw 'Invalid MFA data';


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

The TOTP adapter has mixed return types, making it incompatible with strongly typed client SDKS.

There's also an additional issue with the TOTP adapter that is fixed in this PR as well.

Closes: #8660

## Approach
<!-- Describe the changes in this PR. -->

Changes the response of `enabled: true` to `status: "enabled"`

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)

