### PR TITLE
fix: Server does not start via CLI when `auth` option is set

### DIFF
--- a/spec/CLI.spec.js
+++ b/spec/CLI.spec.js
@@ -302,4 +302,20 @@ describe('execution', () => {
       done.fail(data.toString());
     });
   });
+
+  it('can start Parse Server with auth via CLI', done => {
+    const env = { ...process.env };
+    env.NODE_OPTIONS = '--dns-result-order=ipv4first';
+    childProcess = spawn(binPath, ['./spec/configs/CLIConfigAuth.json'], { env });
+    childProcess.stdout.on('data', data => {
+      data = data.toString();
+      if (data.includes('parse-server running on')) {
+        done();
+      }
+    });
+    childProcess.stderr.on('data', data => {
+      data = data.toString();
+      done.fail(data.toString());
+    });
+  });
 });

--- a/spec/CLI.spec.js
+++ b/spec/CLI.spec.js
@@ -303,7 +303,7 @@ describe('execution', () => {
     });
   });
 
-  fit('can start Parse Server with auth via CLI', done => {
+  it('can start Parse Server with auth via CLI', done => {
     const env = { ...process.env };
     env.NODE_OPTIONS = '--dns-result-order=ipv4first';
     childProcess = spawn(

--- a/spec/CLI.spec.js
+++ b/spec/CLI.spec.js
@@ -303,12 +303,13 @@ describe('execution', () => {
     });
   });
 
-  it('can start Parse Server with auth via CLI', done => {
+  fit('can start Parse Server with auth via CLI', done => {
     const env = { ...process.env };
     env.NODE_OPTIONS = '--dns-result-order=ipv4first';
     childProcess = spawn(binPath, ['./spec/configs/CLIConfigAuth.json'], { env });
     childProcess.stdout.on('data', data => {
       data = data.toString();
+      console.log(data);
       if (data.includes('parse-server running on')) {
         done();
       }

--- a/spec/CLI.spec.js
+++ b/spec/CLI.spec.js
@@ -306,7 +306,11 @@ describe('execution', () => {
   fit('can start Parse Server with auth via CLI', done => {
     const env = { ...process.env };
     env.NODE_OPTIONS = '--dns-result-order=ipv4first';
-    childProcess = spawn(binPath, ['./spec/configs/CLIConfigAuth.json'], { env });
+    childProcess = spawn(
+      binPath,
+      ['--databaseURI', databaseURI, './spec/configs/CLIConfigAuth.json'],
+      { env }
+    );
     childProcess.stdout.on('data', data => {
       data = data.toString();
       console.log(data);

--- a/spec/configs/CLIConfigAuth.json
+++ b/spec/configs/CLIConfigAuth.json
@@ -1,0 +1,11 @@
+{
+  "appName": "test",
+  "appId": "test",
+  "masterKey": "test",
+  "logLevel": "error",
+  "auth": {
+    "facebook": {
+      "appIds": "test"
+    }
+  }
+}

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -103,7 +103,6 @@ module.exports.ParseServerOptions = {
     env: 'PARSE_SERVER_AUTH_PROVIDERS',
     help:
       'Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication',
-    action: parsers.arrayParser,
   },
   cacheAdapter: {
     env: 'PARSE_SERVER_CACHE_ADAPTER',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -20,7 +20,7 @@
  * @property {Adapter<AnalyticsAdapter>} analyticsAdapter Adapter module for the analytics
  * @property {String} appId Your Parse Application ID
  * @property {String} appName Sets the app name
- * @property {AuthAdapter[]} auth Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
+ * @property {Object} auth Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
  * @property {Adapter<CacheAdapter>} cacheAdapter Adapter module for the cache
  * @property {Number} cacheMaxSize Sets the maximum size for the in memory cache, defaults to 10000
  * @property {Number} cacheTTL Sets the TTL for the in memory cache (in ms), defaults to 5000 (5 seconds)

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -149,7 +149,7 @@ export interface ParseServerOptions {
   allowCustomObjectId: ?boolean;
   /* Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
   :ENV: PARSE_SERVER_AUTH_PROVIDERS */
-  auth: ?(AuthAdapter[]);
+  auth: ?{ [string]: AuthAdapter };
   /* Max file size for uploads, defaults to 20mb
   :DEFAULT: 20mb */
   maxUploadSize: ?string;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Auth settings cannot be defined by json.

Closes: #8665

## Approach
<!-- Describe the changes in this PR. -->

First commit is a failing test

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests

