### PR TITLE
feat: Add property `Parse.Server.version` to determine current version of Parse Server in Cloud Code

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -103,6 +103,14 @@ describe('Cloud Code', () => {
     expect(currentConfig.silent).toBeFalse();
   });
 
+  it('can get curent version', () => {
+    const version = require('../package.json').version;
+    const currentConfig = Config.get('test');
+    expect(Parse.Server.version).toBeDefined();
+    expect(currentConfig.version).toBeDefined();
+    expect(Parse.Server.version).toEqual(version);
+  });
+
   it('show warning on duplicate cloud functions', done => {
     const logger = require('../lib/logger').logger;
     spyOn(logger, 'warn').and.callFake(() => {});

--- a/src/Config.js
+++ b/src/Config.js
@@ -7,6 +7,7 @@ import net from 'net';
 import AppCache from './cache';
 import DatabaseController from './Controllers/DatabaseController';
 import { logLevels as validLogLevels } from './Controllers/LoggerController';
+import { version } from '../package.json';
 import {
   AccountLockoutOptions,
   DatabaseOptions,
@@ -50,6 +51,7 @@ export class Config {
     config.generateEmailVerifyTokenExpiresAt = config.generateEmailVerifyTokenExpiresAt.bind(
       config
     );
+    config.version = version;
     return config;
   }
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8531

## Approach
<!-- Describe the changes in this PR. -->

Adds Parse.Server.version for easy access to the Parse Sever version

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
