### PR TITLE
fix: Parse Server option `fileUpload.fileExtensions` does not work with an array of extensions

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1368,7 +1368,7 @@ describe('Parse.File testing', () => {
       await reconfigureServer({
         fileUpload: {
           enableForPublic: true,
-          fileExtensions: ['jpg'],
+          fileExtensions: ['jpg', 'any'],
         },
       });
       await expectAsync(
@@ -1387,6 +1387,18 @@ describe('Parse.File testing', () => {
       ).toBeRejectedWith(
         new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `File upload of extension html is disabled.`)
       );
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/files/file',
+          body: JSON.stringify({
+            _ApplicationId: 'test',
+            _JavaScriptKey: 'test',
+            _ContentType: 'image/jpg',
+            base64: 'PGh0bWw+PC9odG1sPgo=',
+          }),
+        })
+      ).toBeResolved();
     });
 
     it('works with array without Content-Type', async () => {
@@ -1435,26 +1447,5 @@ describe('Parse.File testing', () => {
       expect(b.name).toMatch(/_file.html$/);
       expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.html$/);
     });
-  });
-
-  it('works with array with more elements', async () => {
-    await reconfigureServer({
-      fileUpload: {
-        enableForPublic: true,
-        fileExtensions: ['jpeg', 'png'],
-      },
-    });
-    await expectAsync(
-      request({
-        method: 'POST',
-        url: 'http://localhost:8378/1/files/file',
-        body: JSON.stringify({
-          _ApplicationId: 'test',
-          _JavaScriptKey: 'test',
-          _ContentType: 'image/jpeg',
-          base64: 'PGh0bWw+PC9odG1sPgo=',
-        }),
-      })
-    ).toBeResolved();
   });
 });

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1436,4 +1436,25 @@ describe('Parse.File testing', () => {
       expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.html$/);
     });
   });
+
+  it('works with array with more elements', async () => {
+    await reconfigureServer({
+      fileUpload: {
+        enableForPublic: true,
+        fileExtensions: ['jpeg', 'png'],
+      },
+    });
+    await expectAsync(
+      request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/files/file',
+        body: JSON.stringify({
+          _ApplicationId: 'test',
+          _JavaScriptKey: 'test',
+          _ContentType: 'image/jpeg',
+          base64: 'PGh0bWw+PC9odG1sPgo=',
+        }),
+      })
+    ).toBeResolved();
+  });
 });

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1368,7 +1368,7 @@ describe('Parse.File testing', () => {
       await reconfigureServer({
         fileUpload: {
           enableForPublic: true,
-          fileExtensions: ['jpg', 'any'],
+          fileExtensions: ['jpg', 'wav'],
         },
       });
       await expectAsync(
@@ -1396,6 +1396,18 @@ describe('Parse.File testing', () => {
             _JavaScriptKey: 'test',
             _ContentType: 'image/jpg',
             base64: 'PGh0bWw+PC9odG1sPgo=',
+          }),
+        })
+      ).toBeResolved();
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/files/file',
+          body: JSON.stringify({
+            _ApplicationId: 'test',
+            _JavaScriptKey: 'test',
+            _ContentType: 'audio/wav',
+            base64: 'UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA',
           }),
         })
       ).toBeResolved();

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -147,7 +147,7 @@ export class FilesRouter {
           if (ext === '*') {
             return true;
           }
-          const regex = new RegExp(fileExtensions);
+          const regex = new RegExp(ext);
           if (regex.test(extension)) {
             return true;
           }


### PR DESCRIPTION
Testing uploaded file extension against every pattern provided in file upload config extensions.

## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: [#8687](https://github.com/parse-community/parse-server/issues/8687)

## Approach

Run regexp test for every pattern in the fileExtensions array.