### PR TITLE
feat: Add `runBeforeFindOnInclude`

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -14,6 +14,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS8 | Login with expired 3rd party authentication token defaults to `false` | [#7079](https://github.com/parse-community/parse-server/pull/7079)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | deprecated            | -     |
 | DEPPS9 | Rename LiveQuery `fields` option to `keys` | [#8389](https://github.com/parse-community/parse-server/issues/8389)   | 6.0.0 (2023)                    | 7.0.0 (2024)                    | deprecated            | -     |
 | DEPPS10 | Config option `encodeParseObjectInCloudFunction` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | deprecated            | -     |
+| DEPPS11 | Config option `runBeforeFindOnInclude` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8691)   | 6.3.0 (2023)                    | 8.0.0 (2025)                    | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_removal]: ## "The version and date of the planned removal."

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -485,6 +485,13 @@ module.exports.ParseServerOptions = {
     action: parsers.booleanParser,
     default: true,
   },
+  runBeforeFindOnInclude: {
+    env: 'PARSE_SERVER_RUN_BEFORE_FIND_ON_INCLUDE',
+    help:
+      'If set to `true`, beforeFind triggers will run when include is called. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where beforeFind triggers do not run on `include`.',
+    action: parsers.booleanParser,
+    default: false,
+  },
   scheduledPush: {
     env: 'PARSE_SERVER_SCHEDULED_PUSH',
     help: 'Configuration for push scheduling, defaults to false.',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -87,6 +87,7 @@
  * @property {RequestKeywordDenylist[]} requestKeywordDenylist An array of keys and values that are prohibited in database read and write requests to prevent potential security vulnerabilities. It is possible to specify only a key (`{"key":"..."}`), only a value (`{"value":"..."}`) or a key-value pair (`{"key":"...","value":"..."}`). The specification can use the following types: `boolean`, `numeric` or `string`, where `string` will be interpreted as a regex notation. Request data is deep-scanned for matching definitions to detect also any nested occurrences. Defaults are patterns that are likely to be used in malicious requests. Setting this option will override the default patterns.
  * @property {String} restAPIKey Key for REST calls
  * @property {Boolean} revokeSessionOnPasswordReset When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.
+ * @property {Boolean} runBeforeFindOnInclude If set to `true`, beforeFind triggers will run when include is called. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where beforeFind triggers do not run on `include`.
  * @property {Boolean} scheduledPush Configuration for push scheduling, defaults to false.
  * @property {SchemaOptions} schema Defined schema
  * @property {SecurityOptions} security The security options to identify and report weak security settings.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -205,6 +205,9 @@ export interface ParseServerOptions {
   /* If set to `true`, a `Parse.Object` that is in the payload when calling a Cloud Function will be converted to an instance of `Parse.Object`. If `false`, the object will not be converted and instead be a plain JavaScript object, which contains the raw data of a `Parse.Object` but is not an actual instance of `Parse.Object`. Default is `false`. <br><br>ℹ️ The expected behavior would be that the object is converted to an instance of `Parse.Object`, so you would normally set this option to `true`. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where JavaScript objects are not converted to actual instances of `Parse.Object`.
   :DEFAULT: false */
   encodeParseObjectInCloudFunction: ?boolean;
+  /* If set to `true`, beforeFind triggers will run when include is called. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where beforeFind triggers do not run on `include`.
+  :DEFAULT: false */
+  runBeforeFindOnInclude: ?boolean;
   /* Public URL to your parse server with http:// or https://.
   :ENV: PARSE_PUBLIC_SERVER_URL */
   publicServerURL: ?string;

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -251,7 +251,9 @@ export function getRequestObject(
   parseObject,
   originalParseObject,
   config,
-  context
+  context,
+  isGet,
+  isInclude
 ) {
   const request = {
     triggerName: triggerType,
@@ -288,11 +290,27 @@ export function getRequestObject(
   if (auth.installationId) {
     request['installationId'] = auth.installationId;
   }
+  if (isGet) {
+    request.isGet = true;
+  }
+  if (isInclude) {
+    request.isInclude = true;
+  }
   return request;
 }
 
-export function getRequestQueryObject(triggerType, auth, query, count, config, context, isGet) {
+export function getRequestQueryObject(
+  triggerType,
+  auth,
+  query,
+  count,
+  config,
+  context,
+  isGet,
+  isInclude
+) {
   isGet = !!isGet;
+  isInclude = !!isInclude;
 
   var request = {
     triggerName: triggerType,
@@ -301,6 +319,7 @@ export function getRequestQueryObject(triggerType, auth, query, count, config, c
     count,
     log: config.loggerController,
     isGet,
+    isInclude,
     headers: config.headers,
     ip: config.ip,
     context: context || {},
@@ -424,14 +443,26 @@ export function maybeRunAfterFindTrigger(
   objects,
   config,
   query,
-  context
+  context,
+  isGet,
+  isInclude
 ) {
   return new Promise((resolve, reject) => {
     const trigger = getTrigger(className, triggerType, config.applicationId);
     if (!trigger) {
       return resolve();
     }
-    const request = getRequestObject(triggerType, auth, null, null, config, context);
+    const request = getRequestObject(
+      triggerType,
+      auth,
+      null,
+      null,
+      config,
+      context,
+      isGet,
+      isInclude
+    );
+    console.log({ isGet, isInclude });
     if (query) {
       request.query = query;
     }
@@ -494,7 +525,8 @@ export function maybeRunQueryTrigger(
   config,
   auth,
   context,
-  isGet
+  isGet,
+  isInclude
 ) {
   const trigger = getTrigger(className, triggerType, config.applicationId);
   if (!trigger) {
@@ -520,7 +552,8 @@ export function maybeRunQueryTrigger(
     count,
     config,
     context,
-    isGet
+    isGet,
+    isInclude
   );
   return Promise.resolve()
     .then(() => {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -462,7 +462,6 @@ export function maybeRunAfterFindTrigger(
       isGet,
       isInclude
     );
-    console.log({ isGet, isInclude });
     if (query) {
       request.query = query;
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Currently, `beforeFind` does not run on the target class when `include` is used, but `afterFind` does correctly run.

Closes: #8486

## Approach
<!-- Describe the changes in this PR. -->

Adds temporary parameter `runBeforeFindOnInclude` to prevent this from being a breaking change.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
