### PR TITLE
fix: Redis 4 does not reconnect after unhandled error

### DIFF
--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -17,10 +17,10 @@ export class RedisCacheAdapter {
     this.ttl = isValidTTL(ttl) ? ttl : DEFAULT_REDIS_TTL;
     this.client = createClient(redisCtx);
     this.queue = new KeyPromiseQueue();
-    this.client.on('error', err => logger.error('RedisCacheAdapter Redis Client error', { error: err }));
-	  this.client.on('connect', () => {});
-	  this.client.on('reconnecting', () => {});
-	  this.client.on('ready', () => {});
+    this.client.on('error', err => _logger.error('RedisCacheAdapter Redis Client error', { error: err }));
+    this.client.on('connect', () => {});
+    this.client.on('reconnecting', () => {});
+    this.client.on('ready', () => {});
   }
 
   async connect() {

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -17,7 +17,7 @@ export class RedisCacheAdapter {
     this.ttl = isValidTTL(ttl) ? ttl : DEFAULT_REDIS_TTL;
     this.client = createClient(redisCtx);
     this.queue = new KeyPromiseQueue();
-    this.client.on('error', err => _logger.error('RedisCacheAdapter Redis Client error', { error: err }));
+    this.client.on('error', err => {});
     this.client.on('connect', () => {});
     this.client.on('reconnecting', () => {});
     this.client.on('ready', () => {});

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -17,7 +17,7 @@ export class RedisCacheAdapter {
     this.ttl = isValidTTL(ttl) ? ttl : DEFAULT_REDIS_TTL;
     this.client = createClient(redisCtx);
     this.queue = new KeyPromiseQueue();
-    this.client.on('error', err => {});
+    this.client.on('error', err => { logger.error('RedisCacheAdapter client error', { error: err }) });
     this.client.on('connect', () => {});
     this.client.on('reconnecting', () => {});
     this.client.on('ready', () => {});

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -17,6 +17,10 @@ export class RedisCacheAdapter {
     this.ttl = isValidTTL(ttl) ? ttl : DEFAULT_REDIS_TTL;
     this.client = createClient(redisCtx);
     this.queue = new KeyPromiseQueue();
+    this.client.on('error', err => logger.error('RedisCacheAdapter Redis Client error', { error: err }));
+	  this.client.on('connect', () => {});
+	  this.client.on('reconnecting', () => {});
+	  this.client.on('ready', () => {});
   }
 
   async connect() {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8705

## Approach
<!-- Describe the changes in this PR. -->
Adds mostly empty event handlers to the Redis client, which is now required for Redis 4.

## Tasks
<!-- Delete tasks that don't apply. -->

- [X] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
