### PR TITLE
fix: Remove config logging when launching Parse Server via CLI

### DIFF
--- a/src/cli/utils/runner.js
+++ b/src/cli/utils/runner.js
@@ -1,13 +1,20 @@
 import program from './commander';
 
 function logStartupOptions(options) {
+  if (!options.verbose) {
+    return;
+  }
+  // Keys that may include sensitive information that will be redacted in logs
+  const keysToRedact = [
+    'databaseURI',
+    'masterKey',
+    'maintenanceKey',
+    'push',
+  ];
   for (const key in options) {
     let value = options[key];
-    if (key == 'masterKey') {
-      value = '***REDACTED***';
-    }
-    if (key == 'push' && options.verbose != true) {
-      value = '***REDACTED***';
+    if (keysToRedact.includes(key)) {
+      value = '<REDACTED>';
     }
     if (typeof value === 'object') {
       try {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

When Parse Server is launched via CLI its config is logged by default.
This may not be desired as
- (a) it creates unnecessary log entries
- (b) it may contain information that should not be logged in a prod environment

Closes: #n/a

## Approach

Disables logging by default and only logs if `verbose: true` is set.
Also, this adds `maintenanceKey` and `databaseURI` (may contain password) to the redacted keys.

## Tasks
n/a