### PR TITLE
test: Add tests for `isGet` parameter in Cloud Code trigger `beforeFind`

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2398,9 +2398,9 @@ describe('beforeFind hooks', () => {
     });
   });
 
-  it('sets correct beforeFind trigger isGet parameter for Parse.Object.get request', async() => {
+  fit('sets correct beforeFind trigger isGet parameter for Parse.Object.fetch request', async () => {
     const hook = {
-      method: (req) => {
+      method: req => {
         expect(req.isGet).toEqual(true);
         return Promise.resolve();
       },
@@ -2409,14 +2409,31 @@ describe('beforeFind hooks', () => {
     Parse.Cloud.beforeFind('MyObject', hook.method);
     const obj = new Parse.Object('MyObject');
     await obj.save();
-    const getObj = await obj.get();
+    const getObj = await obj.fetch();
     expect(getObj).toBeInstanceOf(Parse.Object);
     expect(hook.method).toHaveBeenCalledTimes(1);
   });
 
-  it('sets correct beforeFind trigger isGet parameter for Parse.Query.find request', async() => {
+  fit('sets correct beforeFind trigger isGet parameter for Parse.Query.get request', async () => {
     const hook = {
-      method: (req) => {
+      method: req => {
+        expect(req.isGet).toEqual(true);
+        return Promise.resolve();
+      },
+    };
+    spyOn(hook, 'method').and.callThrough();
+    Parse.Cloud.beforeFind('MyObject', hook.method);
+    const obj = new Parse.Object('MyObject');
+    await obj.save();
+    const query = new Parse.Query('MyObject');
+    const getObj = await query.get(obj.id);
+    expect(getObj).toBeInstanceOf(Parse.Object);
+    expect(hook.method).toHaveBeenCalledTimes(1);
+  });
+
+  fit('sets correct beforeFind trigger isGet parameter for Parse.Query.find request', async () => {
+    const hook = {
+      method: req => {
         expect(req.isGet).toEqual(false);
         return Promise.resolve();
       },

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2411,7 +2411,7 @@ describe('beforeFind hooks', () => {
     await obj.save();
     const getObj = await obj.get();
     expect(getObj).toBeInstanceOf(Parse.Object);
-    expect(hook.method).toHaveBeenCalled(1);
+    expect(hook.method).toHaveBeenCalledTimes(1);
   });
 
   it('sets correct beforeFind trigger isGet parameter for Parse.Query.find request', async() => {
@@ -2428,7 +2428,7 @@ describe('beforeFind hooks', () => {
     const query = new Parse.Query('MyObject');
     const findObjs = await query.find();
     expect(findObjs?.[0]).toBeInstanceOf(Parse.Object);
-    expect(hook.method).toHaveBeenCalled(1);
+    expect(hook.method).toHaveBeenCalledTimes(1);
   });
 
   it('should have request headers', done => {

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2417,7 +2417,7 @@ describe('beforeFind hooks', () => {
   fit('sets correct beforeFind trigger isGet parameter for Parse.Query.get request', async () => {
     const hook = {
       method: req => {
-        expect(req.isGet).toEqual(true);
+        expect(req.isGet).toEqual(false);
         return Promise.resolve();
       },
     };

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2398,7 +2398,7 @@ describe('beforeFind hooks', () => {
     });
   });
 
-  fit('sets correct beforeFind trigger isGet parameter for Parse.Object.fetch request', async () => {
+  it('sets correct beforeFind trigger isGet parameter for Parse.Object.fetch request', async () => {
     const hook = {
       method: req => {
         expect(req.isGet).toEqual(true);
@@ -2414,7 +2414,7 @@ describe('beforeFind hooks', () => {
     expect(hook.method).toHaveBeenCalledTimes(1);
   });
 
-  fit('sets correct beforeFind trigger isGet parameter for Parse.Query.get request', async () => {
+  it('sets correct beforeFind trigger isGet parameter for Parse.Query.get request', async () => {
     const hook = {
       method: req => {
         expect(req.isGet).toEqual(false);
@@ -2431,7 +2431,7 @@ describe('beforeFind hooks', () => {
     expect(hook.method).toHaveBeenCalledTimes(1);
   });
 
-  fit('sets correct beforeFind trigger isGet parameter for Parse.Query.find request', async () => {
+  it('sets correct beforeFind trigger isGet parameter for Parse.Query.find request', async () => {
     const hook = {
       method: req => {
         expect(req.isGet).toEqual(false);

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2398,6 +2398,39 @@ describe('beforeFind hooks', () => {
     });
   });
 
+  it('sets correct beforeFind trigger isGet parameter for Parse.Object.get request', async() => {
+    const hook = {
+      method: (req) => {
+        expect(req.isGet).toEqual(true);
+        return Promise.resolve();
+      },
+    };
+    spyOn(hook, 'method').and.callThrough();
+    Parse.Cloud.beforeFind('MyObject', hook.method);
+    const obj = new Parse.Object('MyObject');
+    await obj.save();
+    const getObj = await obj.get();
+    expect(getObj).toBeInstanceOf(Parse.Object);
+    expect(hook.method).toHaveBeenCalled(1);
+  });
+
+  it('sets correct beforeFind trigger isGet parameter for Parse.Query.find request', async() => {
+    const hook = {
+      method: (req) => {
+        expect(req.isGet).toEqual(false);
+        return Promise.resolve();
+      },
+    };
+    spyOn(hook, 'method').and.callThrough();
+    Parse.Cloud.beforeFind('MyObject', hook.method);
+    const obj = new Parse.Object('MyObject');
+    await obj.save();
+    const query = new Parse.Query('MyObject');
+    const findObjs = await query.find();
+    expect(findObjs?.[0]).toBeInstanceOf(Parse.Object);
+    expect(hook.method).toHaveBeenCalled(1);
+  });
+
   it('should have request headers', done => {
     Parse.Cloud.beforeFind('MyObject', req => {
       expect(req.headers).toBeDefined();


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/8736

There are 3 ways of getting an object, in all cases the `isGet` in the beforeFind trigger should be correct; correct here means unchanged compared to behavior in version 6.2.1, to ensure release 6.2.2 did not break that behavior.

Behavior in 6.2.1:
- Parse.Query.get --> isGet == false
- Parse.Query.find --> isGet == false
- Parse.Object.fetch --> isGet == true

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
