### PR TITLE
fix: Parse Server option `fileUpload.fileExtensions` fails to determine file extension if filename contains multiple dots

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1398,6 +1398,7 @@ describe('Parse.File testing', () => {
       await reconfigureServer({
         fileUpload: {
           enableForPublic: true,
+          fileExtensions: ['^[^hH][^tT][^mM][^lL]?$'],
         },
       });
       const headers = {

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1368,6 +1368,7 @@ describe('Parse.File testing', () => {
       await reconfigureServer({
         fileUpload: {
           enableForPublic: true,
+          fileExtensions: ['^[^hH][^tT][^mM][^lL]?$'],
         },
       });
       const headers = {

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1364,6 +1364,30 @@ describe('Parse.File testing', () => {
       );
     });
 
+    it('works with a period in the file name', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          enableForPublic: true,
+        },
+      });
+      const headers = {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+      };
+      await expectAsync(
+        request({
+          method: 'POST',
+          headers: headers,
+          url: 'http://localhost:8378/1/files/file.png.html',
+          body: '<html></html>\n',
+        }).catch(e => {
+          throw new Error(e.data.error);
+        })
+      ).toBeRejectedWith(
+        new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `File upload of extension html is disabled.`)
+      );
+    });
+
     it('works with array', async () => {
       await reconfigureServer({
         fileUpload: {

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1374,18 +1374,60 @@ describe('Parse.File testing', () => {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest',
       };
-      await expectAsync(
-        request({
-          method: 'POST',
-          headers: headers,
-          url: 'http://localhost:8378/1/files/file.png.html',
-          body: '<html></html>\n',
-        }).catch(e => {
-          throw new Error(e.data.error);
-        })
-      ).toBeRejectedWith(
-        new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `File upload of extension html is disabled.`)
-      );
+
+      const values = ['file.png.html', 'file.txt.png.html', 'file.png.txt.html'];
+
+      for (const value of values) {
+        await expectAsync(
+          request({
+            method: 'POST',
+            headers: headers,
+            url: `http://localhost:8378/1/files/${value}`,
+            body: '<html></html>\n',
+          }).catch(e => {
+            throw new Error(e.data.error);
+          })
+        ).toBeRejectedWith(
+          new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `File upload of extension html is disabled.`)
+        );
+      }
+    });
+
+    it('works to stop invalid filenames', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          enableForPublic: true,
+        },
+      });
+      const headers = {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+      };
+
+      const values = [
+        '!invalid.png',
+        '.png',
+        '.html',
+        ' .html',
+        '.png.html',
+        '~invalid.png',
+        '-invalid.png',
+      ];
+
+      for (const value of values) {
+        await expectAsync(
+          request({
+            method: 'POST',
+            headers: headers,
+            url: `http://localhost:8378/1/files/${value}`,
+            body: '<html></html>\n',
+          }).catch(e => {
+            throw new Error(e.data.error);
+          })
+        ).toBeRejectedWith(
+          new Parse.Error(Parse.Error.INVALID_FILE_NAME, `Filename contains invalid characters.`)
+        );
+      }
     });
 
     it('works with array', async () => {

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -155,7 +155,7 @@ export class FilesRouter {
       };
       let extension = contentType;
       if (filename && filename.includes('.')) {
-        extension = filename.split('.')[1];
+        extension = filename.split('.')[filename.split('.').length - 1];
       } else if (contentType && contentType.includes('/')) {
         extension = contentType.split('/')[1];
       }

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -155,7 +155,7 @@ export class FilesRouter {
       };
       let extension = contentType;
       if (filename && filename.includes('.')) {
-        extension = filename.split('.')[filename.split('.').length - 1];
+        extension = filename.substring(filename.lastIndexOf('.') + 1);
       } else if (contentType && contentType.includes('/')) {
         extension = contentType.split('/')[1];
       }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8753 

## Approach
<!-- Describe the changes in this PR. -->

Use the last index of period to determine extension

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests

