### PR TITLE
fix: GridFS file storage doesn't work with certain `enableSchemaHooks` settings

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -61,6 +61,9 @@ if (process.env.PARSE_SERVER_TEST_DB === 'postgres') {
   databaseAdapter = new MongoStorageAdapter({
     uri: mongoURI,
     collectionPrefix: 'test_',
+    mongoOptions: {
+      enableSchemaHooks: true,
+    }
   });
 }
 

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -104,7 +104,10 @@ export function getFilesController(options: ParseServerOptions): FilesController
     throw 'When using an explicit database adapter, you must also use an explicit filesAdapter.';
   }
   const filesControllerAdapter = loadAdapter(filesAdapter, () => {
-    return new GridFSBucketAdapter(databaseURI, databaseOptions, fileKey);
+    const newDatabaseOptions = { ...databaseOptions };
+    // enableSchemaHooks is not a valid mongodb option
+    delete newDatabaseOptions.enableSchemaHooks;  
+    return new GridFSBucketAdapter(databaseURI, newDatabaseOptions, fileKey);
   });
   return new FilesController(filesControllerAdapter, appId, {
     preserveFileName,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
[https://github.com/parse-community/parse-server/issues/8353](https://github.com/parse-community/parse-server/issues/8353)

Closes: 8353

## Approach
Remove enableSchemaHooks option before passing database options into GridFSBucketAdapter

## Tasks

- [x ] Add tests - tests updated
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
