### PR TITLE
ci: Add ability to exclude tests via ID in `testExclusionList.json`

### DIFF
--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -15,6 +15,7 @@
       "equal": true,
       "expectAsync": true,
       "notEqual": true,
+      "it_id": true,
       "it_only_db": true,
       "it_only_mongodb_version": true,
       "it_only_postgres_version": true,

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -428,6 +428,18 @@ global.it_exclude_dbs = excluded => {
   }
 };
 
+// Fetch test exclusion list
+const testExclusionList = require('./testExclusionList.json');
+
+// Bypass test if Test UUID found in testExclusionList
+global.it_id = id => {
+  if (testExclusionList.includes(id)) {
+    return xit;
+  } else {
+    return it;
+  }
+};
+
 global.it_only_db = db => {
   if (
     process.env.PARSE_SERVER_TEST_DB === db ||

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -428,7 +428,7 @@ global.it_exclude_dbs = excluded => {
   }
 };
 
-var testExclusionList = [];
+let testExclusionList = [];
 try {
   // Fetch test exclusion list
   testExclusionList = require('./testExclusionList.json');
@@ -439,7 +439,7 @@ try {
   }
 }
 
-// Bypass test if Test UUID found in testExclusionList
+// Disable test if its UUID is found in testExclusionList
 global.it_id = id => {
   if (testExclusionList.includes(id)) {
     return xit;

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -428,8 +428,16 @@ global.it_exclude_dbs = excluded => {
   }
 };
 
-// Fetch test exclusion list
-const testExclusionList = require('./testExclusionList.json');
+var testExclusionList = [];
+try {
+  // Fetch test exclusion list
+  testExclusionList = require('./testExclusionList.json');
+  console.log("testExclusionList.json Found")
+} catch(error) {
+  if(error.code === "MODULE_NOT_FOUND") {
+    // Even though it says require, it's not.  Don't fail
+  }
+}
 
 // Bypass test if Test UUID found in testExclusionList
 global.it_id = id => {

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -428,14 +428,14 @@ global.it_exclude_dbs = excluded => {
   }
 };
 
-var testExclusionList = [];
+let testExclusionList = [];
 try {
   // Fetch test exclusion list
   testExclusionList = require('./testExclusionList.json');
-  console.log("testExclusionList.json Found")
+  console.log(`Using test exclusion list with ${testExclusionList.length} entries`);
 } catch(error) {
-  if(error.code === "MODULE_NOT_FOUND") {
-    // Even though it says require, it's not.  Don't fail
+  if(error.code !== 'MODULE_NOT_FOUND') {
+    throw error;
   }
 }
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -440,11 +440,14 @@ try {
 }
 
 // Disable test if its UUID is found in testExclusionList
-global.it_id = id => {
+global.it_id = (id, func) => {
   if (testExclusionList.includes(id)) {
     return xit;
   } else {
-    return it;
+    if(func === undefined)
+      return it;
+    else
+      return func;
   }
 };
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -432,10 +432,10 @@ var testExclusionList = [];
 try {
   // Fetch test exclusion list
   testExclusionList = require('./testExclusionList.json');
-  console.log("testExclusionList.json Found")
+  console.log(`Using test exclusion list with ${testExclusionList.length} entries`);
 } catch(error) {
-  if(error.code === "MODULE_NOT_FOUND") {
-    // Even though it says require, it's not.  Don't fail
+  if(error.code !== 'MODULE_NOT_FOUND') {
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Pull Request


## Issue

Add support for testExclusionList so different adapter repos can exclude tests specific to that adapter.
Move test exclusion out of the main parse-server repo
Closes: https://github.com/parse-community/parse-server/issues/8714

## Approach
This PR adds the ability in helper.js to exclude tests based on a uuid
A file, testExclusionList is created in the spec dir and looks like
```
[
"bbd9e2f6-7f61-458f-98f2-4a563586cd8d",
"e1e86b38-b8a4-4109-8330-a324fe628e0c",
"05f1a454-56b1-4f2e-908e-408a9222cbae",
"9ee376ad-dd6c-4c17-ad28-c7899a4411f1"
]
```
and tests to be excluded are prefixed like
`
  it_id('bbd9e2f6-7f61-458f-98f2-4a563586cd8d')('geo line', async done => {
` 
