### PR TITLE
feat: Add `$setOnInsert` operator to `Parse.Server.database.update`

### DIFF
--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -225,11 +225,11 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       },
       classLevelPermissions: {},
     };
-    
+
     const myClassSchema = new Parse.Schema(schema.className);
     myClassSchema.setCLP(schema.classLevelPermissions);
     await myClassSchema.save();
-    
+
     const query = {
       x: 1,
     };

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -213,10 +213,17 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       });
   });
 
-  it('upserts with $setOnInsert', async () => {
+  fit('upserts with $setOnInsert', async () => {
     const uuid = require('uuid');
     const uuid1 = uuid.v4();
     const uuid2 = uuid.v4();
+    const schema = {
+      className: 'MyClass',
+      fields: {
+        x: { type: 'Number' },
+        count: { type: 'Number' },
+      },
+    };
     const query = {
       x: 1,
     };
@@ -225,7 +232,6 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
         __op: 'SetOnInsert',
         amount: uuid1,
       },
-      x: 1,
       count: {
         __op: 'Increment',
         amount: 1,
@@ -244,12 +250,18 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       update,
       { upsert: true },
     );
-    const q = new Parse.Query('MyClass');
-    const docs = await q.find();
-    expect(docs.length).toBe(1);
-    expect(docs[0].id).toBe(uuid1);
-    expect(docs[0].get('x')).toBe(1);
-    expect(docs[0].get('count')).toBe(2);
+    // const res = await Parse.Server.database.find(
+    //   schema.className,
+    //   schema,
+    //   {},
+    //   {},
+    // );
+    // const q = new Parse.Query('MyClass');
+    // const docs = await q.find();
+    // expect(docs.length).toBe(1);
+    // expect(docs[0].id).toBe(uuid1);
+    // expect(docs[0].get('x')).toBe(1);
+    // expect(docs[0].get('count')).toBe(2);
   });
 
   it('handles updating a single object with array, object date', done => {

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -213,6 +213,44 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       });
   });
 
+  it('upserts with $setOnInsert', async () => {
+    const uuid = require('uuid');
+    const schema = {
+      className: 'MyClass',
+      fields: {
+        x: { type: 'Number' },
+        count: { type: 'Number' },
+      },
+    };
+    const query = {
+      x: 1,
+    };
+    const update = {
+      objectId: {
+        __op: 'SetOnInsert',
+        amount: uuid.v4(),
+      },
+      x: 1,
+      count: {
+        __op: 'Increment',
+        amount: 1,
+      },
+    };
+    const res1 = await Parse.Server.database.update(
+      schema,
+      query,
+      update,
+      { upsert: true },
+    );
+    update.objectId.amount = uuid.v4();
+    const res2 = await Parse.Server.database.update(
+      schema,
+      query,
+      update,
+      { upsert: true },
+    );
+  });
+
   it('handles updating a single object with array, object date', done => {
     const adapter = new MongoStorageAdapter({ uri: databaseURI });
 

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -213,7 +213,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       });
   });
 
-  fit('upserts with $setOnInsert', async () => {
+  it('upserts with $setOnInsert', async () => {
     const uuid = require('uuid');
     const uuid1 = uuid.v4();
     const uuid2 = uuid.v4();
@@ -223,7 +223,13 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
         x: { type: 'Number' },
         count: { type: 'Number' },
       },
+      classLevelPermissions: {},
     };
+    
+    const myClassSchema = new Parse.Schema(schema.className);
+    myClassSchema.setCLP(schema.classLevelPermissions);
+    await myClassSchema.save();
+    
     const query = {
       x: 1,
     };
@@ -250,18 +256,16 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       update,
       { upsert: true },
     );
-    // const res = await Parse.Server.database.find(
-    //   schema.className,
-    //   schema,
-    //   {},
-    //   {},
-    // );
-    // const q = new Parse.Query('MyClass');
-    // const docs = await q.find();
-    // expect(docs.length).toBe(1);
-    // expect(docs[0].id).toBe(uuid1);
-    // expect(docs[0].get('x')).toBe(1);
-    // expect(docs[0].get('count')).toBe(2);
+
+    const res = await Parse.Server.database.find(
+      schema.className,
+      {},
+      {},
+    );
+    expect(res.length).toBe(1);
+    expect(res[0].objectId).toBe(uuid1);
+    expect(res[0].count).toBe(2);
+    expect(res[0].x).toBe(1);
   });
 
   it('handles updating a single object with array, object date', done => {

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -215,20 +215,15 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
 
   it('upserts with $setOnInsert', async () => {
     const uuid = require('uuid');
-    const schema = {
-      className: 'MyClass',
-      fields: {
-        x: { type: 'Number' },
-        count: { type: 'Number' },
-      },
-    };
+    const uuid1 = uuid.v4();
+    const uuid2 = uuid.v4();
     const query = {
       x: 1,
     };
     const update = {
       objectId: {
         __op: 'SetOnInsert',
-        amount: uuid.v4(),
+        amount: uuid1,
       },
       x: 1,
       count: {
@@ -236,19 +231,25 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
         amount: 1,
       },
     };
-    const res1 = await Parse.Server.database.update(
-      schema,
+    await Parse.Server.database.update(
+      'MyClass',
       query,
       update,
       { upsert: true },
     );
-    update.objectId.amount = uuid.v4();
-    const res2 = await Parse.Server.database.update(
-      schema,
+    update.objectId.amount = uuid2;
+    await Parse.Server.database.update(
+      'MyClass',
       query,
       update,
       { upsert: true },
     );
+    const q = new Parse.Query('MyClass');
+    const docs = await q.find();
+    expect(docs.length).toBe(1);
+    expect(docs[0].id).toBe(uuid1);
+    expect(docs[0].get('x')).toBe(1);
+    expect(docs[0].get('count')).toBe(2);
   });
 
   it('handles updating a single object with array, object date', done => {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -976,6 +976,13 @@ function transformUpdateOperator({ __op, amount, objects }, flatten) {
         return { __op: '$inc', arg: amount };
       }
 
+    case 'SetOnInsert':
+      if (flatten) {
+        return amount;
+      } else {
+        return { __op: '$setOnInsert', arg: amount };
+      }
+
     case 'Add':
     case 'AddUnique':
       if (!(objects instanceof Array)) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -272,6 +272,9 @@ const flattenUpdateOperatorsForCreate = object => {
           }
           object[key] = object[key].amount;
           break;
+        case 'SetOnInsert':
+          object[key] = object[key].amount;
+          break;
         case 'Add':
           if (!(object[key].objects instanceof Array)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
@@ -1813,7 +1816,7 @@ class DatabaseController {
         keyUpdate &&
         typeof keyUpdate === 'object' &&
         keyUpdate.__op &&
-        ['Add', 'AddUnique', 'Remove', 'Increment'].indexOf(keyUpdate.__op) > -1
+        ['Add', 'AddUnique', 'Remove', 'Increment', 'SetOnInsert'].indexOf(keyUpdate.__op) > -1
       ) {
         // only valid ops that produce an actionable result
         // the op may have happened on a keypath


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8792

## Approach

Add support for `$setOnInsert`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests