### PR TITLE
feat: Add `$setOnInsert` operator to `Parse.Server.database.update`

### DIFF
--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -254,6 +254,44 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     expect(obj.get('foo').test.date[0] instanceof Date).toBeTrue();
   });
 
+  it('upserts with $setOnInsert', async () => {
+    const uuid = require('uuid');
+    const schema = {
+      className: 'MyClass',
+      fields: {
+        x: { type: 'Number' },
+        count: { type: 'Number' },
+      },
+    };
+    const query = {
+      x: 1,
+    };
+    const update = {
+      objectId: {
+        __op: 'SetOnInsert',
+        amount: uuid.v4(),
+      },
+      x: 1,
+      count: {
+        __op: 'Increment',
+        amount: 1,
+      },
+    };
+    const res1 = await Parse.Server.database.update(
+      schema,
+      query,
+      update,
+      { upsert: true },
+    );
+    update.objectId.amount = uuid.v4();
+    const res2 = await Parse.Server.database.update(
+      schema,
+      query,
+      update,
+      { upsert: true },
+    );
+  });
+  
   it('handles updating a single object with array, object date', done => {
     const adapter = new MongoStorageAdapter({ uri: databaseURI });
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -986,6 +986,13 @@ function transformUpdateOperator({ __op, amount, objects }, flatten) {
         return { __op: '$inc', arg: amount };
       }
 
+    case 'SetOnInsert':
+      if (flatten) {
+        return amount;
+      } else {
+        return { __op: '$setOnInsert', arg: amount };
+      }
+
     case 'Add':
     case 'AddUnique':
       if (!(objects instanceof Array)) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -279,6 +279,9 @@ const flattenUpdateOperatorsForCreate = object => {
           }
           object[key] = object[key].amount;
           break;
+        case 'SetOnInsert':
+          object[key] = object[key].amount;
+          break;
         case 'Add':
           if (!(object[key].objects instanceof Array)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
@@ -1817,7 +1820,7 @@ class DatabaseController {
         keyUpdate &&
         typeof keyUpdate === 'object' &&
         keyUpdate.__op &&
-        ['Add', 'AddUnique', 'Remove', 'Increment'].indexOf(keyUpdate.__op) > -1
+        ['Add', 'AddUnique', 'Remove', 'Increment', 'SetOnInsert'].indexOf(keyUpdate.__op) > -1
       ) {
         // only valid ops that produce an actionable result
         // the op may have happened on a keypath


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8792

## Approach

Add support for `$setOnInsert`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests