### PR TITLE
fix: Typo in RestWrite.js

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1379,7 +1379,7 @@ RestWrite.prototype.handleInstallation = function () {
               this.data.objectId &&
               idMatch.objectId == this.data.objectId
             ) {
-              // we passed an objectId, preserve that instalation
+              // we passed an objectId, preserve that Installation
               delQuery['objectId'] = {
                 $ne: idMatch.objectId,
               };


### PR DESCRIPTION
This PR fixes typos in **src/RestWrite.js** file.

Following typos have been fixed:

`instalation` -> `Installation`


No other changes.
