### PR TITLE
feat: Add compatibility for MongoDB Atlas Serverless and AWS Amazon DocumentDB with collation options `enableCollationCaseComparison`, `convertEmailToLowercase`, `convertUsernameToLowercase`

### DIFF
--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -363,7 +363,7 @@ describe('DatabaseController', function () {
     });
   });
 
-  describe('disableCollation', () => {
+  describe('enableCollationCaseComparison', () => {
     const dummyStorageAdapter = {
       find: () => Promise.resolve([]),
       watch: () => Promise.resolve(),
@@ -374,9 +374,9 @@ describe('DatabaseController', function () {
       Config.get(Parse.applicationId).schemaCache.clear();
     });
 
-    it('should force caseInsensitive to false with disableCollation option', async () => {
+    it('should force caseInsensitive to false with enableCollationCaseComparison option', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {
-        disableCollation: true,
+        enableCollationCaseComparison: true,
       });
       const spy = spyOn(dummyStorageAdapter, 'find');
       spy.and.callThrough();
@@ -384,7 +384,7 @@ describe('DatabaseController', function () {
       expect(spy.calls.all()[0].args[3].caseInsensitive).toEqual(false);
     });
 
-    it('should support caseInsensitive without disableCollation option', async () => {
+    it('should support caseInsensitive without enableCollationCaseComparison option', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {});
       const spy = spyOn(dummyStorageAdapter, 'find');
       spy.and.callThrough();
@@ -392,51 +392,57 @@ describe('DatabaseController', function () {
       expect(spy.calls.all()[0].args[3].caseInsensitive).toEqual(true);
     });
 
-    it_only_db('mongo')('should create insensitive indexes without disableCollation', async () => {
-      await reconfigureServer({
-        databaseURI: 'mongodb://localhost:27017/disableCollationFalse',
-        databaseAdapter: undefined,
-      });
-      const user = new Parse.User();
-      await user.save({
-        username: 'example',
-        password: 'password',
-        email: 'example@example.com',
-      });
-      const schemas = await Parse.Schema.all();
-      const UserSchema = schemas.find(({ className }) => className === '_User');
-      expect(UserSchema.indexes).toEqual({
-        _id_: { _id: 1 },
-        username_1: { username: 1 },
-        case_insensitive_username: { username: 1 },
-        case_insensitive_email: { email: 1 },
-        email_1: { email: 1 },
-      });
-    });
+    it_only_db('mongo')(
+      'should create insensitive indexes without enableCollationCaseComparison',
+      async () => {
+        await reconfigureServer({
+          databaseURI: 'mongodb://localhost:27017/enableCollationCaseComparisonFalse',
+          databaseAdapter: undefined,
+        });
+        const user = new Parse.User();
+        await user.save({
+          username: 'example',
+          password: 'password',
+          email: 'example@example.com',
+        });
+        const schemas = await Parse.Schema.all();
+        const UserSchema = schemas.find(({ className }) => className === '_User');
+        expect(UserSchema.indexes).toEqual({
+          _id_: { _id: 1 },
+          username_1: { username: 1 },
+          case_insensitive_username: { username: 1 },
+          case_insensitive_email: { email: 1 },
+          email_1: { email: 1 },
+        });
+      }
+    );
 
-    it_only_db('mongo')('should not create insensitive indexes with disableCollation', async () => {
-      await reconfigureServer({
-        disableCollation: true,
-        databaseURI: 'mongodb://localhost:27017/disableCollationTrue',
-        databaseAdapter: undefined,
-      });
-      const user = new Parse.User();
-      await user.save({
-        username: 'example',
-        password: 'password',
-        email: 'example@example.com',
-      });
-      const schemas = await Parse.Schema.all();
-      const UserSchema = schemas.find(({ className }) => className === '_User');
-      expect(UserSchema.indexes).toEqual({
-        _id_: { _id: 1 },
-        username_1: { username: 1 },
-        email_1: { email: 1 },
-      });
-    });
+    it_only_db('mongo')(
+      'should not create insensitive indexes with enableCollationCaseComparison',
+      async () => {
+        await reconfigureServer({
+          enableCollationCaseComparison: true,
+          databaseURI: 'mongodb://localhost:27017/enableCollationCaseComparisonTrue',
+          databaseAdapter: undefined,
+        });
+        const user = new Parse.User();
+        await user.save({
+          username: 'example',
+          password: 'password',
+          email: 'example@example.com',
+        });
+        const schemas = await Parse.Schema.all();
+        const UserSchema = schemas.find(({ className }) => className === '_User');
+        expect(UserSchema.indexes).toEqual({
+          _id_: { _id: 1 },
+          username_1: { username: 1 },
+          email_1: { email: 1 },
+        });
+      }
+    );
   });
 
-  describe('transformEmailToLowerCase', () => {
+  describe('convertEmailToLowercase', () => {
     const dummyStorageAdapter = {
       createObject: () => Promise.resolve({ ops: [{}] }),
       findOneAndUpdate: () => Promise.resolve({}),
@@ -456,7 +462,7 @@ describe('DatabaseController', function () {
       updatedAt: { iso: undefined, __type: 'Date' },
     };
 
-    it('should not transform email to lower case without transformEmailToLowerCase option on create', async () => {
+    it('should not transform email to lower case without convertEmailToLowercase option on create', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {});
       const spy = spyOn(dummyStorageAdapter, 'createObject');
       spy.and.callThrough();
@@ -469,9 +475,9 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should transform email to lower case with transformEmailToLowerCase option on create', async () => {
+    it('should transform email to lower case with convertEmailToLowercase option on create', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {
-        transformEmailToLowerCase: true,
+        convertEmailToLowercase: true,
       });
       const spy = spyOn(dummyStorageAdapter, 'createObject');
       spy.and.callThrough();
@@ -484,7 +490,7 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should not transform email to lower case without transformEmailToLowerCase option on update', async () => {
+    it('should not transform email to lower case without convertEmailToLowercase option on update', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {});
       const spy = spyOn(dummyStorageAdapter, 'findOneAndUpdate');
       spy.and.callThrough();
@@ -494,9 +500,9 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should transform email to lower case with transformEmailToLowerCase option on update', async () => {
+    it('should transform email to lower case with convertEmailToLowercase option on update', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {
-        transformEmailToLowerCase: true,
+        convertEmailToLowercase: true,
       });
       const spy = spyOn(dummyStorageAdapter, 'findOneAndUpdate');
       spy.and.callThrough();
@@ -506,8 +512,8 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should not find a case insensitive user by email with transformEmailToLowerCase', async () => {
-      await reconfigureServer({ transformEmailToLowerCase: true });
+    it('should not find a case insensitive user by email with convertEmailToLowercase', async () => {
+      await reconfigureServer({ convertEmailToLowercase: true });
       const user = new Parse.User();
       await user.save({ email: 'EXAMPLE@EXAMPLE.COM', password: 'password' });
 
@@ -523,7 +529,7 @@ describe('DatabaseController', function () {
     });
   });
 
-  describe('transformUsernameToLowerCase', () => {
+  describe('convertUsernameToLowercase', () => {
     const dummyStorageAdapter = {
       createObject: () => Promise.resolve({ ops: [{}] }),
       findOneAndUpdate: () => Promise.resolve({}),
@@ -543,7 +549,7 @@ describe('DatabaseController', function () {
       updatedAt: { iso: undefined, __type: 'Date' },
     };
 
-    it('should not transform username to lower case without transformUsernameToLowerCase option on create', async () => {
+    it('should not transform username to lower case without convertUsernameToLowercase option on create', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {});
       const spy = spyOn(dummyStorageAdapter, 'createObject');
       spy.and.callThrough();
@@ -556,9 +562,9 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should transform username to lower case with transformUsernameToLowerCase option on create', async () => {
+    it('should transform username to lower case with convertUsernameToLowercase option on create', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {
-        transformUsernameToLowerCase: true,
+        convertUsernameToLowercase: true,
       });
       const spy = spyOn(dummyStorageAdapter, 'createObject');
       spy.and.callThrough();
@@ -571,7 +577,7 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should not transform username to lower case without transformUsernameToLowerCase option on update', async () => {
+    it('should not transform username to lower case without convertUsernameToLowercase option on update', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {});
       const spy = spyOn(dummyStorageAdapter, 'findOneAndUpdate');
       spy.and.callThrough();
@@ -581,9 +587,9 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should transform username to lower case with transformUsernameToLowerCase option on update', async () => {
+    it('should transform username to lower case with convertUsernameToLowercase option on update', async () => {
       const databaseController = new DatabaseController(dummyStorageAdapter, {
-        transformUsernameToLowerCase: true,
+        convertUsernameToLowercase: true,
       });
       const spy = spyOn(dummyStorageAdapter, 'findOneAndUpdate');
       spy.and.callThrough();
@@ -593,8 +599,8 @@ describe('DatabaseController', function () {
       });
     });
 
-    it('should not find a case insensitive user by username with transformUsernameToLowerCase', async () => {
-      await reconfigureServer({ transformUsernameToLowerCase: true });
+    it('should not find a case insensitive user by username with convertUsernameToLowercase', async () => {
+      await reconfigureServer({ convertUsernameToLowercase: true });
       const user = new Parse.User();
       await user.save({ username: 'EXAMPLE', password: 'password' });
 

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -515,7 +515,7 @@ describe('DatabaseController', function () {
     it('should not find a case insensitive user by email with convertEmailToLowercase', async () => {
       await reconfigureServer({ convertEmailToLowercase: true });
       const user = new Parse.User();
-      await user.save({ email: 'EXAMPLE@EXAMPLE.COM', password: 'password' });
+      await user.save({ username: 'EXAMPLE', email: 'EXAMPLE@EXAMPLE.COM', password: 'password' });
 
       const query = new Parse.Query(Parse.User);
       query.equalTo('email', 'EXAMPLE@EXAMPLE.COM');

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -368,6 +368,22 @@ const relationSchema = {
   fields: { relatedId: { type: 'String' }, owningId: { type: 'String' } },
 };
 
+const transformEmailToLowerCase = (object, className, options) => {
+  if (className === '_User' && options.transformEmailToLowerCase) {
+    if (typeof object['email'] === 'string') {
+      object['email'] = object['email'].toLowerCase();
+    }
+  }
+};
+
+const transformUsernameToLowerCase = (object, className, options) => {
+  if (className === '_User' && options.transformUsernameToLowerCase) {
+    if (typeof object['username'] === 'string') {
+      object['username'] = object['username'].toLowerCase();
+    }
+  }
+};
+
 class DatabaseController {
   adapter: StorageAdapter;
   schemaCache: any;
@@ -573,6 +589,8 @@ class DatabaseController {
                 }
               }
               update = transformObjectACL(update);
+              transformEmailToLowerCase(update, className, this.options);
+              transformUsernameToLowerCase(update, className, this.options);
               transformAuthData(className, update, schema);
               if (validateOnly) {
                 return this.adapter.find(className, schema, query, {}).then(result => {
@@ -822,6 +840,8 @@ class DatabaseController {
     const originalObject = object;
     object = transformObjectACL(object);
 
+    transformEmailToLowerCase(object, className, this.options);
+    transformUsernameToLowerCase(object, className, this.options);
     object.createdAt = { iso: object.createdAt, __type: 'Date' };
     object.updatedAt = { iso: object.updatedAt, __type: 'Date' };
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -368,16 +368,16 @@ const relationSchema = {
   fields: { relatedId: { type: 'String' }, owningId: { type: 'String' } },
 };
 
-const transformEmailToLowerCase = (object, className, options) => {
-  if (className === '_User' && options.transformEmailToLowerCase) {
+const convertEmailToLowercase = (object, className, options) => {
+  if (className === '_User' && options.convertEmailToLowercase) {
     if (typeof object['email'] === 'string') {
       object['email'] = object['email'].toLowerCase();
     }
   }
 };
 
-const transformUsernameToLowerCase = (object, className, options) => {
-  if (className === '_User' && options.transformUsernameToLowerCase) {
+const convertUsernameToLowercase = (object, className, options) => {
+  if (className === '_User' && options.convertUsernameToLowercase) {
     if (typeof object['username'] === 'string') {
       object['username'] = object['username'].toLowerCase();
     }
@@ -589,8 +589,8 @@ class DatabaseController {
                 }
               }
               update = transformObjectACL(update);
-              transformEmailToLowerCase(update, className, this.options);
-              transformUsernameToLowerCase(update, className, this.options);
+              convertEmailToLowercase(update, className, this.options);
+              convertUsernameToLowercase(update, className, this.options);
               transformAuthData(className, update, schema);
               if (validateOnly) {
                 return this.adapter.find(className, schema, query, {}).then(result => {
@@ -840,8 +840,8 @@ class DatabaseController {
     const originalObject = object;
     object = transformObjectACL(object);
 
-    transformEmailToLowerCase(object, className, this.options);
-    transformUsernameToLowerCase(object, className, this.options);
+    convertEmailToLowercase(object, className, this.options);
+    convertUsernameToLowercase(object, className, this.options);
     object.createdAt = { iso: object.createdAt, __type: 'Date' };
     object.updatedAt = { iso: object.updatedAt, __type: 'Date' };
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1235,7 +1235,7 @@ class DatabaseController {
             keys,
             readPreference,
             hint,
-            caseInsensitive,
+            caseInsensitive: this.options.enableCollationCaseComparison ? false : caseInsensitive,
             explain,
           };
           Object.keys(sort).forEach(fieldName => {
@@ -1739,24 +1739,26 @@ class DatabaseController {
       throw error;
     });
 
-    await this.adapter
-      .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
-      .catch(error => {
-        logger.warn('Unable to create case insensitive username index: ', error);
-        throw error;
-      });
+    if (!this.options.enableCollationCaseComparison) {
+      await this.adapter
+        .ensureIndex('_User', requiredUserFields, ['username'], 'case_insensitive_username', true)
+        .catch(error => {
+          logger.warn('Unable to create case insensitive username index: ', error);
+          throw error;
+        });
+
+      await this.adapter
+        .ensureIndex('_User', requiredUserFields, ['email'], 'case_insensitive_email', true)
+        .catch(error => {
+          logger.warn('Unable to create case insensitive email index: ', error);
+          throw error;
+        });
+    }
 
     await this.adapter.ensureUniqueness('_User', requiredUserFields, ['email']).catch(error => {
       logger.warn('Unable to ensure uniqueness for user email addresses: ', error);
       throw error;
     });
-
-    await this.adapter
-      .ensureIndex('_User', requiredUserFields, ['email'], 'case_insensitive_email', true)
-      .catch(error => {
-        logger.warn('Unable to create case insensitive email index: ', error);
-        throw error;
-      });
 
     await this.adapter.ensureUniqueness('_Role', requiredRoleFields, ['name']).catch(error => {
       logger.warn('Unable to ensure uniqueness for role name: ', error);

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -139,6 +139,20 @@ module.exports.ParseServerOptions = {
     help: 'A collection prefix for the classes',
     default: '',
   },
+  convertEmailToLowercase: {
+    env: 'PARSE_SERVER_CONVERT_EMAIL_TO_LOWERCASE',
+    help:
+      'Optional. If set to `true`, the `email` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `email` property is stored as set, without any case modifications. Default is `false`.',
+    action: parsers.booleanParser,
+    default: false,
+  },
+  convertUsernameToLowercase: {
+    env: 'PARSE_SERVER_CONVERT_USERNAME_TO_LOWERCASE',
+    help:
+      'Optional. If set to `true`, the `username` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `username` property is stored as set, without any case modifications. Default is `false`.',
+    action: parsers.booleanParser,
+    default: false,
+  },
   customPages: {
     env: 'PARSE_SERVER_CUSTOM_PAGES',
     help: 'custom pages for password validation and reset',
@@ -175,12 +189,6 @@ module.exports.ParseServerOptions = {
     action: parsers.booleanParser,
     default: true,
   },
-  disableCollation: {
-    env: 'PARSE_SERVER_DISABLE_COLLATION',
-    help:
-      'Disable case insensitivity (collation) on queries and indexes, needed if you use MongoDB serverless or AWS DocumentDB.',
-    action: parsers.booleanParser,
-  },
   dotNetKey: {
     env: 'PARSE_SERVER_DOT_NET_KEY',
     help: 'Key for Unity and .Net SDK',
@@ -208,6 +216,13 @@ module.exports.ParseServerOptions = {
     help: 'Enable (or disable) anonymous users, defaults to true',
     action: parsers.booleanParser,
     default: true,
+  },
+  enableCollationCaseComparison: {
+    env: 'PARSE_SERVER_ENABLE_COLLATION_CASE_COMPARISON',
+    help:
+      'Optional. If set to `true`, the collation rule of case comparison for queries and indexes is enabled. Enable this option to run Parse Server with MongoDB Atlas Serverless or AWS Amazon DocumentDB. If `false`, the collation rule of case comparison is disabled. Default is `false`.',
+    action: parsers.booleanParser,
+    default: false,
   },
   enableExpressErrorHandler: {
     env: 'PARSE_SERVER_ENABLE_EXPRESS_ERROR_HANDLER',
@@ -537,18 +552,6 @@ module.exports.ParseServerOptions = {
   startLiveQueryServer: {
     env: 'PARSE_SERVER_START_LIVE_QUERY_SERVER',
     help: 'Starts the liveQuery server',
-    action: parsers.booleanParser,
-  },
-  transformEmailToLowerCase: {
-    env: 'PARSE_SERVER_TRANSFORM_EMAIL_TO_LOWER_CASE',
-    help:
-      'Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format.',
-    action: parsers.booleanParser,
-  },
-  transformUsernameToLowerCase: {
-    env: 'PARSE_SERVER_TRANSFORM_USERNAME_TO_LOWER_CASE',
-    help:
-      'Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format.',
     action: parsers.booleanParser,
   },
   trustProxy: {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -175,6 +175,12 @@ module.exports.ParseServerOptions = {
     action: parsers.booleanParser,
     default: true,
   },
+  disableCollation: {
+    env: 'PARSE_SERVER_DISABLE_COLLATION',
+    help:
+      'Disable case insensitivity (collation) on queries and indexes, needed if you use MongoDB serverless or AWS DocumentDB.',
+    action: parsers.booleanParser,
+  },
   dotNetKey: {
     env: 'PARSE_SERVER_DOT_NET_KEY',
     help: 'Key for Unity and .Net SDK',
@@ -531,6 +537,18 @@ module.exports.ParseServerOptions = {
   startLiveQueryServer: {
     env: 'PARSE_SERVER_START_LIVE_QUERY_SERVER',
     help: 'Starts the liveQuery server',
+    action: parsers.booleanParser,
+  },
+  transformEmailToLowerCase: {
+    env: 'PARSE_SERVER_TRANSFORM_EMAIL_TO_LOWER_CASE',
+    help:
+      'Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format.',
+    action: parsers.booleanParser,
+  },
+  transformUsernameToLowerCase: {
+    env: 'PARSE_SERVER_TRANSFORM_USERNAME_TO_LOWER_CASE',
+    help:
+      'Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format.',
     action: parsers.booleanParser,
   },
   trustProxy: {

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -96,6 +96,8 @@
  * @property {Number} sessionLength Session duration, in seconds, defaults to 1 year
  * @property {Boolean} silent Disables console output
  * @property {Boolean} startLiveQueryServer Starts the liveQuery server
+ * @property {Boolean} transformEmailToLowerCase Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format.
+ * @property {Boolean} transformUsernameToLowerCase Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format.
  * @property {Any} trustProxy The trust proxy settings. It is important to understand the exact setup of the reverse proxy, since this setting will trust values provided in the Parse Server API request. See the <a href="https://expressjs.com/en/guide/behind-proxies.html">express trust proxy settings</a> documentation. Defaults to `false`.
  * @property {String[]} userSensitiveFields Personally identifiable information fields in the user table the should be removed for non-authorized users. Deprecated @see protectedFields
  * @property {Boolean} verbose Set the logging to verbose

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -28,6 +28,8 @@
  * @property {String} cloud Full path to your cloud code main.js
  * @property {Number|Boolean} cluster Run with cluster, optionally set the number of processes default to os.cpus().length
  * @property {String} collectionPrefix A collection prefix for the classes
+ * @property {Boolean} convertEmailToLowercase Optional. If set to `true`, the `email` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `email` property is stored as set, without any case modifications. Default is `false`.
+ * @property {Boolean} convertUsernameToLowercase Optional. If set to `true`, the `username` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `username` property is stored as set, without any case modifications. Default is `false`.
  * @property {CustomPagesOptions} customPages custom pages for password validation and reset
  * @property {Adapter<StorageAdapter>} databaseAdapter Adapter module for the database; any options that are not explicitly described here are passed directly to the database client.
  * @property {DatabaseOptions} databaseOptions Options to pass to the database client
@@ -39,6 +41,7 @@
  * @property {Boolean} emailVerifyTokenReuseIfValid Set to `true` if a email verification token should be reused in case another token is requested but there is a token that is still valid, i.e. has not expired. This avoids the often observed issue that a user requests multiple emails and does not know which link contains a valid token because each newly generated token would invalidate the previous token.<br><br>Default is `false`.<br>Requires option `verifyUserEmails: true`.
  * @property {Number} emailVerifyTokenValidityDuration Set the validity duration of the email verification token in seconds after which the token expires. The token is used in the link that is set in the email. After the token expires, the link becomes invalid and a new link has to be sent. If the option is not set or set to `undefined`, then the token never expires.<br><br>For example, to expire the token after 2 hours, set a value of 7200 seconds (= 60 seconds * 60 minutes * 2 hours).<br><br>Default is `undefined`.<br>Requires option `verifyUserEmails: true`.
  * @property {Boolean} enableAnonymousUsers Enable (or disable) anonymous users, defaults to true
+ * @property {Boolean} enableCollationCaseComparison Optional. If set to `true`, the collation rule of case comparison for queries and indexes is enabled. Enable this option to run Parse Server with MongoDB Atlas Serverless or AWS Amazon DocumentDB. If `false`, the collation rule of case comparison is disabled. Default is `false`.
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
  * @property {Boolean} encodeParseObjectInCloudFunction If set to `true`, a `Parse.Object` that is in the payload when calling a Cloud Function will be converted to an instance of `Parse.Object`. If `false`, the object will not be converted and instead be a plain JavaScript object, which contains the raw data of a `Parse.Object` but is not an actual instance of `Parse.Object`. Default is `false`. <br><br>ℹ️ The expected behavior would be that the object is converted to an instance of `Parse.Object`, so you would normally set this option to `true`. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where JavaScript objects are not converted to actual instances of `Parse.Object`.
  * @property {String} encryptionKey Key for encrypting your files
@@ -96,8 +99,6 @@
  * @property {Number} sessionLength Session duration, in seconds, defaults to 1 year
  * @property {Boolean} silent Disables console output
  * @property {Boolean} startLiveQueryServer Starts the liveQuery server
- * @property {Boolean} transformEmailToLowerCase Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format.
- * @property {Boolean} transformUsernameToLowerCase Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format.
  * @property {Any} trustProxy The trust proxy settings. It is important to understand the exact setup of the reverse proxy, since this setting will trust values provided in the Parse Server API request. See the <a href="https://expressjs.com/en/guide/behind-proxies.html">express trust proxy settings</a> documentation. Defaults to `false`.
  * @property {String[]} userSensitiveFields Personally identifiable information fields in the user table the should be removed for non-authorized users. Deprecated @see protectedFields
  * @property {Boolean} verbose Set the logging to verbose

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -103,6 +103,12 @@ export interface ParseServerOptions {
   databaseOptions: ?DatabaseOptions;
   /* Adapter module for the database; any options that are not explicitly described here are passed directly to the database client. */
   databaseAdapter: ?Adapter<StorageAdapter>;
+  /* Disable case insensitivity (collation) on queries and indexes, needed if you use MongoDB serverless or AWS DocumentDB. */
+  disableCollation: ?boolean;
+  /* Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format. */
+  transformEmailToLowerCase: ?boolean;
+  /* Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format. */
+  transformUsernameToLowerCase: ?boolean;
   /* Full path to your cloud code main.js */
   cloud: ?string;
   /* A collection prefix for the classes

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -103,8 +103,9 @@ export interface ParseServerOptions {
   databaseOptions: ?DatabaseOptions;
   /* Adapter module for the database; any options that are not explicitly described here are passed directly to the database client. */
   databaseAdapter: ?Adapter<StorageAdapter>;
-  /* Disable case insensitivity (collation) on queries and indexes, needed if you use MongoDB serverless or AWS DocumentDB. */
-  disableCollation: ?boolean;
+  /* Optional. If set to `true`, the collation rule of case comparison for queries and indexes is enabled. Enable this option to run Parse Server with MongoDB Atlas Serverless or AWS Amazon DocumentDB. If `false`, the collation rule of case comparison is disabled. Default is `false`.
+  :DEFAULT: false */
+  enableCollationCaseComparison: ?boolean;
   /* Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format. */
   transformEmailToLowerCase: ?boolean;
   /* Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format. */

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -106,10 +106,12 @@ export interface ParseServerOptions {
   /* Optional. If set to `true`, the collation rule of case comparison for queries and indexes is enabled. Enable this option to run Parse Server with MongoDB Atlas Serverless or AWS Amazon DocumentDB. If `false`, the collation rule of case comparison is disabled. Default is `false`.
   :DEFAULT: false */
   enableCollationCaseComparison: ?boolean;
-  /* Transform Email to lowercase on create/update/login/signup. On queries client needs to ensure to send Email in lowercase format. */
-  transformEmailToLowerCase: ?boolean;
-  /* Transform Username to lowercase on create/update/login/signup. On queries client needs to ensure to send Username in lowercase format. */
-  transformUsernameToLowerCase: ?boolean;
+  /* Optional. If set to `true`, the `email` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `email` property is stored as set, without any case modifications. Default is `false`.
+  :DEFAULT: false */
+  convertEmailToLowercase: ?boolean;
+   /* Optional. If set to `true`, the `username` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `username` property is stored as set, without any case modifications. Default is `false`.
+  :DEFAULT: false */
+  convertUsernameToLowercase: ?boolean;
   /* Full path to your cloud code main.js */
   cloud: ?string;
   /* A collection prefix for the classes


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
Add options to support MongoDB Serverless and AWS DocumentDB which currently does not have collation support.

Closes: #7937 

## Approach
Add 3 abstract options disableCollation, transformEmailToLowerCase and transformUsernameToLowerCase to allow a developer to disable default collations of Parse Server and transformEmailToLowerCase to keep clean emails in the database and transformUsernameToLowerCase to keep clean usernames in the database.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
