### PR TITLE
fix: Config bug in parseObject mapping

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1267,6 +1267,35 @@ describe('miscellaneous', function () {
     });
   });
 
+  it('test cloud function query parameters with array of pointers', done => {
+    Parse.Cloud.define('echoParams', req => {
+      return req.params;
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Javascript-Key': 'test',
+    };
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/functions/echoParams', //?option=1&other=2
+      qs: {
+        option: 1,
+        other: 2,
+      },
+      body: '{"foo":"bar", "other": 1, "arr": [{ "__type": "Pointer" }]}',
+    }).then(response => {
+      const res = response.data.result;
+      expect(res.option).toEqual('1');
+      // Make sure query string params override body params
+      expect(res.other).toEqual('2');
+      expect(res.foo).toEqual('bar');
+      expect(res.arr.length).toEqual(1);
+      done();
+    });
+  });
+
   it('can handle null params in cloud functions (regression test for #1742)', done => {
     Parse.Cloud.define('func', request => {
       expect(request.params.nullParam).toEqual(null);

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -12,7 +12,7 @@ import { logger } from '../logger';
 function parseObject(obj, config) {
   if (Array.isArray(obj)) {
     return obj.map(item => {
-      return parseObject(item);
+      return parseObject(item, config);
     });
   } else if (obj && obj.__type == 'Date') {
     return Object.assign(new Date(obj.iso), obj);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
Closes: https://github.com/parse-community/parse-server/issues/8783

## Approach
A bug was introduced in 6.3.0 ([here](https://github.com/parse-community/parse-server/commit/e212eb51954bfb5c49a59689fd785740489712fc#diff-8f2f0b3d469b333004223792d072d82895edc96039eae3dba67a4eb4e37ae66dR12)) when `config` was added as a property to the `parseObject` function. This PR simply updates the function to pass the config variable when the obj is an array.

## Tasks
- [X] Add tests