### PR TITLE
fix: Conditional email verification not working in some cases if `verifyUserEmails`, `preventLoginWithUnverifiedEmail` set to functions

### DIFF
--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -381,7 +381,7 @@ describe('Email Verification Token Expiration: ', () => {
     await user.signUp();
     expect(sendEmailOptions).toBeUndefined();
     expect(user.getSessionToken()).toBeDefined();
-    expect(verifySpy).toHaveBeenCalledTimes(3);
+    expect(verifySpy).toHaveBeenCalledTimes(2);
     const user2 = new Parse.User();
     user2.setUsername('email');
     user2.setPassword('expiringToken');
@@ -389,7 +389,7 @@ describe('Email Verification Token Expiration: ', () => {
     await user2.signUp();
     expect(user2.getSessionToken()).toBeUndefined();
     expect(sendEmailOptions).toBeDefined();
-    expect(verifySpy).toHaveBeenCalledTimes(6);
+    expect(verifySpy).toHaveBeenCalledTimes(5);
   });
 
   it('can conditionally send user email verification', async () => {

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -381,7 +381,6 @@ describe('Email Verification Token Expiration: ', () => {
     await user.signUp();
     expect(sendEmailOptions).toBeUndefined();
     expect(user.getSessionToken()).toBeDefined();
-    expect(verifySpy).toHaveBeenCalledTimes(2);
     expect(verifySpy).toHaveBeenCalledTimes(3);
     const user2 = new Parse.User();
     user2.setUsername('email');

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -382,6 +382,7 @@ describe('Email Verification Token Expiration: ', () => {
     expect(sendEmailOptions).toBeUndefined();
     expect(user.getSessionToken()).toBeDefined();
     expect(verifySpy).toHaveBeenCalledTimes(2);
+    expect(verifySpy).toHaveBeenCalledTimes(3);
     const user2 = new Parse.User();
     user2.setUsername('email');
     user2.setPassword('expiringToken');
@@ -389,7 +390,7 @@ describe('Email Verification Token Expiration: ', () => {
     await user2.signUp();
     expect(user2.getSessionToken()).toBeUndefined();
     expect(sendEmailOptions).toBeDefined();
-    expect(verifySpy).toHaveBeenCalledTimes(4);
+    expect(verifySpy).toHaveBeenCalledTimes(6);
   });
 
   it('can conditionally send user email verification', async () => {

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -36,11 +36,10 @@ export class UserController extends AdaptableController {
   }
 
   async setEmailVerifyToken(user, req, storage = {}) {
-    let shouldSendEmail = this.shouldVerifyEmails;
-    if (typeof shouldSendEmail === 'function') {
-      const response = await Promise.resolve(shouldSendEmail(req));
-      shouldSendEmail = response !== false;
-    }
+    const shouldSendEmail =
+      this.shouldVerifyEmails === true ||
+      (typeof this.shouldVerifyEmails === 'function' &&
+        (await Promise.resolve(this.shouldVerifyEmails(req))) === true);
     if (!shouldSendEmail) {
       return false;
     }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -941,7 +941,7 @@ RestWrite.prototype.createSessionTokenIfNeeded = async function () {
       ip: this.config.ip,
       installationId: this.auth.installationId,
     };
-    // Get verification conditions which can be boolean or functions
+    // Get verification conditions which can be booleans or functions
     const verifyUserEmails = this.config.verifyUserEmails === true || (typeof this.config.verifyUserEmails === 'function' && await Promise.resolve(this.config.verifyUserEmails(request)) === true);
     const preventLoginWithUnverifiedEmail = this.config.preventLoginWithUnverifiedEmail === true || (typeof this.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(this.config.preventLoginWithUnverifiedEmail(request)) === true);
     // If verification is required

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -932,7 +932,7 @@ RestWrite.prototype.createSessionTokenIfNeeded = async function () {
   }
   // If sign-up call
   if (!this.storage.authProvider) {
-    // Create request object for the verification functions
+    // Create request object for verification functions
     const { originalObject, updatedObject } = this.buildParseObjects();
     const request = {
       original: originalObject,

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -943,7 +943,7 @@ RestWrite.prototype.createSessionTokenIfNeeded = async function () {
     };
     // Get verification conditions which can be booleans or functions; the purpose of this async/await
     // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the
-    // conditional statement below, as a developer may be executing database operations inside of them
+    // conditional statement below, as a developer may decide to execute expensive operations in them
     const verifyUserEmails = async () => this.config.verifyUserEmails === true || (typeof this.config.verifyUserEmails === 'function' && await Promise.resolve(this.config.verifyUserEmails(request)) === true);
     const preventLoginWithUnverifiedEmail = async () => this.config.preventLoginWithUnverifiedEmail === true || (typeof this.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(this.config.preventLoginWithUnverifiedEmail(request)) === true);
     // If verification is required

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -143,6 +143,7 @@ export class UsersRouter extends ClassesRouter {
             ip: req.config.ip,
             installationId: req.auth.installationId,
           };
+          // Get verification conditions which can be booleans or functions
           const verifyUserEmails = req.config.verifyUserEmails === true || (typeof req.config.verifyUserEmails === 'function' && await Promise.resolve(req.config.verifyUserEmails(request)) === true);
           const preventLoginWithUnverifiedEmail = req.config.preventLoginWithUnverifiedEmail === true || (typeof req.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(req.config.preventLoginWithUnverifiedEmail(request)) === true);
           if (verifyUserEmails && preventLoginWithUnverifiedEmail && !user.emailVerified) {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -145,7 +145,7 @@ export class UsersRouter extends ClassesRouter {
           };
           // Get verification conditions which can be booleans or functions; the purpose of this async/await
           // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the
-          // conditional statement below, as a developer may be executing database operations inside of them
+          // conditional statement below, as a developer may decide to execute expensive operations in them
           const verifyUserEmails = async () => req.config.verifyUserEmails === true || (typeof req.config.verifyUserEmails === 'function' && await Promise.resolve(req.config.verifyUserEmails(request)) === true);
           const preventLoginWithUnverifiedEmail = async () => req.config.preventLoginWithUnverifiedEmail === true || (typeof req.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(req.config.preventLoginWithUnverifiedEmail(request)) === true);
           if (await verifyUserEmails() && await preventLoginWithUnverifiedEmail() && !user.emailVerified) {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -126,7 +126,7 @@ export class UsersRouter extends ClassesRouter {
           const accountLockoutPolicy = new AccountLockout(user, req.config);
           return accountLockoutPolicy.handleLoginAttempt(isValidPassword);
         })
-        .then(() => {
+        .then(async () => {
           if (!isValidPassword) {
             throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
           }
@@ -137,11 +137,15 @@ export class UsersRouter extends ClassesRouter {
           if (!req.auth.isMaster && user.ACL && Object.keys(user.ACL).length == 0) {
             throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
           }
-          if (
-            req.config.verifyUserEmails &&
-            req.config.preventLoginWithUnverifiedEmail &&
-            !user.emailVerified
-          ) {
+          // Create request object for verification functions
+          const request = {
+            master: req.auth.isMaster,
+            ip: req.config.ip,
+            installationId: req.auth.installationId,
+          };
+          const verifyUserEmails = req.config.verifyUserEmails === true || (typeof req.config.verifyUserEmails === 'function' && await Promise.resolve(req.config.verifyUserEmails(request)) === true);
+          const preventLoginWithUnverifiedEmail = req.config.preventLoginWithUnverifiedEmail === true || (typeof req.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(req.config.preventLoginWithUnverifiedEmail(request)) === true);
+          if (verifyUserEmails && preventLoginWithUnverifiedEmail && !user.emailVerified) {
             throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, 'User email is not verified.');
           }
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8839

## Approach
<!-- Describe the changes in this PR. -->

Evaluate whether the Parse Server options have a bool or func value.
