### PR TITLE
ci: Auto-release not working due to more than 3 release branches

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -40,8 +40,8 @@ async function config() {
       { name: 'alpha', prerelease: true },
       { name: 'beta', prerelease: true },
       'next-major',
-      // Long-Term-Support branches; defined as GLOB pattern
-      'release-+([0-9]).x.x',
+      // Long-Term-Support branch of previous major version
+      'release-6.x.x',
     ],
     dryRun: false,
     debug: true,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Closes: https://github.com/parse-community/parse-server/issues/8846

## Approach


The issue occurs since the creation of LTS branch `release-6.x.x`. This may be because there now more than 3 release branches: `release`, `release-4.x.x`, `release-5.x.x`, `release-6.x.x`. This PR reduces the number of release branches by specifying `release-6.x.x` instead of the GLOB pattern.

