### PR TITLE
feat: Add `Parse.User` as function parameter to Parse Server options `verifyUserEmails`, `preventLoginWithUnverifiedEmail` on login

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -277,6 +277,9 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
     const verifyUserEmails = {
       method: async (params) => {
         expect(params.object).toBeInstanceOf(Parse.User);
+        expect(params.ip).toBeDefined();
+        expect(params.master).toBeDefined();
+        expect(params.installationId).toBeDefined();
         return true;
       },
     };

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -142,6 +142,7 @@ export class UsersRouter extends ClassesRouter {
             master: req.auth.isMaster,
             ip: req.config.ip,
             installationId: req.auth.installationId,
+            object: Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
           };
           // Get verification conditions which can be booleans or functions; the purpose of this async/await
           // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/8851

## Approach

Add user as `object` parameter to function argument in `verifyUserEmails` and `preventLoginWithUnverifiedEmail`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
