### PR TITLE
Fix cloud functions rejecting Parse pointers inside arrays

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -2012,6 +2012,18 @@ describe('cloud functions', () => {
 
     Parse.Cloud.run('myFunction', {}).then(() => done());
   });
+
+  it('can pass Parse pointers inside arrays', async () => {
+    Parse.Cloud.define('test', function () {
+      return 42;
+    });
+
+    expect(
+      await Parse.Cloud.run('test', {
+        a: [{ __type: 'Pointer', className: 'foo', objectId: 'foo' }],
+      })
+    ).toEqual(42);
+  });
 });
 
 describe('beforeSave hooks', () => {

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -12,7 +12,7 @@ import { logger } from '../logger';
 function parseObject(obj, config) {
   if (Array.isArray(obj)) {
     return obj.map(item => {
-      return parseObject(item);
+      return parseObject(item, config);
     });
   } else if (obj && obj.__type == 'Date') {
     return Object.assign(new Date(obj.iso), obj);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Closes: #8861

## Approach
`FunctionsRouter.js::parseObject`: Propagate the config object even inside arrays

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests