### PR TITLE
feat: Add `installationId`, `ip`, `resendRequest` to arguments passed to `verifyUserEmails` on verification email request

### DIFF
--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -197,7 +197,7 @@ export class UserController extends AdaptableController {
    * @param user
    * @returns {*}
    */
-  async regenerateEmailVerifyToken(user, master) {
+  async regenerateEmailVerifyToken(user, master, installationId, ip) {
     const { _email_verify_token } = user;
     let { _email_verify_token_expires_at } = user;
     if (_email_verify_token_expires_at && _email_verify_token_expires_at.__type === 'Date') {
@@ -211,7 +211,7 @@ export class UserController extends AdaptableController {
     ) {
       return Promise.resolve();
     }
-    const shouldSend = await this.setEmailVerifyToken(user, { user, master });
+    const shouldSend = await this.setEmailVerifyToken(user, { user, master, installationId, ip, resendRequest: true });
     if (!shouldSend) {
       return;
     }
@@ -223,7 +223,7 @@ export class UserController extends AdaptableController {
     if (!aUser || aUser.emailVerified) {
       throw undefined;
     }
-    const generate = await this.regenerateEmailVerifyToken(aUser, req.auth?.isMaster);
+    const generate = await this.regenerateEmailVerifyToken(aUser, req.auth?.isMaster, req.auth?.installationId, req.ip);
     if (generate) {
       this.sendVerificationEmail(aUser, req);
     }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -211,7 +211,13 @@ export class UserController extends AdaptableController {
     ) {
       return Promise.resolve();
     }
-    const shouldSend = await this.setEmailVerifyToken(user, { user, master, installationId, ip, resendRequest: true });
+    const shouldSend = await this.setEmailVerifyToken(user, {
+      object: Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
+      master,
+      installationId,
+      ip,
+      resendRequest: true
+    });
     if (!shouldSend) {
       return;
     }

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -490,7 +490,7 @@ export class UsersRouter extends ClassesRouter {
     }
 
     const userController = req.config.userController;
-    const send = await userController.regenerateEmailVerifyToken(user, req.auth.isMaster);
+    const send = await userController.regenerateEmailVerifyToken(user, req.auth.isMaster, req.auth.installationId, req.ip);
     if (send) {
       userController.sendVerificationEmail(user, req);
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/8874

## Approach

For arguments passed to `verifyUserEmails` when invoked via `Parse.User.requestEmailVerification`:
- Add `ip` parameter.
- Add `installationId` parameter.
- Rename `user` object to `object`.
- Modify user object to be an instance of `Parse.User`.
- Add `resendRequest` parameter to determine whether `verifyUserEmails` is invoked via signup / login request, or resend email verification request. 

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
