### PR TITLE
fix: Parse Server option `emailVerifyTokenReuseIfValid: true` generates new token on every email verification request

### DIFF
--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -869,7 +869,7 @@ describe('Email Verification Token Expiration: ', () => {
     done();
   });
 
-  fit('should match codes with emailVerifyTokenReuseIfValid', async done => {
+  it('should match codes with emailVerifyTokenReuseIfValid', async done => {
     let sendEmailOptions;
     let sendVerificationEmailCallCount = 0;
     const emailAdapter = {
@@ -897,7 +897,7 @@ describe('Email Verification Token Expiration: ', () => {
     const config = Config.get('test');
     const [userBeforeRequest] = await config.database.find('_User', {
       username: 'resends_verification_token',
-    });
+    }, {}, Auth.maintenance(config));
     // store this user before we make our email request
     expect(sendVerificationEmailCallCount).toBe(1);
     await new Promise(resolve => {
@@ -923,7 +923,7 @@ describe('Email Verification Token Expiration: ', () => {
 
     const [userAfterRequest] = await config.database.find('_User', {
       username: 'resends_verification_token',
-    });
+    }, {}, Auth.maintenance(config));
 
     // Verify that token & expiration haven't been changed for this new request
     expect(typeof userAfterRequest).toBe('object');

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -869,7 +869,7 @@ describe('Email Verification Token Expiration: ', () => {
     done();
   });
 
-  it('should match codes with emailVerifyTokenReuseIfValid', async done => {
+  fit('should match codes with emailVerifyTokenReuseIfValid', async done => {
     let sendEmailOptions;
     let sendVerificationEmailCallCount = 0;
     const emailAdapter = {
@@ -925,12 +925,12 @@ describe('Email Verification Token Expiration: ', () => {
       username: 'resends_verification_token',
     });
 
-    // verify that our token & expiration has been changed for this new request
+    // Verify that token & expiration haven't been changed for this new request
     expect(typeof userAfterRequest).toBe('object');
+    expect(userBeforeRequest._email_verify_token).toBeDefined();
     expect(userBeforeRequest._email_verify_token).toEqual(userAfterRequest._email_verify_token);
-    expect(userBeforeRequest._email_verify_token_expires_at).toEqual(
-      userAfterRequest._email_verify_token_expires_at
-    );
+    expect(userBeforeRequest._email_verify_token_expires_at).toBeDefined();
+    expect(userBeforeRequest._email_verify_token_expires_at).toEqual(userAfterRequest._email_verify_token_expires_at);
     done();
   });
 

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -209,7 +209,7 @@ export class UserController extends AdaptableController {
       _email_verify_token &&
       new Date() < new Date(_email_verify_token_expires_at)
     ) {
-      return Promise.resolve();
+      return Promise.resolve(true);
     }
     const shouldSend = await this.setEmailVerifyToken(user, {
       object: Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -6,6 +6,7 @@ import AccountLockout from '../AccountLockout';
 import ClassesRouter from './ClassesRouter';
 import rest from '../rest';
 import Auth from '../Auth';
+import { maintenance } from '../Auth';
 import passwordCrypto from '../password';
 import {
   maybeRunTrigger,
@@ -476,7 +477,7 @@ export class UsersRouter extends ClassesRouter {
       );
     }
 
-    const results = await req.config.database.find('_User', { email: email });
+    const results = await req.config.database.find('_User', { email: email }, {}, Auth.maintenance(req.config));
     if (!results.length || results.length < 1) {
       throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, `No user found with email ${email}`);
     }

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -6,7 +6,6 @@ import AccountLockout from '../AccountLockout';
 import ClassesRouter from './ClassesRouter';
 import rest from '../rest';
 import Auth from '../Auth';
-import { maintenance } from '../Auth';
 import passwordCrypto from '../password';
 import {
   maybeRunTrigger,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8886

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
