### PR TITLE
fix: Username is `undefined` in email verification link on email change

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -137,6 +137,7 @@ describe('Custom Pages, Email Verification, Password Reset', () => {
     spyOn(emailAdapter, 'sendVerificationEmail').and.callFake(options => {
       expect(options.link).not.toBeNull();
       expect(options.link).not.toMatch(/token=undefined/);
+      expect(options.link).not.toMatch(/username=undefined/);
       Promise.resolve();
     });
     const user = new Parse.User();

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -161,7 +161,8 @@ export class UserController extends AdaptableController {
       return;
     }
     const token = encodeURIComponent(user._email_verify_token);
-    // We may need to fetch the user in case of update email
+    // We may need to fetch the user in case of update email; only use the `fetchedUser`
+    // from this point onwards; do not use the `user` as it may not contain all fields.
     const fetchedUser = await this.getUserIfNeeded(user);
     let shouldSendEmail = this.config.sendUserEmailVerification;
     if (typeof shouldSendEmail === 'function') {
@@ -176,7 +177,7 @@ export class UserController extends AdaptableController {
     if (!shouldSendEmail) {
       return;
     }
-    const username = encodeURIComponent(user.username);
+    const username = encodeURIComponent(fetchedUser.username);
 
     const link = buildEmailLink(this.config.verifyEmailURL, username, token, this.config);
     const options = {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8888

## Approach

Use fetched user that contains additional fields, instead of the un-fetched user object.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
