### PR TITLE
feat: Add password validation via POST request for user with unverified email using master key and option `ignoreEmailVerification`

### DIFF
--- a/spec/VerifyUserPassword.spec.js
+++ b/spec/VerifyUserPassword.spec.js
@@ -586,7 +586,7 @@ describe('Verify User Password', () => {
       });
   });
 
-  it('succeed in verifying password of user with unverified email with master key and option `ignoreEmailVerification`', async () => {
+  it('verify password of user with unverified email with master key and ignoreEmailVerification=true', async () => {
     await reconfigureServer({
       publicServerURL: 'http://localhost:8378/',
       appName: 'emailVerify',
@@ -606,20 +606,62 @@ describe('Verify User Password', () => {
     await user.signUp();
 
     const { data: res } = await request({
+      method: 'POST',
       url: Parse.serverURL + '/verifyPassword',
       headers: {
         'X-Parse-Master-Key': Parse.masterKey,
         'X-Parse-Application-Id': Parse.applicationId,
         'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
       },
-      qs: {
+      body: {
         username: 'user',
         password: 'pass',
         ignoreEmailVerification: true,
       },
+      json: true,
     });
     expect(res.objectId).toBe(user.id);
     expect(Object.prototype.hasOwnProperty.call(res, 'sessionToken')).toEqual(false);
     expect(Object.prototype.hasOwnProperty.call(res, 'password')).toEqual(false);
+  });
+
+  it('fails to verify password of user with unverified email with master key and ignoreEmailVerification=false', async () => {
+    await reconfigureServer({
+      publicServerURL: 'http://localhost:8378/',
+      appName: 'emailVerify',
+      verifyUserEmails: true,
+      preventLoginWithUnverifiedEmail: true,
+      emailAdapter: MockEmailAdapterWithOptions({
+        fromAddress: 'parse@example.com',
+        apiKey: 'k',
+        domain: 'd',
+      }),
+    });
+
+    const user = new Parse.User();
+    user.setUsername('user');
+    user.setPassword('pass');
+    user.setEmail('test@example.com');
+    await user.signUp();
+
+    const res = await request({
+      method: 'POST',
+      url: Parse.serverURL + '/verifyPassword',
+      headers: {
+        'X-Parse-Master-Key': Parse.masterKey,
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {
+        username: 'user',
+        password: 'pass',
+        ignoreEmailVerification: false,
+      },
+      json: true,
+    }).catch(e => e);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/User email is not verified/);
   });
 });

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -145,8 +145,8 @@ export class UsersRouter extends ClassesRouter {
             object: Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
           };
 
-          // If request uses master or maintenance key and email verification should be ignored
-          if (!(req.auth.isMaster || req.auth.isMaintenance) && !ignoreEmailVerification) {
+          // If request doesn't use master or maintenance key with ignoring email verification
+          if (!((req.auth.isMaster || req.auth.isMaintenance) && ignoreEmailVerification)) {
 
             // Get verification conditions which can be booleans or functions; the purpose of this async/await
             // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -75,7 +75,7 @@ export class UsersRouter extends ClassesRouter {
       ) {
         payload = req.query;
       }
-      const { username, email, password } = payload;
+      const { username, email, password, ignoreEmailVerification } = payload;
 
       // TODO: use the right error codes / descriptions.
       if (!username && !email) {
@@ -144,13 +144,18 @@ export class UsersRouter extends ClassesRouter {
             installationId: req.auth.installationId,
             object: Parse.User.fromJSON(Object.assign({ className: '_User' }, user)),
           };
-          // Get verification conditions which can be booleans or functions; the purpose of this async/await
-          // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the
-          // conditional statement below, as a developer may decide to execute expensive operations in them
-          const verifyUserEmails = async () => req.config.verifyUserEmails === true || (typeof req.config.verifyUserEmails === 'function' && await Promise.resolve(req.config.verifyUserEmails(request)) === true);
-          const preventLoginWithUnverifiedEmail = async () => req.config.preventLoginWithUnverifiedEmail === true || (typeof req.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(req.config.preventLoginWithUnverifiedEmail(request)) === true);
-          if (await verifyUserEmails() && await preventLoginWithUnverifiedEmail() && !user.emailVerified) {
-            throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, 'User email is not verified.');
+
+          // If request uses master or maintenance key and email verification should be ignored
+          if (!(req.auth.isMaster || req.auth.isMaintenance) && !ignoreEmailVerification) {
+
+            // Get verification conditions which can be booleans or functions; the purpose of this async/await
+            // structure is to avoid unnecessarily executing subsequent functions if previous ones fail in the
+            // conditional statement below, as a developer may decide to execute expensive operations in them
+            const verifyUserEmails = async () => req.config.verifyUserEmails === true || (typeof req.config.verifyUserEmails === 'function' && await Promise.resolve(req.config.verifyUserEmails(request)) === true);
+            const preventLoginWithUnverifiedEmail = async () => req.config.preventLoginWithUnverifiedEmail === true || (typeof req.config.preventLoginWithUnverifiedEmail === 'function' && await Promise.resolve(req.config.preventLoginWithUnverifiedEmail(request)) === true);
+            if (await verifyUserEmails() && await preventLoginWithUnverifiedEmail() && !user.emailVerified) {
+              throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, 'User email is not verified.');
+            }
           }
 
           this._sanitizeAuthData(user);

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -663,6 +663,9 @@ export class UsersRouter extends ClassesRouter {
     this.route('GET', '/verifyPassword', req => {
       return this.handleVerifyPassword(req);
     });
+    this.route('POST', '/verifyPassword', req => {
+      return this.handleVerifyPassword(req);
+    });
     this.route('POST', '/challenge', req => {
       return this.handleChallenge(req);
     });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/8896

## Approach

Introduce new request option `ignoreEmailVerification` that together with the master or maintenance key allows to verify a user password ignoring the email verification status.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
