### PR TITLE
fix: Docker image not published to Docker Hub on new release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - run: npm run madge:circular
   check-docker:
     name: Docker Build
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -130,7 +130,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64/v8
   check-lock-file-version:
     name: NPM Lock File Version
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,17 +117,17 @@ jobs:
   check-docker:
     name: Docker Build
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - run: npm run madge:circular
   check-docker:
     name: Docker Build
-    timeout-minutes: 20
+    timeout-minutes: 15
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -51,7 +51,7 @@ jobs:
         id: branch
         run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           ref: ${{ needs.release.outputs.current_tag }}
       - name: Set up QEMU

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       REGISTRY: docker.io
       IMAGE_NAME: parseplatform/parse-server
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write
@@ -51,23 +51,23 @@ jobs:
         id: branch
         run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.release.outputs.current_tag }}
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Log into Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -75,7 +75,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release.outputs.current_tag }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: parseplatform/parse-server
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write
@@ -23,23 +23,23 @@ jobs:
         id: branch
         run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Log into Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -48,7 +48,7 @@ jobs:
             type=semver,enable=true,pattern={{version}},value=${{ github.event.inputs.ref }}
             type=raw,enable=${{ github.event.inputs.ref == '' }},value=latest
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -23,7 +23,7 @@ jobs:
         id: branch
         run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build stage
 ############################################################
-FROM node:lts-alpine AS build
+FROM node:18-alpine AS build
 
 RUN apk --no-cache add git
 WORKDIR /tmp
@@ -24,7 +24,7 @@ RUN npm ci --omit=dev --ignore-scripts \
 ############################################################
 # Release stage
 ############################################################
-FROM node:lts-alpine AS release
+FROM node:18-alpine AS release
 
 VOLUME /parse-server/cloud /parse-server/config
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
New docker images are not being created on releases. Instead, the CI just hangs.

Closes: #8904 

## Approach
<!-- Describe the changes in this PR. -->
Network issues with node 20 have caused QEMU to have issues with emulating different archs to build containers in GitHub actions. Some issues are noted in https://github.com/docker/build-push-action/issues/977#issuecomment-1757040425.

- Downgrade the `lts-alpine` image to `18` since the [new lts is node 20](https://nodejs.org/en) (parse-server doesn't formally support 20 anyways
- Reduce the GitHub actions OS from `ubuntu-latest` to `ubuntu-20.04` as the latest uses [ubuntu-latest](https://github.com/actions/runner-images#available-images) currently uses `22.04` which is more unreliable when successfully building using QEMU.

You can see similar changes made by me on my repo (redacted) and [here]() to fix my (redacted) docker hub.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Switch docker image to use `18-alpine`
- [x] Use `ubuntu-20.04` when building docker images
- [x] Ensure CI passes