### PR TITLE
feat: Add support for Node 20, drop support for Node 14, 16

### DIFF
--- a/.github/workflows/ci-automated-check-environment.yml
+++ b/.github/workflows/ci-automated-check-environment.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: 14
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Compose branch name for PR
         id: branch
         run: echo "::set-output name=name::ci-bump-environment"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/**.md'
 env:
-  NODE_VERSION: 21.6.1
+  NODE_VERSION: 20.11.1
   PARSE_SERVER_TEST_TIMEOUT: 20000
 jobs:
   check-code-analysis:
@@ -148,36 +148,32 @@ jobs:
           - name: MongoDB 4.2, ReplicaSet
             MONGODB_VERSION: 4.2.19
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: MongoDB 4.4, ReplicaSet
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: MongoDB 5, ReplicaSet
             MONGODB_VERSION: 5.3.2
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: MongoDB 6, ReplicaSet
             MONGODB_VERSION: 6.0.2
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.1
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: Node 18
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 18.19.0
-          - name: Node 20
-            MONGODB_VERSION: 4.4.13
-            MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 20.11.0
+            NODE_VERSION: 18.19.1
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15
@@ -221,25 +217,25 @@ jobs:
         include:
           - name: PostgreSQL 13, PostGIS 3.1
             POSTGRES_IMAGE: postgis/postgis:13-3.1
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: PostgreSQL 13, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:13-3.2
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: PostgreSQL 13, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:13-3.3
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: PostgreSQL 13, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:13-3.4
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: PostgreSQL 14, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:14-3.4
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: PostgreSQL 15, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:15-3.4
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
           - name: PostgreSQL 16, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:15-3.4
-            NODE_VERSION: 21.6.1
+            NODE_VERSION: 20.11.1
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/**.md'
 env:
-  NODE_VERSION: 19.3.0
+  NODE_VERSION: 21.6.1
   PARSE_SERVER_TEST_TIMEOUT: 20000
 jobs:
   check-code-analysis:
@@ -24,7 +24,7 @@ jobs:
         language: ['javascript']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -37,13 +37,13 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
@@ -58,13 +58,13 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
@@ -78,13 +78,13 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
@@ -99,13 +99,13 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v1
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check NPM lock file version
         uses: mansona/npm-lockfile-version@v1
         with:
@@ -148,40 +148,36 @@ jobs:
           - name: MongoDB 4.2, ReplicaSet
             MONGODB_VERSION: 4.2.19
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: MongoDB 4.4, ReplicaSet
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: MongoDB 5, ReplicaSet
             MONGODB_VERSION: 5.3.2
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: MongoDB 6, ReplicaSet
             MONGODB_VERSION: 6.0.2
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.1
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 19.3.0
-          - name: Node 14
-            MONGODB_VERSION: 4.4.13
-            MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 14.21.1
-          - name: Node 16
-            MONGODB_VERSION: 4.4.13
-            MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 16.18.1
+            NODE_VERSION: 21.6.1
           - name: Node 18
             MONGODB_VERSION: 4.4.13
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 18.12.1
+            NODE_VERSION: 18.19.0
+          - name: Node 20
+            MONGODB_VERSION: 4.4.13
+            MONGODB_TOPOLOGY: standalone
+            NODE_VERSION: 20.11.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15
@@ -200,16 +196,13 @@ jobs:
     steps:
       - name: Fix usage of insecure GitHub protocol
         run: sudo git config --system url."https://github".insteadOf "git://github"
-      - name: Fix git protocol for Node 14
-        if: ${{ startsWith(matrix.NODE_VERSION, '14.') }}
-        run: sudo git config --system url."https://github".insteadOf "ssh://git@github"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.NODE_VERSION }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
@@ -228,25 +221,25 @@ jobs:
         include:
           - name: PostgreSQL 13, PostGIS 3.1
             POSTGRES_IMAGE: postgis/postgis:13-3.1
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: PostgreSQL 13, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:13-3.2
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: PostgreSQL 13, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:13-3.3
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: PostgreSQL 13, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:13-3.4
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: PostgreSQL 14, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:14-3.4
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: PostgreSQL 15, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:15-3.4
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
           - name: PostgreSQL 16, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:15-3.4
-            NODE_VERSION: 19.3.0
+            NODE_VERSION: 21.6.1
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15
@@ -272,13 +265,13 @@ jobs:
       PARSE_SERVER_TEST_DATABASE_URI: postgres://postgres:postgres@localhost:5432/parse_server_postgres_adapter_test_database
       NODE_VERSION: ${{ matrix.NODE_VERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.NODE_VERSION }}
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.19.0
+          node-version: 18.19.1
           registry-url: https://registry.npmjs.org/
       - name: Cache Node.js modules
         uses: actions/cache@v4
@@ -93,7 +93,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.19.0
+          node-version: 18.19.1
       - name: Cache Node.js modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -12,15 +12,15 @@ jobs:
       - name: Determine trigger branch name
         id: branch
         run: echo "::set-output name=trigger_branch::${GITHUB_REF#refs/*/}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.1.0
+          node-version: 18.19.0
           registry-url: https://registry.npmjs.org/
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -51,7 +51,7 @@ jobs:
         id: branch
         run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.release.outputs.current_tag }}
       - name: Set up QEMU
@@ -89,13 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.1.0
+          node-version: 18.19.0
       - name: Cache Node.js modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -23,7 +23,7 @@ jobs:
         id: branch
         run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Set up QEMU

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Coverage](https://img.shields.io/codecov/c/github/parse-community/parse-server/alpha.svg)](https://codecov.io/github/parse-community/parse-server?branch=alpha)
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
-[![Node Version](https://img.shields.io/badge/nodejs-14,_16,_18-green.svg?logo=node.js&style=flat)](https://nodejs.org)
+[![Node Version](https://img.shields.io/badge/nodejs-18,_20,_21-green.svg?logo=node.js&style=flat)](https://nodejs.org)
 [![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5,_6-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
 [![Postgres Version](https://img.shields.io/badge/postgresql-13,_14,_15,_16-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
@@ -129,10 +129,9 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
-| Node.js 14 | 14.19.1        | April 2023  | ✅ Yes      |
-| Node.js 16 | 16.14.2        | April 2024  | ✅ Yes      |
-| Node.js 18 | 18.12.1         | April 2025  | ✅ Yes      |
-| Node.js 19 | 19.3.0         | June 2023  | ✅ Yes      |
+| Node.js 18 | 18.19.0        | April 2025  | ✅ Yes      |
+| Node.js 20 | 20.11.0        | April 2026  | ✅ Yes      |
+| Node.js 21 | 16.14.2        | June 2024   | ✅ Yes      |
 
 #### MongoDB
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Coverage](https://img.shields.io/codecov/c/github/parse-community/parse-server/alpha.svg)](https://codecov.io/github/parse-community/parse-server?branch=alpha)
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
-[![Node Version](https://img.shields.io/badge/nodejs-18,_20,_21-green.svg?logo=node.js&style=flat)](https://nodejs.org)
+[![Node Version](https://img.shields.io/badge/nodejs-18,_20-green.svg?logo=node.js&style=flat)](https://nodejs.org)
 [![MongoDB Version](https://img.shields.io/badge/mongodb-4.0,_4.2,_4.4,_5,_6-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
 [![Postgres Version](https://img.shields.io/badge/postgresql-13,_14,_15,_16-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,8 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
-| Node.js 18 | 18.19.0        | April 2025  | ✅ Yes      |
-| Node.js 20 | 20.11.0        | April 2026  | ✅ Yes      |
-| Node.js 21 | 16.14.2        | June 2024   | ✅ Yes      |
+| Node.js 18 | 18.19.1        | April 2025  | ✅ Yes      |
+| Node.js 20 | 20.11.1        | April 2026  | ✅ Yes      |
 
 #### MongoDB
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2873,7 +2873,7 @@
         "xmlhttprequest": "1.8.0"
       },
       "engines": {
-        "node": ">=14.21.0 <17 || >=18 <20"
+        "node": ">=18.0.0 <21"
       },
       "optionalDependencies": {
         "crypto-js": "4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "deepcopy": "2.1.0",
         "express": "4.18.2",
         "express-rate-limit": "6.7.0",
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "1.15.4",
         "graphql": "16.8.1",
         "graphql-list-fields": "2.0.2",
         "graphql-relay": "0.10.0",
@@ -102,7 +102,7 @@
         "yaml": "1.10.0"
       },
       "engines": {
-        "node": ">=14.21.0 <17 || >=18 <19"
+        "node": ">=18 <22"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "yaml": "1.10.0"
       },
       "engines": {
-        "node": ">=18 <22"
+        "node": ">=18.0.0 <22"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "yaml": "1.10.0"
       },
       "engines": {
-        "node": ">=18.0.0 <22"
+        "node": ">=18.0.0 <21"
       },
       "funding": {
         "type": "opencollective",
@@ -2873,7 +2873,7 @@
         "xmlhttprequest": "1.8.0"
       },
       "engines": {
-        "node": ">=18.0.0 <21"
+        "node": ">=14.21.0 <17 || >=18 <20"
       },
       "optionalDependencies": {
         "crypto-js": "4.1.1"

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=18 <22"
+    "node": ">=18.0.0 <22"
   },
   "bin": {
     "parse-server": "bin/parse-server"

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=14.21.0 <17 || >=18 <19"
+    "node": ">=18 <22"
   },
   "bin": {
     "parse-server": "bin/parse-server"

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=18.0.0 <22"
+    "node": ">=18.0.0 <21"
   },
   "bin": {
     "parse-server": "bin/parse-server"


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Node 20 and 21 are not tested in the CI. In addition, node doesn't support versions 14, 16, and 19 anymore, but they are currently supported by parse-server

Closes: #8908 

## Approach
<!-- Describe the changes in this PR. -->
Add support for node 20 and 21. Drop support for 14, 16, and 19.

**This is a breaking change intended of Parse Server 7**

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Update CI to test node 20 and 21
- [x] Update outdated GitHub action versions to latest