### PR TITLE
ci: Fix incorrect release branch config

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -40,8 +40,8 @@ async function config() {
       { name: 'alpha', prerelease: true },
       { name: 'beta', prerelease: true },
       'next-major',
-      // Long-Term-Support branches; defined as GLOB pattern
-      'release-+([0-9]).x.x',
+      // Long-Term-Support branch of previous major version
+      'release-6.x.x',
     ],
     dryRun: false,
     debug: true,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Semantic release branch config doesn't allow more than 3 branches.

## Approach

Changing from GLOB pattern to discrete LTS branch name.

## Tasks
n/a