### PR TITLE
ci: Fix failing Docker release by removing arm/v6 and arm/v7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   check-docker:
     name: Docker Build
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
+          platforms: linux/amd64, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       REGISTRY: docker.io
       IMAGE_NAME: parseplatform/parse-server
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
+          platforms: linux/amd64, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: parseplatform/parse-server
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build stage
 ############################################################
-FROM node:18-alpine AS build
+FROM node:lts-alpine AS build
 
 RUN apk --no-cache add git
 WORKDIR /tmp
@@ -24,7 +24,7 @@ RUN npm ci --omit=dev --ignore-scripts \
 ############################################################
 # Release stage
 ############################################################
-FROM node:18-alpine AS release
+FROM node:lts-alpine AS release
 
 VOLUME /parse-server/cloud /parse-server/config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ COPY . .
 
 # Install without scripts
 RUN npm ci --omit=dev --ignore-scripts \
-    # Copy production node_modules aside for later
- && cp -R node_modules prod_node_modules \
-    # Install all dependencies
- && npm ci \
-    # Run build steps
+ # Copy production node_modules aside for later
+ && cp -R node_modules prod_node_modules
+    
+# Install all dependencies
+RUN npm ci \
+ # Run build steps
  && npm run build
 
 ############################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,11 @@ COPY . .
 
 # Install without scripts
 RUN npm ci --omit=dev --ignore-scripts \
- # Copy production node_modules aside for later
- && cp -R node_modules prod_node_modules
-    
-# Install all dependencies
-RUN npm ci \
- # Run build steps
+    # Copy production node_modules aside for later
+ && cp -R node_modules prod_node_modules \
+    # Install all dependencies
+ && npm ci \
+    # Run build steps
  && npm run build
 
 ############################################################


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The `arm/v6` and `arm/v7` aren't building in the docker CI.

Closes: #8904 

## Approach
<!-- Describe the changes in this PR. -->
Remove the `arm/v6` and `arm/v7` platform. These are Raspberry Pi 2 and 3 platforms. They can be added back in the future with another PR if someone wants to get them working.