### PR TITLE
ci: Fix failing Docker release by removing arm/v6 and arm/v7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   check-docker:
     name: Docker Build
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,20 +117,20 @@ jobs:
   check-docker:
     name: Docker Build
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64/v8
   check-lock-file-version:
     name: NPM Lock File Version
     timeout-minutes: 5

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
+          platforms: linux/amd64, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       REGISTRY: docker.io
       IMAGE_NAME: parseplatform/parse-server
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       REGISTRY: docker.io
       IMAGE_NAME: parseplatform/parse-server
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write
@@ -56,18 +56,18 @@ jobs:
           ref: ${{ needs.release.outputs.current_tag }}
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Log into Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -75,10 +75,10 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release.outputs.current_tag }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
+          platforms: linux/amd64, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: parseplatform/parse-server
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-manual-docker.yml
+++ b/.github/workflows/release-manual-docker.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: parseplatform/parse-server
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write
@@ -28,18 +28,18 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Log into Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -48,10 +48,10 @@ jobs:
             type=semver,enable=true,pattern={{version}},value=${{ github.event.inputs.ref }}
             type=raw,enable=${{ github.event.inputs.ref == '' }},value=latest
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          platforms: linux/amd64, linux/arm/v6, linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################################################
 # Build stage
 ############################################################
-FROM node:lts-alpine AS build
+FROM node:18-alpine AS build
 
 RUN apk --no-cache add git
 WORKDIR /tmp
@@ -24,7 +24,7 @@ RUN npm ci --omit=dev --ignore-scripts \
 ############################################################
 # Release stage
 ############################################################
-FROM node:lts-alpine AS release
+FROM node:18-alpine AS release
 
 VOLUME /parse-server/cloud /parse-server/config
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
New docker images are not being created on releases. Instead, the CI just hangs.

Closes: #8904 

## Approach
<!-- Describe the changes in this PR. -->
Remove builds for `arm/v6` and `arm/v7` platforms as they are causing issues. These are Raspberry Pi 2 and 3 builds. Someone can create a PR in the future to add these back.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Switch docker image to use `18-alpine` to keep the version of node the server was originally built for
- [x] Remove builds for `arm/v6` and `arm/v7` platforms
- [x] Ensure CI passes
