### PR TITLE
fix: Server crashes when receiving an array of `Parse.Pointer` in the request body

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1267,7 +1267,7 @@ describe('miscellaneous', function () {
     });
   });
 
-  it('test cloud function query parameters with array of pointers', done => {
+  it('test cloud function query parameters with array of pointers', async () => {
     Parse.Cloud.define('echoParams', req => {
       return req.params;
     });
@@ -1276,24 +1276,14 @@ describe('miscellaneous', function () {
       'X-Parse-Application-Id': 'test',
       'X-Parse-Javascript-Key': 'test',
     };
-    request({
+    const response = await request({
       method: 'POST',
       headers: headers,
-      url: 'http://localhost:8378/1/functions/echoParams', //?option=1&other=2
-      qs: {
-        option: 1,
-        other: 2,
-      },
-      body: '{"foo":"bar", "other": 1, "arr": [{ "__type": "Pointer" }]}',
-    }).then(response => {
-      const res = response.data.result;
-      expect(res.option).toEqual('1');
-      // Make sure query string params override body params
-      expect(res.other).toEqual('2');
-      expect(res.foo).toEqual('bar');
-      expect(res.arr.length).toEqual(1);
-      done();
+      url: 'http://localhost:8378/1/functions/echoParams',
+      body: '{"arr": [{ "__type": "Pointer", "className": "PointerTest" }]}',
     });
+    const res = response.data.result;
+    expect(res.arr.length).toEqual(1);
   });
  
   it('can handle null params in cloud functions (regression test for #1742)', done => {

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1285,7 +1285,6 @@ describe('miscellaneous', function () {
     const res = response.data.result;
     expect(res.arr.length).toEqual(1);
   });
- 
   it('can handle null params in cloud functions (regression test for #1742)', done => {
     Parse.Cloud.define('func', request => {
       expect(request.params.nullParam).toEqual(null);

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1295,7 +1295,7 @@ describe('miscellaneous', function () {
       done();
     });
   });
-  
+ 
   it('can handle null params in cloud functions (regression test for #1742)', done => {
     Parse.Cloud.define('func', request => {
       expect(request.params.nullParam).toEqual(null);

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1267,6 +1267,35 @@ describe('miscellaneous', function () {
     });
   });
 
+  it('test cloud function query parameters with array of pointers', done => {
+    Parse.Cloud.define('echoParams', req => {
+      return req.params;
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Javascript-Key': 'test',
+    };
+    request({
+      method: 'POST',
+      headers: headers,
+      url: 'http://localhost:8378/1/functions/echoParams', //?option=1&other=2
+      qs: {
+        option: 1,
+        other: 2,
+      },
+      body: '{"foo":"bar", "other": 1, "arr": [{ "__type": "Pointer" }]}',
+    }).then(response => {
+      const res = response.data.result;
+      expect(res.option).toEqual('1');
+      // Make sure query string params override body params
+      expect(res.other).toEqual('2');
+      expect(res.foo).toEqual('bar');
+      expect(res.arr.length).toEqual(1);
+      done();
+    });
+  });
+  
   it('can handle null params in cloud functions (regression test for #1742)', done => {
     Parse.Cloud.define('func', request => {
       expect(request.params.nullParam).toEqual(null);

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -12,7 +12,7 @@ import { logger } from '../logger';
 function parseObject(obj, config) {
   if (Array.isArray(obj)) {
     return obj.map(item => {
-      return parseObject(item);
+      return parseObject(item, config);
     });
   } else if (obj && obj.__type == 'Date') {
     return Object.assign(new Date(obj.iso), obj);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/9010

same as : https://github.com/parse-community/parse-server/issues/8783

## Approach
<!-- Describe the changes in this PR. -->

Copied / exactly the same as PR https://github.com/parse-community/parse-server/pull/8784

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
