### PR TITLE
refactor: Dry `handleAuthData` for safer code maintenance in the future

### DIFF
--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -487,6 +487,33 @@ describe('Auth Adapter features', () => {
     expect(baseAdapter2.validateAuthData).toHaveBeenCalledTimes(2);
   });
 
+  it('should not perform authData validation twice when data mutated', async () => {
+    spyOn(baseAdapter, 'validateAuthData').and.resolveTo({});
+    await reconfigureServer({
+      auth: { baseAdapter },
+      allowExpiredAuthDataToken: false,
+    });
+
+    const user = new Parse.User();
+
+    await user.save({
+      authData: {
+        baseAdapter: { id: 'baseAdapter', token: "sometoken1" },
+      },
+    });
+
+    expect(baseAdapter.validateAuthData).toHaveBeenCalledTimes(1);
+
+    const user2 = new Parse.User();
+    await user2.save({
+      authData: {
+        baseAdapter: { id: 'baseAdapter', token: "sometoken2" },
+      },
+    });
+
+    expect(baseAdapter.validateAuthData).toHaveBeenCalledTimes(2);
+  });
+
   it('should require additional provider if configured', async () => {
     await reconfigureServer({
       auth: { baseAdapter, additionalAdapter },
@@ -860,7 +887,7 @@ describe('Auth Adapter features', () => {
       auth: { challengeAdapter: throwInChallengeAdapter },
     });
     let logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => {});
+    spyOn(logger, 'error').and.callFake(() => { });
     await expectAsync(
       requestWithExpectedError({
         headers: headers,
@@ -885,7 +912,7 @@ describe('Auth Adapter features', () => {
 
     await reconfigureServer({ auth: { modernAdapter: throwInSetup } });
     logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => {});
+    spyOn(logger, 'error').and.callFake(() => { });
     let user = new Parse.User();
     await expectAsync(
       user.save({ authData: { modernAdapter: { id: 'modernAdapter' } } })
@@ -907,7 +934,7 @@ describe('Auth Adapter features', () => {
 
     await reconfigureServer({ auth: { modernAdapter: throwInUpdate } });
     logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => {});
+    spyOn(logger, 'error').and.callFake(() => { });
     user = new Parse.User();
     await user.save({ authData: { modernAdapter: { id: 'updateAdapter' } } });
     await expectAsync(
@@ -937,7 +964,7 @@ describe('Auth Adapter features', () => {
       allowExpiredAuthDataToken: false,
     });
     logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => {});
+    spyOn(logger, 'error').and.callFake(() => { });
     user = new Parse.User();
     await user.save({ authData: { modernAdapter: { id: 'modernAdapter' } } });
     const user2 = new Parse.User();

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -887,7 +887,7 @@ describe('Auth Adapter features', () => {
       auth: { challengeAdapter: throwInChallengeAdapter },
     });
     let logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => { });
+    spyOn(logger, 'error').and.callFake(() => {});
     await expectAsync(
       requestWithExpectedError({
         headers: headers,
@@ -912,7 +912,7 @@ describe('Auth Adapter features', () => {
 
     await reconfigureServer({ auth: { modernAdapter: throwInSetup } });
     logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => { });
+    spyOn(logger, 'error').and.callFake(() => {});
     let user = new Parse.User();
     await expectAsync(
       user.save({ authData: { modernAdapter: { id: 'modernAdapter' } } })
@@ -934,7 +934,7 @@ describe('Auth Adapter features', () => {
 
     await reconfigureServer({ auth: { modernAdapter: throwInUpdate } });
     logger = require('../lib/logger').logger;
-    spyOn(logger, 'error').and.callFake(() => { });
+    spyOn(logger, 'error').and.callFake(() => {});
     user = new Parse.User();
     await user.save({ authData: { modernAdapter: { id: 'updateAdapter' } } });
     await expectAsync(

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3350,7 +3350,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to emailVerified', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3386,7 +3386,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/me (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3429,7 +3429,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/id (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3477,7 +3477,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on login (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3521,7 +3521,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to hidden fields', async () => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3546,7 +3546,7 @@ describe('Parse.User testing', () => {
 
   it('should allow updates to fields with maintenanceKey', async () => {
     const emailAdapter = {
-      sendVerificationEmail: () => { },
+      sendVerificationEmail: () => {},
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3576,8 +3576,8 @@ describe('Parse.User testing', () => {
         expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         expect(
           e.message === 'Invalid username/password.' ||
-          e.message ===
-          'Your account is locked due to multiple failed login attempts. Please try again after 1 minute(s)'
+            e.message ===
+              'Your account is locked due to multiple failed login attempts. Please try again after 1 minute(s)'
         ).toBeTrue();
       }
     }

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3350,7 +3350,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to emailVerified', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3386,7 +3386,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/me (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3429,7 +3429,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on GET users/id (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3477,7 +3477,7 @@ describe('Parse.User testing', () => {
 
   it('should not retrieve hidden fields on login (#3432)', done => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3521,7 +3521,7 @@ describe('Parse.User testing', () => {
 
   it('should not allow updates to hidden fields', async () => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3546,7 +3546,7 @@ describe('Parse.User testing', () => {
 
   it('should allow updates to fields with maintenanceKey', async () => {
     const emailAdapter = {
-      sendVerificationEmail: () => {},
+      sendVerificationEmail: () => { },
       sendPasswordResetEmail: () => Promise.resolve(),
       sendMail: () => Promise.resolve(),
     };
@@ -3576,8 +3576,8 @@ describe('Parse.User testing', () => {
         expect(e.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
         expect(
           e.message === 'Invalid username/password.' ||
-            e.message ===
-              'Your account is locked due to multiple failed login attempts. Please try again after 1 minute(s)'
+          e.message ===
+          'Your account is locked due to multiple failed login attempts. Please try again after 1 minute(s)'
         ).toBeTrue();
       }
     }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -525,7 +525,6 @@ RestWrite.prototype.handleAuthData = async function (authData) {
 
   const userId = this.getUserId();
   const userResult = results[0];
-
   const foundUserIsNotCurrentUser = userId && userResult && userId !== userResult.objectId;
 
   if (results.length > 1 || foundUserIsNotCurrentUser) {
@@ -1309,7 +1308,7 @@ RestWrite.prototype.handleInstallation = function () {
           throw new Parse.Error(
             132,
             'Must specify installationId when deviceToken ' +
-            'matches multiple Installation objects'
+              'matches multiple Installation objects'
           );
         } else {
           // Multiple device token matches and we specified an installation ID,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Duplicated code related to an old GHSA on auth system. A quick dry refactor.

Closes: NONE

## Approach
<!-- Describe the changes in this PR. -->
A small DRY refactor for easiest, safer futur code maintenance on auth.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [x] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
