### PR TITLE
docs: Remove MongoDB rapid releases from support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 
 #### MongoDB
 
-Parse Server is continuously tested with the most recent releases of MongoDB to ensure compatibility. We follow the [MongoDB support schedule](https://www.mongodb.com/support-policy) and [MongoDB lifecycle schedule](https://www.mongodb.com/support-policy/lifecycles) and only test against versions that are officially supported and have not reached their end-of-life date. We consider the end-of-life date of a MongoDB "rapid release" to be the same as its major version release.
+Parse Server is continuously tested with the most recent releases of MongoDB to ensure compatibility. We follow the [MongoDB support schedule](https://www.mongodb.com/support-policy) and [MongoDB lifecycle schedule](https://www.mongodb.com/support-policy/lifecycles) and only test against versions that are officially supported and have not reached their end-of-life date. MongoDB "rapid releases" are ignored as these are considered pre-releases of the next major version.
 
 | Version     | Latest Version | End-of-Life   | Compatible |
 | ----------- | -------------- | ------------- | ---------- |


### PR DESCRIPTION
MongoDB "rapid releases" are a concept for pre-releases of the next major version. Since these have their own EOL dates - which are only a few months - we ignore them. See [docs](https://www.mongodb.com/blog/post/understanding-mongodb-stable-api-rapid-release-cadence).