### PR TITLE
docs: Generate API documentation for release branch

### DIFF
--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -29,7 +29,7 @@
     "template": "./node_modules/clean-jsdoc-theme",
     "theme_opts": {
       "default_theme": "dark",
-      "title": "<img src='../.github/parse-server-logo.png' class='logo'/>",
+      "title": "<img src='https://raw.githubusercontent.com/parse-community/parse-server/alpha/.github/parse-server-logo.png' class='logo'/>",
       "create_style": "header, .sidebar-section-title, .sidebar-title { color: #139cee !important } .logo { margin-left : 40px; margin-right: 40px }"
     }
   },

--- a/release_docs.sh
+++ b/release_docs.sh
@@ -1,8 +1,15 @@
 #!/bin/sh -e
 set -x
+# GITHUB_ACTIONS=true SOURCE_TAG=test ./release_docs.sh
+
 if [ "${GITHUB_ACTIONS}" = "" ];
 then
   echo "Cannot release docs without GITHUB_ACTIONS set"
+  exit 0;
+fi
+if [ "${SOURCE_TAG}" = "" ];
+then
+  echo "Cannot release docs without SOURCE_TAG set"
   exit 0;
 fi
 REPO="https://github.com/parse-community/parse-server"
@@ -13,20 +20,20 @@ cd docs
 git pull origin gh-pages
 cd ..
 
-DEST="master"
+RELEASE="release"
+VERSION="${SOURCE_TAG}"
 
-if [ "${SOURCE_TAG}" != "" ];
-then
-  DEST="${SOURCE_TAG}"
-  # change the default page to the latest
-  echo "<meta http-equiv='refresh' content='0; url=/parse-server/api/${DEST}'>" > "docs/api/index.html"
-fi
+# change the default page to the latest
+echo "<meta http-equiv='refresh' content='0; url=/parse-server/api/${VERSION}'>" > "docs/api/index.html"
 
 npm run definitions
 npm run docs
 
-mkdir -p "docs/api/${DEST}"
-cp -R out/* "docs/api/${DEST}"
+mkdir -p "docs/api/${RELEASE}"
+cp -R out/* "docs/api/${RELEASE}"
+
+mkdir -p "docs/api/${VERSION}"
+cp -R out/* "docs/api/${VERSION}"
 
 # Copy other resources
 RESOURCE_DIR=".github"


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Master branch has been removed in favor of a release branch. Currently there is no permanent link to the documentation for the latest api. There are release version specific links but those can get stale as new releases are publish.

## Approach
<!-- Describe the changes in this PR. -->
Adds support for links that match the latest release. Fixes broken image link in documentation.

Before: 
https://parseplatform.org/parse-server/api/master/ParseServerOptions.html

After:
https://parseplatform.org/parse-server/api/release/ParseServerOptions.html

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [x] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
