### PR TITLE
refactor: Upgrade pg-promise from 11.5.5 to 11.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "parse": "5.0.0",
         "path-to-regexp": "6.2.1",
         "pg-monitor": "2.0.0",
-        "pg-promise": "11.5.5",
+        "pg-promise": "11.6.0",
         "pluralize": "8.0.0",
         "rate-limit-redis": "4.2.0",
         "redis": "4.6.13",
@@ -5328,14 +5328,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "node_modules/buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -15518,11 +15510,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "node_modules/pad": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
@@ -15676,15 +15663,13 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/pg": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
+      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
       "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -15710,9 +15695,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -15783,20 +15768,20 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-promise": {
-      "version": "11.5.5",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.5.5.tgz",
-      "integrity": "sha512-DpJkDDH7rG0wUwFRRHimdV6DtG/UTK2SBEKC7KGFR6a5Zuqf9eGThR7dqIaHXnEBDZuWxUfWC5zMRqyk4EP7Lw==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.6.0.tgz",
+      "integrity": "sha512-NDRPMfkv3ia89suWlJ4iGvP6X5YFrLJ2+9AIVISeBFFZ29Eb4FNXX9JaVb1p1OrpQkE2yT7igmXPL7UYQhk+6A==",
       "dependencies": {
         "assert-options": "0.8.1",
-        "pg": "8.11.3",
+        "pg": "8.11.5",
         "pg-minify": "1.6.3",
         "spex": "3.3.0"
       },
@@ -15805,9 +15790,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -23528,11 +23513,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
-    "buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
-    },
     "busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -31057,11 +31037,6 @@
         "release-zalgo": "^1.0.0"
       }
     },
-    "packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "pad": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
@@ -31180,16 +31155,14 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "pg": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
+      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
       "requires": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
         "pg-cloudflare": "^1.1.1",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
@@ -31201,9 +31174,9 @@
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -31264,26 +31237,26 @@
       }
     },
     "pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
       "requires": {}
     },
     "pg-promise": {
-      "version": "11.5.5",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.5.5.tgz",
-      "integrity": "sha512-DpJkDDH7rG0wUwFRRHimdV6DtG/UTK2SBEKC7KGFR6a5Zuqf9eGThR7dqIaHXnEBDZuWxUfWC5zMRqyk4EP7Lw==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.6.0.tgz",
+      "integrity": "sha512-NDRPMfkv3ia89suWlJ4iGvP6X5YFrLJ2+9AIVISeBFFZ29Eb4FNXX9JaVb1p1OrpQkE2yT7igmXPL7UYQhk+6A==",
       "requires": {
         "assert-options": "0.8.1",
-        "pg": "8.11.3",
+        "pg": "8.11.5",
         "pg-minify": "1.6.3",
         "spex": "3.3.0"
       }
     },
     "pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "parse": "5.0.0",
         "path-to-regexp": "6.2.1",
         "pg-monitor": "2.0.0",
-        "pg-promise": "11.6.0",
+        "pg-promise": "11.7.8",
         "pluralize": "8.0.0",
         "rate-limit-redis": "4.2.0",
         "redis": "4.6.13",
@@ -15881,11 +15881,11 @@
       }
     },
     "node_modules/pg-minify": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.3.tgz",
-      "integrity": "sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.4.tgz",
+      "integrity": "sha512-cf6hBt1YqzqPX0OznXKSv4U7e4o7eUU4zp2zQsbJ+4OCNNr7EnnAVWkIz4k0dv6UN4ouS1ZL4WlXxCrZHHl69g==",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/pg-monitor": {
@@ -15949,13 +15949,13 @@
       }
     },
     "node_modules/pg-promise": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.6.0.tgz",
-      "integrity": "sha512-NDRPMfkv3ia89suWlJ4iGvP6X5YFrLJ2+9AIVISeBFFZ29Eb4FNXX9JaVb1p1OrpQkE2yT7igmXPL7UYQhk+6A==",
+      "version": "11.7.8",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.7.8.tgz",
+      "integrity": "sha512-s5pcLp8QLIFNhnEsxaqBtDh7LsOG3hjJbVOVpYlWPqg/g1LIixGMtbNgbxW1HkTSY5rKT9tyE0J+dw2X7bD3rQ==",
       "dependencies": {
         "assert-options": "0.8.1",
         "pg": "8.11.5",
-        "pg-minify": "1.6.3",
+        "pg-minify": "1.6.4",
         "spex": "3.3.0"
       },
       "engines": {
@@ -31681,9 +31681,9 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-minify": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.3.tgz",
-      "integrity": "sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ=="
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.4.tgz",
+      "integrity": "sha512-cf6hBt1YqzqPX0OznXKSv4U7e4o7eUU4zp2zQsbJ+4OCNNr7EnnAVWkIz4k0dv6UN4ouS1ZL4WlXxCrZHHl69g=="
     },
     "pg-monitor": {
       "version": "2.0.0",
@@ -31740,13 +31740,13 @@
       "requires": {}
     },
     "pg-promise": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.6.0.tgz",
-      "integrity": "sha512-NDRPMfkv3ia89suWlJ4iGvP6X5YFrLJ2+9AIVISeBFFZ29Eb4FNXX9JaVb1p1OrpQkE2yT7igmXPL7UYQhk+6A==",
+      "version": "11.7.8",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.7.8.tgz",
+      "integrity": "sha512-s5pcLp8QLIFNhnEsxaqBtDh7LsOG3hjJbVOVpYlWPqg/g1LIixGMtbNgbxW1HkTSY5rKT9tyE0J+dw2X7bD3rQ==",
       "requires": {
         "assert-options": "0.8.1",
         "pg": "8.11.5",
-        "pg-minify": "1.6.3",
+        "pg-minify": "1.6.4",
         "spex": "3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "parse": "5.0.0",
     "path-to-regexp": "6.2.1",
     "pg-monitor": "2.0.0",
-    "pg-promise": "11.5.5",
+    "pg-promise": "11.6.0",
     "pluralize": "8.0.0",
     "rate-limit-redis": "4.2.0",
     "redis": "4.6.13",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "parse": "5.0.0",
     "path-to-regexp": "6.2.1",
     "pg-monitor": "2.0.0",
-    "pg-promise": "11.6.0",
+    "pg-promise": "11.7.8",
     "pluralize": "8.0.0",
     "rate-limit-redis": "4.2.0",
     "redis": "4.6.13",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
pg-promise and related dependencies are out-of-date.

Closes: #9140 

## Approach
<!-- Describe the changes in this PR. -->
Update pg-promise

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Ensure CI passes
