### PR TITLE
fix: Parse Server option `extendSessionOnUse` not working for session lengths < 24 hours

### DIFF
--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -260,3 +260,58 @@ describe('Auth', () => {
     });
   });
 });
+
+describe('extendSessionOnUse', () => {
+  const tests = [
+    {
+      title: 'Updated more than 24 hrs ago',
+      sessionLength: 86460,
+      sessionUpdatedAt: 86410,
+      result: true,
+    },
+    {
+      title: 'Updated less than 24 hrs ago',
+      sessionLength: 86460,
+      sessionUpdatedAt: 86390,
+      result: false,
+    },
+    {
+      title: 'Update more than an hour ago',
+      sessionLength: 3660,
+      sessionUpdatedAt: 3610,
+      result: true,
+    },
+    {
+      title: 'Updated less than an hour ago',
+      sessionLength: 3660,
+      sessionUpdatedAt: 3590,
+      result: false,
+    },
+    {
+      title: 'Updated more than a minute ago.',
+      sessionLength: 120,
+      sessionUpdatedAt: 70,
+      result: true,
+    },
+    {
+      title: 'Updated less than a minute ago.',
+      sessionLength: 120,
+      sessionUpdatedAt: 50,
+      result: false,
+    },
+  ];
+
+  tests.forEach(({ title, sessionLength, sessionUpdatedAt, result }) => {
+    it(`shouldUpdateSessionExpiry() when ${title}`, async () => {
+      const { shouldUpdateSessionExpiry } = require('../lib/Auth');
+      let update = new Date();
+      update.setTime(update.getTime() - sessionUpdatedAt * 1000);
+      const res = shouldUpdateSessionExpiry(
+        { sessionLength: sessionLength },
+        { updatedAt: update }
+      );
+
+      expect(res).toBe(result);
+    });
+  });
+});

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -304,7 +304,7 @@ describe('extendSessionOnUse', () => {
   tests.forEach(({ title, sessionLength, sessionUpdatedAt, result }) => {
     it(`shouldUpdateSessionExpiry() when ${title}`, async () => {
       const { shouldUpdateSessionExpiry } = require('../lib/Auth');
-      let update = new Date();
+      const update = new Date();
       update.setTime(update.getTime() - sessionUpdatedAt * 1000);
       const res = shouldUpdateSessionExpiry(
         { sessionLength: sessionLength },

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -262,56 +262,22 @@ describe('Auth', () => {
 });
 
 describe('extendSessionOnUse', () => {
-  const tests = [
-    {
-      title: 'Updated more than 24 hrs ago',
-      sessionLength: 86460,
-      sessionUpdatedAt: 86410,
-      result: true,
-    },
-    {
-      title: 'Updated less than 24 hrs ago',
-      sessionLength: 86460,
-      sessionUpdatedAt: 86390,
-      result: false,
-    },
-    {
-      title: 'Update more than an hour ago',
-      sessionLength: 3660,
-      sessionUpdatedAt: 3610,
-      result: true,
-    },
-    {
-      title: 'Updated less than an hour ago',
-      sessionLength: 3660,
-      sessionUpdatedAt: 3590,
-      result: false,
-    },
-    {
-      title: 'Updated more than a minute ago.',
-      sessionLength: 120,
-      sessionUpdatedAt: 70,
-      result: true,
-    },
-    {
-      title: 'Updated less than a minute ago.',
-      sessionLength: 120,
-      sessionUpdatedAt: 50,
-      result: false,
-    },
-  ];
+  it(`shouldUpdateSessionExpiry()`, async () => {
+    const { shouldUpdateSessionExpiry } = require('../lib/Auth');
+    let update = new Date(Date.now() - 86410 * 1000);
 
-  tests.forEach(({ title, sessionLength, sessionUpdatedAt, result }) => {
-    it(`shouldUpdateSessionExpiry() when ${title}`, async () => {
-      const { shouldUpdateSessionExpiry } = require('../lib/Auth');
-      const update = new Date();
-      update.setTime(update.getTime() - sessionUpdatedAt * 1000);
-      const res = shouldUpdateSessionExpiry(
-        { sessionLength: sessionLength },
-        { updatedAt: update }
-      );
+    const res = shouldUpdateSessionExpiry(
+      { sessionLength: 86460 },
+      { updatedAt: update }
+    );
 
-      expect(res).toBe(result);
-    });
+    update = new Date(Date.now() - 43210 * 1000);
+    const res2 = shouldUpdateSessionExpiry(
+      { sessionLength: 86460 },
+      { updatedAt: update }
+    );
+
+    expect(res).toBe(true);
+    expect(res2).toBe(false);
   });
 });

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -71,15 +71,7 @@ function nobody(config) {
  * Checks whether session should be updated based on last update time & session length.
  */
 function shouldUpdateSessionExpiry(config, session) {
-  let resetAfter = 60;
-  if (config.sessionLength > 86400) {
-    resetAfter = 86400; // Every 24 hours
-  } else if (config.sessionLength > 3600) {
-    resetAfter = 3600; // 1 hour
-  } else {
-    resetAfter = 60; // Every minute
-  }
-
+  const resetAfter = config.sessionLength / 2;
   const lastUpdated = new Date(session?.updatedAt);
   const skipRange = new Date();
   skipRange.setTime(skipRange.getTime() - resetAfter * 1000);

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -67,7 +67,9 @@ function nobody(config) {
   return new Auth({ config, isMaster: false });
 }
 
-// A helper to check whether session should be updated based on last update time & session length.
+/**
+ * Checks whether session should be updated based on last update time & session length.
+ */
 function shouldUpdateSessionExpiry(config, session) {
   let resetAfter = 60;
   if (config.sessionLength > 86400) {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -259,7 +259,8 @@ module.exports.ParseServerOptions = {
   },
   extendSessionOnUse: {
     env: 'PARSE_SERVER_EXTEND_SESSION_ON_USE',
-    help: 'Whether Parse Server should automatically extend a valid session by the sessionLength',
+    help:
+      "Whether Parse Server should automatically extend a valid session by the sessionLength. The session will be extended when a request is received after half of the session's lifetime has passed.",
     action: parsers.booleanParser,
     default: false,
   },

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -260,7 +260,7 @@ module.exports.ParseServerOptions = {
   extendSessionOnUse: {
     env: 'PARSE_SERVER_EXTEND_SESSION_ON_USE',
     help:
-      "Whether Parse Server should automatically extend a valid session by the sessionLength. The session will be extended when a request is received after half of the session's lifetime has passed.",
+      "Whether Parse Server should automatically extend a valid session by the sessionLength. In order to reduce the number of session updates in the database, a session will only be extended when a request is received after at least half of the current session's lifetime has passed.",
     action: parsers.booleanParser,
     default: false,
   },

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -47,7 +47,7 @@
  * @property {String} encryptionKey Key for encrypting your files
  * @property {Boolean} enforcePrivateUsers Set to true if new users should be created without public read and write access.
  * @property {Boolean} expireInactiveSessions Sets whether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
- * @property {Boolean} extendSessionOnUse Whether Parse Server should automatically extend a valid session by the sessionLength
+ * @property {Boolean} extendSessionOnUse Whether Parse Server should automatically extend a valid session by the sessionLength. The session will be extended when a request is received after half of the session's lifetime has passed.
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system
  * @property {FileUploadOptions} fileUpload Options for file uploads

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -47,7 +47,7 @@
  * @property {String} encryptionKey Key for encrypting your files
  * @property {Boolean} enforcePrivateUsers Set to true if new users should be created without public read and write access.
  * @property {Boolean} expireInactiveSessions Sets whether we should expire the inactive sessions, defaults to true. If false, all new sessions are created with no expiration date.
- * @property {Boolean} extendSessionOnUse Whether Parse Server should automatically extend a valid session by the sessionLength. The session will be extended when a request is received after half of the session's lifetime has passed.
+ * @property {Boolean} extendSessionOnUse Whether Parse Server should automatically extend a valid session by the sessionLength. In order to reduce the number of session updates in the database, a session will only be extended when a request is received after at least half of the current session's lifetime has passed.
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system
  * @property {FileUploadOptions} fileUpload Options for file uploads

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -228,7 +228,7 @@ export interface ParseServerOptions {
   /* Session duration, in seconds, defaults to 1 year
   :DEFAULT: 31536000 */
   sessionLength: ?number;
-  /* Whether Parse Server should automatically extend a valid session by the sessionLength. The session will be extended when a request is received after half of the session's lifetime has passed.
+  /* Whether Parse Server should automatically extend a valid session by the sessionLength. In order to reduce the number of session updates in the database, a session will only be extended when a request is received after at least half of the current session's lifetime has passed.
   :DEFAULT: false */
   extendSessionOnUse: ?boolean;
   /* Default value for limit option on queries, defaults to `100`.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -228,7 +228,7 @@ export interface ParseServerOptions {
   /* Session duration, in seconds, defaults to 1 year
   :DEFAULT: 31536000 */
   sessionLength: ?number;
-  /* Whether Parse Server should automatically extend a valid session by the sessionLength
+  /* Whether Parse Server should automatically extend a valid session by the sessionLength. The session will be extended when a request is received after half of the session's lifetime has passed.
   :DEFAULT: false */
   extendSessionOnUse: ?boolean;
   /* Default value for limit option on queries, defaults to `100`.


### PR DESCRIPTION
## Pull Request
This PR helps with dynamically extending session based on session Length.

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #8981 

## Approach
I followed a similar approach to what @mman suggested [here](https://github.com/parse-community/parse-server/issues/8981#issuecomment-1976147677).

## Tasks
- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
