### PR TITLE
fix: Facebook Limited Login not workind due to incorrect domain in JWT validation

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -2081,7 +2081,7 @@ describe('facebook limited auth adapter', () => {
 
   it('should use algorithm from key header to verify id_token', async () => {
     const fakeClaim = {
-      iss: 'https://facebook.com',
+      iss: 'https://www.facebook.com',
       aud: 'secret',
       exp: Date.now(),
       sub: 'the_user_id',
@@ -2145,7 +2145,7 @@ describe('facebook limited auth adapter', () => {
 
   it('(using client id as string) should verify id_token', async () => {
     const fakeClaim = {
-      iss: 'https://facebook.com',
+      iss: 'https://www.facebook.com',
       aud: 'secret',
       exp: Date.now(),
       sub: 'the_user_id',
@@ -2172,7 +2172,7 @@ describe('facebook limited auth adapter', () => {
 
   it('(using client id as array) should verify id_token', async () => {
     const fakeClaim = {
-      iss: 'https://facebook.com',
+      iss: 'https://www.facebook.com',
       aud: 'secret',
       exp: Date.now(),
       sub: 'the_user_id',
@@ -2199,7 +2199,7 @@ describe('facebook limited auth adapter', () => {
 
   it('(using client id as array with multiple items) should verify id_token', async () => {
     const fakeClaim = {
-      iss: 'https://facebook.com',
+      iss: 'https://www.facebook.com',
       aud: 'secret',
       exp: Date.now(),
       sub: 'the_user_id',
@@ -2250,7 +2250,7 @@ describe('facebook limited auth adapter', () => {
       fail();
     } catch (e) {
       expect(e.message).toBe(
-        'id token not issued by correct OpenID provider - expected: https://facebook.com | from: https://not.facebook.com'
+        'id token not issued by correct OpenID provider - expected: https://www.facebook.com | from: https://not.facebook.com'
       );
     }
   });
@@ -2286,7 +2286,7 @@ describe('facebook limited auth adapter', () => {
       fail();
     } catch (e) {
       expect(e.message).toBe(
-        'id token not issued by correct OpenID provider - expected: https://facebook.com | from: https://not.facebook.com'
+        'id token not issued by correct OpenID provider - expected: https://www.facebook.com | from: https://not.facebook.com'
       );
     }
   });
@@ -2320,7 +2320,7 @@ describe('facebook limited auth adapter', () => {
       fail();
     } catch (e) {
       expect(e.message).toBe(
-        'id token not issued by correct OpenID provider - expected: https://facebook.com | from: https://not.facebook.com'
+        'id token not issued by correct OpenID provider - expected: https://www.facebook.com | from: https://not.facebook.com'
       );
     }
   });
@@ -2378,7 +2378,7 @@ describe('facebook limited auth adapter', () => {
 
   it('should throw error with with invalid user id', async () => {
     const fakeClaim = {
-      iss: 'https://facebook.com',
+      iss: 'https://www.facebook.com',
       aud: 'invalid_client_id',
       sub: 'a_different_user_id',
     };

--- a/src/Adapters/Auth/facebook.js
+++ b/src/Adapters/Auth/facebook.js
@@ -7,7 +7,7 @@ const jwt = require('jsonwebtoken');
 const httpsRequest = require('./httpsRequest');
 const authUtils = require('./utils');
 
-const TOKEN_ISSUER = 'https://facebook.com';
+const TOKEN_ISSUER = 'https://www.facebook.com';
 
 function getAppSecretPath(authData, options = {}) {
   const appSecret = options.appSecret;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
[Add support for Facebook auth JWT token #9117](https://github.com/parse-community/parse-server/issues/9117)

Closes: #9117

## Approach
A JWT token validation implementation seems to be already in place, however the host needs to be changed from facebook.com to www.facebook.com as suggested by @SebC99, because the old host is returning error 301 which is not followed by the jwt-rsa package.

## Tasks
- [ ] Add changes to documentation (guides, repository pages, code comments)
