### PR TITLE
ci: Fix docker image fails build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@
 ############################################################
 FROM node:lts-alpine AS build
 
-RUN apk --no-cache add git \
-   python3 \
-   build-base
+RUN apk --no-cache add \
+   build-base \
+   git \
+   python3
 
 WORKDIR /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@
 ############################################################
 FROM node:lts-alpine AS build
 
-RUN apk --no-cache add git
+RUN apk --no-cache add git \
+   python3 \
+   build-base
+
 WORKDIR /tmp
 
 # Copy package.json first to benefit from layer caching


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Docker images aren't building because necessary executables have been removed in dependency docker images.

Closes: #9130

## Approach
<!-- Describe the changes in this PR. -->
Install necessary executables in the build stage of the parse-server image, similar to `git` in #5861 (see #8359 for more details about reasons for only having in build stage). This shouldn't change the size of the release image.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Ensure Docker build passes in CI
