### PR TITLE
fix: Saving object with a pointer field set to `undefined` throws error for Postgres 

### DIFF
--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -587,8 +587,6 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
     // Create a 'Test' parse object with the 'pointerTo' field set to undefined
     const obj = new Parse.Object(testClassName);
     obj.set(pointerToFieldName, undefined);
-
-    // Saving 'Test' object should not throw
     expectAsync(obj.save()).toBeResolved();
 
     // Create a 'Test parse object with the fields set to undefined directly in the constructor

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -571,7 +571,7 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
     await client.none(qs);
   });
 
-  it('An object with a pointer field set to undefined should save without error', async () => {
+  it('saves object with a pointer field set to undefined', async () => {
     // Make a new class 'PointerTest'
     const pointerTestClassName = 'PointerTest';
     const pointerTestSchema = new Parse.Schema(pointerTestClassName);

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -571,7 +571,7 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
     await client.none(qs);
   });
 
-  it('saves object with a pointer field set to undefined', async () => {
+  fit('saves object with a pointer field set to undefined', async () => {
     const pointerTestClassName = 'PointerTest';
     const pointerTestSchema = new Parse.Schema(pointerTestClassName);
     await pointerTestSchema.save();

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -572,7 +572,6 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
   });
 
   it('saves object with a pointer field set to undefined', async () => {
-    // Make a new class 'PointerTest'
     const pointerTestClassName = 'PointerTest';
     const pointerTestSchema = new Parse.Schema(pointerTestClassName);
     await pointerTestSchema.save();

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -570,6 +570,38 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
     await adapter.deleteIdempotencyFunction();
     await client.none(qs);
   });
+
+  fit('An object with a pointer field set to undefined should save without error', async () => {
+    // Make a new class 'PointerTest'
+    const pointerTestClassName = 'PointerTest';
+    const pointerTestSchema = new Parse.Schema(pointerTestClassName);
+    await pointerTestSchema.save();
+
+    // Make another class 'Test' with a pointer field to the first class
+    const testClassName = 'Test';
+    const testSchema = new Parse.Schema(testClassName);
+    const pointerToFieldName = 'pointerTo';
+    testSchema.addPointer(pointerToFieldName, pointerTestClassName); // Field points to Pointer Test
+    await testSchema.save();
+
+    // Create a 'Test' parse object with the 'pointerTo' field set to undefined
+    const obj = new Parse.Object(testClassName);
+    obj.set(pointerToFieldName, undefined);
+
+    // Saving 'Test' object should not throw
+    expectAsync(obj.save()).toBeResolved();
+
+    // Create a 'Test parse object with the fields set to undefined directly in the constructor
+    const fields = {
+      [pointerToFieldName]: undefined,
+    };
+    const obj2 = new Parse.Object(testClassName, fields);
+    expectAsync(obj2.save()).toBeResolved();
+
+    // Create a 'Test' parse object with the fields set to undefined directly in the save method
+    const obj3 = new Parse.Object(testClassName);
+    expectAsync(obj3.save(fields)).toBeResolved();
+  });
 });
 
 describe_only_db('postgres')('PostgresStorageAdapter shutdown', () => {

--- a/spec/PostgresStorageAdapter.spec.js
+++ b/spec/PostgresStorageAdapter.spec.js
@@ -571,7 +571,7 @@ describe_only_db('postgres')('PostgresStorageAdapter', () => {
     await client.none(qs);
   });
 
-  fit('An object with a pointer field set to undefined should save without error', async () => {
+  it('An object with a pointer field set to undefined should save without error', async () => {
     // Make a new class 'PointerTest'
     const pointerTestClassName = 'PointerTest';
     const pointerTestSchema = new Parse.Schema(pointerTestClassName);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #9146 

## Approach
<!-- Describe the changes in this PR. -->
Work in progress, attempting to write a failing test case. Need to see if it fails for Postgres in CI (afaik i can only test on mongo locally. It passes for mongo but shouldn't for postgres)

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
