### PR TITLE
ci: Disable ci fail on codecov upload fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,8 @@ jobs:
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: true
+          # Set to `true` once codecov token bug is fixed; https://github.com/parse-community/parse-server/issues/9129
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
   check-postgres:
     strategy:


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Codecov upload fails, see https://github.com/parse-community/parse-server/issues/9129; so disable CI failing for now if cocecov upload fails.

