### PR TITLE
fix: Invalid push notification tokens are not cleaned up from database for FCM API v2

### DIFF
--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -248,7 +248,7 @@ export function pushStatusHandler(config, existingObjectId) {
             if (
               error?.code === 'messaging/registration-token-not-registered' ||
               error?.code === 'messaging/invalid-registration-token' ||
-              (error?.code === 'messaging/invalid-argument' && error.message === 'The registration token is not a valid FCM registration token')
+              (error?.code === 'messaging/invalid-argument' && error?.message === 'The registration token is not a valid FCM registration token')
             ) {
               devicesToRemove.push(token);
             }

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -237,11 +237,23 @@ export function pushStatusHandler(config, existingObjectId) {
           ) {
             const token = result.device.deviceToken;
             const error = result.response.error;
-            // GCM errors
+            // GCM / FCM HTTP v1 API errors; see:
+            // https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
             if (error === 'NotRegistered' || error === 'InvalidRegistration') {
               devicesToRemove.push(token);
             }
-            // APNS errors
+            // FCM API v2 errors; see:
+            // https://firebase.google.com/docs/cloud-messaging/manage-tokens
+            // https://github.com/firebase/functions-samples/blob/703c0359eacf07a551751d1319d34f912a2cd828/Node/fcm-notifications/functions/index.js#L89-L93C16
+            if (
+              error?.code === 'messaging/registration-token-not-registered' ||
+              error?.code === 'messaging/invalid-registration-token' ||
+              (error?.code === 'messaging/invalid-argument' && error.message === 'The registration token is not a valid FCM registration token')
+            ) {
+              devicesToRemove.push(token);
+            }
+            // APNS errors; see:
+            // https://developer.apple.com/documentation/usernotifications/handling-notification-responses-from-apns
             if (error === 'Unregistered' || error === 'BadDeviceToken') {
               devicesToRemove.push(token);
             }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #9085 

## Approach

The references on how to manage the token responses:
- https://github.com/firebase/functions-samples/blob/703c0359eacf07a551751d1319d34f912a2cd828/Node/fcm-notifications/functions/index.js#L85-L95
- https://firebase.google.com/docs/cloud-messaging/manage-tokens

Tokens will be cleaned up in the following cases:

- `messaging/registration-token-not-registered`
- `messaging/invalid-registration-token`
- `messaging/invalid-argument` but only if error message is `The registration token is not a valid FCM registration token` --> I tested this out; this error response is received if the token format itself is invalid, for example a token value of `invalid_test_token`

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests