### PR TITLE
fix: Incorrect Parse.Object field values with Parse JS SDK 5.2.0

### DIFF
--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2055,4 +2055,30 @@ describe('Parse.Object testing', () => {
     const object = new Parse.Object('CloudCodeIsNew');
     await object.save();
   });
+
+  fit('returns correct field values', async () => {
+    const values = [
+      { field: 'string', value: 'string' },
+      { field: 'number', value: 1 },
+      { field: 'boolean', value: true },
+      { field: 'array', value: [1, 2, 3] },
+      { field: 'object', value: { key: 'value' } },
+      { field: 'date', value: new Date() },
+      { field: 'file', value: Parse.File.fromJSON({
+        __type: 'File',
+        name: 'name',
+        url: 'http://localhost:8378/1/files/test/name',
+      }) },
+      { field: 'geoPoint', value: new Parse.GeoPoint(40, -30) },
+      { field: 'bytes', value: { __type: 'Bytes', base64: 'ZnJveW8=' } },
+    ];
+    for (const value of values) {
+      const object = new TestObject();
+      object.set(value.field, value.value);
+      await object.save();
+      const query = new Parse.Query(TestObject);
+      const objectAgain = await query.get(object.id);
+      expect(objectAgain.get(value.field)).toEqual(value.value);
+    }
+  });
 });

--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2062,7 +2062,10 @@ describe('Parse.Object testing', () => {
       { field: 'number', value: 1 },
       { field: 'boolean', value: true },
       { field: 'array', value: [1, 2, 3] },
-      { field: 'object', value: { key: 'value' } },
+      { field: 'object1', value: { key: 'value' } },
+      { field: 'object2', value: { key1: 'value1', key2: 'value2' } },
+      { field: 'object3', value: { key1: 1, key2: 2 } },
+      { field: 'object4', value: { '1': 1 } },
       { field: 'date', value: new Date() },
       { field: 'file', value: Parse.File.fromJSON({
         __type: 'File',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2198

## Approach

Trying to add a failing test to verify issue.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests