### PR TITLE
test: Object data type should not change from `beforeSave` to `afterSave` trigger

### DIFF
--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2120,7 +2120,7 @@ describe('Parse.Object testing', () => {
     await object.save();
   });
 
-  it('should not change the json field to array in afterSave', async () => {
+  fit('should not change the json field to array in afterSave', async () => {
     Parse.Cloud.beforeSave('failingJSONTestCase', req => {
       expect(req.object.get('jsonField')).toEqual({ '123': 'test' });
     });

--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2120,7 +2120,7 @@ describe('Parse.Object testing', () => {
     await object.save();
   });
 
-  fit('should not change the json field to array in afterSave', async () => {
+  it('should not change the json field to array in afterSave', async () => {
     Parse.Cloud.beforeSave('failingJSONTestCase', req => {
       expect(req.object.get('jsonField')).toEqual({ '123': 'test' });
     });

--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2055,4 +2055,18 @@ describe('Parse.Object testing', () => {
     const object = new Parse.Object('CloudCodeIsNew');
     await object.save();
   });
+
+  it('should not change the json field to array in afterSave', async () => {
+    Parse.Cloud.beforeSave('failingJSONTestCase', req => {
+      expect(req.object.get('jsonField')).toEqual({ '123': 'test' });
+    });
+
+    Parse.Cloud.afterSave('failingJSONTestCase', req => {
+      expect(req.object.get('jsonField')).toEqual({ '123': 'test' });
+    });
+
+    const object = new Parse.Object('failingJSONTestCase');
+    object.set('jsonField', { '123': 'test' });
+    await object.save();
+  });
 });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
Change in data of the object from beforeSave to afterSave hook.

Closes: #9176

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
