### PR TITLE
test: Add test to return correct field values

### DIFF
--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2078,7 +2078,7 @@ describe('Parse.Object testing', () => {
         value: Parse.File.fromJSON({
           __type: 'File',
           name: 'name',
-          url: 'http://localhost:1337/parse/files/integration/name',
+          url: 'http://localhost:8378/1/files/test/name',
         }),
       },
       { field: 'geoPoint', value: new Parse.GeoPoint(40, -30) },

--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -2055,4 +2055,42 @@ describe('Parse.Object testing', () => {
     const object = new Parse.Object('CloudCodeIsNew');
     await object.save();
   });
+
+  it('returns correct field values', async () => {
+    const values = [
+      { field: 'string', value: 'string' },
+      { field: 'number', value: 1 },
+      { field: 'boolean', value: true },
+      { field: 'array', value: [0, 1, 2] },
+      { field: 'array', value: [1, 2, 3] },
+      { field: 'array', value: [{ '0': 'a' }, 2, 3] },
+      { field: 'object', value: { key: 'value' } },
+      { field: 'object', value: { key1: 'value1', key2: 'value2' } },
+      { field: 'object', value: { key1: 1, key2: 2 } },
+      { field: 'object', value: { '1x1': 1 } },
+      { field: 'object', value: { '1x1': 1, '2': 2 } },
+      { field: 'object', value: { '0': 0 } },
+      { field: 'object', value: { '1': 1 } },
+      { field: 'object', value: { '0': { '0': 'a', '1': 'b' } } },
+      { field: 'date', value: new Date() },
+      {
+        field: 'file',
+        value: Parse.File.fromJSON({
+          __type: 'File',
+          name: 'name',
+          url: 'http://localhost:1337/parse/files/integration/name',
+        }),
+      },
+      { field: 'geoPoint', value: new Parse.GeoPoint(40, -30) },
+      { field: 'bytes', value: { __type: 'Bytes', base64: 'ZnJveW8=' } },
+    ];
+    for (const value of values) {
+      const object = new TestObject();
+      object.set(value.field, value.value);
+      await object.save();
+      const query = new Parse.Query(TestObject);
+      const objectAgain = await query.get(object.id);
+      expect(objectAgain.get(value.field)).toEqual(value.value);
+    }
+  });
 });


### PR DESCRIPTION
This test is to ensure that server-side changes like https://github.com/parse-community/parse-server/pull/9115 don't cause issues like https://github.com/parse-community/Parse-SDK-JS/issues/2198. Same test added to JS SDK in https://github.com/parse-community/Parse-SDK-JS/pull/2201.