### PR TITLE
test: Investigate flaky tests by turning off tests randomizer

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1362,6 +1362,7 @@ describe('Cloud Code', () => {
   });
 
   it('should not encode Parse Objects', async () => {
+    await reconfigureServer({ encodeParseObjectInCloudFunction: false });
     const user = new Parse.User();
     user.setUsername('username');
     user.setPassword('password');

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1268,6 +1268,7 @@ describe('miscellaneous', function () {
   });
 
   it('test cloud function query parameters with array of pointers', async () => {
+    await reconfigureServer({ encodeParseObjectInCloudFunction: false });
     Parse.Cloud.define('echoParams', req => {
       return req.params;
     });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -2,5 +2,5 @@
   "spec_dir": "spec",
   "spec_files": ["*spec.js"],
   "helpers": ["helper.js"],
-  "random": true
+  "random": false
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Attempt to fix flaky tests when the server isn't properly initialized. I believe this is caused by tests that shuts down the server to reproduce a disconnection and restarts. I am unable to reproduce this issue local so the CI should be ran a few times to ensure it works.

Closes: https://github.com/parse-community/parse-server/issues/9149

## Approach
<!-- Describe the changes in this PR. -->
* Enable live query server by default
* Track connections to live query server
* Properly destroy connections
* Properly handle open connections
* Enable `encodeParseObjectInCloudFunction` by default
* Turn off randomizer in test suite

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [x] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
