### PR TITLE
feat: Upgrade to @parse/push-adapter 6.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@graphql-tools/schema": "10.0.3",
         "@graphql-tools/utils": "8.12.0",
         "@parse/fs-files-adapter": "3.0.0",
-        "@parse/push-adapter": "6.2.0",
+        "@parse/push-adapter": "6.4.0",
         "bcryptjs": "2.4.3",
         "body-parser": "1.20.2",
         "commander": "12.0.0",
@@ -2506,48 +2506,48 @@
       "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.7.tgz",
-      "integrity": "sha512-baH1AA5zxfaz4O8w0vDwETByrKTQqB5CDjRls79Sa4eAGAoERw4Tnung7XbMl3jbJ4B/dmmtsMrdki0KikwDYA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.8.tgz",
+      "integrity": "sha512-LcNvxGLLGjBwB0dJUsBGCej2fqAepWyBubs4jt1Tiuns7QLbXHuyObZ4aMeBjZjWx4m8g1LoVI9QFpSaq/k4/g==",
       "dependencies": {
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.9.7",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.5.tgz",
-      "integrity": "sha512-cAfwBqMQuW6HbhwI3Cb/gDqZg7aR0OmaJ85WUxlnoYW2Tm4eR0hFl5FEijI3/gYPUiUcUPQvTkGV222VkT7KPw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.6.tgz",
+      "integrity": "sha512-nrexUEG/fpVlHtWKkyfhTC3834kZ1WS7voNyqbBsBCqHXQOvznN5Z0L3nxBqdXSJyltNAf4ndFlQqm5gZiEczQ==",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.2",
         "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.7",
+        "@firebase/component": "0.6.8",
         "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.9.7",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.5.tgz",
-      "integrity": "sha512-NDSMaDjQ+TZEMDMmzJwlTL05kh1+0Y84C+kVMaOmNOzRGRM7VHi29I6YUhCetXH+/b1Wh4ZZRyp1CuWkd8s6hg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.6.tgz",
+      "integrity": "sha512-1OGA0sLY47mkXjhICCrUTXEYFnSSXoiXWm1SHsN62b+Lzs5aKA3aWTjTUmYIoK93kDAMPkYpulSv8jcbH4Hwew==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/database": "1.0.5",
-        "@firebase/database-types": "1.0.3",
+        "@firebase/component": "0.6.8",
+        "@firebase/database": "1.0.6",
+        "@firebase/database-types": "1.0.4",
         "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.9.7",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.3.tgz",
-      "integrity": "sha512-39V/Riv2R3O/aUjYKh0xypj7NTNXNAK1bcgY5Kx+hdQPRS/aPTS8/5c0CGFYKgVuFbYlnlnhrCTYsh2uNhGwzA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.4.tgz",
+      "integrity": "sha512-mz9ZzbH6euFXbcBo+enuJ36I5dR5w+enJHHjy9Y5ThCdKUseqfDjW3vCp1YxE9zygFCSjJJ/z1cQ+zodvUcwPQ==",
       "dependencies": {
         "@firebase/app-types": "0.9.2",
-        "@firebase/util": "1.9.6"
+        "@firebase/util": "1.9.7"
       }
     },
     "node_modules/@firebase/logger": {
@@ -2559,17 +2559,17 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.6.tgz",
-      "integrity": "sha512-IBr1MZbp4d5MjBCXL3TW1dK/PDXX4yOGbiwRNh1oAbE/+ci5Uuvy9KIrsFYY80as1I0iOaD5oOMA9Q8j4TJWcw==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
+      "integrity": "sha512-fBVNH/8bRbYjqlbIhZ+lBtdAAS4WqZumx03K06/u7fJSpz1TGjEMm1ImvKD47w+xaFKIP2ori6z8BrbakRfjJA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.7.0.tgz",
-      "integrity": "sha512-41/vBFXOeSYjFI/2mJuJrDwg2umGk+FDrI/SCGzBRUe+UZWDN4GoahIbGZ19YQsY0ANNl6DRiAy4wD6JezK02g==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.9.0.tgz",
+      "integrity": "sha512-c4ALHT3G08rV7Zwv8Z2KG63gZh66iKdhCBeDfCpIkLrjX6EAjTD/szMdj14M+FnQuClZLFfW5bAgoOjfNmLtJg==",
       "optional": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2582,9 +2582,9 @@
       }
     },
     "node_modules/@google-cloud/paginator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz",
-      "integrity": "sha512-87aeg6QQcEPxGCOthnpUjvw4xAZ57G7pL8FS0C4e/81fr3FjkpUpibf1s2v5XGyGhUVGF4Jfg7yEcxqn2iUw1w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
       "optional": true,
       "dependencies": {
         "arrify": "^2.0.0",
@@ -2622,9 +2622,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.0.tgz",
-      "integrity": "sha512-W+OPOCgq7a3aAMANALbJAlEnpMV9fy681JWIm7dYe5W/+nRhq/UvA477TJT5/oPNA5DgiAdMEdiitdoLpZqhJg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.2.tgz",
+      "integrity": "sha512-jJOrKyOdujfrSF8EJODW9yY6hqO4jSTk6eVITEj2gsD43BSXuDlnMlLOaBUQhXL29VGnSkxDgYl5tlFhA6LKSA==",
       "optional": true,
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -2742,9 +2742,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.10.tgz",
+      "integrity": "sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==",
       "optional": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
@@ -3793,20 +3793,20 @@
       }
     },
     "node_modules/@parse/push-adapter": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-6.2.0.tgz",
-      "integrity": "sha512-WihGQ+5YxfEtuGIJtFv78e0+c3oKxyMKJvUV/rVZRG69ldgI/gsJq3bLGqFOPvq1/5bl6H37yPOIl3aLVhl1rQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-6.4.0.tgz",
+      "integrity": "sha512-u09vCm42iKJQiwG/uYDX/FROcP2jhkWRmU/fLllcMNizc77OR/Pvh+3AAsBCClZEB3RjEWwPebEPq6/AEKBS+Q==",
       "dependencies": {
         "@parse/node-apn": "6.0.1",
         "@parse/node-gcm": "1.0.2",
         "expo-server-sdk": "3.10.0",
-        "firebase-admin": "12.1.0",
+        "firebase-admin": "12.1.1",
         "npmlog": "7.0.1",
-        "parse": "5.0.0",
+        "parse": "5.1.0",
         "web-push": "3.6.7"
       },
       "engines": {
-        "node": ">=18.0.0 <21"
+        "node": "18 || 20 || 22"
       }
     },
     "node_modules/@parse/push-adapter/node_modules/@babel/runtime-corejs3": {
@@ -3822,9 +3822,9 @@
       }
     },
     "node_modules/@parse/push-adapter/node_modules/parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-5.0.0.tgz",
-      "integrity": "sha512-6gOARZWiHjmGusbTskhC1qlRn527olMEsdt2LLj9cP2GY3n4VFOwFwV8z/vm2+YfzPfPcv8z7qLih1NzmqzO0g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-5.1.0.tgz",
+      "integrity": "sha512-46gVRe1JHsh21Ht0/Ko6PeMDl6wELLMYxnZPFD6iZm2EWsWnzi2txNGE6PvnIv+G7yOufZIOD0BCZLYOFl3toA==",
       "dependencies": {
         "@babel/runtime-corejs3": "7.23.2",
         "idb-keyval": "6.2.1",
@@ -7754,9 +7754,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
-      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
       "funding": [
         {
           "type": "github",
@@ -8178,17 +8178,17 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.1.0.tgz",
-      "integrity": "sha512-bU7uPKMmIXAihWxntpY/Ma9zucn5y3ec+HQPqFQ/zcEfP9Avk9E/6D8u+yT/VwKHNZyg7yDVWOoJi73TIdR4Ww==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.1.1.tgz",
+      "integrity": "sha512-Nuoxk//gaYrspS7TvwBINdGvFhh2QeiaWpRW6+PJ+tWyn2/CugBc7jKa1NaBg0AvhGSOXFOCIsXhzCzHA47Rew==",
       "dependencies": {
         "@fastify/busboy": "^2.1.0",
         "@firebase/database-compat": "^1.0.2",
         "@firebase/database-types": "^1.0.0",
         "@types/node": "^20.10.3",
-        "farmhash": "^3.3.0",
+        "farmhash": "^3.3.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.0.1",
+        "jwks-rsa": "^3.1.0",
         "long": "^5.2.3",
         "node-forge": "^1.3.1",
         "uuid": "^9.0.0"
@@ -8197,7 +8197,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^7.1.0",
+        "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0"
       }
     },
@@ -8485,16 +8485,16 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.6.0.tgz",
-      "integrity": "sha512-bpOZVQV5gthH/jVCSuYuokRo2bTKOcuBiVWpjmTn6C5Agl5zclGfTljuGsQZxwwDBkli+YhZhP4TdlqTnhOezQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.0.tgz",
+      "integrity": "sha512-DSrkyMTfAnAm4ks9Go20QGOcXEyW/NmZhvTYBU2rb4afBB393WIMQPWPEDMl/k8xqiNN9HYq2zao3oWXsdl2Tg==",
       "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
         "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -8513,9 +8513,9 @@
       }
     },
     "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "optional": true,
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -8550,6 +8550,19 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "optional": true
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/gaxios/node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -8810,9 +8823,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.10.0.tgz",
-      "integrity": "sha512-ol+oSa5NbcGdDqA+gZ3G3mev59OHBZksBTxY/tYwjtcp1H/scAFwJfSQU9/1RALoyZ7FslNbke8j4i3ipwlyuQ==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
+      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
       "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -8848,33 +8861,27 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.3.3.tgz",
-      "integrity": "sha512-f4F2Y9X4+mqsrJuLZsuTljYuQpcBnQsCt9ScvZpdM8jGjqrcxyJi5JUiqtq0jtpdHVPzyit0N7f5t07e+kH5EA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.3.7.tgz",
+      "integrity": "sha512-3bnD8RASQyaxOYTdWLgwpQco/aytTxFavoI/UN5QN5txDLp8QRrBHNtCUJ5+Ago+551GD92jG8jJduwvmaneUw==",
       "optional": true,
       "dependencies": {
-        "@grpc/grpc-js": "~1.10.3",
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "google-auth-library": "^9.3.0",
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "7.2.6",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
         "retry-request": "^7.0.0",
         "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/google-gax/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "optional": true
     },
     "node_modules/google-gax/node_modules/node-fetch": {
       "version": "2.7.0",
@@ -8894,30 +8901,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/google-gax/node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/google-gax/node_modules/tr46": {
@@ -12153,9 +12136,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.62.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
-      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
+      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -16685,9 +16668,9 @@
       }
     },
     "node_modules/proto3-json-serializer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.1.tgz",
-      "integrity": "sha512-8awBvjO+FwkMd6gNoGFZyqkHZXCFd54CIYTb6De7dPaufGJ2XNW+QUNqbMr8MaAocMdb+KpsD4rxEOaTBDCffA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
       "optional": true,
       "dependencies": {
         "protobufjs": "^7.2.5"
@@ -16697,9 +16680,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -21744,48 +21727,48 @@
       "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
     },
     "@firebase/component": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.7.tgz",
-      "integrity": "sha512-baH1AA5zxfaz4O8w0vDwETByrKTQqB5CDjRls79Sa4eAGAoERw4Tnung7XbMl3jbJ4B/dmmtsMrdki0KikwDYA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.8.tgz",
+      "integrity": "sha512-LcNvxGLLGjBwB0dJUsBGCej2fqAepWyBubs4jt1Tiuns7QLbXHuyObZ4aMeBjZjWx4m8g1LoVI9QFpSaq/k4/g==",
       "requires": {
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.9.7",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.5.tgz",
-      "integrity": "sha512-cAfwBqMQuW6HbhwI3Cb/gDqZg7aR0OmaJ85WUxlnoYW2Tm4eR0hFl5FEijI3/gYPUiUcUPQvTkGV222VkT7KPw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.6.tgz",
+      "integrity": "sha512-nrexUEG/fpVlHtWKkyfhTC3834kZ1WS7voNyqbBsBCqHXQOvznN5Z0L3nxBqdXSJyltNAf4ndFlQqm5gZiEczQ==",
       "requires": {
         "@firebase/app-check-interop-types": "0.3.2",
         "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.7",
+        "@firebase/component": "0.6.8",
         "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.9.7",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-compat": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.5.tgz",
-      "integrity": "sha512-NDSMaDjQ+TZEMDMmzJwlTL05kh1+0Y84C+kVMaOmNOzRGRM7VHi29I6YUhCetXH+/b1Wh4ZZRyp1CuWkd8s6hg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.6.tgz",
+      "integrity": "sha512-1OGA0sLY47mkXjhICCrUTXEYFnSSXoiXWm1SHsN62b+Lzs5aKA3aWTjTUmYIoK93kDAMPkYpulSv8jcbH4Hwew==",
       "requires": {
-        "@firebase/component": "0.6.7",
-        "@firebase/database": "1.0.5",
-        "@firebase/database-types": "1.0.3",
+        "@firebase/component": "0.6.8",
+        "@firebase/database": "1.0.6",
+        "@firebase/database-types": "1.0.4",
         "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.9.7",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.3.tgz",
-      "integrity": "sha512-39V/Riv2R3O/aUjYKh0xypj7NTNXNAK1bcgY5Kx+hdQPRS/aPTS8/5c0CGFYKgVuFbYlnlnhrCTYsh2uNhGwzA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.4.tgz",
+      "integrity": "sha512-mz9ZzbH6euFXbcBo+enuJ36I5dR5w+enJHHjy9Y5ThCdKUseqfDjW3vCp1YxE9zygFCSjJJ/z1cQ+zodvUcwPQ==",
       "requires": {
         "@firebase/app-types": "0.9.2",
-        "@firebase/util": "1.9.6"
+        "@firebase/util": "1.9.7"
       }
     },
     "@firebase/logger": {
@@ -21797,17 +21780,17 @@
       }
     },
     "@firebase/util": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.6.tgz",
-      "integrity": "sha512-IBr1MZbp4d5MjBCXL3TW1dK/PDXX4yOGbiwRNh1oAbE/+ci5Uuvy9KIrsFYY80as1I0iOaD5oOMA9Q8j4TJWcw==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
+      "integrity": "sha512-fBVNH/8bRbYjqlbIhZ+lBtdAAS4WqZumx03K06/u7fJSpz1TGjEMm1ImvKD47w+xaFKIP2ori6z8BrbakRfjJA==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@google-cloud/firestore": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.7.0.tgz",
-      "integrity": "sha512-41/vBFXOeSYjFI/2mJuJrDwg2umGk+FDrI/SCGzBRUe+UZWDN4GoahIbGZ19YQsY0ANNl6DRiAy4wD6JezK02g==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.9.0.tgz",
+      "integrity": "sha512-c4ALHT3G08rV7Zwv8Z2KG63gZh66iKdhCBeDfCpIkLrjX6EAjTD/szMdj14M+FnQuClZLFfW5bAgoOjfNmLtJg==",
       "optional": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -21817,9 +21800,9 @@
       }
     },
     "@google-cloud/paginator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz",
-      "integrity": "sha512-87aeg6QQcEPxGCOthnpUjvw4xAZ57G7pL8FS0C4e/81fr3FjkpUpibf1s2v5XGyGhUVGF4Jfg7yEcxqn2iUw1w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
       "optional": true,
       "requires": {
         "arrify": "^2.0.0",
@@ -21847,9 +21830,9 @@
       "optional": true
     },
     "@google-cloud/storage": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.0.tgz",
-      "integrity": "sha512-W+OPOCgq7a3aAMANALbJAlEnpMV9fy681JWIm7dYe5W/+nRhq/UvA477TJT5/oPNA5DgiAdMEdiitdoLpZqhJg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.2.tgz",
+      "integrity": "sha512-jJOrKyOdujfrSF8EJODW9yY6hqO4jSTk6eVITEj2gsD43BSXuDlnMlLOaBUQhXL29VGnSkxDgYl5tlFhA6LKSA==",
       "optional": true,
       "requires": {
         "@google-cloud/paginator": "^5.0.0",
@@ -21938,9 +21921,9 @@
       "requires": {}
     },
     "@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "version": "1.10.10",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.10.tgz",
+      "integrity": "sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==",
       "optional": true,
       "requires": {
         "@grpc/proto-loader": "^0.7.13",
@@ -22726,16 +22709,16 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-6.2.0.tgz",
-      "integrity": "sha512-WihGQ+5YxfEtuGIJtFv78e0+c3oKxyMKJvUV/rVZRG69ldgI/gsJq3bLGqFOPvq1/5bl6H37yPOIl3aLVhl1rQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-6.4.0.tgz",
+      "integrity": "sha512-u09vCm42iKJQiwG/uYDX/FROcP2jhkWRmU/fLllcMNizc77OR/Pvh+3AAsBCClZEB3RjEWwPebEPq6/AEKBS+Q==",
       "requires": {
         "@parse/node-apn": "6.0.1",
         "@parse/node-gcm": "1.0.2",
         "expo-server-sdk": "3.10.0",
-        "firebase-admin": "12.1.0",
+        "firebase-admin": "12.1.1",
         "npmlog": "7.0.1",
-        "parse": "5.0.0",
+        "parse": "5.1.0",
         "web-push": "3.6.7"
       },
       "dependencies": {
@@ -22749,9 +22732,9 @@
           }
         },
         "parse": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-5.0.0.tgz",
-          "integrity": "sha512-6gOARZWiHjmGusbTskhC1qlRn527olMEsdt2LLj9cP2GY3n4VFOwFwV8z/vm2+YfzPfPcv8z7qLih1NzmqzO0g==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse/-/parse-5.1.0.tgz",
+          "integrity": "sha512-46gVRe1JHsh21Ht0/Ko6PeMDl6wELLMYxnZPFD6iZm2EWsWnzi2txNGE6PvnIv+G7yOufZIOD0BCZLYOFl3toA==",
           "requires": {
             "@babel/runtime-corejs3": "7.23.2",
             "crypto-js": "4.2.0",
@@ -25773,9 +25756,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-xml-parser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
-      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
       "optional": true,
       "requires": {
         "strnum": "^1.0.5"
@@ -26067,19 +26050,19 @@
       }
     },
     "firebase-admin": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.1.0.tgz",
-      "integrity": "sha512-bU7uPKMmIXAihWxntpY/Ma9zucn5y3ec+HQPqFQ/zcEfP9Avk9E/6D8u+yT/VwKHNZyg7yDVWOoJi73TIdR4Ww==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.1.1.tgz",
+      "integrity": "sha512-Nuoxk//gaYrspS7TvwBINdGvFhh2QeiaWpRW6+PJ+tWyn2/CugBc7jKa1NaBg0AvhGSOXFOCIsXhzCzHA47Rew==",
       "requires": {
         "@fastify/busboy": "^2.1.0",
         "@firebase/database-compat": "^1.0.2",
         "@firebase/database-types": "^1.0.0",
-        "@google-cloud/firestore": "^7.1.0",
+        "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0",
         "@types/node": "^20.10.3",
-        "farmhash": "^3.3.0",
+        "farmhash": "^3.3.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.0.1",
+        "jwks-rsa": "^3.1.0",
         "long": "^5.2.3",
         "node-forge": "^1.3.1",
         "uuid": "^9.0.0"
@@ -26288,16 +26271,16 @@
       }
     },
     "gaxios": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.6.0.tgz",
-      "integrity": "sha512-bpOZVQV5gthH/jVCSuYuokRo2bTKOcuBiVWpjmTn6C5Agl5zclGfTljuGsQZxwwDBkli+YhZhP4TdlqTnhOezQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.0.tgz",
+      "integrity": "sha512-DSrkyMTfAnAm4ks9Go20QGOcXEyW/NmZhvTYBU2rb4afBB393WIMQPWPEDMl/k8xqiNN9HYq2zao3oWXsdl2Tg==",
       "optional": true,
       "requires": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
         "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "uuid": "^10.0.0"
       },
       "dependencies": {
         "agent-base": {
@@ -26310,9 +26293,9 @@
           }
         },
         "https-proxy-agent": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-          "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+          "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
           "optional": true,
           "requires": {
             "agent-base": "^7.0.2",
@@ -26332,6 +26315,12 @@
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "optional": true
+        },
+        "uuid": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
           "optional": true
         },
         "webidl-conversions": {
@@ -26541,9 +26530,9 @@
       }
     },
     "google-auth-library": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.10.0.tgz",
-      "integrity": "sha512-ol+oSa5NbcGdDqA+gZ3G3mev59OHBZksBTxY/tYwjtcp1H/scAFwJfSQU9/1RALoyZ7FslNbke8j4i3ipwlyuQ==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.11.0.tgz",
+      "integrity": "sha512-epX3ww/mNnhl6tL45EQ/oixsY8JLEgUFoT4A5E/5iAR4esld9Kqv6IJGk7EmGuOgDvaarwF95hU2+v7Irql9lw==",
       "optional": true,
       "requires": {
         "base64-js": "^1.3.0",
@@ -26578,31 +26567,25 @@
       }
     },
     "google-gax": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.3.3.tgz",
-      "integrity": "sha512-f4F2Y9X4+mqsrJuLZsuTljYuQpcBnQsCt9ScvZpdM8jGjqrcxyJi5JUiqtq0jtpdHVPzyit0N7f5t07e+kH5EA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.3.7.tgz",
+      "integrity": "sha512-3bnD8RASQyaxOYTdWLgwpQco/aytTxFavoI/UN5QN5txDLp8QRrBHNtCUJ5+Ago+551GD92jG8jJduwvmaneUw==",
       "optional": true,
       "requires": {
-        "@grpc/grpc-js": "~1.10.3",
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "google-auth-library": "^9.3.0",
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "7.2.6",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
         "retry-request": "^7.0.0",
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-          "optional": true
-        },
         "node-fetch": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -26610,26 +26593,6 @@
           "optional": true,
           "requires": {
             "whatwg-url": "^5.0.0"
-          }
-        },
-        "protobufjs": {
-          "version": "7.2.6",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
-          "optional": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
           }
         },
         "tr46": {
@@ -29058,9 +29021,9 @@
       }
     },
     "node-abi": {
-      "version": "3.62.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
-      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
+      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
       "requires": {
         "semver": "^7.3.5"
       }
@@ -32339,18 +32302,18 @@
       }
     },
     "proto3-json-serializer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.1.tgz",
-      "integrity": "sha512-8awBvjO+FwkMd6gNoGFZyqkHZXCFd54CIYTb6De7dPaufGJ2XNW+QUNqbMr8MaAocMdb+KpsD4rxEOaTBDCffA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
       "optional": true,
       "requires": {
         "protobufjs": "^7.2.5"
       }
     },
     "protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@graphql-tools/schema": "10.0.3",
     "@graphql-tools/utils": "8.12.0",
     "@parse/fs-files-adapter": "3.0.0",
-    "@parse/push-adapter": "6.2.0",
+    "@parse/push-adapter": "6.4.0",
     "bcryptjs": "2.4.3",
     "body-parser": "1.20.2",
     "commander": "12.0.0",

--- a/spec/AdapterLoader.spec.js
+++ b/spec/AdapterLoader.spec.js
@@ -1,6 +1,5 @@
-const loadAdapter = require('../lib/Adapters/AdapterLoader').loadAdapter;
+const { loadAdapter, loadModule } = require('../lib/Adapters/AdapterLoader');
 const FilesAdapter = require('@parse/fs-files-adapter').default;
-const ParsePushAdapter = require('@parse/push-adapter').default;
 const MockFilesAdapter = require('mock-files-adapter');
 const Config = require('../lib/Config');
 
@@ -103,19 +102,19 @@ describe('AdapterLoader', () => {
     done();
   });
 
-  it('should load push adapter from options', done => {
+  it('should load push adapter from options', async () => {
     const options = {
       android: {
         senderId: 'yolo',
         apiKey: 'yolo',
       },
     };
+    const ParsePushAdapter = await loadModule('@parse/push-adapter');
     expect(() => {
       const adapter = loadAdapter(undefined, ParsePushAdapter, options);
       expect(adapter.constructor).toBe(ParsePushAdapter);
       expect(adapter).not.toBe(undefined);
     }).not.toThrow();
-    done();
   });
 
   it('should load custom push adapter from string (#3544)', done => {

--- a/src/Adapters/AdapterLoader.js
+++ b/src/Adapters/AdapterLoader.js
@@ -53,6 +53,9 @@ export async function loadModule(modulePath) {
   } catch (err) {
     if (err.code === 'ERR_REQUIRE_ESM') {
       module = await import(modulePath);
+      if (module.default) {
+        module = module.default;
+      }
     } else {
       throw err;
     }

--- a/src/Adapters/AdapterLoader.js
+++ b/src/Adapters/AdapterLoader.js
@@ -46,4 +46,18 @@ export function loadAdapter<T>(adapter, defaultAdapter, options): T {
   return adapter;
 }
 
+export async function loadModule(modulePath) {
+  let module;
+  try {
+    module = require(modulePath);
+  } catch (err) {
+    if (err.code === 'ERR_REQUIRE_ESM') {
+      module = await import(modulePath);
+    } else {
+      throw err;
+    }
+  }
+  return module;
+}
+
 export default loadAdapter;

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -182,7 +182,7 @@ export async function getPushController(options: ParseServerOptions): PushContro
   const ParsePushAdapter = await loadModule('@parse/push-adapter');
   const pushAdapter = loadAdapter(
     pushOptions && pushOptions.adapter,
-    ParsePushAdapter.default,
+    ParsePushAdapter,
     pushOptions
   );
   // We pass the options and the base class for the adatper,

--- a/src/Controllers/index.js
+++ b/src/Controllers/index.js
@@ -1,6 +1,6 @@
 import authDataManager from '../Adapters/Auth';
 import { ParseServerOptions } from '../Options';
-import { loadAdapter } from '../Adapters/AdapterLoader';
+import { loadAdapter, loadModule } from '../Adapters/AdapterLoader';
 import defaults from '../defaults';
 // Controllers
 import { LoggerController } from './LoggerController';
@@ -22,7 +22,6 @@ import { InMemoryCacheAdapter } from '../Adapters/Cache/InMemoryCacheAdapter';
 import { AnalyticsAdapter } from '../Adapters/Analytics/AnalyticsAdapter';
 import MongoStorageAdapter from '../Adapters/Storage/Mongo/MongoStorageAdapter';
 import PostgresStorageAdapter from '../Adapters/Storage/Postgres/PostgresStorageAdapter';
-import ParsePushAdapter from '@parse/push-adapter';
 import ParseGraphQLController from './ParseGraphQLController';
 import SchemaCache from '../Adapters/Cache/SchemaCache';
 
@@ -30,13 +29,6 @@ export function getControllers(options: ParseServerOptions) {
   const loggerController = getLoggerController(options);
   const filesController = getFilesController(options);
   const userController = getUserController(options);
-  const {
-    pushController,
-    hasPushScheduledSupport,
-    hasPushSupport,
-    pushControllerQueue,
-    pushWorker,
-  } = getPushController(options);
   const cacheController = getCacheController(options);
   const analyticsController = getAnalyticsController(options);
   const liveQueryController = getLiveQueryController(options);
@@ -51,11 +43,6 @@ export function getControllers(options: ParseServerOptions) {
     loggerController,
     filesController,
     userController,
-    pushController,
-    hasPushScheduledSupport,
-    hasPushSupport,
-    pushWorker,
-    pushControllerQueue,
     analyticsController,
     cacheController,
     parseGraphQLController,
@@ -182,7 +169,7 @@ interface PushControlling {
   pushWorker: PushWorker;
 }
 
-export function getPushController(options: ParseServerOptions): PushControlling {
+export async function getPushController(options: ParseServerOptions): PushControlling {
   const { scheduledPush, push } = options;
 
   const pushOptions = Object.assign({}, push);
@@ -192,9 +179,10 @@ export function getPushController(options: ParseServerOptions): PushControlling 
   }
 
   // Pass the push options too as it works with the default
+  const ParsePushAdapter = await loadModule('@parse/push-adapter');
   const pushAdapter = loadAdapter(
     pushOptions && pushOptions.adapter,
-    ParsePushAdapter,
+    ParsePushAdapter.default,
     pushOptions
   );
   // We pass the options and the base class for the adatper,

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -161,7 +161,6 @@ class ParseServer {
         }
       }
       const pushController = await controllers.getPushController(this.config);
-      this.config = { ...this.config, ...pushController };
       await hooksController.load();
       const startupPromises = [];
       if (schema) {
@@ -198,6 +197,7 @@ class ParseServer {
         new CheckRunner(security).run();
       }
       this.config.state = 'ok';
+      this.config = { ...this.config, ...pushController };
       Config.put(this.config);
       return this;
     } catch (error) {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -160,6 +160,8 @@ class ParseServer {
           throw e;
         }
       }
+      const pushController = await controllers.getPushController(this.config);
+      this.config = { ...this.config, ...pushController };
       await hooksController.load();
       const startupPromises = [];
       if (schema) {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The push adapter now supports ES6 and Node 22

```
*/node_modules/@parse/push-adapter/lib/WEB.js:59
var _ref = _asyncToGenerator( /#PURE/regeneratorRuntime.mark(function _callee(data, devices) {
^

ReferenceError: regeneratorRuntime is not defined
at /node_modules/@parse/push-adapter/lib/WEB.js:59:50
at /node_modules/@parse/push-adapter/lib/WEB.js:134:6
at Object. (/node_modules/@parse/push-adapter/lib/WEB.js:202:2)
at Module._compile (node:internal/modules/cjs/loader:1358:14)
at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
at Module.load (node:internal/modules/cjs/loader:1208:32)
at Module._load (node:internal/modules/cjs/loader:1024:12)
at Module.require (node:internal/modules/cjs/loader:1233:19)
at require (node:internal/modules/helpers:179:18)
at Object. (/node_modules/@parse/push-adapter/lib/ParsePushAdapter.js:29:12)
```
Closes: https://github.com/parse-community/parse-server-push-adapter/issues/256

