### PR TITLE
ci: Add specific node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/**.md'
 env:
-  NODE_VERSION: 20.12.0
+  NODE_VERSION: 22.4.1
   PARSE_SERVER_TEST_TIMEOUT: 20000
 jobs:
   check-code-analysis:
@@ -143,36 +143,36 @@ jobs:
           - name: MongoDB 4.2, ReplicaSet
             MONGODB_VERSION: 4.2.25
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22
+            NODE_VERSION: 22.4.1
           - name: MongoDB 4.4, ReplicaSet
             MONGODB_VERSION: 4.4.29
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22
+            NODE_VERSION: 22.4.1
           - name: MongoDB 5, ReplicaSet
             MONGODB_VERSION: 5.0.26
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22
+            NODE_VERSION: 22.4.1
           - name: MongoDB 6, ReplicaSet
             MONGODB_VERSION: 6.0.14
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22
+            NODE_VERSION: 22.4.1
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.8
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22
+            NODE_VERSION: 22.4.1
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 7.0.8
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 22
-          - name: Node 18
-            MONGODB_VERSION: 7.0.8
-            MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 18
+            NODE_VERSION: 22.4.1
           - name: Node 20
             MONGODB_VERSION: 7.0.8
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 20
+            NODE_VERSION: 20.15.1
+          - name: Node 18
+            MONGODB_VERSION: 7.0.8
+            MONGODB_TOPOLOGY: standalone
+            NODE_VERSION: 18.20.4
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15
@@ -221,25 +221,25 @@ jobs:
         include:
           - name: PostgreSQL 13, PostGIS 3.1
             POSTGRES_IMAGE: postgis/postgis:13-3.1
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
           - name: PostgreSQL 13, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:13-3.2
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
           - name: PostgreSQL 13, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:13-3.3
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
           - name: PostgreSQL 13, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:13-3.4
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
           - name: PostgreSQL 14, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:14-3.4
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
           - name: PostgreSQL 15, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:15-3.4
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
           - name: PostgreSQL 16, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:15-3.4
-            NODE_VERSION: 20.12.0
+            NODE_VERSION: 22.4.1
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ Before you start make sure you have installed:
 
 Parse Server is continuously tested with the most recent releases of Node.js to ensure compatibility. We follow the [Node.js Long Term Support plan](https://github.com/nodejs/Release) and only test against versions that are officially supported and have not reached their end-of-life date.
 
-| Version    | End-of-Life | Compatible |
-|------------|-------------|------------|
-| Node.js 18 | April 2025  | ✅ Yes      |
-| Node.js 20 | April 2026  | ✅ Yes      |
-| Node.js 22 | April 2027  | ✅ Yes      |
+| Version    | Latest Version | End-of-Life | Compatible |
+|------------|----------------|-------------|------------|
+| Node.js 18 | 18.20.4        | April 2025  | ✅ Yes      |
+| Node.js 20 | 20.15.1        | April 2026  | ✅ Yes      |
+| Node.js 22 | 22.4.1         | April 2027  | ✅ Yes      |
 
 #### MongoDB
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

https://github.com/parse-community/parse-server/pull/9187 removed specifying exact Node versions from the CI workflow. As a consequence, it is now unclear which exact Node version Parse Server was tested with and is compatible with. For developers to be able to trust that Parse Server works with a specific Node version, this PR re-introduced exact Node version definitions in the CI workflow.

TODO:
- With the next Parse Server major release, the engine version in package.json also must contain for each major Node version a specific min. version that it has been tested with.

## Approach
<!-- Describe the changes in this PR. -->


