### PR TITLE
fix: Parse Server `databaseOptions` nested keys incorrectly identified as invalid

### DIFF
--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -1,7 +1,7 @@
 const Config = require('../lib/Config');
 
 fdescribe('Config Keys', () => {
-  const invalidKeyErrorMessage = 'Invalid key(s) found in Parse Server configuration';
+  const invalidKeyErrorMessage = 'Invalid key\\(s\\) found in Parse Server configuration';
   let loggerErrorSpy;
 
   beforeEach(async () => {
@@ -58,7 +58,7 @@ fdescribe('Config Keys', () => {
       ]
     })).toBeRejected();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch('Invalid key(s) found in Parse Server configuration');
+    expect(error).toMatch(invalidKeyErrorMessage);
     expect(error).toMatch('rateLimit\\[0\\]\\.invalidKey');
     expect(error).toMatch('rateLimit\\[1\\]\\.RequestPath');
     expect(error).toMatch('rateLimit\\[2\\]\\.RequestTimeWindow');
@@ -71,7 +71,7 @@ fdescribe('Config Keys', () => {
     expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(invalidKeyErrorMessage);
   });
 
-  fit('recognizes valid keys in databaseOptions', async () => {
+  it('recognizes valid keys in databaseOptions', async () => {
     await expectAsync(reconfigureServer({
       databaseURI: 'mongodb://localhost:27017/parse',
       filesAdapter: null,

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -1,6 +1,6 @@
 const Config = require('../lib/Config');
 
-fdescribe('Config Keys', () => {
+describe('Config Keys', () => {
   const invalidKeyErrorMessage = 'Invalid key\\(s\\) found in Parse Server configuration';
   let loggerErrorSpy;
 

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -15,7 +15,7 @@ fdescribe('Config Keys', () => {
       invalidKey: 1,
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Unknown key(s) found in Parse Server configuration`);
+    expect(error).toMatch(`Invalid key(s) found in Parse Server configuration`);
   });
 
   it('recognizes invalid keys in pages.customUrls', async () => {
@@ -29,7 +29,7 @@ fdescribe('Config Keys', () => {
       }
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Unknown key(s) found in Parse Server configuration`);
+    expect(error).toMatch(`Invalid key(s) found in Parse Server configuration`);
     expect(error).toMatch(`invalidKey`);
     expect(error).toMatch(`EmailVerificationSendFail`);
   });
@@ -43,7 +43,7 @@ fdescribe('Config Keys', () => {
       }
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Unknown key(s) found in Parse Server configuration`);
+    expect(error).toMatch(`Invalid key(s) found in Parse Server configuration`);
     expect(error).toMatch(`MasterKey`);
   });
 
@@ -57,7 +57,7 @@ fdescribe('Config Keys', () => {
       ]
     })).toBeRejected();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch('Unknown key(s) found in Parse Server configuration');
+    expect(error).toMatch('Invalid key(s) found in Parse Server configuration');
     expect(error).toMatch('rateLimit\\[0\\]\\.invalidKey');
     expect(error).toMatch('rateLimit\\[1\\]\\.RequestPath');
     expect(error).toMatch('rateLimit\\[2\\]\\.RequestTimeWindow');
@@ -67,7 +67,7 @@ fdescribe('Config Keys', () => {
     await expectAsync(reconfigureServer({
       ...defaultConfiguration,
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Unknown key(s) found in Parse Server configuration`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid key(s) found in Parse Server configuration`);
   });
 
   fit('recognizes valid keys in databaseOptions', async () => {
@@ -82,6 +82,6 @@ fdescribe('Config Keys', () => {
         maxPoolSize: 10,
       },
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Unknown key(s) found in Parse Server configuration`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid key(s) found in Parse Server configuration`);
   });
 });

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -1,6 +1,6 @@
 const Config = require('../lib/Config');
 
-describe('Config Keys', () => {
+fdescribe('Config Keys', () => {
   let loggerErrorSpy;
 
   beforeEach(async () => {

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -1,52 +1,87 @@
 const Config = require('../lib/Config');
-const ParseServer = require('../lib/index').ParseServer;
 
 describe('Config Keys', () => {
-  const tests = [
-    {
-      name: 'Invalid Root Keys',
-      options: { unknow: 'val', masterKeyIPs: '' },
-      error: 'unknow, masterKeyIPs',
-    },
-    { name: 'Invalid Schema Keys', options: { schema: { Strict: 'val' } }, error: 'schema.Strict' },
-    {
-      name: 'Invalid Pages Keys',
-      options: { pages: { customUrls: { EmailVerificationSendFail: 'val' } } },
-      error: 'pages.customUrls.EmailVerificationSendFail',
-    },
-    {
-      name: 'Invalid LiveQueryServerOptions Keys',
-      options: { liveQueryServerOptions: { MasterKey: 'value' } },
-      error: 'liveQueryServerOptions.MasterKey',
-    },
-    {
-      name: 'Invalid RateLimit Keys - Array Item',
-      options: { rateLimit: [{ RequestPath: '' }, { RequestTimeWindow: '' }] },
-      error: 'rateLimit[0].RequestPath, rateLimit[1].RequestTimeWindow',
-    },
-  ];
+  let loggerErrorSpy;
 
-  tests.forEach(test => {
-    it(test.name, async () => {
-      const logger = require('../lib/logger').logger;
-      spyOn(logger, 'error').and.callThrough();
-      spyOn(Config, 'validateOptions').and.callFake(() => {});
-
-      new ParseServer({
-        ...defaultConfiguration,
-        ...test.options,
-      });
-      expect(logger.error).toHaveBeenCalledWith(`Invalid Option Keys Found: ${test.error}`);
-    });
+  beforeEach(async () => {
+    const logger = require('../lib/logger').logger;
+    loggerErrorSpy = spyOn(logger, 'error').and.callThrough();
+    spyOn(Config, 'validateOptions').and.callFake(() => {});
   });
 
-  it('should run fine', async () => {
-    try {
-      await reconfigureServer({
-        ...defaultConfiguration,
-      });
-    } catch (err) {
-      fail('Should run without error');
-    }
+  it('recognizes invalid keys in root', async () => {
+    await expectAsync(reconfigureServer({
+      ...defaultConfiguration,
+      invalidKey: 1,
+    })).toBeResolved();
+    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    expect(error).toMatch(`Invalid Option Keys Found`);
+  });
+
+  it('recognizes invalid keys in pages.customUrls', async () => {
+    await expectAsync(reconfigureServer({
+      ...defaultConfiguration,
+      pages: {
+        customUrls: {
+          invalidKey: 1,
+          EmailVerificationSendFail: 1,
+        }
+      }
+    })).toBeResolved();
+    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    expect(error).toMatch(`Invalid Option Keys Found`);
+    expect(error).toMatch(`invalidKey`);
+    expect(error).toMatch(`EmailVerificationSendFail`);
+  });
+
+  it('recognizes invalid keys in liveQueryServerOptions', async () => {
+    await expectAsync(reconfigureServer({
+      ...defaultConfiguration,
+      liveQueryServerOptions: {
+        invalidKey: 1,
+        MasterKey: 1,
+      }
+    })).toBeResolved();
+    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    expect(error).toMatch(`Invalid Option Keys Found`);
+    expect(error).toMatch(`MasterKey`);
+  });
+
+  it('recognizes invalid keys in rateLimit', async () => {
+    await expectAsync(reconfigureServer({
+      ...defaultConfiguration,
+      rateLimit: [
+        { invalidKey: 1 },
+        { RequestPath: 1 },
+        { RequestTimeWindow: 1 },
+      ]
+    })).toBeRejected();
+    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    expect(error).toMatch('Invalid Option Keys Found');
+    expect(error).toMatch('rateLimit\\[0\\]\\.invalidKey');
+    expect(error).toMatch('rateLimit\\[1\\]\\.RequestPath');
+    expect(error).toMatch('rateLimit\\[2\\]\\.RequestTimeWindow');
+  });
+
+  it('recognizes valid keys in default configuration', async () => {
+    await expectAsync(reconfigureServer({
+      ...defaultConfiguration,
+    })).toBeResolved();
+    expect(loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
+  });
+
+  it('recognizes valid keys in databaseOptions', async () => {
+    await expectAsync(reconfigureServer({
+      databaseURI: 'mongodb://localhost:27017/parse',
+      filesAdapter: null,
+      databaseAdapter: null,
+      databaseOptions: {
+        retryWrites: true,
+        maxTimeMS: 1000,
+        maxStalenessSeconds: 10,
+        maxPoolSize: 10,
+      },
+    })).toBeResolved();
+    expect(loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
   });
 });

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -71,7 +71,7 @@ describe('Config Keys', () => {
     expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(invalidKeyErrorMessage);
   });
 
-  it('recognizes valid keys in databaseOptions', async () => {
+  it_only_db('mongo')('recognizes valid keys in databaseOptions (MongoDB)', async () => {
     await expectAsync(reconfigureServer({
       databaseURI: 'mongodb://localhost:27017/parse',
       filesAdapter: null,

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -14,7 +14,7 @@ describe('Config Keys', () => {
       ...defaultConfiguration,
       invalidKey: 1,
     })).toBeResolved();
-    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
     expect(error).toMatch(`Invalid Option Keys Found`);
   });
 
@@ -28,7 +28,7 @@ describe('Config Keys', () => {
         }
       }
     })).toBeResolved();
-    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
     expect(error).toMatch(`Invalid Option Keys Found`);
     expect(error).toMatch(`invalidKey`);
     expect(error).toMatch(`EmailVerificationSendFail`);
@@ -42,7 +42,7 @@ describe('Config Keys', () => {
         MasterKey: 1,
       }
     })).toBeResolved();
-    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
     expect(error).toMatch(`Invalid Option Keys Found`);
     expect(error).toMatch(`MasterKey`);
   });
@@ -56,7 +56,7 @@ describe('Config Keys', () => {
         { RequestTimeWindow: 1 },
       ]
     })).toBeRejected();
-    const error = loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '');
+    const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
     expect(error).toMatch('Invalid Option Keys Found');
     expect(error).toMatch('rateLimit\\[0\\]\\.invalidKey');
     expect(error).toMatch('rateLimit\\[1\\]\\.RequestPath');
@@ -67,7 +67,7 @@ describe('Config Keys', () => {
     await expectAsync(reconfigureServer({
       ...defaultConfiguration,
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
   });
 
   it('recognizes valid keys in databaseOptions', async () => {
@@ -82,6 +82,6 @@ describe('Config Keys', () => {
         maxPoolSize: 10,
       },
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((string, call) => string = call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
   });
 });

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -15,7 +15,7 @@ fdescribe('Config Keys', () => {
       invalidKey: 1,
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Invalid Option Keys Found`);
+    expect(error).toMatch(`Unknown key(s) found in Parse Server configuration`);
   });
 
   it('recognizes invalid keys in pages.customUrls', async () => {
@@ -29,7 +29,7 @@ fdescribe('Config Keys', () => {
       }
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Invalid Option Keys Found`);
+    expect(error).toMatch(`Unknown key(s) found in Parse Server configuration`);
     expect(error).toMatch(`invalidKey`);
     expect(error).toMatch(`EmailVerificationSendFail`);
   });
@@ -43,7 +43,7 @@ fdescribe('Config Keys', () => {
       }
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Invalid Option Keys Found`);
+    expect(error).toMatch(`Unknown key(s) found in Parse Server configuration`);
     expect(error).toMatch(`MasterKey`);
   });
 
@@ -57,7 +57,7 @@ fdescribe('Config Keys', () => {
       ]
     })).toBeRejected();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch('Invalid Option Keys Found');
+    expect(error).toMatch('Unknown key(s) found in Parse Server configuration');
     expect(error).toMatch('rateLimit\\[0\\]\\.invalidKey');
     expect(error).toMatch('rateLimit\\[1\\]\\.RequestPath');
     expect(error).toMatch('rateLimit\\[2\\]\\.RequestTimeWindow');
@@ -67,10 +67,10 @@ fdescribe('Config Keys', () => {
     await expectAsync(reconfigureServer({
       ...defaultConfiguration,
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Unknown key(s) found in Parse Server configuration`);
   });
 
-  it('recognizes valid keys in databaseOptions', async () => {
+  fit('recognizes valid keys in databaseOptions', async () => {
     await expectAsync(reconfigureServer({
       databaseURI: 'mongodb://localhost:27017/parse',
       filesAdapter: null,
@@ -82,6 +82,6 @@ fdescribe('Config Keys', () => {
         maxPoolSize: 10,
       },
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid Option Keys Found`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Unknown key(s) found in Parse Server configuration`);
   });
 });

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -1,6 +1,7 @@
 const Config = require('../lib/Config');
 
 fdescribe('Config Keys', () => {
+  const invalidKeyErrorMessage = 'Invalid key(s) found in Parse Server configuration';
   let loggerErrorSpy;
 
   beforeEach(async () => {
@@ -15,7 +16,7 @@ fdescribe('Config Keys', () => {
       invalidKey: 1,
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Invalid key(s) found in Parse Server configuration`);
+    expect(error).toMatch(invalidKeyErrorMessage);
   });
 
   it('recognizes invalid keys in pages.customUrls', async () => {
@@ -29,7 +30,7 @@ fdescribe('Config Keys', () => {
       }
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Invalid key(s) found in Parse Server configuration`);
+    expect(error).toMatch(invalidKeyErrorMessage);
     expect(error).toMatch(`invalidKey`);
     expect(error).toMatch(`EmailVerificationSendFail`);
   });
@@ -43,7 +44,7 @@ fdescribe('Config Keys', () => {
       }
     })).toBeResolved();
     const error = loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '');
-    expect(error).toMatch(`Invalid key(s) found in Parse Server configuration`);
+    expect(error).toMatch(invalidKeyErrorMessage);
     expect(error).toMatch(`MasterKey`);
   });
 
@@ -67,7 +68,7 @@ fdescribe('Config Keys', () => {
     await expectAsync(reconfigureServer({
       ...defaultConfiguration,
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid key(s) found in Parse Server configuration`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(invalidKeyErrorMessage);
   });
 
   fit('recognizes valid keys in databaseOptions', async () => {
@@ -82,6 +83,6 @@ fdescribe('Config Keys', () => {
         maxPoolSize: 10,
       },
     })).toBeResolved();
-    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(`Invalid key(s) found in Parse Server configuration`);
+    expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(invalidKeyErrorMessage);
   });
 });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -1,0 +1,49 @@
+const Utils = require('../src/Utils');
+
+describe('Utils', () => {
+  describe('addNestedKeysToRoot', () => {
+    it('should move the nested keys to root of object', async () => {
+      const obj = {
+        a: 1,
+        b: {
+          c: 2,
+          d: 3
+        },
+        e: 4
+      };
+      Utils.addNestedKeysToRoot(obj, 'b');
+      expect(obj).toEqual({
+        a: 1,
+        c: 2,
+        d: 3,
+        e: 4
+      });
+    });
+
+    it('should not modify the object if the key does not exist', async () => {
+      const obj = {
+        a: 1,
+        e: 4
+      };
+      Utils.addNestedKeysToRoot(obj, 'b');
+      expect(obj).toEqual({
+        a: 1,
+        e: 4
+      });
+    });
+
+    it('should not modify the object if the key is not an object', () => {
+      const obj = {
+        a: 1,
+        b: 2,
+        e: 4
+      };
+      Utils.addNestedKeysToRoot(obj, 'b');
+      expect(obj).toEqual({
+        a: 1,
+        b: 2,
+        e: 4
+      });
+    });
+  });
+});

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -1051,6 +1051,29 @@ module.exports.DatabaseOptions = {
     action: parsers.booleanParser,
     default: false,
   },
+  maxPoolSize: {
+    env: 'PARSE_SERVER_DATABASE_MAX_POOL_SIZE',
+    help:
+      'The MongoDB driver option to set the maximum number of opened, cached, ready-to-use database connections maintained by the driver.',
+    action: parsers.numberParser('maxPoolSize'),
+  },
+  maxStalenessSeconds: {
+    env: 'PARSE_SERVER_DATABASE_MAX_STALENESS_SECONDS',
+    help:
+      'The MongoDB driver option to set the maximum replication lag for reads from secondary nodes.',
+    action: parsers.numberParser('maxStalenessSeconds'),
+  },
+  maxTimeMS: {
+    env: 'PARSE_SERVER_DATABASE_MAX_TIME_MS',
+    help:
+      'The MongoDB driver option to set a cumulative time limit in milliseconds for processing operations on a cursor.',
+    action: parsers.numberParser('maxTimeMS'),
+  },
+  retryWrites: {
+    env: 'PARSE_SERVER_DATABASE_RETRY_WRITES',
+    help: 'The MongoDB driver option to set whether to retry failed writes.',
+    action: parsers.booleanParser,
+  },
   schemaCacheTtl: {
     env: 'PARSE_SERVER_DATABASE_SCHEMA_CACHE_TTL',
     help:

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -235,6 +235,10 @@
 /**
  * @interface DatabaseOptions
  * @property {Boolean} enableSchemaHooks Enables database real-time hooks to update single schema cache. Set to `true` if using multiple Parse Servers instances connected to the same database. Failing to do so will cause a schema change to not propagate to all instances and re-syncing will only happen when the instances restart. To use this feature with MongoDB, a replica set cluster with [change stream](https://docs.mongodb.com/manual/changeStreams/#availability) support is required.
+ * @property {Number} maxPoolSize The MongoDB driver option to set the maximum number of opened, cached, ready-to-use database connections maintained by the driver.
+ * @property {Number} maxStalenessSeconds The MongoDB driver option to set the maximum replication lag for reads from secondary nodes.
+ * @property {Number} maxTimeMS The MongoDB driver option to set a cumulative time limit in milliseconds for processing operations on a cursor.
+ * @property {Boolean} retryWrites The MongoDB driver option to set whether to retry failed writes.
  * @property {Number} schemaCacheTtl The duration in seconds after which the schema cache expires and will be refetched from the database. Use this option if using multiple Parse Servers instances connected to the same database. A low duration will cause the schema cache to be updated too often, causing unnecessary database reads. A high duration will cause the schema to be updated too rarely, increasing the time required until schema changes propagate to all server instances. This feature can be used as an alternative or in conjunction with the option `enableSchemaHooks`. Default is infinite which means the schema cache never expires.
  */
 

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -596,6 +596,14 @@ export interface DatabaseOptions {
   enableSchemaHooks: ?boolean;
   /* The duration in seconds after which the schema cache expires and will be refetched from the database. Use this option if using multiple Parse Servers instances connected to the same database. A low duration will cause the schema cache to be updated too often, causing unnecessary database reads. A high duration will cause the schema to be updated too rarely, increasing the time required until schema changes propagate to all server instances. This feature can be used as an alternative or in conjunction with the option `enableSchemaHooks`. Default is infinite which means the schema cache never expires. */
   schemaCacheTtl: ?number;
+  /* The MongoDB driver option to set whether to retry failed writes. */
+  retryWrites: ?boolean;
+  /* The MongoDB driver option to set a cumulative time limit in milliseconds for processing operations on a cursor. */
+  maxTimeMS: ?number;
+  /* The MongoDB driver option to set the maximum replication lag for reads from secondary nodes.*/
+  maxStalenessSeconds: ?number;
+  /* The MongoDB driver option to set the maximum number of opened, cached, ready-to-use database connections maintained by the driver. */
+  maxPoolSize: ?number;
 }
 
 export interface AuthAdapter {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -109,7 +109,7 @@ class ParseServer {
     const diff = validateKeyNames(options, optionsBlueprint);
     if (diff.length > 0) {
       const logger = logging.logger;
-      logger.error(`Invalid Option Keys Found: ${diff.join(', ')}`);
+      logger.error(`Unknown key(s) found in Parse Server configuration: ${diff.join(', ')}`);
     }
 
     // Set option defaults

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -46,6 +46,7 @@ import CheckRunner from './Security/CheckRunner';
 import Deprecator from './Deprecator/Deprecator';
 import { DefinedSchemas } from './SchemaMigrations/DefinedSchemas';
 import OptionsDefinitions from './Options/Definitions';
+import Utils from './Utils';
 
 // Mutate the Parse object to add the Cloud Code handlers
 addParseCloud();
@@ -110,6 +111,11 @@ class ParseServer {
     if (diff.length > 0) {
       const logger = logging.logger;
       logger.error(`Invalid key(s) found in Parse Server configuration: ${diff.join(', ')}`);
+    }
+
+    // Move unsafe database driver options
+    if (options.databaseOptions !== undefined) {
+      options.databaseOptions = Utils.addNestedKeysToRoot(options.databaseOptions, 'unsafeDriverOptions');
     }
 
     // Set option defaults

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -113,11 +113,6 @@ class ParseServer {
       logger.error(`Invalid key(s) found in Parse Server configuration: ${diff.join(', ')}`);
     }
 
-    // Move unsafe database driver options
-    if (options.databaseOptions !== undefined) {
-      options.databaseOptions = Utils.addNestedKeysToRoot(options.databaseOptions, 'unsafeDriverOptions');
-    }
-
     // Set option defaults
     injectDefaults(options);
     const {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -46,7 +46,6 @@ import CheckRunner from './Security/CheckRunner';
 import Deprecator from './Deprecator/Deprecator';
 import { DefinedSchemas } from './SchemaMigrations/DefinedSchemas';
 import OptionsDefinitions from './Options/Definitions';
-import Utils from './Utils';
 
 // Mutate the Parse object to add the Cloud Code handlers
 addParseCloud();

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -109,7 +109,7 @@ class ParseServer {
     const diff = validateKeyNames(options, optionsBlueprint);
     if (diff.length > 0) {
       const logger = logging.logger;
-      logger.error(`Unknown key(s) found in Parse Server configuration: ${diff.join(', ')}`);
+      logger.error(`Invalid key(s) found in Parse Server configuration: ${diff.join(', ')}`);
     }
 
     // Set option defaults

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -374,8 +374,9 @@ class Utils {
   /**
    * Moves the nested keys of a specified key in an object to the root of the object.
    *
-   * @param {object} obj The object to modify.
+   * @param {Object} obj The object to modify.
    * @param {String} key The key whose nested keys will be moved to root.
+   * @returns {Object} The modified object, or the original object if no modification happened.
    * @example
    * const obj = {
    *   a: 1,
@@ -396,6 +397,7 @@ class Utils {
       // Delete original nested key
       delete obj[key];
     }
+    return obj;
   }
 }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -370,6 +370,33 @@ class Utils {
       }
     }
   }
+
+  /**
+   * Moves the nested keys of a specified key in an object to the root of the object.
+   *
+   * @param {object} obj The object to modify.
+   * @param {String} key The key whose nested keys will be moved to root.
+   * @example
+   * const obj = {
+   *   a: 1,
+   *   b: {
+   *     c: 2,
+   *     d: 3
+   *   },
+   *   e: 4
+   * };
+   * addNestedKeysToRoot(obj, 'b');
+   * console.log(obj);
+   * // Output: { a: 1, e: 4, c: 2, d: 3 }
+  */
+  static addNestedKeysToRoot(obj, key) {
+    if (obj[key] && typeof obj[key] === 'object') {
+      // Add nested keys to root
+      Object.assign(obj, { ...obj[key] });
+      // Delete original nested key
+      delete obj[key];
+    }
+  }
 }
 
 module.exports = Utils;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #9211 

## Approach

- Exclude `databaseOptions` from validation

Additional:
- Refactor tests
- Rephrase error log

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
