### PR TITLE
feat: Add atomic operations for Cloud Config parameters

### DIFF
--- a/spec/ParseGlobalConfig.spec.js
+++ b/spec/ParseGlobalConfig.spec.js
@@ -28,7 +28,7 @@ describe('a GlobalConfig', () => {
         },
         query,
         {
-          params: { companies: ['US', 'DK'], internalParam: 'internal' },
+          params: { companies: ['US', 'DK'], counter: 20, internalParam: 'internal' },
           masterKeyOnly: { internalParam: true },
         }
       )
@@ -112,6 +112,66 @@ describe('a GlobalConfig', () => {
       expect(body.result).toEqual(true);
       done();
     });
+  });
+
+  it('can addUnique', async () => {
+    const response = await request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { companies: { __op: 'AddUnique', objects: ['PA', 'RS', 'E'] } } },
+      headers,
+    });
+    expect(response.status).toEqual(200);
+    expect(response.data.result).toEqual(true);
+    const config = await Parse.Config.get();
+    const companies = config.get('companies');
+    expect(companies).toEqual(['US', 'DK', 'PA', 'RS', 'E']);
+  });
+
+  it('can add to array', async () => {
+    const response = await request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { companies: { __op: 'Add', objects: ['PA'] } } },
+      headers,
+    });
+    expect(response.status).toEqual(200);
+    expect(response.data.result).toEqual(true);
+    const config = await Parse.Config.get();
+    const companies = config.get('companies');
+    expect(companies).toEqual(['US', 'DK', 'PA']);
+  });
+
+  it('can remove from array', async () => {
+    const response = await request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { companies: { __op: 'Remove', objects: ['US'] } } },
+      headers,
+    });
+    expect(response.status).toEqual(200);
+    expect(response.data.result).toEqual(true);
+    const config = await Parse.Config.get();
+    const companies = config.get('companies');
+    expect(companies).toEqual(['DK']);
+  });
+
+  it('can increment', async () => {
+    const response = await request({
+      method: 'PUT',
+      url: 'http://localhost:8378/1/config',
+      json: true,
+      body: { params: { counter: { __op: 'Increment', amount: 49 } } },
+      headers,
+    });
+    expect(response.status).toEqual(200);
+    expect(response.data.result).toEqual(true);
+    const config = await Parse.Config.get();
+    const counter = config.get('counter');
+    expect(counter).toEqual(69);
   });
 
   it('can add and retrive files', done => {

--- a/spec/ParseGlobalConfig.spec.js
+++ b/spec/ParseGlobalConfig.spec.js
@@ -114,21 +114,21 @@ describe('a GlobalConfig', () => {
     });
   });
 
-  it('can addUnique', async () => {
+  it_only_db('mongo')('can addUnique', async () => {
     await Parse.Config.save({ companies: { __op: 'AddUnique', objects: ['PA', 'RS', 'E'] }  });
     const config = await Parse.Config.get();
     const companies = config.get('companies');
     expect(companies).toEqual(['US', 'DK', 'PA', 'RS', 'E']);
   });
 
-  it('can add to array', async () => {
+  it_only_db('mongo')('can add to array', async () => {
     await Parse.Config.save({ companies: { __op: 'Add', objects: ['PA'] }  });
     const config = await Parse.Config.get();
     const companies = config.get('companies');
     expect(companies).toEqual(['US', 'DK', 'PA']);
   });
 
-  it('can remove from array', async () => {
+  it_only_db('mongo')('can remove from array', async () => {
     await Parse.Config.save({ companies: { __op: 'Remove', objects: ['US'] }  });
     const config = await Parse.Config.get();
     const companies = config.get('companies');

--- a/spec/ParseGlobalConfig.spec.js
+++ b/spec/ParseGlobalConfig.spec.js
@@ -115,60 +115,28 @@ describe('a GlobalConfig', () => {
   });
 
   it('can addUnique', async () => {
-    const response = await request({
-      method: 'PUT',
-      url: 'http://localhost:8378/1/config',
-      json: true,
-      body: { params: { companies: { __op: 'AddUnique', objects: ['PA', 'RS', 'E'] } } },
-      headers,
-    });
-    expect(response.status).toEqual(200);
-    expect(response.data.result).toEqual(true);
+    await Parse.Config.save({ companies: { __op: 'AddUnique', objects: ['PA', 'RS', 'E'] }  });
     const config = await Parse.Config.get();
     const companies = config.get('companies');
     expect(companies).toEqual(['US', 'DK', 'PA', 'RS', 'E']);
   });
 
   it('can add to array', async () => {
-    const response = await request({
-      method: 'PUT',
-      url: 'http://localhost:8378/1/config',
-      json: true,
-      body: { params: { companies: { __op: 'Add', objects: ['PA'] } } },
-      headers,
-    });
-    expect(response.status).toEqual(200);
-    expect(response.data.result).toEqual(true);
+    await Parse.Config.save({ companies: { __op: 'Add', objects: ['PA'] }  });
     const config = await Parse.Config.get();
     const companies = config.get('companies');
     expect(companies).toEqual(['US', 'DK', 'PA']);
   });
 
   it('can remove from array', async () => {
-    const response = await request({
-      method: 'PUT',
-      url: 'http://localhost:8378/1/config',
-      json: true,
-      body: { params: { companies: { __op: 'Remove', objects: ['US'] } } },
-      headers,
-    });
-    expect(response.status).toEqual(200);
-    expect(response.data.result).toEqual(true);
+    await Parse.Config.save({ companies: { __op: 'Remove', objects: ['US'] }  });
     const config = await Parse.Config.get();
     const companies = config.get('companies');
     expect(companies).toEqual(['DK']);
   });
 
   it('can increment', async () => {
-    const response = await request({
-      method: 'PUT',
-      url: 'http://localhost:8378/1/config',
-      json: true,
-      body: { params: { counter: { __op: 'Increment', amount: 49 } } },
-      headers,
-    });
-    expect(response.status).toEqual(200);
-    expect(response.data.result).toEqual(true);
+    await Parse.Config.save({ counter: { __op: 'Increment', amount: 49 }  });
     const config = await Parse.Config.get();
     const counter = config.get('counter');
     expect(counter).toEqual(69);
@@ -225,6 +193,7 @@ describe('a GlobalConfig', () => {
       body: {
         params: {
           companies: { __op: 'Delete' },
+          counter: { __op: 'Delete' },
           internalParam: { __op: 'Delete' },
           foo: 'bar',
         },
@@ -243,6 +212,7 @@ describe('a GlobalConfig', () => {
         try {
           expect(response.status).toEqual(200);
           expect(body.params.companies).toBeUndefined();
+          expect(body.params.counter).toBeUndefined();
           expect(body.params.foo).toBe('bar');
           expect(Object.keys(body.params).length).toBe(1);
         } catch (e) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -582,7 +582,7 @@ export class MongoStorageAdapter implements StorageAdapter {
       .catch(err => this.handleError(err));
   }
 
-  // Hopefully we can get rid of this. It's only used for config and hooks.
+  // Hopefully we can get rid of this. It's only used for hooks.
   upsertOneObject(
     className: string,
     schema: SchemaType,

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -582,7 +582,7 @@ export class MongoStorageAdapter implements StorageAdapter {
       .catch(err => this.handleError(err));
   }
 
-  // Hopefully we can get rid of this. It's only used for hooks.
+  // Hopefully we can get rid of this. It's only used for config and hooks.
   upsertOneObject(
     className: string,
     schema: SchemaType,

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -46,7 +46,7 @@ export class GlobalConfigRouter extends PromiseRouter {
       return acc;
     }, {});
     return req.config.database
-      .update('_GlobalConfig', { objectId: '1' }, update, {})
+      .update('_GlobalConfig', { objectId: '1' }, update, { upsert: true }, true)
       .then(() => ({ response: { result: true } }));
   }
 

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -46,7 +46,7 @@ export class GlobalConfigRouter extends PromiseRouter {
       return acc;
     }, {});
     return req.config.database
-      .update('_GlobalConfig', { objectId: '1' }, update, { upsert: true })
+      .update('_GlobalConfig', { objectId: '1' }, update, {})
       .then(() => ({ response: { result: true } }));
   }
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Atomic operations aren't supported for Cloud Config

Closes: https://github.com/parse-community/parse-server/issues/8649

## Approach
<!-- Describe the changes in this PR. -->
Skip sanitization of db results since it can't handle dot notation on atomic operations when using upsert. We aren't returning the results to the client anyway so it can be skipped.
```
await Parse.Config.save({ number: { __op: 'Increment', amount: 10 } });
```
Cloud Config uses dot notation to save data. Postgres only supports increment on dot notation currently.