### PR TITLE
feat: Add Cloud Code triggers `Parse.Cloud.beforeSave` and `Parse.Cloud.afterSave` for Parse Config

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -4017,7 +4017,7 @@ describe('Cloud Config hooks', () => {
       fail('error should have thrown');
     } catch (e) {
       expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
-      expect(e.message).toBe(null);
+      expect(e.message).toBe('Script failed. Unknown error.');
     }
   });
 
@@ -4071,7 +4071,7 @@ describe('Cloud Config hooks', () => {
       await testConfig();
       fail('error should have thrown');
     } catch (e) {
-      expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
+      expect(e.code).toBe(400);
       expect(e.message).toBe('It should fail');
     }
   });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3921,6 +3921,162 @@ describe('saveFile hooks', () => {
   });
 });
 
+describe('Cloud Config hooks', () => {
+  function testConfig() {
+    return Parse.Config.save({ internal: 'i', string: 's', number: 12 }, { internal: true });
+  }
+
+  it('beforeSave(Parse.Config) can run hook with new config', async () => {
+    let count = 0;
+    Parse.Cloud.beforeSave(Parse.Config, (req) => {
+      expect(req.object).toBeDefined();
+      expect(req.original).toBeUndefined();
+      expect(req.user).toBeUndefined();
+      expect(req.headers).toBeDefined();
+      expect(req.ip).toBeDefined();
+      expect(req.installationId).toBeDefined();
+      expect(req.context).toBeDefined();
+      const config = req.object;
+      expect(config.get('internal')).toBe('i');
+      expect(config.get('string')).toBe('s');
+      expect(config.get('number')).toBe(12);
+      count += 1;
+    });
+    await testConfig();
+    const config = await Parse.Config.get({ useMasterKey: true });
+    expect(config.get('internal')).toBe('i');
+    expect(config.get('string')).toBe('s');
+    expect(config.get('number')).toBe(12);
+    expect(count).toBe(1);
+  });
+
+  it('beforeSave(Parse.Config) can run hook with existing config', async () => {
+    let count = 0;
+    Parse.Cloud.beforeSave(Parse.Config, (req) => {
+      if (count === 0) {
+        expect(req.object.get('number')).toBe(12);
+        expect(req.original).toBeUndefined();
+      }
+      if (count === 1) {
+        expect(req.object.get('number')).toBe(13);
+        expect(req.original.get('number')).toBe(12);
+      }
+      count += 1;
+    });
+    await testConfig();
+    await Parse.Config.save({ number: 13 });
+    expect(count).toBe(2);
+  });
+
+  it('beforeSave(Parse.Config) should not change config if nothing is returned', async () => {
+    let count = 0;
+    Parse.Cloud.beforeSave(Parse.Config, () => {
+      count += 1;
+      return;
+    });
+    await testConfig();
+    const config = await Parse.Config.get({ useMasterKey: true });
+    expect(config.get('internal')).toBe('i');
+    expect(config.get('string')).toBe('s');
+    expect(config.get('number')).toBe(12);
+    expect(count).toBe(1);
+  });
+
+  it('beforeSave(Parse.Config) throw custom error', async () => {
+    Parse.Cloud.beforeSave(Parse.Config, () => {
+      throw new Parse.Error(Parse.Error.SCRIPT_FAILED, 'It should fail');
+    });
+    try {
+      await testConfig();
+      fail('error should have thrown');
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
+      expect(e.message).toBe('It should fail');
+    }
+  });
+
+  it('beforeSave(Parse.Config) throw string error', async () => {
+    Parse.Cloud.beforeSave(Parse.Config, () => {
+      throw 'before save failed';
+    });
+    try {
+      await testConfig();
+      fail('error should have thrown');
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
+      expect(e.message).toBe('before save failed');
+    }
+  });
+
+  it('beforeSave(Parse.Config) throw empty error', async () => {
+    Parse.Cloud.beforeSave(Parse.Config, () => {
+      throw null;
+    });
+    try {
+      await testConfig();
+      fail('error should have thrown');
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
+      expect(e.message).toBe(null);
+    }
+  });
+
+  it('afterSave(Parse.Config) can run hook with new config', async () => {
+    let count = 0;
+    Parse.Cloud.afterSave(Parse.Config, (req) => {
+      expect(req.object).toBeDefined();
+      expect(req.original).toBeUndefined();
+      expect(req.user).toBeUndefined();
+      expect(req.headers).toBeDefined();
+      expect(req.ip).toBeDefined();
+      expect(req.installationId).toBeDefined();
+      expect(req.context).toBeDefined();
+      const config = req.object;
+      expect(config.get('internal')).toBe('i');
+      expect(config.get('string')).toBe('s');
+      expect(config.get('number')).toBe(12);
+      count += 1;
+    });
+    await testConfig();
+    const config = await Parse.Config.get({ useMasterKey: true });
+    expect(config.get('internal')).toBe('i');
+    expect(config.get('string')).toBe('s');
+    expect(config.get('number')).toBe(12);
+    expect(count).toBe(1);
+  });
+
+  it('afterSave(Parse.Config) can run hook with existing config', async () => {
+    let count = 0;
+    Parse.Cloud.afterSave(Parse.Config, (req) => {
+      if (count === 0) {
+        expect(req.object.get('number')).toBe(12);
+        expect(req.original).toBeUndefined();
+      }
+      if (count === 1) {
+        expect(req.object.get('number')).toBe(13);
+        expect(req.original.get('number')).toBe(12);
+      }
+      count += 1;
+    });
+    await testConfig();
+    await Parse.Config.save({ number: 13 });
+    expect(count).toBe(2);
+  });
+
+  it('afterSave(Parse.Config) should throw error', async () => {
+    Parse.Cloud.afterSave(Parse.Config, () => {
+      throw new Parse.Error(400, 'It should fail');
+    });
+    try {
+      await testConfig();
+      fail('error should have thrown');
+    } catch (e) {
+      expect(e.code).toBe(Parse.Error.SCRIPT_FAILED);
+      expect(e.message).toBe('It should fail');
+    }
+  });
+});
+
 describe('sendEmail', () => {
   it('can send email via Parse.Cloud', async done => {
     const emailAdapter = {

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -2,6 +2,15 @@
 import Parse from 'parse/node';
 import PromiseRouter from '../PromiseRouter';
 import * as middleware from '../middlewares';
+import * as triggers from '../triggers';
+
+const getConfigFromParams = params => {
+  const config = new Parse.Config();
+  for (const attr in params) {
+    config.attributes[attr] = Parse._decode(undefined, params[attr]);
+  }
+  return config;
+};
 
 export class GlobalConfigRouter extends PromiseRouter {
   getGlobalConfig(req) {
@@ -30,7 +39,7 @@ export class GlobalConfigRouter extends PromiseRouter {
       });
   }
 
-  updateGlobalConfig(req) {
+  async updateGlobalConfig(req) {
     if (req.auth.isReadOnly) {
       throw new Parse.Error(
         Parse.Error.OPERATION_FORBIDDEN,
@@ -45,9 +54,37 @@ export class GlobalConfigRouter extends PromiseRouter {
       acc[`masterKeyOnly.${key}`] = masterKeyOnly[key] || false;
       return acc;
     }, {});
-    return req.config.database
-      .update('_GlobalConfig', { objectId: '1' }, update, { upsert: true }, true)
-      .then(() => ({ response: { result: true } }));
+    const className = triggers.getClassName(Parse.Config);
+    const hasBeforeSaveHook = triggers.triggerExists(className, triggers.Types.beforeSave, req.config.applicationId);
+    const hasAfterSaveHook = triggers.triggerExists(className, triggers.Types.afterSave, req.config.applicationId);
+    let originalConfigObject;
+    let updatedConfigObject;
+    const configObject = new Parse.Config();
+    configObject.attributes = params;
+
+    const results = await req.config.database.find('_GlobalConfig', { objectId: '1' }, { limit: 1 });
+    const isNew = results.length !== 1;
+    if (!isNew && (hasBeforeSaveHook || hasAfterSaveHook)) {
+      originalConfigObject = getConfigFromParams(results[0].params);
+    }
+    try {
+      await triggers.maybeRunGlobalConfigTrigger(triggers.Types.beforeSave, req.auth, configObject, originalConfigObject, req.config, req.context);
+      if (isNew) {
+        await req.config.database.update('_GlobalConfig', { objectId: '1' }, update, { upsert: true }, true)
+        updatedConfigObject = configObject;
+      } else {
+        const result = await req.config.database.update('_GlobalConfig', { objectId: '1' }, update, {}, true);
+        updatedConfigObject = getConfigFromParams(result.params);
+      }
+      await triggers.maybeRunGlobalConfigTrigger(triggers.Types.afterSave, req.auth, updatedConfigObject, originalConfigObject, req.config, req.context);
+      return { response: { result: true } }
+    } catch (err) {
+      const error = triggers.resolveError(err, {
+        code: Parse.Error.SCRIPT_FAILED,
+        message: 'Script failed. Unknown error.',
+      });
+      throw error;
+    }
   }
 
   mountRoutes() {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -79,9 +79,13 @@ const getRoute = parseClass => {
       _User: 'users',
       _Session: 'sessions',
       '@File': 'files',
+      '@Config' : 'config',
     }[parseClass] || 'classes';
   if (parseClass === '@File') {
     return `/${route}/:id?(.*)`;
+  }
+  if (parseClass === '@Config') {
+    return `/${route}`;
   }
   return `/${route}/${parseClass}/:id?(.*)`;
 };


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
When changing any value in Remote Config, the previous value is lost without any possibility to undo the change. That means that any user mistake can lead to information irreversibly lost.

Closes: https://github.com/parse-community/parse-server/issues/8267

## Approach
<!-- Describe the changes in this PR. -->
Add a Cloud Code trigger beforeSave and afterSave that is invoked when the remove config is changed. This allows a developer to catch any changes to the Remote Config parameters and log them, or store a history of changed.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
