### PR TITLE
ci: Fix flaky direct access transaction tests

### DIFF
--- a/spec/ParseServerRESTController.spec.js
+++ b/spec/ParseServerRESTController.spec.js
@@ -2,7 +2,6 @@ const ParseServerRESTController = require('../lib/ParseServerRESTController')
   .ParseServerRESTController;
 const ParseServer = require('../lib/ParseServer').default;
 const Parse = require('parse/node').Parse;
-const TestUtils = require('../lib/TestUtils');
 
 let RESTController;
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
https://github.com/parse-community/parse-server/pull/9210 fixed the transaction flaky test for `batch.spec.js`. This PR fixes it for the ParseServerRESTConroller

https://github.com/parse-community/parse-server/actions/runs/10019940136/job/27697049679?pr=9218
