### PR TITLE
feat: Pass the set of roles the user has to triggers and cloud functions

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1192,8 +1192,8 @@ describe('Cloud Code', () => {
   });
 
   it('should not have user roles for anonymous calls', async () => {
-    let beforeSaveFlag = false,
-      afterSaveFlag = false;
+    let beforeSaveFlag = false;
+    let afterSaveFlag = false;
     Parse.Cloud.beforeSave('SaveTriggerUserRoles', async function (req) {
       expect(req.getRoles).toBeUndefined();
       beforeSaveFlag = true;

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1166,12 +1166,12 @@ describe('Cloud Code', () => {
   it('test save triggers get user roles', async () => {
     let beforeSaveFlag = false;
     let afterSaveFlag = false;
-    Parse.Cloud.beforeSave('SaveTriggerUserRoles', async function (req) {
+    Parse.Cloud.beforeSave('SaveTriggerUserRoles', async req => {
       expect(await req.getRoles()).toEqual(['TestRole']);
       beforeSaveFlag = true;
     });
 
-    Parse.Cloud.afterSave('SaveTriggerUserRoles', async function (req) {
+    Parse.Cloud.afterSave('SaveTriggerUserRoles', async req => {
       expect(await req.getRoles()).toEqual(['TestRole']);
       afterSaveFlag = true;
     });
@@ -1194,12 +1194,12 @@ describe('Cloud Code', () => {
   it('should not have user roles for anonymous calls', async () => {
     let beforeSaveFlag = false;
     let afterSaveFlag = false;
-    Parse.Cloud.beforeSave('SaveTriggerUserRoles', async function (req) {
+    Parse.Cloud.beforeSave('SaveTriggerUserRoles', async req => {
       expect(req.getRoles).toBeUndefined();
       beforeSaveFlag = true;
     });
 
-    Parse.Cloud.afterSave('SaveTriggerUserRoles', async function (req) {
+    Parse.Cloud.afterSave('SaveTriggerUserRoles', async req => {
       expect(req.getRoles).toBeUndefined();
       afterSaveFlag = true;
     });
@@ -2064,7 +2064,7 @@ describe('cloud functions', () => {
 
   it('should have user roles', async () => {
     let flag = false;
-    Parse.Cloud.define('myFunction', async function (req) {
+    Parse.Cloud.define('myFunction', async req => {
       expect(await req.getRoles()).toEqual(['TestRole']);
       flag = true;
     });
@@ -2084,7 +2084,7 @@ describe('cloud functions', () => {
 
   it('should not have user roles for anonymous calls', async () => {
     let flag = false;
-    Parse.Cloud.define('myFunction', async function (req) {
+    Parse.Cloud.define('myFunction', async req => {
       expect(req.getRoles).toBeUndefined();
       flag = true;
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1164,8 +1164,8 @@ describe('Cloud Code', () => {
   });
 
   it('test save triggers get user roles', async () => {
-    let beforeSaveFlag = false,
-      afterSaveFlag = false;
+    let beforeSaveFlag = false;
+    let afterSaveFlag = false;
     Parse.Cloud.beforeSave('SaveTriggerUserRoles', async function (req) {
       expect(await req.getRoles()).toEqual(['TestRole']);
       beforeSaveFlag = true;

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1167,12 +1167,12 @@ describe('Cloud Code', () => {
     let beforeSaveFlag = false;
     let afterSaveFlag = false;
     Parse.Cloud.beforeSave('SaveTriggerUserRoles', async req => {
-      expect(await req.getRoles()).toEqual(['TestRole']);
+      expect(await req.getUserRoles()).toEqual(['TestRole']);
       beforeSaveFlag = true;
     });
 
     Parse.Cloud.afterSave('SaveTriggerUserRoles', async req => {
-      expect(await req.getRoles()).toEqual(['TestRole']);
+      expect(await req.getUserRoles()).toEqual(['TestRole']);
       afterSaveFlag = true;
     });
 
@@ -1195,12 +1195,12 @@ describe('Cloud Code', () => {
     let beforeSaveFlag = false;
     let afterSaveFlag = false;
     Parse.Cloud.beforeSave('SaveTriggerUserRoles', async req => {
-      expect(req.getRoles).toBeUndefined();
+      expect(req.getUserRoles).toBeUndefined();
       beforeSaveFlag = true;
     });
 
     Parse.Cloud.afterSave('SaveTriggerUserRoles', async req => {
-      expect(req.getRoles).toBeUndefined();
+      expect(req.getUserRoles).toBeUndefined();
       afterSaveFlag = true;
     });
 
@@ -2065,7 +2065,7 @@ describe('cloud functions', () => {
   it('should have user roles', async () => {
     let flag = false;
     Parse.Cloud.define('myFunction', async req => {
-      expect(await req.getRoles()).toEqual(['TestRole']);
+      expect(await req.getUserRoles()).toEqual(['TestRole']);
       flag = true;
     });
 
@@ -2085,7 +2085,7 @@ describe('cloud functions', () => {
   it('should not have user roles for anonymous calls', async () => {
     let flag = false;
     Parse.Cloud.define('myFunction', async req => {
-      expect(req.getRoles).toBeUndefined();
+      expect(req.getUserRoles).toBeUndefined();
       flag = true;
     });
 

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -131,11 +131,11 @@ export class FunctionsRouter extends PromiseRouter {
       params: params,
       master: req.auth && req.auth.isMaster,
       user: req.auth && req.auth.user,
-      getRoles:
+      getUserRoles:
         req.auth && req.auth.user
           ? async () => {
-            return (await req.auth.getUserRoles()).map(r => r.substr('role:'.length));
-          }
+              return (await req.auth.getUserRoles()).map(r => r.substr('role:'.length));
+            }
           : undefined,
       installationId: req.info.installationId,
       log: req.config.loggerController,

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -8,6 +8,7 @@ import { promiseEnforceMasterKeyAccess, promiseEnsureIdempotency } from '../midd
 import { jobStatusHandler } from '../StatusHandler';
 import _ from 'lodash';
 import { logger } from '../logger';
+import Utils from '../Utils';
 
 function parseObject(obj, config) {
   if (Array.isArray(obj)) {
@@ -134,7 +135,7 @@ export class FunctionsRouter extends PromiseRouter {
       getUserRoles:
         req.auth && req.auth.user
           ? async () => {
-              return (await req.auth.getUserRoles()).map(r => r.substr('role:'.length));
+              return (await req.auth.getUserRoles()).map(Utils.stripACLRolePrefix);
             }
           : undefined,
       installationId: req.info.installationId,

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -131,6 +131,12 @@ export class FunctionsRouter extends PromiseRouter {
       params: params,
       master: req.auth && req.auth.isMaster,
       user: req.auth && req.auth.user,
+      getRoles:
+        req.auth && req.auth.user
+          ? async () => {
+            return (await req.auth.getUserRoles()).map(r => r.substr('role:'.length));
+          }
+          : undefined,
       installationId: req.info.installationId,
       log: req.config.loggerController,
       headers: req.config.headers,

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -399,6 +399,18 @@ class Utils {
     }
     return obj;
   }
+
+  /**
+   * Strips the "role:" prefix from the role name as it appears in the ACL.
+   *
+   * @param {String} entry The role name prefixed with the string "role:".
+   * @returns {String} The role name, without the "role": prefix.
+   * @example
+   * stripACLRolePrefix("role:myrole") // Returns "myrole"
+   */
+  static stripACLRolePrefix(entry) {
+    return entry.substr(5 /* 'role:'.length */);
+  }
 }
 
 module.exports = Utils;

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -292,7 +292,7 @@ export function getRequestObject(
   }
   if (auth.user) {
     request['user'] = auth.user;
-    request['getRoles'] = async () => {
+    request['getUserRoles'] = async () => {
       return (await auth.getUserRoles()).map(r => r.substr('role:'.length));
     };
   }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -1,6 +1,7 @@
 // triggers.js
 import Parse from 'parse/node';
 import { logger } from './logger';
+import Utils from './Utils';
 
 export const Types = {
   beforeLogin: 'beforeLogin',
@@ -293,7 +294,7 @@ export function getRequestObject(
   if (auth.user) {
     request['user'] = auth.user;
     request['getUserRoles'] = async () => {
-      return (await auth.getUserRoles()).map(r => r.substr('role:'.length));
+      return (await auth.getUserRoles()).map(Utils.stripACLRolePrefix);
     };
   }
   if (auth.installationId) {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -292,6 +292,9 @@ export function getRequestObject(
   }
   if (auth.user) {
     request['user'] = auth.user;
+    request['getRoles'] = async () => {
+      return (await auth.getUserRoles()).map(r => r.substr('role:'.length));
+    };
   }
   if (auth.installationId) {
     request['installationId'] = auth.installationId;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
Closes: #9298 

## Approach
Expose a field `getRoles` to cloud functions and triggers if the caller is a user. The field, if it exists, is an async function that resolves to a list of strings, which is the set of roles the user has.

The exposed function uses Parse's internal cache of user roles, if it is populated. Otherwise, it queries the set of roles and populates the cache before returning them.
## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
