### PR TITLE
Fix: Remove `await` key in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ const server = new ParseServer({
 });
 
 // Start server
-await server.start();
+server.start();
 
 // Serve the Parse API on the /parse URL prefix
 app.use('/parse', server.app);
@@ -911,7 +911,7 @@ app.use('/parse', parseServer.app); // (Optional) Mounts the REST API
 parseGraphQLServer.applyGraphQL(app); // Mounts the GraphQL API
 parseGraphQLServer.applyPlayground(app); // (Optional) Mounts the GraphQL Playground - do NOT use in Production
 
-await parseServer.start();
+parseServer.start();
 app.listen(1337, function() {
   console.log('REST API running on http://localhost:1337/parse');
   console.log('GraphQL API running on http://localhost:1337/graphql');


### PR DESCRIPTION
Due to ssample code didn't have async with following message:

```
await server.start();
^^^^^

SyntaxError: await is only valid in async functions and the top level bodies of modules
```

So this PR will fix it.

## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
