### PR TITLE
refactor: Upgrade pg-promise from 11.9.1 to 11.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "parse": "5.3.0",
         "path-to-regexp": "6.3.0",
         "pg-monitor": "2.1.0",
-        "pg-promise": "11.9.1",
+        "pg-promise": "11.10.1",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
         "rate-limit-redis": "4.2.0",
@@ -6639,9 +6639,10 @@
       }
     },
     "node_modules/assert-options": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
-      "integrity": "sha512-5lNGRB5g5i2bGIzb+J1QQE1iKU/WEMVBReFIc5pPDWjcPj23otPL0eI6PB2v7QPi0qU6Mhym5D3y0ZiSIOf3GA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.2.tgz",
+      "integrity": "sha512-XaXoMxY0zuwAb0YuZjxIm8FeWvNq0aWNIbrzHhFjme8Smxw4JlPoyrAKQ6808k5UvQdhvnWqHZCphq5mXd4TDA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -17485,13 +17486,14 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/pg": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
-      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.0.tgz",
+      "integrity": "sha512-34wkUTh3SxTClfoHB3pQ7bIMvw9dpFU1audQQeZG837fmHfHpr14n/AELVDoOYVDW2h5RDWU78tFjkD+erSBsw==",
+      "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.6.4",
-        "pg-pool": "^3.6.2",
-        "pg-protocol": "^1.6.1",
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -17514,17 +17516,30 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
       "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
-      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-cursor": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.12.0.tgz",
+      "integrity": "sha512-rppw54OnuYZfMUjiJI2zJMwAjjt2V9EtLUb+t7V5tqwSE5Jxod+7vA7Y0FI6Nq976jNLciA0hoVkwvjjB8qzEw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -17549,36 +17564,56 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
-      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.0.tgz",
+      "integrity": "sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==",
+      "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-promise": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.9.1.tgz",
-      "integrity": "sha512-qvMmyDvWd64X0a25hCuWV40GLMbgeYf4z7ZmzxQqGHtUIlzMtxcMtaBHAMr7XVOL62wFv2ZVKW5pFruD/4ZAOg==",
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.10.1.tgz",
+      "integrity": "sha512-TceugkypE+VkHTjlklMmLYLN5hUDbM9dIhKZQq2onxN9F//6X6Q5czQ7Ms5sCi0JB5pkbt8fgoC7OLHM2EVI7Q==",
+      "license": "MIT",
       "dependencies": {
-        "assert-options": "0.8.1",
-        "pg": "8.12.0",
+        "assert-options": "0.8.2",
+        "pg": "8.13.0",
         "pg-minify": "1.6.5",
-        "spex": "3.3.0"
+        "spex": "3.4.0"
       },
       "engines": {
         "node": ">=14.0"
+      },
+      "peerDependencies": {
+        "pg-query-stream": "4.7.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
-      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.7.0.tgz",
+      "integrity": "sha512-aQpK8yfFTvOzvPmhXEzWfkwM24lv2Y3TfFY0HJYwx0YM/2fL4DhqpBhLni2Kd+l9p/XoDEi+HFvEvOCm7oqaLg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-cursor": "^2.12.0"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -17594,6 +17629,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -17797,6 +17833,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -17805,6 +17842,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17813,6 +17851,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17821,6 +17860,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -19707,11 +19747,12 @@
       "dev": true
     },
     "node_modules/spex": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-3.3.0.tgz",
-      "integrity": "sha512-VNiXjFp6R4ldPbVRYbpxlD35yRHceecVXlct1J4/X80KuuPnW2AXMq3sGwhnJOhKkUsOxAT6nRGfGE5pocVw5w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.4.0.tgz",
+      "integrity": "sha512-8JeZJ7QlEBnSj1W1fKXgbB2KUPA8k4BxFMf6lZX/c1ZagU/1b9uZWZK0yD6yjfzqAIuTNG4YlRmtMpQiXuohsg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/split2": {
@@ -26194,9 +26235,9 @@
       }
     },
     "assert-options": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
-      "integrity": "sha512-5lNGRB5g5i2bGIzb+J1QQE1iKU/WEMVBReFIc5pPDWjcPj23otPL0eI6PB2v7QPi0qU6Mhym5D3y0ZiSIOf3GA=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.2.tgz",
+      "integrity": "sha512-XaXoMxY0zuwAb0YuZjxIm8FeWvNq0aWNIbrzHhFjme8Smxw4JlPoyrAKQ6808k5UvQdhvnWqHZCphq5mXd4TDA=="
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -33979,14 +34020,14 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "pg": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
-      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.0.tgz",
+      "integrity": "sha512-34wkUTh3SxTClfoHB3pQ7bIMvw9dpFU1audQQeZG837fmHfHpr14n/AELVDoOYVDW2h5RDWU78tFjkD+erSBsw==",
       "requires": {
         "pg-cloudflare": "^1.1.1",
-        "pg-connection-string": "^2.6.4",
-        "pg-pool": "^3.6.2",
-        "pg-protocol": "^1.6.1",
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
@@ -33998,9 +34039,16 @@
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
-      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA=="
+    },
+    "pg-cursor": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.12.0.tgz",
+      "integrity": "sha512-rppw54OnuYZfMUjiJI2zJMwAjjt2V9EtLUb+t7V5tqwSE5Jxod+7vA7Y0FI6Nq976jNLciA0hoVkwvjjB8qzEw==",
+      "peer": true,
+      "requires": {}
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -34021,26 +34069,35 @@
       }
     },
     "pg-pool": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
-      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.0.tgz",
+      "integrity": "sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==",
       "requires": {}
     },
     "pg-promise": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.9.1.tgz",
-      "integrity": "sha512-qvMmyDvWd64X0a25hCuWV40GLMbgeYf4z7ZmzxQqGHtUIlzMtxcMtaBHAMr7XVOL62wFv2ZVKW5pFruD/4ZAOg==",
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.10.1.tgz",
+      "integrity": "sha512-TceugkypE+VkHTjlklMmLYLN5hUDbM9dIhKZQq2onxN9F//6X6Q5czQ7Ms5sCi0JB5pkbt8fgoC7OLHM2EVI7Q==",
       "requires": {
-        "assert-options": "0.8.1",
-        "pg": "8.12.0",
+        "assert-options": "0.8.2",
+        "pg": "8.13.0",
         "pg-minify": "1.6.5",
-        "spex": "3.3.0"
+        "spex": "3.4.0"
       }
     },
     "pg-protocol": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
-      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ=="
+    },
+    "pg-query-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.7.0.tgz",
+      "integrity": "sha512-aQpK8yfFTvOzvPmhXEzWfkwM24lv2Y3TfFY0HJYwx0YM/2fL4DhqpBhLni2Kd+l9p/XoDEi+HFvEvOCm7oqaLg==",
+      "peer": true,
+      "requires": {
+        "pg-cursor": "^2.12.0"
+      }
     },
     "pg-types": {
       "version": "2.2.0",
@@ -35576,9 +35633,9 @@
       "dev": true
     },
     "spex": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-3.3.0.tgz",
-      "integrity": "sha512-VNiXjFp6R4ldPbVRYbpxlD35yRHceecVXlct1J4/X80KuuPnW2AXMq3sGwhnJOhKkUsOxAT6nRGfGE5pocVw5w=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.4.0.tgz",
+      "integrity": "sha512-8JeZJ7QlEBnSj1W1fKXgbB2KUPA8k4BxFMf6lZX/c1ZagU/1b9uZWZK0yD6yjfzqAIuTNG4YlRmtMpQiXuohsg=="
     },
     "split2": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "parse": "5.3.0",
     "path-to-regexp": "6.3.0",
     "pg-monitor": "2.1.0",
-    "pg-promise": "11.9.1",
+    "pg-promise": "11.10.1",
     "pluralize": "8.0.0",
     "punycode": "2.3.1",
     "rate-limit-redis": "4.2.0",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The dependencies `pg-promise` and `node-postgres` are out-of-date.

Closes: #9346 

## Approach
<!-- Describe the changes in this PR. -->
Update the dependencies using `npm i -E pg-promise@11.10.1`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Ensure tests pass
