### PR TITLE
feat: Increase required minimum Node versions to `18.20.4`, `20.18.0`, `22.12.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/**.md'
 env:
-  NODE_VERSION: 22.4.1
+  NODE_VERSION: 22.12.0
   PARSE_SERVER_TEST_TIMEOUT: 20000
 permissions:
   actions: write
@@ -145,36 +145,36 @@ jobs:
           - name: MongoDB 4.2, ReplicaSet
             MONGODB_VERSION: 4.2.25
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: MongoDB 4.4, ReplicaSet
             MONGODB_VERSION: 4.4.29
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: MongoDB 5, ReplicaSet
             MONGODB_VERSION: 5.0.26
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: MongoDB 6, ReplicaSet
             MONGODB_VERSION: 6.0.14
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.8
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: MongoDB 8, ReplicaSet
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: Node 20
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 20.15.1
+            NODE_VERSION: 20.18.0
           - name: Node 18
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
@@ -227,31 +227,31 @@ jobs:
         include:
           - name: PostgreSQL 13, PostGIS 3.1
             POSTGRES_IMAGE: postgis/postgis:13-3.1
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:13-3.2
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:13-3.3
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:13-3.4
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:13-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 14, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:14-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 15, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:15-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 16, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:16-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 17, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:17-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.12.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 20

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.20.0
+          node-version: 18.20.4
       - name: Cache Node.js modules
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Parse Server is continuously tested with the most recent releases of Node.js to 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
 | Node.js 18 | 18.20.4        | April 2025  | ✅ Yes      |
-| Node.js 20 | 20.15.1        | April 2026  | ✅ Yes      |
-| Node.js 22 | 22.4.1         | April 2027  | ✅ Yes      |
+| Node.js 20 | 20.18.0        | April 2026  | ✅ Yes      |
+| Node.js 22 | 22.12.0        | April 2027  | ✅ Yes      |
 
 #### MongoDB
 
@@ -150,13 +150,13 @@ Parse Server is continuously tested with the most recent releases of MongoDB to 
 
 Parse Server is continuously tested with the most recent releases of PostgreSQL and PostGIS to ensure compatibility, using [PostGIS docker images](https://registry.hub.docker.com/r/postgis/postgis/tags?page=1&ordering=last_updated). We follow the [PostgreSQL support schedule](https://www.postgresql.org/support/versioning) and [PostGIS support schedule](https://www.postgis.net/eol_policy/) and only test against versions that are officially supported and have not reached their end-of-life date. Due to the extensive PostgreSQL support duration of 5 years, Parse Server drops support about 2 years before the official end-of-life date.
 
-| Version     | PostGIS Version    | End-of-Life   | Parse Server Support | Compatible |
-|-------------|--------------------|---------------|----------------------|------------|
+| Version     | PostGIS Version         | End-of-Life   | Parse Server Support | Compatible |
+|-------------|-------------------------|---------------|----------------------|------------|
 | Postgres 13 | 3.1, 3.2, 3.3, 3.4, 3.5 | November 2025 | <= 6.x (2023)        | ✅ Yes      |
-| Postgres 14 | 3.5                | November 2026 | <= 7.x (2024)        | ✅ Yes      |
-| Postgres 15 | 3.5                | November 2027 | <= 8.x (2025)        | ✅ Yes      |
-| Postgres 16 | 3.5                | November 2028 | <= 9.x (2026)        | ✅ Yes      |
-| Postgres 17 | 3.5                | November 2029 | <= 9.x (2026)        | ✅ Yes      |
+| Postgres 14 | 3.5                     | November 2026 | <= 7.x (2024)        | ✅ Yes      |
+| Postgres 15 | 3.5                     | November 2027 | <= 8.x (2025)        | ✅ Yes      |
+| Postgres 16 | 3.5                     | November 2028 | <= 9.x (2026)        | ✅ Yes      |
+| Postgres 17 | 3.5                     | November 2029 | <= 9.x (2026)        | ✅ Yes      |
 
 ### Locally
 

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=18.0.0 <19.0.0 || >=19.0.0 <20.0.0 || >=20.0.0 <21.0.0 || >=22.0.0 <23.0.0"
+    "node": ">=18.20.4 <19.0.0 || >=19.0.0 <20.0.0 || >=20.18.0 <21.0.0 || >=22.12.0 <23.0.0"
   },
   "bin": {
     "parse-server": "bin/parse-server"

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular"
   },
   "engines": {
-    "node": ">=18.20.4 <19.0.0 || >=19.0.0 <20.0.0 || >=20.18.0 <21.0.0 || >=22.12.0 <23.0.0"
+    "node": ">=18.20.4 <19.0.0 || >=20.18.0 <21.0.0 || >=22.12.0 <23.0.0"
   },
   "bin": {
     "parse-server": "bin/parse-server"

--- a/src/Adapters/AdapterLoader.js
+++ b/src/Adapters/AdapterLoader.js
@@ -47,20 +47,8 @@ export function loadAdapter<T>(adapter, defaultAdapter, options): T {
 }
 
 export async function loadModule(modulePath) {
-  let module;
-  try {
-    module = require(modulePath);
-  } catch (err) {
-    if (err.code === 'ERR_REQUIRE_ESM') {
-      module = await import(modulePath);
-      if (module.default) {
-        module = module.default;
-      }
-    } else {
-      throw err;
-    }
-  }
-  return module;
+  const module = await import(modulePath);
+  return module?.default || module;
 }
 
 export default loadAdapter;

--- a/src/Adapters/AdapterLoader.js
+++ b/src/Adapters/AdapterLoader.js
@@ -47,8 +47,20 @@ export function loadAdapter<T>(adapter, defaultAdapter, options): T {
 }
 
 export async function loadModule(modulePath) {
-  const module = await import(modulePath);
-  return module?.default || module;
+  let module;
+  try {
+    module = require(modulePath);
+  } catch (err) {
+    if (err.code === 'ERR_REQUIRE_ESM') {
+      module = await import(modulePath);
+      if (module.default) {
+        module = module.default;
+      }
+    } else {
+      throw err;
+    }
+  }
+  return module;
 }
 
 export default loadAdapter;


### PR DESCRIPTION
Bump req. min. Node versions to latest releases in package.json `engines.node` and CI:
- Node 18.0.0 -> 18.20.4
- Node 20.0.0 -> 20.18.0
- Node 22.0.0 -> 22.12.0
