### PR TITLE
fix: Push adapter not loading on some versions of Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/**.md'
 env:
-  NODE_VERSION: 22.13.0
+  NODE_VERSION: 22.12.0
   PARSE_SERVER_TEST_TIMEOUT: 20000
 permissions:
   actions: write
@@ -145,32 +145,32 @@ jobs:
           - name: MongoDB 4.2, ReplicaSet
             MONGODB_VERSION: 4.2.25
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: MongoDB 4.4, ReplicaSet
             MONGODB_VERSION: 4.4.29
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: MongoDB 5, ReplicaSet
             MONGODB_VERSION: 5.0.26
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: MongoDB 6, ReplicaSet
             MONGODB_VERSION: 6.0.14
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.8
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: MongoDB 8, ReplicaSet
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: Node 20
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
@@ -227,31 +227,31 @@ jobs:
         include:
           - name: PostgreSQL 13, PostGIS 3.1
             POSTGRES_IMAGE: postgis/postgis:13-3.1
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:13-3.2
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:13-3.3
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:13-3.4
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 13, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:13-3.5
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 14, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:14-3.5
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 15, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:15-3.5
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 16, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:16-3.5
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
           - name: PostgreSQL 17, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:17-3.5
-            NODE_VERSION: 22.13.0
+            NODE_VERSION: 22.12.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - '**/**.md'
 env:
-  NODE_VERSION: 22.4.1
+  NODE_VERSION: 22.13.0
   PARSE_SERVER_TEST_TIMEOUT: 20000
 permissions:
   actions: write
@@ -145,33 +145,29 @@ jobs:
           - name: MongoDB 4.2, ReplicaSet
             MONGODB_VERSION: 4.2.25
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: MongoDB 4.4, ReplicaSet
             MONGODB_VERSION: 4.4.29
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: MongoDB 5, ReplicaSet
             MONGODB_VERSION: 5.0.26
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: MongoDB 6, ReplicaSet
             MONGODB_VERSION: 6.0.14
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.8
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: MongoDB 8, ReplicaSet
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: Redis Cache
             PARSE_SERVER_TEST_CACHE: redis
-            MONGODB_VERSION: 8.0.0
-            MONGODB_TOPOLOGY: standalone
-            NODE_VERSION: 22.4.1
-          - name: Node 22
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
             NODE_VERSION: 22.13.0
@@ -231,31 +227,31 @@ jobs:
         include:
           - name: PostgreSQL 13, PostGIS 3.1
             POSTGRES_IMAGE: postgis/postgis:13-3.1
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 13, PostGIS 3.2
             POSTGRES_IMAGE: postgis/postgis:13-3.2
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 13, PostGIS 3.3
             POSTGRES_IMAGE: postgis/postgis:13-3.3
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 13, PostGIS 3.4
             POSTGRES_IMAGE: postgis/postgis:13-3.4
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 13, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:13-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 14, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:14-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 15, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:15-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 16, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:16-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
           - name: PostgreSQL 17, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:17-3.5
-            NODE_VERSION: 22.4.1
+            NODE_VERSION: 22.13.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,10 @@ jobs:
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone
             NODE_VERSION: 22.4.1
+          - name: Node 22
+            MONGODB_VERSION: 8.0.0
+            MONGODB_TOPOLOGY: standalone
+            NODE_VERSION: 22.13.0
           - name: Node 20
             MONGODB_VERSION: 8.0.0
             MONGODB_TOPOLOGY: standalone

--- a/src/Adapters/AdapterLoader.js
+++ b/src/Adapters/AdapterLoader.js
@@ -47,22 +47,8 @@ export function loadAdapter<T>(adapter, defaultAdapter, options): T {
 }
 
 export async function loadModule(modulePath) {
-  let module;
-  try {
-    module = require(modulePath);
-  } catch (err) {
-    if (err.code === 'ERR_REQUIRE_ESM') {
-      module = await import(modulePath);
-    } else {
-      throw err;
-    }
-  }
-
-  if (module.default) {
-    module = module.default;
-  }
-  
-  return module;
+  const module = await import(modulePath);
+  return module?.default || module;
 }
 
 export default loadAdapter;

--- a/src/Adapters/AdapterLoader.js
+++ b/src/Adapters/AdapterLoader.js
@@ -53,13 +53,15 @@ export async function loadModule(modulePath) {
   } catch (err) {
     if (err.code === 'ERR_REQUIRE_ESM') {
       module = await import(modulePath);
-      if (module.default) {
-        module = module.default;
-      }
     } else {
       throw err;
     }
   }
+
+  if (module.default) {
+    module = module.default;
+  }
+  
   return module;
 }
 


### PR DESCRIPTION
Closes: https://github.com/parse-community/parse-server/issues/9517

Backport to Parse Server 7 of https://github.com/parse-community/parse-server/pull/9524