### PR TITLE
feat: Change default value of Parse Server option `encodeParseObjectInCloudFunction` to `true`

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -13,7 +13,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS7 | Remove file trigger syntax `Parse.Cloud.beforeSaveFile((request) => {})` | [#7966](https://github.com/parse-community/parse-server/pull/7966)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS8 | Login with expired 3rd party authentication token defaults to `false` | [#7079](https://github.com/parse-community/parse-server/pull/7079)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS9 | Rename LiveQuery `fields` option to `keys` | [#8389](https://github.com/parse-community/parse-server/issues/8389)   | 6.0.0 (2023)                    | 7.0.0 (2024)                    | removed            | -     |
-| DEPPS10 | Config option `encodeParseObjectInCloudFunction` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | deprecated            | -     |
+| DEPPS10 | Config option `encodeParseObjectInCloudFunction` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | removed            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_removal]: ## "The version and date of the planned removal."

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -13,7 +13,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS7 | Remove file trigger syntax `Parse.Cloud.beforeSaveFile((request) => {})` | [#7966](https://github.com/parse-community/parse-server/pull/7966)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS8 | Login with expired 3rd party authentication token defaults to `false` | [#7079](https://github.com/parse-community/parse-server/pull/7079)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS9 | Rename LiveQuery `fields` option to `keys` | [#8389](https://github.com/parse-community/parse-server/issues/8389)   | 6.0.0 (2023)                    | 7.0.0 (2024)                    | removed            | -     |
-| DEPPS10 | Config option `encodeParseObjectInCloudFunction` defaults to `true`  | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | removed            | -     |
+| DEPPS10 | Encode `Parse.Object` in Cloud Function and remove option `encodeParseObjectInCloudFunction` | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | removed            | -     |
 | DEPPS11 | Replace `PublicAPIRouter` with `PagesRouter` | [#7625](https://github.com/parse-community/parse-server/issues/7625)   | 8.0.0 (2025)                    | 9.0.0 (2026)                    | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -13,7 +13,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS7 | Remove file trigger syntax `Parse.Cloud.beforeSaveFile((request) => {})` | [#7966](https://github.com/parse-community/parse-server/pull/7966)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS8 | Login with expired 3rd party authentication token defaults to `false` | [#7079](https://github.com/parse-community/parse-server/pull/7079)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS9 | Rename LiveQuery `fields` option to `keys` | [#8389](https://github.com/parse-community/parse-server/issues/8389)   | 6.0.0 (2023)                    | 7.0.0 (2024)                    | removed            | -     |
-| DEPPS10 | Encode `Parse.Object` in Cloud Function and remove option `encodeParseObjectInCloudFunction` | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 9.0.0 (2026)                    | removed            | -     |
+| DEPPS10 | Encode `Parse.Object` in Cloud Function and remove option `encodeParseObjectInCloudFunction` | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 9.0.0 (2026)                    | deprecated            | -     |
 | DEPPS11 | Replace `PublicAPIRouter` with `PagesRouter` | [#7625](https://github.com/parse-community/parse-server/issues/7625)   | 8.0.0 (2025)                    | 9.0.0 (2026)                    | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -13,7 +13,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS7 | Remove file trigger syntax `Parse.Cloud.beforeSaveFile((request) => {})` | [#7966](https://github.com/parse-community/parse-server/pull/7966)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS8 | Login with expired 3rd party authentication token defaults to `false` | [#7079](https://github.com/parse-community/parse-server/pull/7079)   | 5.3.0 (2022)                    | 7.0.0 (2024)                    | removed            | -     |
 | DEPPS9 | Rename LiveQuery `fields` option to `keys` | [#8389](https://github.com/parse-community/parse-server/issues/8389)   | 6.0.0 (2023)                    | 7.0.0 (2024)                    | removed            | -     |
-| DEPPS10 | Encode `Parse.Object` in Cloud Function and remove option `encodeParseObjectInCloudFunction` | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 8.0.0 (2025)                    | removed            | -     |
+| DEPPS10 | Encode `Parse.Object` in Cloud Function and remove option `encodeParseObjectInCloudFunction` | [#8634](https://github.com/parse-community/parse-server/issues/8634)   | 6.2.0 (2023)                    | 9.0.0 (2026)                    | removed            | -     |
 | DEPPS11 | Replace `PublicAPIRouter` with `PagesRouter` | [#7625](https://github.com/parse-community/parse-server/issues/7625)   | 8.0.0 (2025)                    | 9.0.0 (2026)                    | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -15,4 +15,4 @@
  *
  * If there are no deprecations, this must return an empty array.
  */
-module.exports = [];
+module.exports = [{ optionKey: 'encodeParseObjectInCloudFunction', changeNewKey: '' }]

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -15,4 +15,4 @@
  *
  * If there are no deprecations, this must return an empty array.
  */
-module.exports = [{ optionKey: 'encodeParseObjectInCloudFunction', changeNewDefault: 'true' }];
+module.exports = [];

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -238,7 +238,7 @@ module.exports.ParseServerOptions = {
     help:
       'If set to `true`, a `Parse.Object` that is in the payload when calling a Cloud Function will be converted to an instance of `Parse.Object`. If `false`, the object will not be converted and instead be a plain JavaScript object, which contains the raw data of a `Parse.Object` but is not an actual instance of `Parse.Object`. Default is `false`. <br><br>\u2139\uFE0F The expected behavior would be that the object is converted to an instance of `Parse.Object`, so you would normally set this option to `true`. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where JavaScript objects are not converted to actual instances of `Parse.Object`.',
     action: parsers.booleanParser,
-    default: false,
+    default: true,
   },
   encryptionKey: {
     env: 'PARSE_SERVER_ENCRYPTION_KEY',

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -212,7 +212,7 @@ export interface ParseServerOptions {
   /* Adapter module for email sending */
   emailAdapter: ?Adapter<MailAdapter>;
   /* If set to `true`, a `Parse.Object` that is in the payload when calling a Cloud Function will be converted to an instance of `Parse.Object`. If `false`, the object will not be converted and instead be a plain JavaScript object, which contains the raw data of a `Parse.Object` but is not an actual instance of `Parse.Object`. Default is `false`. <br><br>ℹ️ The expected behavior would be that the object is converted to an instance of `Parse.Object`, so you would normally set this option to `true`. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where JavaScript objects are not converted to actual instances of `Parse.Object`.
-  :DEFAULT: false */
+  :DEFAULT: true */
   encodeParseObjectInCloudFunction: ?boolean;
   /* Public URL to your parse server with http:// or https://.
   :ENV: PARSE_PUBLIC_SERVER_URL */


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
