### PR TITLE
feat: Allow File adapter to create file with specific locations or dynamic filenames

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3696,12 +3696,17 @@ describe('saveFile hooks', () => {
       },
     };
     const config = Config.get('test');
+    const expectedConfig = {
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
+    };
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       'text/plain',
       newOptions,
-      config
+      expectedConfig
     );
   });
 
@@ -3730,12 +3735,17 @@ describe('saveFile hooks', () => {
       },
     };
     const config = Config.get('test');
+    const expectedConfig = {
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
+    };
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       newContentType,
       newOptions,
-      config
+      expectedConfig
     );
     const expectedFileName = 'donald_duck.pdf';
     expect(file._name.indexOf(expectedFileName)).toBe(file._name.length - expectedFileName.length);
@@ -3762,12 +3772,17 @@ describe('saveFile hooks', () => {
       tags: { bar: 'foo' },
     };
     const config = Config.get('test');
+    const expectedConfig = {
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
+    };
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       jasmine.any(Buffer),
       'text/plain',
       options,
-      config
+      expectedConfig
     );
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3695,11 +3695,13 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
+    const config = Config.get('test');
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       'text/plain',
-      newOptions
+      newOptions,
+      config
     );
   });
 
@@ -3727,11 +3729,13 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
+    const config = Config.get('test');
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       newContentType,
-      newOptions
+      newOptions,
+      config
     );
     const expectedFileName = 'donald_duck.pdf';
     expect(file._name.indexOf(expectedFileName)).toBe(file._name.length - expectedFileName.length);
@@ -3757,11 +3761,13 @@ describe('saveFile hooks', () => {
       metadata: { foo: 'bar' },
       tags: { bar: 'foo' },
     };
+    const config = Config.get('test');
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       jasmine.any(Buffer),
       'text/plain',
-      options
+      options,
+      config
     );
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3695,19 +3695,13 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
-    // Get the actual config values that will be used
-    const config = Config.get('test');
-
-    if (!config.mount){
-      config.mount = 'http://localhost:8378/1'; // Default mount for tests
-    }
 
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       'text/plain',
       newOptions,
-      config
+      jasmine.objectContaining({ applicationId: 'test' })
     );
   });
 
@@ -3735,18 +3729,15 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
-    const config = Config.get('test');
-
-    if (!config.mount){
-      config.mount = 'http://localhost:8378/1'; // Default mount for tests
-    }
 
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       newContentType,
       newOptions,
-      config
+      jasmine.objectContaining({
+        applicationId: 'test'
+      })
     );
     const expectedFileName = 'donald_duck.pdf';
     expect(file._name.indexOf(expectedFileName)).toBe(file._name.length - expectedFileName.length);
@@ -3772,18 +3763,14 @@ describe('saveFile hooks', () => {
       metadata: { foo: 'bar' },
       tags: { bar: 'foo' },
     };
-    const config = Config.get('test');
 
-    if (!config.mount){
-      config.mount = 'http://localhost:8378/1'; // Default mount for tests
-    }
 
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       jasmine.any(Buffer),
       'text/plain',
       options,
-      config
+      jasmine.objectContaining({ applicationId: 'test' })
     );
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3695,11 +3695,11 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
-    const config = Config.get('test');
+    // Get the actual config values that will be used
     const expectedConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
+      applicationId: 'test',
+      mount: 'http://localhost:8378/1',
+      fileKey: 'test'
     };
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
@@ -3734,11 +3734,11 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
-    const config = Config.get('test');
+    // Get the actual config values that will be used
     const expectedConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
+      applicationId: 'test',
+      mount: 'http://localhost:8378/1',
+      fileKey: 'test'
     };
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
@@ -3771,11 +3771,11 @@ describe('saveFile hooks', () => {
       metadata: { foo: 'bar' },
       tags: { bar: 'foo' },
     };
-    const config = Config.get('test');
+    // Get the actual config values that will be used
     const expectedConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
+      applicationId: 'test',
+      mount: 'http://localhost:8378/1',
+      fileKey: 'test'
     };
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3698,18 +3698,16 @@ describe('saveFile hooks', () => {
     // Get the actual config values that will be used
     const config = Config.get('test');
 
-    const expectedConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
-    };
+    if (!config.mount){
+      config.mount = 'http://localhost:8378/1'; // Default mount for tests
+    }
 
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       'text/plain',
       newOptions,
-      expectedConfig
+      config
     );
   });
 
@@ -3739,18 +3737,16 @@ describe('saveFile hooks', () => {
     };
     const config = Config.get('test');
 
-    const expectedConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
-    };
+    if (!config.mount){
+      config.mount = 'http://localhost:8378/1'; // Default mount for tests
+    }
 
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       newContentType,
       newOptions,
-      expectedConfig
+      config
     );
     const expectedFileName = 'donald_duck.pdf';
     expect(file._name.indexOf(expectedFileName)).toBe(file._name.length - expectedFileName.length);
@@ -3778,18 +3774,16 @@ describe('saveFile hooks', () => {
     };
     const config = Config.get('test');
 
-    const expectedConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
-    };
+    if (!config.mount){
+      config.mount = 'http://localhost:8378/1'; // Default mount for tests
+    }
 
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       jasmine.any(Buffer),
       'text/plain',
       options,
-      expectedConfig
+      config
     );
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -4144,11 +4144,13 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
+
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       'text/plain',
-      newOptions
+      newOptions,
+      jasmine.objectContaining({ applicationId: 'test', mount: Parse.serverURL })
     );
   });
 
@@ -4176,11 +4178,13 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
+
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
       newContentType,
-      newOptions
+      newOptions,
+      jasmine.objectContaining({ applicationId: 'test', mount: Parse.serverURL })
     );
     const expectedFileName = 'donald_duck.pdf';
     expect(file._name.indexOf(expectedFileName)).toBe(file._name.length - expectedFileName.length);
@@ -4206,11 +4210,13 @@ describe('saveFile hooks', () => {
       metadata: { foo: 'bar' },
       tags: { bar: 'foo' },
     };
+
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       jasmine.any(Buffer),
       'text/plain',
-      options
+      options,
+      jasmine.objectContaining({ applicationId: 'test', mount: Parse.serverURL })
     );
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -3696,11 +3696,14 @@ describe('saveFile hooks', () => {
       },
     };
     // Get the actual config values that will be used
+    const config = Config.get('test');
+
     const expectedConfig = {
-      applicationId: 'test',
-      mount: 'http://localhost:8378/1',
-      fileKey: 'test'
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
     };
+
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
@@ -3734,12 +3737,14 @@ describe('saveFile hooks', () => {
         foo: 'bar',
       },
     };
-    // Get the actual config values that will be used
+    const config = Config.get('test');
+
     const expectedConfig = {
-      applicationId: 'test',
-      mount: 'http://localhost:8378/1',
-      fileKey: 'test'
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
     };
+
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       newData,
@@ -3771,12 +3776,14 @@ describe('saveFile hooks', () => {
       metadata: { foo: 'bar' },
       tags: { bar: 'foo' },
     };
-    // Get the actual config values that will be used
+    const config = Config.get('test');
+
     const expectedConfig = {
-      applicationId: 'test',
-      mount: 'http://localhost:8378/1',
-      fileKey: 'test'
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
     };
+
     expect(createFileSpy).toHaveBeenCalledWith(
       jasmine.any(String),
       jasmine.any(Buffer),

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -219,10 +219,8 @@ describe('FilesController', () => {
     done();
   });
 
-  it('should return valid filename or url from createFile response when provided', async () => {
+  it('should return filename and url when adapter returns both', async () => {
     const config = Config.get(Parse.applicationId);
-
-    // Test case 1: adapter returns new filename and url
     const adapterWithReturn = { ...mockAdapter };
     adapterWithReturn.createFile = () => {
       return Promise.resolve({
@@ -234,17 +232,20 @@ describe('FilesController', () => {
       return Promise.resolve('http://default.url/file.txt');
     };
     const controllerWithReturn = new FilesController(adapterWithReturn, null, { preserveFileName: true });
-    // preserveFileName is true to make filename behaviors predictable
-    const result1 = await controllerWithReturn.createFile(
+
+    const result = await controllerWithReturn.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain'
     );
-    expect(result1.name).toBe('newFilename.txt');
-    expect(result1.url).toBe('http://new.url/newFilename.txt');
 
-    // Test case 2: adapter returns nothing, falling back to default behavior
+    expect(result.name).toBe('newFilename.txt');
+    expect(result.url).toBe('http://new.url/newFilename.txt');
+  });
+
+  it('should use original filename and generate url when adapter returns nothing', async () => {
+    const config = Config.get(Parse.applicationId);
     const adapterWithoutReturn = { ...mockAdapter };
     adapterWithoutReturn.createFile = () => {
       return Promise.resolve();
@@ -254,20 +255,20 @@ describe('FilesController', () => {
     };
 
     const controllerWithoutReturn = new FilesController(adapterWithoutReturn, null, { preserveFileName: true });
-    const result2 = await controllerWithoutReturn.createFile(
+    const result = await controllerWithoutReturn.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain',
       {}
     );
-    
-    expect(result2.name).toBe('originalFile.txt');
-    expect(result2.url).toBe('http://default.url/originalFile.txt');
 
-    // Test case 3: adapter returns partial info (only url)
-    // This is a valid scenario, as the adapter may return a modified filename
-    // but may result in a mismatch between the filename and the resource URL
+    expect(result.name).toBe('originalFile.txt');
+    expect(result.url).toBe('http://default.url/originalFile.txt');
+  });
+
+  it('should use original filename when adapter returns only url', async () => {
+    const config = Config.get(Parse.applicationId);
     const adapterWithOnlyURL = { ...mockAdapter };
     adapterWithOnlyURL.createFile = () => {
       return Promise.resolve({
@@ -277,20 +278,22 @@ describe('FilesController', () => {
     adapterWithOnlyURL.getFileLocation = () => {
       return Promise.resolve('http://default.url/file.txt');
     };
-    
+
     const controllerWithPartial = new FilesController(adapterWithOnlyURL, null, { preserveFileName: true });
-    const result3 = await controllerWithPartial.createFile(
+    const result = await controllerWithPartial.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain',
       {}
     );
-    
-    expect(result3.name).toBe('originalFile.txt');
-    expect(result3.url).toBe('http://new.url/partialFile.txt'); // Technically, the resource does not need to match the filename
 
-    // Test case 4: adapter returns only filename
+    expect(result.name).toBe('originalFile.txt');
+    expect(result.url).toBe('http://new.url/partialFile.txt');
+  });
+
+  it('should use adapter filename and generate url when adapter returns only filename', async () => {
+    const config = Config.get(Parse.applicationId);
     const adapterWithOnlyFilename = { ...mockAdapter };
     adapterWithOnlyFilename.createFile = () => {
       return Promise.resolve({
@@ -300,17 +303,17 @@ describe('FilesController', () => {
     adapterWithOnlyFilename.getFileLocation = (config, filename) => {
       return Promise.resolve(`http://default.url/${filename}`);
     };
-    
+
     const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename, null, { preserveFileName: true });
-    const result4 = await controllerWithOnlyFilename.createFile(
+    const result = await controllerWithOnlyFilename.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain',
       {}
     );
-    
-    expect(result4.name).toBe('newname.txt');
-    expect(result4.url).toBe('http://default.url/newname.txt');
+
+    expect(result.name).toBe('newname.txt');
+    expect(result.url).toBe('http://default.url/newname.txt');
   });
 });

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -218,4 +218,102 @@ describe('FilesController', () => {
     expect(gridFSAdapter.validateFilename(fileName)).not.toBe(null);
     done();
   });
+
+  it('should return filename and url when adapter returns both', async () => {
+    const config = Config.get(Parse.applicationId);
+    const adapterWithReturn = { ...mockAdapter };
+    adapterWithReturn.createFile = () => {
+      return Promise.resolve({
+        name: 'newFilename.txt',
+        url: 'http://example.com/newFilename.txt'
+      });
+    };
+    adapterWithReturn.getFileLocation = () => {
+      return Promise.resolve('http://example.com/file.txt');
+    };
+    const controllerWithReturn = new FilesController(adapterWithReturn, null, { preserveFileName: true });
+
+    const result = await controllerWithReturn.createFile(
+      config,
+      'originalFile.txt',
+      'data',
+      'text/plain'
+    );
+
+    expect(result.name).toBe('newFilename.txt');
+    expect(result.url).toBe('http://example.com/newFilename.txt');
+  });
+
+  it('should use original filename and generate url when adapter returns nothing', async () => {
+    const config = Config.get(Parse.applicationId);
+    const adapterWithoutReturn = { ...mockAdapter };
+    adapterWithoutReturn.createFile = () => {
+      return Promise.resolve();
+    };
+    adapterWithoutReturn.getFileLocation = (config, filename) => {
+      return Promise.resolve(`http://example.com/${filename}`);
+    };
+
+    const controllerWithoutReturn = new FilesController(adapterWithoutReturn, null, { preserveFileName: true });
+    const result = await controllerWithoutReturn.createFile(
+      config,
+      'originalFile.txt',
+      'data',
+      'text/plain',
+      {}
+    );
+
+    expect(result.name).toBe('originalFile.txt');
+    expect(result.url).toBe('http://example.com/originalFile.txt');
+  });
+
+  it('should use original filename when adapter returns only url', async () => {
+    const config = Config.get(Parse.applicationId);
+    const adapterWithOnlyURL = { ...mockAdapter };
+    adapterWithOnlyURL.createFile = () => {
+      return Promise.resolve({
+        url: 'http://example.com/partialFile.txt'
+      });
+    };
+    adapterWithOnlyURL.getFileLocation = () => {
+      return Promise.resolve('http://example.com/file.txt');
+    };
+
+    const controllerWithPartial = new FilesController(adapterWithOnlyURL, null, { preserveFileName: true });
+    const result = await controllerWithPartial.createFile(
+      config,
+      'originalFile.txt',
+      'data',
+      'text/plain',
+      {}
+    );
+
+    expect(result.name).toBe('originalFile.txt');
+    expect(result.url).toBe('http://example.com/partialFile.txt');
+  });
+
+  it('should use adapter filename and generate url when adapter returns only filename', async () => {
+    const config = Config.get(Parse.applicationId);
+    const adapterWithOnlyFilename = { ...mockAdapter };
+    adapterWithOnlyFilename.createFile = () => {
+      return Promise.resolve({
+        name: 'newname.txt'
+      });
+    };
+    adapterWithOnlyFilename.getFileLocation = (config, filename) => {
+      return Promise.resolve(`http://example.com/${filename}`);
+    };
+
+    const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename, null, { preserveFileName: true });
+    const result = await controllerWithOnlyFilename.createFile(
+      config,
+      'originalFile.txt',
+      'data',
+      'text/plain',
+      {}
+    );
+
+    expect(result.name).toBe('newname.txt');
+    expect(result.url).toBe('http://example.com/newname.txt');
+  });
 });

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -221,101 +221,91 @@ describe('FilesController', () => {
 
   it('should return valid filename or url from createFile response when provided', async () => {
     const config = Config.get(Parse.applicationId);
-    
+
     // Test case 1: adapter returns new filename and url
-    const adapterWithReturn = {
-      createFile: () => {
-        return Promise.resolve({
-          name: 'newfilename.txt',
-          url: 'http://new.url/newfilename.txt'
-        });
-      },
-      getFileLocation: () => {
-        return Promise.resolve('http://default.url/file.txt');
-      },
-      validateFilename: () => null
+    const adapterWithReturn = { ...mockAdapter };
+    adapterWithReturn.createFile = () => {
+      return Promise.resolve({
+        name: 'newFilename.txt',
+        url: 'http://new.url/newFilename.txt'
+      });
     };
-    
+    adapterWithReturn.getFileLocation = () => {
+      return Promise.resolve('http://default.url/file.txt');
+    };
     const controllerWithReturn = new FilesController(adapterWithReturn);
     const result1 = await controllerWithReturn.createFile(
       config,
-      'originalfile.txt',
+      'originalFile.txt',
       'data',
       'text/plain'
     );
-    
-    expect(result1.name).toBe('newfilename.txt');
-    expect(result1.url).toBe('http://new.url/newfilename.txt');
+    expect(result1.name).toBe('newFilename.txt');
+    expect(result1.url).toBe('http://new.url/newFilename.txt');
 
     // Test case 2: adapter returns nothing, falling back to default behavior
-    const adapterWithoutReturn = {
-      createFile: () => {
-        return Promise.resolve();
-      },
-      getFileLocation: (config, filename) => {
-        return Promise.resolve(`http://default.url/${filename}`);
-      },
-      validateFilename: () => null
+    const adapterWithoutReturn = { ...mockAdapter };
+    adapterWithoutReturn.createFile = () => {
+      return Promise.resolve();
     };
-    
+    adapterWithoutReturn.getFileLocation = (config, filename) => {
+      return Promise.resolve(`http://default.url/${filename}`);
+    };
+
     const controllerWithoutReturn = new FilesController(adapterWithoutReturn);
     const result2 = await controllerWithoutReturn.createFile(
       config,
-      'originalfile.txt',
+      'originalFile.txt',
       'data',
       'text/plain',
       {},
       { preserveFileName: true }  // To make filename predictable
     );
     
-    expect(result2.name).toBe('originalfile.txt');
-    expect(result2.url).toBe('http://default.url/originalfile.txt');
+    expect(result2.name).toBe('originalFile.txt');
+    expect(result2.url).toBe('http://default.url/originalFile.txt');
 
     // Test case 3: adapter returns partial info (only url)
     // This is a valid scenario, as the adapter may return a modified filename
     // but may result in a mismatch between the filename and the resource URL
-    const adapterWithOnlyURL = {
-      createFile: () => {
-        return Promise.resolve({
-          url: 'http://new.url/partialfile.txt'
-        });
-      },
-      getFileLocation: () => {
-        return Promise.resolve('http://default.url/file.txt');
-      },
-      validateFilename: () => null
+    const adapterWithOnlyURL = { ...mockAdapter };
+    adapterWithOnlyURL.createFile = () => {
+      return Promise.resolve({
+        url: 'http://new.url/partialFile.txt'
+      });
+    };
+    adapterWithOnlyURL.getFileLocation = () => {
+      return Promise.resolve('http://default.url/file.txt');
     };
     
     const controllerWithPartial = new FilesController(adapterWithOnlyURL);
     const result3 = await controllerWithPartial.createFile(
       config,
-      'originalfile.txt',
+      'originalFile.txt',
       'data',
       'text/plain',
       {},
       { preserveFileName: true }  // To make filename predictable
     );
     
-    expect(result3.name).toBe('originalfile.txt');
-    expect(result3.url).toBe('http://new.url/partialfile.txt'); // Technically, the resource does not need to match the filename
+    expect(result3.name).toBe('originalFile.txt');
+    expect(result3.url).toBe('http://new.url/partialFile.txt'); // Technically, the resource does not need to match the filename
 
     // Test case 4: adapter returns only filename
-    const adapterWithOnlyFilename = {
-      createFile: () => {
-        return Promise.resolve({
-          name: 'newname.txt'
-        });
-      },
-      getFileLocation: (config, filename) => {
-        return Promise.resolve(`http://default.url/${filename}`);
-      },
-      validateFilename: () => null
+    const adapterWithOnlyFilename = { ...mockAdapter };
+    adapterWithOnlyFilename.createFile = () => {
+      return Promise.resolve({
+        name: 'newname.txt'
+      });
+    };
+    adapterWithOnlyFilename.getFileLocation = (config, filename) => {
+      return Promise.resolve(`http://default.url/${filename}`);
     };
     
     const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename);
     const result4 = await controllerWithOnlyFilename.createFile(
       config,
-      'originalfile.txt',
+      'originalFile.txt',
       'data',
       'text/plain',
       {},

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -225,11 +225,11 @@ describe('FilesController', () => {
     adapterWithReturn.createFile = () => {
       return Promise.resolve({
         name: 'newFilename.txt',
-        url: 'http://new.url/newFilename.txt'
+        url: 'http://example.com/newFilename.txt'
       });
     };
     adapterWithReturn.getFileLocation = () => {
-      return Promise.resolve('http://default.url/file.txt');
+      return Promise.resolve('http://example.com/file.txt');
     };
     const controllerWithReturn = new FilesController(adapterWithReturn, null, { preserveFileName: true });
 
@@ -241,7 +241,7 @@ describe('FilesController', () => {
     );
 
     expect(result.name).toBe('newFilename.txt');
-    expect(result.url).toBe('http://new.url/newFilename.txt');
+    expect(result.url).toBe('http://example.com/newFilename.txt');
   });
 
   it('should use original filename and generate url when adapter returns nothing', async () => {
@@ -251,7 +251,7 @@ describe('FilesController', () => {
       return Promise.resolve();
     };
     adapterWithoutReturn.getFileLocation = (config, filename) => {
-      return Promise.resolve(`http://default.url/${filename}`);
+      return Promise.resolve(`http://example.com/${filename}`);
     };
 
     const controllerWithoutReturn = new FilesController(adapterWithoutReturn, null, { preserveFileName: true });
@@ -264,7 +264,7 @@ describe('FilesController', () => {
     );
 
     expect(result.name).toBe('originalFile.txt');
-    expect(result.url).toBe('http://default.url/originalFile.txt');
+    expect(result.url).toBe('http://example.com/originalFile.txt');
   });
 
   it('should use original filename when adapter returns only url', async () => {
@@ -272,11 +272,11 @@ describe('FilesController', () => {
     const adapterWithOnlyURL = { ...mockAdapter };
     adapterWithOnlyURL.createFile = () => {
       return Promise.resolve({
-        url: 'http://new.url/partialFile.txt'
+        url: 'http://example.com/partialFile.txt'
       });
     };
     adapterWithOnlyURL.getFileLocation = () => {
-      return Promise.resolve('http://default.url/file.txt');
+      return Promise.resolve('http://example.com/file.txt');
     };
 
     const controllerWithPartial = new FilesController(adapterWithOnlyURL, null, { preserveFileName: true });
@@ -289,7 +289,7 @@ describe('FilesController', () => {
     );
 
     expect(result.name).toBe('originalFile.txt');
-    expect(result.url).toBe('http://new.url/partialFile.txt');
+    expect(result.url).toBe('http://example.com/partialFile.txt');
   });
 
   it('should use adapter filename and generate url when adapter returns only filename', async () => {
@@ -301,7 +301,7 @@ describe('FilesController', () => {
       });
     };
     adapterWithOnlyFilename.getFileLocation = (config, filename) => {
-      return Promise.resolve(`http://default.url/${filename}`);
+      return Promise.resolve(`http://example.com/${filename}`);
     };
 
     const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename, null, { preserveFileName: true });
@@ -314,6 +314,6 @@ describe('FilesController', () => {
     );
 
     expect(result.name).toBe('newname.txt');
-    expect(result.url).toBe('http://default.url/newname.txt');
+    expect(result.url).toBe('http://example.com/newname.txt');
   });
 });

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -218,4 +218,111 @@ describe('FilesController', () => {
     expect(gridFSAdapter.validateFilename(fileName)).not.toBe(null);
     done();
   });
+
+  it('should return valid filename or url from createFile response when provided', async () => {
+    const config = Config.get(Parse.applicationId);
+    
+    // Test case 1: adapter returns new filename and url
+    const adapterWithReturn = {
+      createFile: () => {
+        return Promise.resolve({
+          name: 'newfilename.txt',
+          url: 'http://new.url/newfilename.txt'
+        });
+      },
+      getFileLocation: () => {
+        return Promise.resolve('http://default.url/file.txt');
+      },
+      validateFilename: () => null
+    };
+    
+    const controllerWithReturn = new FilesController(adapterWithReturn);
+    const result1 = await controllerWithReturn.createFile(
+      config,
+      'originalfile.txt',
+      'data',
+      'text/plain'
+    );
+    
+    expect(result1.name).toBe('newfilename.txt');
+    expect(result1.url).toBe('http://new.url/newfilename.txt');
+
+    // Test case 2: adapter returns nothing, falling back to default behavior
+    const adapterWithoutReturn = {
+      createFile: () => {
+        return Promise.resolve();
+      },
+      getFileLocation: (config, filename) => {
+        return Promise.resolve(`http://default.url/${filename}`);
+      },
+      validateFilename: () => null
+    };
+    
+    const controllerWithoutReturn = new FilesController(adapterWithoutReturn);
+    const result2 = await controllerWithoutReturn.createFile(
+      config,
+      'originalfile.txt',
+      'data',
+      'text/plain',
+      {},
+      { preserveFileName: true }  // To make filename predictable
+    );
+    
+    expect(result2.name).toBe('originalfile.txt');
+    expect(result2.url).toBe('http://default.url/originalfile.txt');
+
+    // Test case 3: adapter returns partial info (only url)
+    // This is a valid scenario, as the adapter may return a modified filename
+    // but may result in a mismatch between the filename and the resource URL
+    const adapterWithOnlyURL = {
+      createFile: () => {
+        return Promise.resolve({
+          url: 'http://new.url/partialfile.txt'
+        });
+      },
+      getFileLocation: () => {
+        return Promise.resolve('http://default.url/file.txt');
+      },
+      validateFilename: () => null
+    };
+    
+    const controllerWithPartial = new FilesController(adapterWithOnlyURL);
+    const result3 = await controllerWithPartial.createFile(
+      config,
+      'originalfile.txt',
+      'data',
+      'text/plain',
+      {},
+      { preserveFileName: true }  // To make filename predictable
+    );
+    
+    expect(result3.name).toBe('originalfile.txt');
+    expect(result3.url).toBe('http://new.url/partialfile.txt'); // Technically, the resource does not need to match the filename
+
+    // Test case 4: adapter returns only filename
+    const adapterWithOnlyFilename = {
+      createFile: () => {
+        return Promise.resolve({
+          name: 'newname.txt'
+        });
+      },
+      getFileLocation: (config, filename) => {
+        return Promise.resolve(`http://default.url/${filename}`);
+      },
+      validateFilename: () => null
+    };
+    
+    const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename);
+    const result4 = await controllerWithOnlyFilename.createFile(
+      config,
+      'originalfile.txt',
+      'data',
+      'text/plain',
+      {},
+      { preserveFileName: true }
+    );
+    
+    expect(result4.name).toBe('newname.txt');
+    expect(result4.url).toBe('http://default.url/newname.txt');
+  });
 });

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -233,7 +233,8 @@ describe('FilesController', () => {
     adapterWithReturn.getFileLocation = () => {
       return Promise.resolve('http://default.url/file.txt');
     };
-    const controllerWithReturn = new FilesController(adapterWithReturn);
+    const controllerWithReturn = new FilesController(adapterWithReturn, null, { preserveFileName: true });
+    // preserveFileName is true to make filename behaviors predictable
     const result1 = await controllerWithReturn.createFile(
       config,
       'originalFile.txt',
@@ -252,14 +253,13 @@ describe('FilesController', () => {
       return Promise.resolve(`http://default.url/${filename}`);
     };
 
-    const controllerWithoutReturn = new FilesController(adapterWithoutReturn);
+    const controllerWithoutReturn = new FilesController(adapterWithoutReturn, null, { preserveFileName: true });
     const result2 = await controllerWithoutReturn.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain',
-      {},
-      { preserveFileName: true }  // To make filename predictable
+      {}
     );
     
     expect(result2.name).toBe('originalFile.txt');
@@ -278,14 +278,13 @@ describe('FilesController', () => {
       return Promise.resolve('http://default.url/file.txt');
     };
     
-    const controllerWithPartial = new FilesController(adapterWithOnlyURL);
+    const controllerWithPartial = new FilesController(adapterWithOnlyURL, null, { preserveFileName: true });
     const result3 = await controllerWithPartial.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain',
-      {},
-      { preserveFileName: true }  // To make filename predictable
+      {}
     );
     
     expect(result3.name).toBe('originalFile.txt');
@@ -302,14 +301,13 @@ describe('FilesController', () => {
       return Promise.resolve(`http://default.url/${filename}`);
     };
     
-    const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename);
+    const controllerWithOnlyFilename = new FilesController(adapterWithOnlyFilename, null, { preserveFileName: true });
     const result4 = await controllerWithOnlyFilename.createFile(
       config,
       'originalFile.txt',
       'data',
       'text/plain',
-      {},
-      { preserveFileName: true }
+      {}
     );
     
     expect(result4.name).toBe('newname.txt');

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -30,10 +30,11 @@ export class FilesAdapter {
    * @param {string} contentType - the supposed contentType
    * @discussion the contentType can be undefined if the controller was not able to determine it
    * @param {object} options - (Optional) options to be passed to file adapter (S3 File Adapter Only)
-   * @param {Config} config -(Optional) server configuration
    * - tags: object containing key value pairs that will be stored with file
-   * - metadata: object containing key value pairs that will be sotred with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
-   * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility
+   * - metadata: object containing key value pairs that will be stored with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
+   * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility 
+   * @param {Config} config -(Optional) server configuration
+   * @discussion config is not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
    * @return {Promise<any>|Promise<{url?: string, name?: string, location?: string}>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
    */

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -36,7 +36,7 @@ export class FilesAdapter {
    * @param {Config} config -(Optional) server configuration
    * @discussion config is not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
-   * @return {Promise<any>|Promise<{url?: string, name?: string, location?: string}>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
+   * @return {Promise<{url?: string, name?: string, location?: string}>|Promise<undefined>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
    */
   createFile(filename: string, data, contentType: string, options: Object, config: Config): Promise {}
 

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -35,7 +35,7 @@ export class FilesAdapter {
    * - metadata: object containing key value pairs that will be sotred with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
    * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
-   * @return {Promise<any>|Promise<{url?: string, name?: string}>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename
+   * @return {Promise<any>|Promise<{url?: string, name?: string, location?: string}>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
    */
   createFile(filename: string, data, contentType: string, options: Object, config: Config): Promise {}
 

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -36,9 +36,15 @@ export class FilesAdapter {
    * @param {Config} config - (Optional) server configuration
    * @discussion config may be passed to adapter to allow for more complex configuration and internal call of getFileLocation (if needed). This argument is not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
-   * @return {Promise<{url?: string, name?: string, location?: string}>|Promise<undefined>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
+   * @return {Promise<{url?: string, name?: string}>|Promise<undefined>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing a url the adapter already resolved and/or a filename the adapter changed. Anything the adapter omits falls back to the filename it was given and a url derived from getFileLocation.
    */
-  createFile(filename: string, data, contentType: string, options: Object, config: Config): Promise {}
+  createFile(
+    filename: string,
+    data,
+    contentType: string,
+    options: Object,
+    config?: Config
+  ): Promise {}
 
   /** Whether this adapter supports receiving Readable streams in createFile().
    * If false (default), streams are buffered to a Buffer before being passed.

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -32,7 +32,7 @@ export class FilesAdapter {
    * @param {object} options - (Optional) options to be passed to file adapter (S3 File Adapter Only)
    * - tags: object containing key value pairs that will be stored with file
    * - metadata: object containing key value pairs that will be stored with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
-   * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility 
+   * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility
    * @param {Config} config -(Optional) server configuration
    * @discussion config is not supported by all file adapters. Check the your adapter's documentation for compatibility
    *

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -33,8 +33,8 @@ export class FilesAdapter {
    * - tags: object containing key value pairs that will be stored with file
    * - metadata: object containing key value pairs that will be stored with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
    * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility
-   * @param {Config} config -(Optional) server configuration
-   * @discussion config is not supported by all file adapters. Check the your adapter's documentation for compatibility
+   * @param {Config} config - (Optional) server configuration
+   * @discussion config may be passed to adapter to allow for more complex configuration and internal call of getFileLocation (if needed). This argument is not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
    * @return {Promise<{url?: string, name?: string, location?: string}>|Promise<undefined>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
    */

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -31,12 +31,14 @@ export class FilesAdapter {
    * @discussion the contentType can be undefined if the controller was not able to determine it
    * @param {object} options - (Optional) options to be passed to file adapter (S3 File Adapter Only)
    * - tags: object containing key value pairs that will be stored with file
-   * - metadata: object containing key value pairs that will be sotred with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
+   * - metadata: object containing key value pairs that will be stored with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
    * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility
+   * @param {Config} config - (Optional) server configuration
+   * @discussion config may be passed to adapter to allow for more complex configuration and internal call of getFileLocation (if needed). This argument is not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
-   * @return {Promise} a promise that should fail if the storage didn't succeed
+   * @return {Promise<{url?: string, name?: string, location?: string}>|Promise<undefined>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename and/or location (if relevant)
    */
-  createFile(filename: string, data, contentType: string, options: Object): Promise {}
+  createFile(filename: string, data, contentType: string, options: Object, config: Config): Promise {}
 
   /** Whether this adapter supports receiving Readable streams in createFile().
    * If false (default), streams are buffered to a Buffer before being passed.

--- a/src/Adapters/Files/FilesAdapter.js
+++ b/src/Adapters/Files/FilesAdapter.js
@@ -30,13 +30,14 @@ export class FilesAdapter {
    * @param {string} contentType - the supposed contentType
    * @discussion the contentType can be undefined if the controller was not able to determine it
    * @param {object} options - (Optional) options to be passed to file adapter (S3 File Adapter Only)
+   * @param {Config} config -(Optional) server configuration
    * - tags: object containing key value pairs that will be stored with file
    * - metadata: object containing key value pairs that will be sotred with file (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-object-metadata.html)
    * @discussion options are not supported by all file adapters. Check the your adapter's documentation for compatibility
    *
-   * @return {Promise} a promise that should fail if the storage didn't succeed
+   * @return {Promise<any>|Promise<{url?: string, name?: string}>} Either a plain promise that should fail if storage didn't succeed, or a promise resolving to an object containing url and/or an updated filename
    */
-  createFile(filename: string, data, contentType: string, options: Object): Promise {}
+  createFile(filename: string, data, contentType: string, options: Object, config: Config): Promise {}
 
   /** Responsible for deleting the specified file
    *

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -33,7 +33,7 @@ export class FilesController extends AdaptableController {
     filename = createResult?.name || filename; // if createFile returns a new filename, use it
 
     const url = createResult?.url || await this.adapter.getFileLocation(config, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
-    
+
     return {
       url: url,
       name: filename,

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -29,10 +29,17 @@ export class FilesController extends AdaptableController {
       filename = randomHexString(32) + '_' + filename;
     }
 
-    const createResult = await this.adapter.createFile(filename, data, contentType, options, config);
+    // Create a clean config object with only the properties needed by file adapters
+    const adapterConfig = {
+      applicationId: config.applicationId,
+      mount: config.mount,
+      fileKey: config.fileKey
+    };
+
+    const createResult = await this.adapter.createFile(filename, data, contentType, options, adapterConfig);
     filename = createResult?.name || filename; // if createFile returns a new filename, use it
 
-    const url = createResult?.url || await this.adapter.getFileLocation(config, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
+    const url = createResult?.url || await this.adapter.getFileLocation(adapterConfig, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
 
     return {
       url: url,

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -29,11 +29,14 @@ export class FilesController extends AdaptableController {
       filename = randomHexString(32) + '_' + filename;
     }
 
-    const defaultLocation = await this.adapter.getFileLocation(config, filename);
     const createResult = await this.adapter.createFile(filename, data, contentType, options, config);
+    filename = createResult?.name || filename; // if createFile returns a new filename, use it
+
+    const url = createResult?.url || await this.adapter.getFileLocation(config, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
+    
     return {
-      url: createResult?.url || defaultLocation,
-      name: createResult?.name || filename,
+      url: url,
+      name: filename,
     }
   }
 

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -29,11 +29,11 @@ export class FilesController extends AdaptableController {
       filename = randomHexString(32) + '_' + filename;
     }
 
-    const location = await this.adapter.getFileLocation(config, filename);
-    await this.adapter.createFile(filename, data, contentType, options);
+    const defaultLocation = await this.adapter.getFileLocation(config, filename);
+    const createResult = await this.adapter.createFile(filename, data, contentType, options, config);
     return {
-      url: location,
-      name: filename,
+      url: createResult?.url || defaultLocation,
+      name: createResult?.name || filename,
     }
   }
 

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -29,17 +29,11 @@ export class FilesController extends AdaptableController {
       filename = randomHexString(32) + '_' + filename;
     }
 
-    // Create a clean config object with only the properties needed by file adapters
-    const basicServerConfig = {
-      applicationId: config.applicationId,
-      mount: config.mount,
-      fileKey: config.fileKey
-    };
 
-    const createResult = await this.adapter.createFile(filename, data, contentType, options, basicServerConfig);
+    const createResult = await this.adapter.createFile(filename, data, contentType, options, config);
     filename = createResult?.name || filename; // if createFile returns a new filename, use it
 
-    const url = createResult?.url || await this.adapter.getFileLocation(basicServerConfig, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
+    const url = createResult?.url || await this.adapter.getFileLocation(config, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
 
     return {
       url: url,

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -30,16 +30,16 @@ export class FilesController extends AdaptableController {
     }
 
     // Create a clean config object with only the properties needed by file adapters
-    const adapterConfig = {
+    const basicServerConfig = {
       applicationId: config.applicationId,
       mount: config.mount,
       fileKey: config.fileKey
     };
 
-    const createResult = await this.adapter.createFile(filename, data, contentType, options, adapterConfig);
+    const createResult = await this.adapter.createFile(filename, data, contentType, options, basicServerConfig);
     filename = createResult?.name || filename; // if createFile returns a new filename, use it
 
-    const url = createResult?.url || await this.adapter.getFileLocation(adapterConfig, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
+    const url = createResult?.url || await this.adapter.getFileLocation(basicServerConfig, filename); // if createFile returns a new url, use it otherwise get the url from the adapter
 
     return {
       url: url,

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -46,11 +46,23 @@ export class FilesController extends AdaptableController {
       });
     }
 
-    const location = await this.adapter.getFileLocation(config, filename);
-    await this.adapter.createFile(filename, data, contentType, options);
+    // The adapter receives the server config so that it can derive a location
+    // itself, and may report back a filename it changed and a url it already
+    // resolved. An adapter that returns nothing keeps the previous behavior.
+    const createResult = await this.adapter.createFile(
+      filename,
+      data,
+      contentType,
+      options,
+      config
+    );
+    // The location has to be resolved after creation, not before, because the
+    // adapter may have renamed the file.
+    const name = createResult?.name || filename;
+    const url = createResult?.url || (await this.adapter.getFileLocation(config, name));
     return {
-      url: location,
-      name: filename,
+      url,
+      name,
     }
   }
 


### PR DESCRIPTION
Allow file adapter to override file name and location + give createFile access to config to allow getFileLocation calls internally

File adapter may specify a different filename or location during creation which should be returned after content storage.

Example, adapter timestamps upload filenames. getFileLocation may result in a slightly different url than the one used to create the file.

In the case where the url returned is identical this is not a problem. Additionally file adapter could call getFile location internally if it wanted to (and should probably have access to config for that reason).

In principle, if user wanted to name every file uploaded in an ordinal fashion (eg 1.jpg,2.jpg,3.jpg), they should allowed to do this.

As a separate improvement, this allows the url to be assigned during createFile as well (to prevent extra calls if the url is already known). Passing config to createFile allows getFileLocation to be called internally). Otherwise if url is not assigned, then getFileLocation can be called to retrieve it with the updated filename.

If url is not provided and filename is unchanged by createFile, then this code will not alter current functionality

## Pull Request

## Issue

Closes: https://github.com/parse-community/parse-server/issues/9556

## Approach
1) Allow file location and filename as generated to be overwritten by adapter.createFile if the file adapter desires
2) Pass config as additional argument to fileadapter so that the adapter can call getFileLocation during createFile if desired (optional)

## Tasks
- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated file save behavior tests to verify configuration is passed to file adapter
  * Added comprehensive file controller tests for different adapter response scenarios

* **Refactor**
  * File adapter API updated to accept configuration parameter
<!-- end of auto-generated comment: release notes by coderabbit.ai -->