### PR TITLE
feat: Add support for MongoDB `databaseOptions` keys `minPoolSize`, `connectTimeoutMS`, `socketTimeoutMS`, `autoSelectFamily`, `autoSelectFamilyAttemptTimeout`

### DIFF
--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -84,6 +84,8 @@ describe('Config Keys', () => {
         minPoolSize: 5,
         connectTimeoutMS: 5000,
         socketTimeoutMS: 5000,
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 3000
       },
     })).toBeResolved();
     expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(invalidKeyErrorMessage);

--- a/spec/ParseConfigKey.spec.js
+++ b/spec/ParseConfigKey.spec.js
@@ -81,6 +81,9 @@ describe('Config Keys', () => {
         maxTimeMS: 1000,
         maxStalenessSeconds: 10,
         maxPoolSize: 10,
+        minPoolSize: 5,
+        connectTimeoutMS: 5000,
+        socketTimeoutMS: 5000,
       },
     })).toBeResolved();
     expect(loggerErrorSpy.calls.all().reduce((s, call) => s += call.args[0], '')).not.toMatch(invalidKeyErrorMessage);

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -1044,6 +1044,12 @@ module.exports.FileUploadOptions = {
   },
 };
 module.exports.DatabaseOptions = {
+  connectTimeoutMS: {
+    env: 'PARSE_SERVER_DATABASE_CONNECT_TIMEOUT_MS',
+    help:
+      'The MongoDB driver option to specify the amount of time, in milliseconds, to wait to establish a single TCP socket connection to the server before raising an error. Specifying 0 disables the connection timeout.',
+    action: parsers.numberParser('connectTimeoutMS'),
+  },
   enableSchemaHooks: {
     env: 'PARSE_SERVER_DATABASE_ENABLE_SCHEMA_HOOKS',
     help:
@@ -1069,6 +1075,12 @@ module.exports.DatabaseOptions = {
       'The MongoDB driver option to set a cumulative time limit in milliseconds for processing operations on a cursor.',
     action: parsers.numberParser('maxTimeMS'),
   },
+  minPoolSize: {
+    env: 'PARSE_SERVER_DATABASE_MIN_POOL_SIZE',
+    help:
+      'The MongoDB driver option to set the minimum number of opened, cached, ready-to-use database connections maintained by the driver.',
+    action: parsers.numberParser('minPoolSize'),
+  },
   retryWrites: {
     env: 'PARSE_SERVER_DATABASE_RETRY_WRITES',
     help: 'The MongoDB driver option to set whether to retry failed writes.',
@@ -1079,6 +1091,12 @@ module.exports.DatabaseOptions = {
     help:
       'The duration in seconds after which the schema cache expires and will be refetched from the database. Use this option if using multiple Parse Servers instances connected to the same database. A low duration will cause the schema cache to be updated too often, causing unnecessary database reads. A high duration will cause the schema to be updated too rarely, increasing the time required until schema changes propagate to all server instances. This feature can be used as an alternative or in conjunction with the option `enableSchemaHooks`. Default is infinite which means the schema cache never expires.',
     action: parsers.numberParser('schemaCacheTtl'),
+  },
+  socketTimeoutMS: {
+    env: 'PARSE_SERVER_DATABASE_SOCKET_TIMEOUT_MS',
+    help:
+      'The MongoDB driver option to specify the amount of time, in milliseconds, spent attempting to send or receive on a socket before timing out. Specifying 0 means no timeout.',
+    action: parsers.numberParser('socketTimeoutMS'),
   },
 };
 module.exports.AuthAdapter = {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -1044,6 +1044,18 @@ module.exports.FileUploadOptions = {
   },
 };
 module.exports.DatabaseOptions = {
+  autoSelectFamily: {
+    env: 'PARSE_SERVER_DATABASE_AUTO_SELECT_FAMILY',
+    help:
+      'The MongoDB driver option to set whether the socket attempts to connect to IPv6 and IPv4 addresses until a connection is established. If available, the driver will select the first IPv6 address.',
+    action: parsers.booleanParser,
+  },
+  autoSelectFamilyAttemptTimeout: {
+    env: 'PARSE_SERVER_DATABASE_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT',
+    help:
+      'The MongoDB driver option to specify the amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the autoSelectFamily option. If set to a positive integer less than 10, the value 10 is used instead.',
+    action: parsers.numberParser('autoSelectFamilyAttemptTimeout'),
+  },
   connectTimeoutMS: {
     env: 'PARSE_SERVER_DATABASE_CONNECT_TIMEOUT_MS',
     help:

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -234,6 +234,8 @@
 
 /**
  * @interface DatabaseOptions
+ * @property {Boolean} autoSelectFamily The MongoDB driver option to set whether the socket attempts to connect to IPv6 and IPv4 addresses until a connection is established. If available, the driver will select the first IPv6 address.
+ * @property {Number} autoSelectFamilyAttemptTimeout The MongoDB driver option to specify the amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the autoSelectFamily option. If set to a positive integer less than 10, the value 10 is used instead.
  * @property {Number} connectTimeoutMS The MongoDB driver option to specify the amount of time, in milliseconds, to wait to establish a single TCP socket connection to the server before raising an error. Specifying 0 disables the connection timeout.
  * @property {Boolean} enableSchemaHooks Enables database real-time hooks to update single schema cache. Set to `true` if using multiple Parse Servers instances connected to the same database. Failing to do so will cause a schema change to not propagate to all instances and re-syncing will only happen when the instances restart. To use this feature with MongoDB, a replica set cluster with [change stream](https://docs.mongodb.com/manual/changeStreams/#availability) support is required.
  * @property {Number} maxPoolSize The MongoDB driver option to set the maximum number of opened, cached, ready-to-use database connections maintained by the driver.

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -234,12 +234,15 @@
 
 /**
  * @interface DatabaseOptions
+ * @property {Number} connectTimeoutMS The MongoDB driver option to specify the amount of time, in milliseconds, to wait to establish a single TCP socket connection to the server before raising an error. Specifying 0 disables the connection timeout.
  * @property {Boolean} enableSchemaHooks Enables database real-time hooks to update single schema cache. Set to `true` if using multiple Parse Servers instances connected to the same database. Failing to do so will cause a schema change to not propagate to all instances and re-syncing will only happen when the instances restart. To use this feature with MongoDB, a replica set cluster with [change stream](https://docs.mongodb.com/manual/changeStreams/#availability) support is required.
  * @property {Number} maxPoolSize The MongoDB driver option to set the maximum number of opened, cached, ready-to-use database connections maintained by the driver.
  * @property {Number} maxStalenessSeconds The MongoDB driver option to set the maximum replication lag for reads from secondary nodes.
  * @property {Number} maxTimeMS The MongoDB driver option to set a cumulative time limit in milliseconds for processing operations on a cursor.
+ * @property {Number} minPoolSize The MongoDB driver option to set the minimum number of opened, cached, ready-to-use database connections maintained by the driver.
  * @property {Boolean} retryWrites The MongoDB driver option to set whether to retry failed writes.
  * @property {Number} schemaCacheTtl The duration in seconds after which the schema cache expires and will be refetched from the database. Use this option if using multiple Parse Servers instances connected to the same database. A low duration will cause the schema cache to be updated too often, causing unnecessary database reads. A high duration will cause the schema to be updated too rarely, increasing the time required until schema changes propagate to all server instances. This feature can be used as an alternative or in conjunction with the option `enableSchemaHooks`. Default is infinite which means the schema cache never expires.
+ * @property {Number} socketTimeoutMS The MongoDB driver option to specify the amount of time, in milliseconds, spent attempting to send or receive on a socket before timing out. Specifying 0 means no timeout.
  */
 
 /**

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -602,8 +602,14 @@ export interface DatabaseOptions {
   maxTimeMS: ?number;
   /* The MongoDB driver option to set the maximum replication lag for reads from secondary nodes.*/
   maxStalenessSeconds: ?number;
+  /* The MongoDB driver option to set the minimum number of opened, cached, ready-to-use database connections maintained by the driver. */
+  minPoolSize: ?number;
   /* The MongoDB driver option to set the maximum number of opened, cached, ready-to-use database connections maintained by the driver. */
   maxPoolSize: ?number;
+  /* The MongoDB driver option to specify the amount of time, in milliseconds, to wait to establish a single TCP socket connection to the server before raising an error. Specifying 0 disables the connection timeout. */
+  connectTimeoutMS: ?number;
+  /* The MongoDB driver option to specify the amount of time, in milliseconds, spent attempting to send or receive on a socket before timing out. Specifying 0 means no timeout. */
+  socketTimeoutMS: ?number;
 }
 
 export interface AuthAdapter {

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -610,6 +610,10 @@ export interface DatabaseOptions {
   connectTimeoutMS: ?number;
   /* The MongoDB driver option to specify the amount of time, in milliseconds, spent attempting to send or receive on a socket before timing out. Specifying 0 means no timeout. */
   socketTimeoutMS: ?number;
+  /* The MongoDB driver option to set whether the socket attempts to connect to IPv6 and IPv4 addresses until a connection is established. If available, the driver will select the first IPv6 address. */
+  autoSelectFamily: ?boolean;
+  /* The MongoDB driver option to specify the amount of time in milliseconds to wait for a connection attempt to finish before trying the next address when using the autoSelectFamily option. If set to a positive integer less than 10, the value 10 is used instead. */
+  autoSelectFamilyAttemptTimeout: ?number;
 }
 
 export interface AuthAdapter {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
NOTE: This is a clone of #9522 so that the update can go out in 7.x.x in addition to 8.

[9523](https://github.com/parse-community/parse-server/issues/9523)

Closes: [9523](https://github.com/parse-community/parse-server/issues/9523)

## Approach
As discussed in #9211, the decision was made to maintain a list of valid database options for the Parse config that can be passed to MongoDB. There are many options (46 in total) and this PR adds 3 more that I was using. This approach just follows the same approach used in https://github.com/parse-community/parse-server/pull/9213

## Tasks
<!-- Delete tasks that don't apply. -->

- [X] Add tests
