### PR TITLE
fix: LiveQueryServer crashes using cacheAdapter on disconnect from Redis 4 server

### DIFF
--- a/spec/RedisPubSub.spec.js
+++ b/spec/RedisPubSub.spec.js
@@ -3,7 +3,10 @@ const RedisPubSub = require('../lib/Adapters/PubSub/RedisPubSub').RedisPubSub;
 describe('RedisPubSub', function () {
   beforeEach(function (done) {
     // Mock redis
-    const createClient = jasmine.createSpy('createClient');
+    const createClient = jasmine.createSpy('createClient').and.returnValue({
+      connect: jasmine.createSpy('connect').and.resolveTo(),
+      on: jasmine.createSpy('on'),
+    });
     jasmine.mockLibrary('redis', 'createClient', createClient);
     done();
   });

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -27,7 +27,7 @@ export class RedisCacheAdapter {
     if (this.client.isOpen) {
       return;
     }
-    return this.client.connect();
+    return await this.client.connect();
   }
 
   async handleShutdown() {

--- a/src/Adapters/PubSub/RedisPubSub.js
+++ b/src/Adapters/PubSub/RedisPubSub.js
@@ -1,13 +1,24 @@
 import { createClient } from 'redis';
+import { logger } from '../../logger';
 
 function createPublisher({ redisURL, redisOptions = {} }): any {
   redisOptions.no_ready_check = true;
-  return createClient({ url: redisURL, ...redisOptions });
+  const client = createClient({ url: redisURL, ...redisOptions });
+  client.on('error', err => { logger.error('RedisPubSub Publisher client error', { error: err }) });
+  client.on('connect', () => {});
+  client.on('reconnecting', () => {});
+  client.on('ready', () => {});
+  return client;
 }
 
 function createSubscriber({ redisURL, redisOptions = {} }): any {
   redisOptions.no_ready_check = true;
-  return createClient({ url: redisURL, ...redisOptions });
+  const client = createClient({ url: redisURL, ...redisOptions });
+  client.on('error', err => { logger.error('RedisPubSub Subscriber client error', { error: err }) });
+  client.on('connect', () => {});
+  client.on('reconnecting', () => {});
+  client.on('ready', () => {});
+  return client;
 }
 
 const RedisPubSub = {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -534,9 +534,14 @@ export const addRateLimit = (route, config, cloud) => {
     store: null,
   };
   if (route.redisUrl) {
+    const log = config?.loggerController || defaultLogger;
     const client = createClient({
       url: route.redisUrl,
     });
+    client.on('error', err => { log.error('Middlewares addRateLimit Redis client error', { error: err }) });
+    client.on('connect', () => {});
+    client.on('reconnecting', () => {});
+    client.on('ready', () => {});
     redisStore.connectionPromise = async () => {
       if (client.isOpen) {
         return;
@@ -544,7 +549,6 @@ export const addRateLimit = (route, config, cloud) => {
       try {
         await client.connect();
       } catch (e) {
-        const log = config?.loggerController || defaultLogger;
         log.error(`Could not connect to redisURL in rate limit: ${e}`);
       }
     };


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues/9432).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/9432

## Approach
<!-- Describe the changes in this PR. -->
Add empty handlers to redis client error, connect, reconnecting, ready events.
