### PR TITLE
ci: Fix flaky LiveQuery tests

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -1173,14 +1173,18 @@ describe('ParseLiveQuery', function () {
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     client.serverURL = 'ws://localhost:1345/1';
     const query = await new Parse.Query('Yolo').subscribe();
+    let liveQueryConnectionCount = await getConnectionsCount(server.liveQueryServer.server);
+    expect(liveQueryConnectionCount > 0).toBe(true);
     await Promise.all([
       server.handleShutdown(),
       new Promise(resolve => query.on('close', resolve)),
     ]);
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await sleep(100);
     expect(server.liveQueryServer.server.address()).toBeNull();
     expect(server.liveQueryServer.subscriber.isOpen).toBeFalse();
-    await new Promise(resolve => server.server.close(resolve));
+    
+    liveQueryConnectionCount = await getConnectionsCount(server.liveQueryServer.server);
+    expect(liveQueryConnectionCount).toBe(0);
   });
 
   it_id('45655b74-716f-4fa1-a058-67eb21f3c3db')(it)('does shutdown separate liveQuery server', async () => {
@@ -1245,7 +1249,7 @@ describe('ParseLiveQuery', function () {
       new Promise(resolve => query.on('close', resolve)),
     ]);
     expect(close).toBe(true);
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await sleep(100);
     expect(parseServer.liveQueryServer.server.address()).toBeNull();
     expect(parseServer.liveQueryServer.subscriber.isOpen).toBeFalse();
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
This live query server isn't shut down properly. If this issue continues then it must be the subscriptions not closing.

https://github.com/parse-community/parse-server/actions/runs/14230874758/job/39881107431?pr=9693


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved tests for liveQuery server shutdown by adding checks to verify active connections before and after shutdown.
  - Replaced manual delay logic with a standardized sleep utility for better test consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->