### PR TITLE
Before find fix

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -200,13 +200,14 @@ describe('Cloud Code', () => {
       done();
     }
   });
-
-  it('beforeFind can return object without DB operation', async () => {
+  fit('beforeFind can return object without DB operation', async () => {
+    await reconfigureServer({ silent: false });
     Parse.Cloud.beforeFind('beforeFind', () => {
       return new Parse.Object('TestObject', { foo: 'bar' });
     });
-    Parse.Cloud.afterFind('beforeFind', () => {
-      throw 'afterFind should not run';
+    Parse.Cloud.afterFind('beforeFind', req => {
+      expect(req.objects).toBeDefined();
+      expect(req.objects[0].className).toBe('TestObject');
     });
     const newObj = await new Parse.Query('beforeFind').first();
     expect(newObj.className).toBe('TestObject');
@@ -214,12 +215,13 @@ describe('Cloud Code', () => {
     await newObj.save();
   });
 
-  it('beforeFind can return array of objects without DB operation', async () => {
+  fit('beforeFind can return array of objects without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [new Parse.Object('TestObject', { foo: 'bar' })];
     });
-    Parse.Cloud.afterFind('beforeFind', () => {
-      throw 'afterFind should not run';
+    Parse.Cloud.afterFind('beforeFind', req => {
+      expect(req.objects).toBeDefined();
+      expect(req.objects[0].className).toBe('TestObject');
     });
     const newObj = await new Parse.Query('beforeFind').first();
     expect(newObj.className).toBe('TestObject');
@@ -227,12 +229,13 @@ describe('Cloud Code', () => {
     await newObj.save();
   });
 
-  it('beforeFind can return object for get query without DB operation', async () => {
+  fit('beforeFind can return object for get query without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [new Parse.Object('TestObject', { foo: 'bar' })];
     });
-    Parse.Cloud.afterFind('beforeFind', () => {
-      throw 'afterFind should not run';
+    Parse.Cloud.afterFind('beforeFind', req => {
+      expect(req.objects).toBeDefined();
+      expect(req.objects[0].className).toBe('TestObject');
     });
     const newObj = await new Parse.Query('beforeFind').get('objId');
     expect(newObj.className).toBe('TestObject');

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -208,11 +208,10 @@ describe('Cloud Code', () => {
     Parse.Cloud.afterFind('beforeFind', () => {
       throw 'afterFind should not run';
     });
-    const obj = new Parse.Object('beforeFind');
-    await obj.save();
     const newObj = await new Parse.Query('beforeFind').first();
     expect(newObj.className).toBe('TestObject');
     expect(newObj.toJSON()).toEqual({ foo: 'bar' });
+    await newObj.save();
   });
 
   it('beforeFind can return array of objects without DB operation', async () => {
@@ -222,11 +221,10 @@ describe('Cloud Code', () => {
     Parse.Cloud.afterFind('beforeFind', () => {
       throw 'afterFind should not run';
     });
-    const obj = new Parse.Object('beforeFind');
-    await obj.save();
     const newObj = await new Parse.Query('beforeFind').first();
     expect(newObj.className).toBe('TestObject');
     expect(newObj.toJSON()).toEqual({ foo: 'bar' });
+    await newObj.save();
   });
 
   it('beforeFind can return object for get query without DB operation', async () => {
@@ -236,11 +234,10 @@ describe('Cloud Code', () => {
     Parse.Cloud.afterFind('beforeFind', () => {
       throw 'afterFind should not run';
     });
-    const obj = new Parse.Object('beforeFind');
-    await obj.save();
-    const newObj = await new Parse.Query('beforeFind').get(obj.id);
+    const newObj = await new Parse.Query('beforeFind').get('objId');
     expect(newObj.className).toBe('TestObject');
     expect(newObj.toJSON()).toEqual({ foo: 'bar' });
+    await newObj.save();
   });
 
   it('beforeFind can return empty array without DB operation', async () => {

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -201,7 +201,7 @@ describe('Cloud Code', () => {
     }
   });
 
-  it('beforeFind can short circuit', async () => {
+  it('beforeFind can return object without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return new Parse.Object('TestObject', { foo: 'bar' });
     });
@@ -215,7 +215,7 @@ describe('Cloud Code', () => {
     expect(newObj.toJSON()).toEqual({ foo: 'bar' });
   });
 
-  it('beforeFind can short circuit arrays', async () => {
+  it('beforeFind can return array of objects without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [new Parse.Object('TestObject', { foo: 'bar' })];
     });
@@ -229,7 +229,7 @@ describe('Cloud Code', () => {
     expect(newObj.toJSON()).toEqual({ foo: 'bar' });
   });
 
-  it('beforeFind can short circuit get', async () => {
+  it('beforeFind can return object for get query without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [new Parse.Object('TestObject', { foo: 'bar' })];
     });
@@ -243,7 +243,7 @@ describe('Cloud Code', () => {
     expect(newObj.toJSON()).toEqual({ foo: 'bar' });
   });
 
-  it('beforeFind can short circuit empty array', async () => {
+  it('beforeFind can return empty array without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [];
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -200,8 +200,7 @@ describe('Cloud Code', () => {
       done();
     }
   });
-  fit('beforeFind can return object without DB operation', async () => {
-    await reconfigureServer({ silent: false });
+  it('beforeFind can return object without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return new Parse.Object('TestObject', { foo: 'bar' });
     });
@@ -215,7 +214,7 @@ describe('Cloud Code', () => {
     await newObj.save();
   });
 
-  fit('beforeFind can return array of objects without DB operation', async () => {
+  it('beforeFind can return array of objects without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [new Parse.Object('TestObject', { foo: 'bar' })];
     });
@@ -229,7 +228,7 @@ describe('Cloud Code', () => {
     await newObj.save();
   });
 
-  fit('beforeFind can return object for get query without DB operation', async () => {
+  it('beforeFind can return object for get query without DB operation', async () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [new Parse.Object('TestObject', { foo: 'bar' })];
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -201,6 +201,61 @@ describe('Cloud Code', () => {
     }
   });
 
+  it('beforeFind can short circuit', async () => {
+    Parse.Cloud.beforeFind('beforeFind', () => {
+      return new Parse.Object('TestObject', { foo: 'bar' });
+    });
+    Parse.Cloud.afterFind('beforeFind', () => {
+      throw 'afterFind should not run';
+    });
+    const obj = new Parse.Object('beforeFind');
+    await obj.save();
+    const newObj = await new Parse.Query('beforeFind').first();
+    expect(newObj.className).toBe('TestObject');
+    expect(newObj.toJSON()).toEqual({ foo: 'bar' });
+  });
+
+  it('beforeFind can short circuit arrays', async () => {
+    Parse.Cloud.beforeFind('beforeFind', () => {
+      return [new Parse.Object('TestObject', { foo: 'bar' })];
+    });
+    Parse.Cloud.afterFind('beforeFind', () => {
+      throw 'afterFind should not run';
+    });
+    const obj = new Parse.Object('beforeFind');
+    await obj.save();
+    const newObj = await new Parse.Query('beforeFind').first();
+    expect(newObj.className).toBe('TestObject');
+    expect(newObj.toJSON()).toEqual({ foo: 'bar' });
+  });
+
+  it('beforeFind can short circuit get', async () => {
+    Parse.Cloud.beforeFind('beforeFind', () => {
+      return [new Parse.Object('TestObject', { foo: 'bar' })];
+    });
+    Parse.Cloud.afterFind('beforeFind', () => {
+      throw 'afterFind should not run';
+    });
+    const obj = new Parse.Object('beforeFind');
+    await obj.save();
+    const newObj = await new Parse.Query('beforeFind').get(obj.id);
+    expect(newObj.className).toBe('TestObject');
+    expect(newObj.toJSON()).toEqual({ foo: 'bar' });
+  });
+
+  it('beforeFind can short circuit empty array', async () => {
+    Parse.Cloud.beforeFind('beforeFind', () => {
+      return [];
+    });
+    Parse.Cloud.afterFind('beforeFind', () => {
+      throw 'afterFind should not run';
+    });
+    const obj = new Parse.Object('beforeFind');
+    await obj.save();
+    const newObj = await new Parse.Query('beforeFind').first();
+    expect(newObj).toBeUndefined();
+  });
+
   it('beforeSave rejection with custom error code', function (done) {
     Parse.Cloud.beforeSave('BeforeSaveFailWithErrorCode', function () {
       throw new Parse.Error(999, 'Nope');

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -206,7 +206,7 @@ describe('Cloud Code', () => {
     });
     Parse.Cloud.afterFind('beforeFind', req => {
       expect(req.objects).toBeDefined();
-      expect(req.objects[0].className).toBe('TestObject');
+      expect(req.objects[0].get('foo')).toBe('bar');
     });
     const newObj = await new Parse.Query('beforeFind').first();
     expect(newObj.className).toBe('TestObject');
@@ -220,7 +220,7 @@ describe('Cloud Code', () => {
     });
     Parse.Cloud.afterFind('beforeFind', req => {
       expect(req.objects).toBeDefined();
-      expect(req.objects[0].className).toBe('TestObject');
+      expect(req.objects[0].get('foo')).toBe('bar');
     });
     const newObj = await new Parse.Query('beforeFind').first();
     expect(newObj.className).toBe('TestObject');
@@ -234,7 +234,7 @@ describe('Cloud Code', () => {
     });
     Parse.Cloud.afterFind('beforeFind', req => {
       expect(req.objects).toBeDefined();
-      expect(req.objects[0].className).toBe('TestObject');
+      expect(req.objects[0].get('foo')).toBe('bar');
     });
     const newObj = await new Parse.Query('beforeFind').get('objId');
     expect(newObj.className).toBe('TestObject');
@@ -246,8 +246,8 @@ describe('Cloud Code', () => {
     Parse.Cloud.beforeFind('beforeFind', () => {
       return [];
     });
-    Parse.Cloud.afterFind('beforeFind', () => {
-      throw 'afterFind should not run';
+    Parse.Cloud.afterFind('beforeFind', req => {
+      expect(req.objects.length).toBe(0);
     });
     const obj = new Parse.Object('beforeFind');
     await obj.save();

--- a/src/rest.js
+++ b/src/rest.js
@@ -39,6 +39,11 @@ function find(config, auth, className, restWhere, restOptions, clientSDK, contex
     .then(result => {
       restWhere = result.restWhere || restWhere;
       restOptions = result.restOptions || restOptions;
+      if (result?.objects) {
+        return {
+          results: result.objects.map(row => row._toFullJSON()),
+        };
+      }
       const query = new RestQuery(
         config,
         auth,
@@ -71,6 +76,11 @@ const get = (config, auth, className, objectId, restOptions, clientSDK, context)
     .then(result => {
       restWhere = result.restWhere || restWhere;
       restOptions = result.restOptions || restOptions;
+      if (result?.objects) {
+        return {
+          results: result.objects.map(row => row._toFullJSON()),
+        };
+      }
       const query = new RestQuery(
         config,
         auth,

--- a/src/rest.js
+++ b/src/rest.js
@@ -23,76 +23,75 @@ function checkLiveQuery(className, config) {
   return config.liveQueryController && config.liveQueryController.hasLiveQuery(className);
 }
 
-// Returns a promise for an object with optional keys 'results' and 'count'.
-function find(config, auth, className, restWhere, restOptions, clientSDK, context) {
-  enforceRoleSecurity('find', className, auth);
-  return triggers
-    .maybeRunQueryTrigger(
-      triggers.Types.beforeFind,
-      className,
-      restWhere,
-      restOptions,
-      config,
+async function runFindTriggers(
+  config,
+  auth,
+  className,
+  restWhere,
+  restOptions,
+  clientSDK,
+  context,
+  isGet
+) {
+  const result = await triggers.maybeRunQueryTrigger(
+    triggers.Types.beforeFind,
+    className,
+    restWhere,
+    restOptions,
+    config,
+    auth,
+    context,
+    isGet
+  );
+  restWhere = result.restWhere || restWhere;
+  restOptions = result.restOptions || restOptions;
+  if (result?.objects) {
+    const objects = result.objects;
+    await triggers.maybeRunAfterFindTrigger(
+      triggers.Types.afterFind,
       auth,
+      className,
+      objects,
+      config,
+      restWhere,
       context
-    )
-    .then(result => {
-      restWhere = result.restWhere || restWhere;
-      restOptions = result.restOptions || restOptions;
-      if (result?.objects) {
-        return {
-          results: result.objects.map(row => row._toFullJSON()),
-        };
-      }
-      const query = new RestQuery(
-        config,
-        auth,
-        className,
-        restWhere,
-        restOptions,
-        clientSDK,
-        true,
-        context
-      );
-      return query.execute();
-    });
+    );
+    return {
+      results: objects.map(row => row._toFullJSON()),
+    };
+  }
+  const query = new RestQuery(
+    config,
+    auth,
+    className,
+    restWhere,
+    restOptions,
+    clientSDK,
+    true,
+    context
+  );
+  return await query.execute();
 }
+
+// Returns a promise for an object with optional keys 'results' and 'count'.
+const find = (config, auth, className, restWhere, restOptions, clientSDK, context) => {
+  enforceRoleSecurity('find', className, auth);
+  return runFindTriggers(config, auth, className, restWhere, restOptions, clientSDK, context);
+};
 
 // get is just like find but only queries an objectId.
 const get = (config, auth, className, objectId, restOptions, clientSDK, context) => {
-  var restWhere = { objectId };
   enforceRoleSecurity('get', className, auth);
-  return triggers
-    .maybeRunQueryTrigger(
-      triggers.Types.beforeFind,
-      className,
-      restWhere,
-      restOptions,
-      config,
-      auth,
-      context,
-      true
-    )
-    .then(result => {
-      restWhere = result.restWhere || restWhere;
-      restOptions = result.restOptions || restOptions;
-      if (result?.objects) {
-        return {
-          results: result.objects.map(row => row._toFullJSON()),
-        };
-      }
-      const query = new RestQuery(
-        config,
-        auth,
-        className,
-        restWhere,
-        restOptions,
-        clientSDK,
-        true,
-        context
-      );
-      return query.execute();
-    });
+  return runFindTriggers(
+    config,
+    auth,
+    className,
+    { objectId },
+    restOptions,
+    clientSDK,
+    context,
+    true
+  );
 };
 
 // Returns a promise that doesn't resolve to any useful value.

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -586,9 +586,19 @@ export function maybeRunQueryTrigger(
           restOptions = restOptions || {};
           restOptions.subqueryReadPreference = requestObject.subqueryReadPreference;
         }
+        let objects = undefined;
+        if (result instanceof Parse.Object) {
+          objects = [result];
+        } else if (
+          Array.isArray(result) &&
+          (!result.length || result.some(obj => obj instanceof Parse.Object))
+        ) {
+          objects = result;
+        }
         return {
           restWhere,
           restOptions,
+          objects,
         };
       },
       err => {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -454,6 +454,9 @@ export function maybeRunAfterFindTrigger(
     );
     request.objects = objects.map(object => {
       //setting the class name to transform into parse object
+      if (object instanceof Parse.Object) {
+        return object;
+      }
       object.className = className;
       return Parse.Object.fromJSON(object);
     });

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -454,10 +454,10 @@ export function maybeRunAfterFindTrigger(
     );
     request.objects = objects.map(object => {
       //setting the class name to transform into parse object
+      object.className = className;
       if (object instanceof Parse.Object) {
         return object;
       }
-      object.className = className;
       return Parse.Object.fromJSON(object);
     });
     return Promise.resolve()


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/8693

## Approach
<!-- Describe the changes in this PR. -->
This PR continues and supersedes #8694 by @dblythy.
Adds ability to return objects (or an empty array) from a beforeFind trigger.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for advanced query triggers, allowing custom objects or arrays of objects to be returned directly from triggers, including for empty results.
- **Bug Fixes**
  - Improved handling of objects returned from triggers to ensure correct processing and accessibility in subsequent operations.
- **Tests**
  - Added comprehensive test cases to verify new trigger behaviors and ensure correct object handling in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->