### PR TITLE
feat: Add configurable GraphQL introspection

### DIFF
--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -65,7 +65,7 @@ class ParseGraphQLServer {
         // needed since we use graphql upload
         requestHeaders: ['X-Parse-Application-Id'],
       },
-      introspection: true,
+      introspection: this.parseServer.config.graphQLIntrospection,
       plugins: [ApolloServerPluginCacheControlDisabled()],
       schema,
     });

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -287,6 +287,12 @@ module.exports.ParseServerOptions = {
     type: 'FileUploadOptions',
     default: {},
   },
+  graphQLIntrospection: {
+    env: 'PARSE_SERVER_GRAPHQL_INTROSPECTION',
+    help: 'Enables GraphQL Introspection - never use this option in production',
+    action: parsers.booleanParser,
+    default: true,
+  },
   graphQLPath: {
     env: 'PARSE_SERVER_GRAPHQL_PATH',
     help: 'Mount path for the GraphQL endpoint, defaults to /graphql',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -52,6 +52,7 @@
  * @property {String} fileKey Key for your files
  * @property {Adapter<FilesAdapter>} filesAdapter Adapter module for the files sub-system
  * @property {FileUploadOptions} fileUpload Options for file uploads
+ * @property {Boolean} graphQLIntrospection Enables GraphQL Introspection - never use this option in production
  * @property {String} graphQLPath Mount path for the GraphQL endpoint, defaults to /graphql
  * @property {String} graphQLSchema Full path to your GraphQL custom schema.graphql file
  * @property {String} host The host to serve ParseServer on, defaults to 0.0.0.0

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -314,6 +314,10 @@ export interface ParseServerOptions {
   :ENV: PARSE_SERVER_PLAYGROUND_PATH
   :DEFAULT: /playground */
   playgroundPath: ?string;
+  /* Enables GraphQL Introspection - never use this option in production
+  :ENV: PARSE_SERVER_GRAPHQL_INTROSPECTION
+  :DEFAULT: true */
+  graphQLIntrospection: ?boolean;
   /* Defined schema
   :ENV: PARSE_SERVER_SCHEMA
   */

--- a/src/Security/CheckGroups/CheckGroupServerConfig.js
+++ b/src/Security/CheckGroups/CheckGroupServerConfig.js
@@ -80,6 +80,17 @@ class CheckGroupServerConfig extends CheckGroup {
           }
         },
       }),
+      new Check({
+        title: 'GraphQL Introspection is enabled',
+        warning:
+          'Attackers can retrieve the complete API schema through Introspection queries.',
+        solution: "Change Parse Server configuration to 'graphQLIntrospection: false'.",
+        check: () => {
+          if (config.graphQLIntrospection) {
+            throw 1;
+          }
+        },
+      })
     ];
   }
 }

--- a/types/Options/index.d.ts
+++ b/types/Options/index.d.ts
@@ -115,6 +115,7 @@ export interface ParseServerOptions {
     graphQLPath?: string;
     mountPlayground?: boolean;
     playgroundPath?: string;
+    graphQLIntrospection?: boolean;
     schema?: SchemaOptions;
     serverCloseComplete?: () => void;
     security?: SecurityOptions;


### PR DESCRIPTION
## Issue
Closes: https://github.com/parse-community/parse-server/issues/8800

## Approach
Add a new option called `graphQLIntrospection` which is enabled by default. This is not a secure default but I'm unsure if having it disabled by default would be a breaking change.

## Tasks

- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option to enable or disable GraphQL introspection, controllable via environment variable and server settings.
- **Security**
  - Introduced a security check that warns if GraphQL introspection is enabled, recommending disabling it to prevent exposure of the API schema.
- **Documentation**
  - Updated documentation to describe the new GraphQL introspection option and its security implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->