### PR TITLE
fix: Server crashes due to insufficient schema validation when schema type is not a string

### DIFF
--- a/spec/MongoSchemaCollectionAdapter.spec.js
+++ b/spec/MongoSchemaCollectionAdapter.spec.js
@@ -160,6 +160,7 @@ describe('MongoSchemaCollection', () => {
       } catch (error) {
         expect(error.code).toBe(255);
         expect(error.message).toContain('Invalid field type');
+        expect(error.message).toContain('Expected a string');
       }
     });
 
@@ -172,6 +173,7 @@ describe('MongoSchemaCollection', () => {
       } catch (error) {
         expect(error.code).toBe(255);
         expect(error.message).toContain('Invalid field type');
+        expect(error.message).toContain('Expected a string');
       }
     });
 
@@ -184,6 +186,7 @@ describe('MongoSchemaCollection', () => {
       } catch (error) {
         expect(error.code).toBe(255);
         expect(error.message).toContain('Invalid field type');
+        expect(error.message).toContain('Expected a string');
       }
     });
 
@@ -196,6 +199,7 @@ describe('MongoSchemaCollection', () => {
       } catch (error) {
         expect(error.code).toBe(255);
         expect(error.message).toContain('Invalid field type');
+        expect(error.message).toContain('Expected a string');
       }
     });
   });

--- a/spec/MongoSchemaCollectionAdapter.spec.js
+++ b/spec/MongoSchemaCollectionAdapter.spec.js
@@ -96,4 +96,107 @@ describe('MongoSchemaCollection', () => {
     });
     done();
   });
+
+  describe('mongoFieldToParseSchemaField function', () => {
+    // Test successful type conversions
+    it('should convert valid mongo field types to parse schema fields', () => {
+      const testCases = [
+        { input: 'string', expected: { type: 'String' } },
+        { input: 'number', expected: { type: 'Number' } },
+        { input: 'boolean', expected: { type: 'Boolean' } },
+        { input: 'date', expected: { type: 'Date' } },
+        { input: 'map', expected: { type: 'Object' } },
+        { input: 'object', expected: { type: 'Object' } },
+        { input: 'array', expected: { type: 'Array' } },
+        { input: 'geopoint', expected: { type: 'GeoPoint' } },
+        { input: 'file', expected: { type: 'File' } },
+        { input: 'bytes', expected: { type: 'Bytes' } },
+        { input: 'polygon', expected: { type: 'Polygon' } },
+        { input: '*_User', expected: { type: 'Pointer', targetClass: '_User' } },
+        { input: '*Post', expected: { type: 'Pointer', targetClass: 'Post' } },
+        { input: 'relation<_User>', expected: { type: 'Relation', targetClass: '_User' } },
+        { input: 'relation<Post>', expected: { type: 'Relation', targetClass: 'Post' } },
+      ];
+
+      testCases.forEach(({ input, expected }) => {
+        const result = MongoSchemaCollection._TESTmongoSchemaToParseSchema({
+          _id: 'TestClass',
+          testField: input,
+        });
+
+        expect(result.fields.testField).toEqual(expected);
+      });
+    });
+
+    // Test error handling for invalid types (non-string values)
+    it('should throw error for invalid field types', () => {
+      const invalidInputs = [
+        null,
+        undefined,
+        123,
+        true,
+        false,
+        {},
+        [],
+        '',
+      ];
+
+      invalidInputs.forEach(invalidInput => {
+        expect(() => {
+          MongoSchemaCollection._TESTmongoSchemaToParseSchema({
+            _id: 'TestClass',
+            testField: invalidInput,
+          });
+        }).toThrow();
+      });
+    });
+
+    it('should throw error with correct message for null input', () => {
+      try {
+        MongoSchemaCollection._TESTmongoSchemaToParseSchema({
+          _id: 'TestClass',
+          testField: null,
+        });
+      } catch (error) {
+        expect(error.code).toBe(255);
+        expect(error.message).toContain('Invalid field type');
+      }
+    });
+
+    it('should throw error with correct message for undefined input', () => {
+      try {
+        MongoSchemaCollection._TESTmongoSchemaToParseSchema({
+          _id: 'TestClass',
+          testField: undefined,
+        });
+      } catch (error) {
+        expect(error.code).toBe(255);
+        expect(error.message).toContain('Invalid field type');
+      }
+    });
+
+    it('should throw error with correct message for non-string input', () => {
+      try {
+        MongoSchemaCollection._TESTmongoSchemaToParseSchema({
+          _id: 'TestClass',
+          testField: 123,
+        });
+      } catch (error) {
+        expect(error.code).toBe(255);
+        expect(error.message).toContain('Invalid field type');
+      }
+    });
+
+    it('should throw error with correct message for empty string input', () => {
+      try {
+        MongoSchemaCollection._TESTmongoSchemaToParseSchema({
+          _id: 'TestClass',
+          testField: '',
+        });
+      } catch (error) {
+        expect(error.code).toBe(255);
+        expect(error.message).toContain('Invalid field type');
+      }
+    });
+  });
 });

--- a/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
@@ -6,7 +6,7 @@ function mongoFieldToParseSchemaField(type) {
   if (!type || typeof type !== 'string') {
     throw new Parse.Error(
       Parse.Error.INVALID_SCHEMA_OPERATION,
-      `Invalid field type: ${type}. Expected a string. Field type must be one of: string, number, boolean, date, map, object, array, geopoint, file, bytes, polygon, or a valid relation/pointer format.`
+      `Invalid field type: ${type}. Expected a string. Fix the type mismatch in your schema configuration.`
     );
   }
 

--- a/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
@@ -2,6 +2,14 @@ import MongoCollection from './MongoCollection';
 import Parse from 'parse/node';
 
 function mongoFieldToParseSchemaField(type) {
+  // Add type validation to prevent TypeError
+  if (!type || typeof type !== 'string') {
+    throw new Parse.Error(
+      Parse.Error.INVALID_SCHEMA_OPERATION,
+      `Invalid field type: ${type}. Expected a string. Field type must be one of: string, number, boolean, date, map, object, array, geopoint, file, bytes, polygon, or a valid relation/pointer format.`
+    );
+  }
+
   if (type[0] === '*') {
     return {
       type: 'Pointer',

--- a/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
@@ -1,12 +1,12 @@
 import MongoCollection from './MongoCollection';
 import Parse from 'parse/node';
 
-function mongoFieldToParseSchemaField(type) {
+function mongoFieldToParseSchemaField(type, fieldName, className) {
   // Add type validation to prevent TypeError
   if (!type || typeof type !== 'string') {
     throw new Parse.Error(
       Parse.Error.INVALID_SCHEMA_OPERATION,
-      `Invalid field type: ${type}. Expected a string. Fix the type mismatch in your schema configuration.`
+      `Invalid field type: ${type} for field '${fieldName}' in class '_SCHEMA' (id: ${className}). Expected a string. Fix the type mismatch in your schema configuration.`
     );
   }
 
@@ -51,7 +51,7 @@ const nonFieldSchemaKeys = ['_id', '_metadata', '_client_permissions'];
 function mongoSchemaFieldsToParseSchemaFields(schema) {
   var fieldNames = Object.keys(schema).filter(key => nonFieldSchemaKeys.indexOf(key) === -1);
   var response = fieldNames.reduce((obj, fieldName) => {
-    obj[fieldName] = mongoFieldToParseSchemaField(schema[fieldName]);
+    obj[fieldName] = mongoFieldToParseSchemaField(schema[fieldName], fieldName, schema._id);
     if (
       schema._metadata &&
       schema._metadata.fields_options &&


### PR DESCRIPTION
Added a type check in mongoFieldToParseSchemaField to ensure `type` is a string before calling `startsWith`. This prevents crashes when Parse Server processes MongoDB schema fields with undefined, null, or unexpected type values.

Closes #9847

## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues/9847).

## Issue
<!-- Add the link to the issue that this PR closes. -->
- Link to issue [issue](https://github.com/parse-community/parse-server/issues/9847)



## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema validation for Mongo-backed storage: invalid, empty, or non-string field types now produce clear, user-facing errors instead of crashes.

* **Tests**
  * Added comprehensive tests covering valid field-type mappings and verifying invalid inputs reliably throw the expected errors.

* **Chores**
  * Strengthened input guards to reduce ambiguous failures and improve reliability during schema setup and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->