### PR TITLE
fix: GraphQL playground shows blank page

### DIFF
--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -167,14 +167,14 @@ class ParseGraphQLServer {
            new window.EmbeddedSandbox({
              target: "#sandbox",
              endpointIsEditable: false,
-             initialEndpoint: "${JSON.stringify(this.config.graphQLPath)}",
+             initialEndpoint: ${JSON.stringify(this.config.graphQLPath)},
              handleRequest: (endpointUrl, options) => {
               return fetch(endpointUrl, {
                 ...options,
                 headers: {
                     ...options.headers,
-                    'X-Parse-Application-Id': "${JSON.stringify(this.parseServer.config.appId)}",
-                    'X-Parse-Master-Key': "${JSON.stringify(this.parseServer.config.masterKey)}",
+                    'X-Parse-Application-Id': ${JSON.stringify(this.parseServer.config.appId)},
+                    'X-Parse-Master-Key': ${JSON.stringify(this.parseServer.config.masterKey)},
                 },
               })
             },


### PR DESCRIPTION
this fixes the error when activating graphql playground and opening it in the browser. the page is blank.

"${JSON.stringify(this.config.graphQLPath)}"  the result -> ""/graphql""
by removing the double quotes
${JSON.stringify(this.config.graphQLPath)}  the result -> "/graphql"

and the problem fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization of the GraphQL embedded sandbox to correctly set the endpoint and headers, preventing escaped/invalid values.
  * Ensures request headers (including authentication) are applied as intended, improving connectivity and reliability in the in-browser GraphQL console.
* **Notes**
  * No changes to server-side behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->