### PR TITLE
feat: Add regex option `u` for unicode support in `Parse.Query.matches` for MongoDB

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2113,6 +2113,19 @@ describe('Parse.Query testing', () => {
       .then(done);
   });
 
+  it('regex with unicode option', function (done) {
+    const thing = new TestObject();
+    thing.set('myString', 'hello 世界');
+    Parse.Object.saveAll([thing]).then(function () {
+      const query = new Parse.Query(TestObject);
+      query.matches('myString', '世界', 'u');
+      query.find().then(function (results) {
+        equal(results.length, 1);
+        done();
+      });
+    });
+  });
+
   it_id('823852f6-1de5-45ba-a2b9-ed952fcc6012')(it)('Use a regex that requires all modifiers', function (done) {
     const thing = new TestObject();
     thing.set('myString', 'PArSe\nCom');

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2113,17 +2113,14 @@ describe('Parse.Query testing', () => {
       .then(done);
   });
 
-  it('regex with unicode option', function (done) {
+  it_id('351f57a8-e00a-4da2-887d-6e25c9e359fc')(it)('regex with unicode option', async function () {
     const thing = new TestObject();
     thing.set('myString', 'hello 世界');
-    Parse.Object.saveAll([thing]).then(function () {
-      const query = new Parse.Query(TestObject);
-      query.matches('myString', '世界', 'u');
-      query.find().then(function (results) {
-        equal(results.length, 1);
-        done();
-      });
-    });
+    await Parse.Object.saveAll([thing]);
+    const query = new Parse.Query(TestObject);
+    query.matches('myString', '世界', 'u');
+    const results = await query.find();
+    equal(results.length, 1);
   });
 
   it_id('823852f6-1de5-45ba-a2b9-ed952fcc6012')(it)('Use a regex that requires all modifiers', function (done) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -111,7 +111,7 @@ const validateQuery = (
   Object.keys(query).forEach(key => {
     if (query && query[key] && query[key].$regex) {
       if (typeof query[key].$options === 'string') {
-        if (!query[key].$options.match(/^[imxs]+$/)) {
+        if (!query[key].$options.match(/^[imxsu]+$/)) {
           throw new Parse.Error(
             Parse.Error.INVALID_QUERY,
             `Bad $options value for query: ${query[key].$options}`


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Parse Server doesn't support the unicode regex option.

## Approach

Add regex option `u` for unicode support in `Parse.Query.matches`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Regex queries now support the 'u' (Unicode) option, enabling Unicode-aware pattern matching. Supported flags expand from i, m, x, s to i, m, x, s, u.

- Bug Fixes
  - Validation of regex options improved to avoid rejecting queries that use the 'u' flag, preventing false errors for Unicode regex searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->