### PR TITLE
feat: Add support for Postgres 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,9 @@ jobs:
           - name: PostgreSQL 17, PostGIS 3.5
             POSTGRES_IMAGE: postgis/postgis:17-3.5
             NODE_VERSION: 22.12.0
+          - name: PostgreSQL 18, PostGIS 3.6
+            POSTGRES_IMAGE: postgis/postgis:18-3.6
+            NODE_VERSION: 22.12.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 20

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Parse Server is continuously tested with the most recent releases of PostgreSQL 
 | Postgres 15 | 3.3, 3.4, 3.5           | November 2027 | <= 8.x (2025)        |
 | Postgres 16 | 3.5                     | November 2028 | <= 9.x (2026)        |
 | Postgres 17 | 3.5                     | November 2029 | <= 10.x (2027)       |
-| Postgres 17 | 3.6                     | November 2030 | <= 11.x (2028)       |
+| Postgres 18 | 3.6                     | November 2030 | <= 11.x (2028)       |
 
 ### Locally
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Node Version](https://img.shields.io/badge/nodejs-18,_20,_22-green.svg?logo=node.js&style=flat)](https://nodejs.org)
 [![MongoDB Version](https://img.shields.io/badge/mongodb-6,_7,_8-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
-[![Postgres Version](https://img.shields.io/badge/postgresql-13,_14,_15,_16,_17-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
+[![Postgres Version](https://img.shields.io/badge/postgresql-13,_14,_15,_16,_17,_18-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
 [![npm latest version](https://img.shields.io/npm/v/parse-server/latest.svg)](https://www.npmjs.com/package/parse-server)
 [![npm alpha version](https://img.shields.io/npm/v/parse-server/alpha.svg)](https://www.npmjs.com/package/parse-server)
@@ -152,6 +152,7 @@ Parse Server is continuously tested with the most recent releases of PostgreSQL 
 | Postgres 15 | 3.3, 3.4, 3.5           | November 2027 | <= 8.x (2025)        |
 | Postgres 16 | 3.5                     | November 2028 | <= 9.x (2026)        |
 | Postgres 17 | 3.5                     | November 2029 | <= 10.x (2027)       |
+| Postgres 17 | 3.6                     | November 2030 | <= 11.x (2028)       |
 
 ### Locally
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #9871 

## Approach
<!-- Describe the changes in this PR. -->
Add support for Postgres 18. Note that [Postgis 3.6](https://postgis.net/2025/09/PostGIS-3.6.0/) is made for Posgres 18.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] @mtrezza should update the repo settings to require the CI passes for `ci / PostgreSQL 18, PostGIS 3.6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated badges to include PostgreSQL 18.
  * Expanded compatibility table with a new row for PostgreSQL 18 (PostGIS 3.6), including EOL and version compatibility details.

* **Chores**
  * Extended CI coverage to test against PostgreSQL 18 with PostGIS 3.6 by adding an extra matrix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->