### PR TITLE
fix: Relation column is always present in the query result regardless of keys/excludeKeys query parameter

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -3770,6 +3770,71 @@ describe('Parse.Query testing', () => {
     expect(response.data.results[0].hello).toBe('world');
   });
 
+  it('respects keys selection for relation fields', async () => {
+    const parent = new Parse.Object('Parent');
+    parent.set('name', 'p1');
+    const child = new Parse.Object('Child');
+    await Parse.Object.saveAll([child, parent]);
+
+    parent.relation('children').add(child);
+    await parent.save();
+
+    // if we select only the name column we expect only that key.
+    const omitRelation = await request({
+      url: Parse.serverURL + '/classes/Parent',
+      qs: {
+        keys: 'name',
+        where: JSON.stringify({ objectId: parent.id }),
+      },
+      headers: masterKeyHeaders,
+    });
+    expect(omitRelation.data.results.length).toBe(1);
+    expect(omitRelation.data.results[0].name).toBe('p1');
+    expect(omitRelation.data.results[0].children).toBeUndefined();
+
+    // if we also include key of the children Relation column it should also be included
+    const includeRelation = await request({
+      url: Parse.serverURL + '/classes/Parent',
+      qs: {
+        keys: 'name,children',
+        where: JSON.stringify({ objectId: parent.id }),
+      },
+      headers: masterKeyHeaders,
+    });
+    expect(includeRelation.data.results.length).toBe(1);
+    expect(includeRelation.data.results[0].children).toEqual({
+      __type: 'Relation',
+      className: 'Child',
+    });
+
+    // if we exclude the children (Relation) column we expect it to not be returned.
+    const excludeRelation = await request({
+      url: Parse.serverURL + '/classes/Parent',
+      qs: {
+        excludeKeys: 'children',
+        where: JSON.stringify({ objectId: parent.id }),
+      },
+      headers: masterKeyHeaders,
+    });
+    expect(excludeRelation.data.results.length).toBe(1);
+    expect(excludeRelation.data.results[0].name).toBe('p1');
+    expect(excludeRelation.data.results[0].children).toBeUndefined();
+
+    // Default should still work, getting the relation column as normal.
+    const defaultResponse = await request({
+      url: Parse.serverURL + '/classes/Parent',
+      qs: {
+        where: JSON.stringify({ objectId: parent.id }),
+      },
+      headers: masterKeyHeaders,
+    });
+    expect(defaultResponse.data.results.length).toBe(1);
+    expect(defaultResponse.data.results[0].children).toEqual({
+      __type: 'Relation',
+      className: 'Child',
+    });
+  });
+
   it('select keys with each query', function (done) {
     const obj = new TestObject({ foo: 'baz', bar: 1 });
 

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -664,7 +664,30 @@ export class MongoStorageAdapter implements StorageAdapter {
         if (explain) {
           return objects;
         }
-        return objects.map(object => mongoObjectToParseObject(className, object, schema));
+        return objects.map(object => {
+          const parseObject = mongoObjectToParseObject(className, object, schema);
+          // If there are returned keys specified; we filter them first.
+          // We need to do this because in `mongoObjectToParseObject`, all 'Relation' fields
+          // are copied over from schema without any filters. (either keep this filtering here 
+          // or pass keys into `mongoObjectToParseObject` via additional optional parameter)
+          if (Array.isArray(keys)) {
+            // set of string keys
+            const keysSet = new Set(keys);
+            const shouldIncludeField = (fieldName) => {
+              return keysSet.has(fieldName);
+            };
+            // filter out relation fields
+            Object.keys(schema.fields).forEach(fieldName => {
+              if (
+                schema.fields[fieldName].type === 'Relation' &&
+                !shouldIncludeField(fieldName)
+              ) {
+                delete parseObject[fieldName];
+              }
+            });
+          }
+          return parseObject;
+        });
       })
       .catch(err => this.handleError(err));
   }

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -670,7 +670,7 @@ export class MongoStorageAdapter implements StorageAdapter {
           // We need to do this because in `mongoObjectToParseObject`, all 'Relation' fields
           // are copied over from schema without any filters. (either keep this filtering here 
           // or pass keys into `mongoObjectToParseObject` via additional optional parameter)
-          if (Array.isArray(keys)) {
+          if (Array.isArray(keys) && keys.length > 0) {
             // set of string keys
             const keysSet = new Set(keys);
             const shouldIncludeField = (fieldName) => {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1927,7 +1927,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
           // We need to do this because in `postgresObjectToParseObject`, all 'Relation' fields
           // are copied over from schema without any filters. (either keep this filtering here 
           // or pass keys into `postgresObjectToParseObject` via additional optional parameter)
-          if (selectedKeys.length > 0) {
+          if (Array.isArray(selectedKeys) && selectedKeys.length > 0) {
             // set of string keys
             const keysSet = new Set(selectedKeys);
             const shouldIncludeField = (fieldName) => {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1873,6 +1873,9 @@ export class PostgresStorageAdapter implements StorageAdapter {
       sortPattern = `ORDER BY ${where.sorts.join()}`;
     }
 
+    // For postgres adapter we need to copy the `keys` variable to selectedKeys first 
+    // because `keys` will be mutated in the next block.
+    const selectedKeys = Array.isArray(keys) ? keys.slice() : undefined;
     let columns = '*';
     if (keys) {
       // Exclude empty keys
@@ -1918,7 +1921,30 @@ export class PostgresStorageAdapter implements StorageAdapter {
         if (explain) {
           return results;
         }
-        return results.map(object => this.postgresObjectToParseObject(className, object, schema));
+        return results.map(object => {
+          const parseObject = this.postgresObjectToParseObject(className, object, schema);
+          // If there are returned keys specified; we filter them first.
+          // We need to do this because in `postgresObjectToParseObject`, all 'Relation' fields
+          // are copied over from schema without any filters. (either keep this filtering here 
+          // or pass keys into `postgresObjectToParseObject` via additional optional parameter)
+          if (selectedKeys) {
+            // set of string keys
+            const keysSet = new Set(selectedKeys);
+            const shouldIncludeField = (fieldName) => {
+              return keysSet.has(fieldName);
+            };
+            // filter out relation fields
+            Object.keys(schema.fields).forEach(fieldName => {
+              if (
+                schema.fields[fieldName].type === 'Relation' &&
+                !shouldIncludeField(fieldName)
+              ) {
+                delete parseObject[fieldName];
+              }
+            });
+          }
+          return parseObject;
+        });
       });
   }
 

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1927,7 +1927,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
           // We need to do this because in `postgresObjectToParseObject`, all 'Relation' fields
           // are copied over from schema without any filters. (either keep this filtering here 
           // or pass keys into `postgresObjectToParseObject` via additional optional parameter)
-          if (selectedKeys) {
+          if (selectedKeys.length > 0) {
             // set of string keys
             const keysSet = new Set(selectedKeys);
             const shouldIncludeField = (fieldName) => {

--- a/src/GraphQL/loaders/parseClassQueries.js
+++ b/src/GraphQL/loaders/parseClassQueries.js
@@ -108,6 +108,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
             selectedFields
               .filter(field => field.startsWith('edges.node.'))
               .map(field => field.replace('edges.node.', ''))
+              .map(field => field.replace(/\.edges\.node/g, ''))
               .filter(field => field.indexOf('edges.node') < 0)
           );
           const parseOrder = order && order.join(',');

--- a/src/GraphQL/loaders/parseClassQueries.js
+++ b/src/GraphQL/loaders/parseClassQueries.js
@@ -107,8 +107,13 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
           const { keys, include } = extractKeysAndInclude(
             selectedFields
               .filter(field => field.startsWith('edges.node.'))
-              .map(field => field.replace('edges.node.', ''))
-              .map(field => field.replace(/\.edges\.node/g, ''))
+              // GraphQL relation connections expose data under `edges.node.*`. Those
+              // segments do not correspond to actual Parse fields, so strip them to
+              // ensure the root relation key remains in the keys list (e.g. convert
+              // `users.edges.node.username` -> `users.username`). This preserves the
+              // synthetic relation placeholders that Parse injects while still
+              // respecting field projections.
+              .map(field => field.replace('edges.node.', '').replace(/\.edges\.node/g, ''))
               .filter(field => field.indexOf('edges.node') < 0)
           );
           const parseOrder = order && order.join(',');

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -351,11 +351,11 @@ const load = (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLCla
     ...defaultGraphQLTypes.PARSE_OBJECT_FIELDS,
     ...(className === '_User'
       ? {
-          authDataResponse: {
-            description: `auth provider response when triggered on signUp/logIn.`,
-            type: defaultGraphQLTypes.OBJECT,
-          },
-        }
+        authDataResponse: {
+          description: `auth provider response when triggered on signUp/logIn.`,
+          type: defaultGraphQLTypes.OBJECT,
+        },
+      }
       : {}),
   };
   const outputFields = () => {
@@ -386,8 +386,13 @@ const load = (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLCla
                 const { keys, include } = extractKeysAndInclude(
                   selectedFields
                     .filter(field => field.startsWith('edges.node.'))
-                    .map(field => field.replace('edges.node.', ''))
-                    .map(field => field.replace(/\.edges\.node/g, ''))
+                    // GraphQL relation connections expose data under `edges.node.*`. Those
+                    // segments do not correspond to actual Parse fields, so strip them to
+                    // ensure the root relation key remains in the keys list (e.g. convert
+                    // `users.edges.node.username` -> `users.username`). This preserves the
+                    // synthetic relation placeholders that Parse injects while still
+                    // respecting field projections.
+                    .map(field => field.replace('edges.node.', '').replace(/\.edges\.node/g, ''))
                     .filter(field => field.indexOf('edges.node') < 0)
                 );
                 const parseOrder = order && order.join(',');

--- a/src/GraphQL/loaders/parseClassTypes.js
+++ b/src/GraphQL/loaders/parseClassTypes.js
@@ -387,6 +387,7 @@ const load = (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseGraphQLCla
                   selectedFields
                     .filter(field => field.startsWith('edges.node.'))
                     .map(field => field.replace('edges.node.', ''))
+                    .map(field => field.replace(/\.edges\.node/g, ''))
                     .filter(field => field.indexOf('edges.node') < 0)
                 );
                 const parseOrder = order && order.join(',');

--- a/src/GraphQL/parseGraphQLUtils.js
+++ b/src/GraphQL/parseGraphQLUtils.js
@@ -22,13 +22,7 @@ export function toGraphQLError(error) {
 export const extractKeysAndInclude = selectedFields => {
   selectedFields = selectedFields
     .filter(field => !field.includes('__typename'))
-    // GraphQL relation connections expose data under `edges.node.*`. Those
-    // segments do not correspond to actual Parse fields, so strip them to
-    // ensure the root relation key remains in the keys list (e.g. convert
-    // `users.edges.node.username` -> `users.username`). This preserves the
-    // synthetic relation placeholders that Parse injects while still
-    // respecting field projections.
-    .map(field => field.replace(/\.edges\.node/g, ''));
+
   // Handles "id" field for both current and included objects
   selectedFields = selectedFields.map(field => {
     if (field === 'id') { return 'objectId'; }

--- a/src/GraphQL/parseGraphQLUtils.js
+++ b/src/GraphQL/parseGraphQLUtils.js
@@ -20,7 +20,15 @@ export function toGraphQLError(error) {
 }
 
 export const extractKeysAndInclude = selectedFields => {
-  selectedFields = selectedFields.filter(field => !field.includes('__typename'));
+  selectedFields = selectedFields
+    .filter(field => !field.includes('__typename'))
+    // GraphQL relation connections expose data under `edges.node.*`. Those
+    // segments do not correspond to actual Parse fields, so strip them to
+    // ensure the root relation key remains in the keys list (e.g. convert
+    // `users.edges.node.username` -> `users.username`). This preserves the
+    // synthetic relation placeholders that Parse injects while still
+    // respecting field projections.
+    .map(field => field.replace(/\.edges\.node/g, ''));
   // Handles "id" field for both current and included objects
   selectedFields = selectedFields.map(field => {
     if (field === 'id') { return 'objectId'; }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/parse-server/issues/8500

## Approach
<!-- Describe the changes in this PR. -->
This PR addresses issue #8500 where relation fields are never excluded from the returned objects when excludeKeys or specific keys are specified. This is due to the code of both mongoObjectToParseObject and postgresObjectToParseObject  internally always spreading the "Relation" keys to the returned object as pointers.
The approach taken in this PR is we check if specific keys are specified, and if so, we filter out the Relation fields outside. (A different approach would require passing in those specific keys into mongoObjectToParseObject and postgresObjectToParseObject so they can skip internally too).
A minimal edit to GraphQL was necessary too due to previous behaviour not traversing edge.node properly for nested fields, meaning it never addressed nested fields properly, which with this PR would fail. This (hopefully) corrects the behaviour to as intended.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relation field selection now respects requested keys: only included relations are returned, excluded relations are omitted, and default behavior is preserved.
  * GraphQL field normalization improved to handle nested edge.node paths for accurate projections.
  * Consistent filtering of non-selected relation fields across storage backends for cleaner responses.

* **Tests**
  * Added tests validating inclusion, exclusion, and default behavior for relation field selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->