### PR TITLE
ci: Cancel obsolete performance benchmark jobs

### DIFF
--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -325,3 +325,6 @@ jobs:
           else
             echo "⚠️ Benchmark comparison not available" >> $GITHUB_STEP_SUMMARY
           fi
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Obsolete performance benchmark jobs keep running.

## Approach

Cancel obsolete performance benchmark jobs.