### PR TITLE
fix: Race condition can cause multiple Apollo server initializations under load

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -118,6 +118,20 @@ describe('ParseGraphQLServer', () => {
       expect(server3).not.toBe(server2);
       expect(server3).toBe(server4);
     });
+
+    it('should return same server reference when called 100 times in parallel', async () => {
+      parseGraphQLServer.server = undefined;
+
+      // Call _getServer 100 times in parallel
+      const promises = Array.from({ length: 100 }, () => parseGraphQLServer._getServer());
+      const servers = await Promise.all(promises);
+
+      // All resolved servers should be the same reference
+      const firstServer = servers[0];
+      servers.forEach((server, index) => {
+        expect(server).toBe(firstServer);
+      });
+    });
   });
 
   describe('_getGraphQLOptions', () => {

--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -97,21 +97,31 @@ class ParseGraphQLServer {
     if (schemaRef === newSchemaRef && this._server) {
       return this._server;
     }
-    const { schema, context } = await this._getGraphQLOptions();
-    const apollo = new ApolloServer({
-      csrfPrevention: {
-        // See https://www.apollographql.com/docs/router/configuration/csrf/
-        // needed since we use graphql upload
-        requestHeaders: ['X-Parse-Application-Id'],
-      },
-      introspection: this.config.graphQLPublicIntrospection,
-      plugins: [ApolloServerPluginCacheControlDisabled(), IntrospectionControlPlugin(this.config.graphQLPublicIntrospection)],
-      schema,
-    });
-    await apollo.start();
-    this._server = expressMiddleware(apollo, {
-      context,
-    });
+    // It means a parallel _getServer call is already in progress
+    if (this._schemaRefMutex === newSchemaRef) {
+      return this._server;
+    }
+    // Update the schema ref mutex to avoid parallel _getServer calls
+    this._schemaRefMutex = newSchemaRef;
+    const createServer = async () => {
+      const { schema, context } = await this._getGraphQLOptions();
+      const apollo = new ApolloServer({
+        csrfPrevention: {
+          // See https://www.apollographql.com/docs/router/configuration/csrf/
+          // needed since we use graphql upload
+          requestHeaders: ['X-Parse-Application-Id'],
+        },
+        introspection: this.config.graphQLPublicIntrospection,
+        plugins: [ApolloServerPluginCacheControlDisabled(), IntrospectionControlPlugin(this.config.graphQLPublicIntrospection)],
+        schema,
+      });
+      await apollo.start();
+      return expressMiddleware(apollo, {
+        context,
+      });
+    }
+    // Do not await so parallel request will wait the same promise ref
+    this._server = createServer();
     return this._server;
   }
 

--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -104,21 +104,28 @@ class ParseGraphQLServer {
     // Update the schema ref mutex to avoid parallel _getServer calls
     this._schemaRefMutex = newSchemaRef;
     const createServer = async () => {
-      const { schema, context } = await this._getGraphQLOptions();
-      const apollo = new ApolloServer({
-        csrfPrevention: {
-          // See https://www.apollographql.com/docs/router/configuration/csrf/
-          // needed since we use graphql upload
-          requestHeaders: ['X-Parse-Application-Id'],
-        },
-        introspection: this.config.graphQLPublicIntrospection,
-        plugins: [ApolloServerPluginCacheControlDisabled(), IntrospectionControlPlugin(this.config.graphQLPublicIntrospection)],
-        schema,
-      });
-      await apollo.start();
-      return expressMiddleware(apollo, {
-        context,
-      });
+      try {
+        const { schema, context } = await this._getGraphQLOptions();
+        const apollo = new ApolloServer({
+          csrfPrevention: {
+            // See https://www.apollographql.com/docs/router/configuration/csrf/
+            // needed since we use graphql upload
+            requestHeaders: ['X-Parse-Application-Id'],
+          },
+          introspection: this.config.graphQLPublicIntrospection,
+          plugins: [ApolloServerPluginCacheControlDisabled(), IntrospectionControlPlugin(this.config.graphQLPublicIntrospection)],
+          schema,
+        });
+        await apollo.start();
+        return expressMiddleware(apollo, {
+          context,
+        });
+      } catch (e) {
+        // Reset all mutexes and forward the error
+        this._server = null;
+        this._schemaRefMutex = null;
+        throw e;
+      }
     }
     // Do not await so parallel request will wait the same promise ref
     this._server = createServer();


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Underload, apollo server can be initialized multiple times. Schema ref should be used as mutex to prevent parallel init, so all _getServer await the same promise ref

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->
Using schema as a ref mutex

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent initialization so parallel requests reuse the same server instance, preventing duplicate server creation during simultaneous access.

* **Tests**
  * Added a test that verifies repeated parallel calls to server initialization return the same shared server reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->