### PR TITLE
feat(mongodb): Add mongodb client metadata

### DIFF
--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -10,6 +10,7 @@
 import { MongoClient, GridFSBucket, Db } from 'mongodb';
 import { FilesAdapter, validateFilename } from './FilesAdapter';
 import defaults, { ParseServerDatabaseOptions } from '../../defaults';
+import { version } from '../../../package.json';
 const crypto = require('crypto');
 
 export class GridFSBucketAdapter extends FilesAdapter {
@@ -48,6 +49,7 @@ export class GridFSBucketAdapter extends FilesAdapter {
       this._connectionPromise = MongoClient.connect(this._databaseURI, this._mongoOptions).then(
         client => {
           this._client = client;
+          client.appendMetadata({ name: 'parse_server_gridfs', version: version });
           return client.db(client.s.options.dbName);
         }
       );

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -19,6 +19,7 @@ import _ from 'lodash';
 import defaults, { ParseServerDatabaseOptions } from '../../../defaults';
 import logger from '../../../logger';
 import Utils from '../../../Utils';
+import { version } from '../../../../package.json';
 
 // @flow-disable-next
 const mongodb = require('mongodb');
@@ -184,6 +185,7 @@ export class MongoStorageAdapter implements StorageAdapter {
         // Starting mongoDB 3.0, the MongoClient.connect don't return a DB anymore but a client
         // Fortunately, we can get back the options and use them to select the proper DB.
         // https://github.com/mongodb/node-mongodb-native/blob/2c35d76f08574225b8db02d7bef687123e6bb018/lib/mongo_client.js#L885
+        client.appendMetadata({ name: 'parse_server_storage', version: version });
         const options = client.s.options;
         const database = client.db(options.dbName);
         if (!database) {


### PR DESCRIPTION
## Pull Request

The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to mongos or mongod logs.

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Approach
<!-- Describe the changes in this PR. -->
Appends client metadata when mongo clients are created.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version metadata is now attached to MongoDB client connections in database adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->