### PR TITLE
fix: Queries with object field `authData.provider.id` are incorrectly transformed to `_auth_data_provider.id` for custom classes

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -521,6 +521,23 @@ describe('parseObjectToMongoObjectForCreate', () => {
     expect(output.authData).toBe('random');
     done();
   });
+
+  it('should only transform authData.provider.id for _User class', () => {
+    // Test that for _User class, authData.facebook.id is transformed
+    const userInput = {
+      'authData.facebook.id': '10000000000000001',
+    };
+    const userOutput = transform.transformWhere('_User', userInput, { fields: {} });
+    expect(userOutput['_auth_data_facebook.id']).toBe('10000000000000001');
+
+    // Test that for non-User classes, authData.facebook.id is NOT transformed
+    const customInput = {
+      'authData.facebook.id': '10000000000000001',
+    };
+    const customOutput = transform.transformWhere('SpamAlerts', customInput, { fields: {} });
+    expect(customOutput['authData.facebook.id']).toBe('10000000000000001');
+    expect(customOutput['_auth_data_facebook.id']).toBeUndefined();
+  });
 });
 
 it('cannot have a custom field name beginning with underscore', done => {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -305,7 +305,7 @@ function transformQueryKeyValue(className, key, value, schema, count = false) {
     default: {
       // Other auth data
       const authDataMatch = key.match(/^authData\.([a-zA-Z0-9_]+)\.id$/);
-      if (authDataMatch) {
+      if (authDataMatch && className === '_User') {
         const provider = authDataMatch[1];
         // Special-case auth data.
         return { key: `_auth_data_${provider}.id`, value };


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Queries with `authData.provider.id` are incorrectly transformed to `_auth_data_provider.id` for all classes. This transformation should only occur for the `_User` class, where `authData` is a special field with internal MongoDB representation. For custom classes, `authData` should be treated as a regular field and remain untransformed.

## Approach

Changes:
- Add `className` check in `transformQueryKeyValue` to restrict `authData` transformation to `_User` class only
- Add test case verifying `authData` queries work correctly for both `_User` and custom classes

All other MongoDB authData transformations are already class-specific:
- DatabaseController.js:317 - Already checks className === '_User'
- MongoTransform.js:1204 - Already checks className === '_User'

This fix at line was the only missing check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authData transformation logic to correctly restrict transformations to User records, preventing unintended behavior where other data types could be incorrectly transformed.

* **Tests**
  * Added test coverage for authData transformation behavior across different record types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->