### PR TITLE
fix: Deprecation warning logged at server launch for nested Parse Server option even if option is explicitly set

### DIFF
--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -122,4 +122,55 @@ describe('Utils', () => {
       expect(result).toBe('{"name":"test","number":42,"nested":{"key":"value"}}');
     });
   });
+
+  describe('getNestedProperty', () => {
+    it('should get top-level property', () => {
+      const obj = { foo: 'bar' };
+      expect(Utils.getNestedProperty(obj, 'foo')).toBe('bar');
+    });
+
+    it('should get nested property with dot notation', () => {
+      const obj = { database: { options: { enabled: true } } };
+      expect(Utils.getNestedProperty(obj, 'database.options.enabled')).toBe(true);
+    });
+
+    it('should return undefined for non-existent property', () => {
+      const obj = { foo: 'bar' };
+      expect(Utils.getNestedProperty(obj, 'baz')).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent nested property', () => {
+      const obj = { database: { options: {} } };
+      expect(Utils.getNestedProperty(obj, 'database.options.enabled')).toBeUndefined();
+    });
+
+    it('should return undefined when path traverses non-object', () => {
+      const obj = { database: 'string' };
+      expect(Utils.getNestedProperty(obj, 'database.options.enabled')).toBeUndefined();
+    });
+
+    it('should return undefined for null object', () => {
+      expect(Utils.getNestedProperty(null, 'foo')).toBeUndefined();
+    });
+
+    it('should return undefined for empty path', () => {
+      const obj = { foo: 'bar' };
+      expect(Utils.getNestedProperty(obj, '')).toBeUndefined();
+    });
+
+    it('should handle value of 0', () => {
+      const obj = { database: { timeout: 0 } };
+      expect(Utils.getNestedProperty(obj, 'database.timeout')).toBe(0);
+    });
+
+    it('should handle value of false', () => {
+      const obj = { database: { enabled: false } };
+      expect(Utils.getNestedProperty(obj, 'database.enabled')).toBe(false);
+    });
+
+    it('should handle value of empty string', () => {
+      const obj = { database: { name: '' } };
+      expect(Utils.getNestedProperty(obj, 'database.name')).toBe('');
+    });
+  });
 });

--- a/src/Deprecator/Deprecator.js
+++ b/src/Deprecator/Deprecator.js
@@ -1,5 +1,6 @@
 import logger from '../logger';
 import Deprecations from './Deprecations';
+import Utils from '../Utils';
 
 /**
  * The deprecator class.
@@ -21,7 +22,7 @@ class Deprecator {
       const changeNewDefault = deprecation.changeNewDefault;
 
       // If default will change, only throw a warning if option is not set
-      if (changeNewDefault != null && options[optionKey] == null) {
+      if (changeNewDefault != null && Utils.getNestedProperty(options, optionKey) == null) {
         Deprecator._logOption({ optionKey, changeNewDefault, solution });
       }
     }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -444,6 +444,31 @@ class Utils {
       return value;
     };
   }
+
+  /**
+   * Gets a nested property value from an object using dot notation.
+   * @param {Object} obj The object to get the property from.
+   * @param {String} path The property path in dot notation, e.g. 'databaseOptions.allowPublicExplain'.
+   * @returns {any} The property value or undefined if not found.
+   * @example
+   * const obj = { database: { options: { enabled: true } } };
+   * Utils.getNestedProperty(obj, 'database.options.enabled');
+   * // Output: true
+   */
+  static getNestedProperty(obj, path) {
+    if (!obj || !path) {
+      return undefined;
+    }
+    const keys = path.split('.');
+    let current = obj;
+    for (const key of keys) {
+      if (current == null || typeof current !== 'object') {
+        return undefined;
+      }
+      current = current[key];
+    }
+    return current;
+  }
 }
 
 module.exports = Utils;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

The deprecator incorrectly handles nested option keys like `databaseOptions.allowPublicExplain` as it doesn't consider the dot notation to access nested properties.

## Approach

Parse dot notation of deprecated option keys.