### PR TITLE
fix: Parse Server option `rateLimit.zone` does not use default value `ip`

### DIFF
--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -690,7 +690,7 @@ module.exports.RateLimitOptions = {
   zone: {
     env: 'PARSE_SERVER_RATE_LIMIT_ZONE',
     help:
-      'The type of rate limit to apply. The following types are supported:<ul><li>`global`: rate limit based on the number of requests made by all users</li><li>`ip`: rate limit based on the IP address of the request</li><li>`user`: rate limit based on the user ID of the request</li><li>`session`: rate limit based on the session token of the request</li></ul>',
+      'The type of rate limit to apply. The following types are supported:<ul><li>`global`: rate limit based on the number of requests made by all users</li><li>`ip`: rate limit based on the IP address of the request</li><li>`user`: rate limit based on the user ID of the request</li><li>`session`: rate limit based on the session token of the request</li></ul>Default is `ip`.',
     default: 'ip',
   },
 };

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -690,7 +690,8 @@ module.exports.RateLimitOptions = {
   zone: {
     env: 'PARSE_SERVER_RATE_LIMIT_ZONE',
     help:
-      "The type of rate limit to apply. The following types are supported:<br><br>- `global`: rate limit based on the number of requests made by all users <br>- `ip`: rate limit based on the IP address of the request <br>- `user`: rate limit based on the user ID of the request <br>- `session`: rate limit based on the session token of the request <br><br><br>:default: 'ip'",
+      'The type of rate limit to apply. The following types are supported:<ul><li>`global`: rate limit based on the number of requests made by all users</li><li>`ip`: rate limit based on the IP address of the request</li><li>`user`: rate limit based on the user ID of the request</li><li>`session`: rate limit based on the session token of the request</li></ul>',
+    default: 'ip',
   },
 };
 module.exports.SecurityOptions = {

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -122,7 +122,7 @@
  * @property {String[]} requestMethods Optional, the HTTP request methods to which the rate limit should be applied, default is all methods.
  * @property {String} requestPath The path of the API route to be rate limited. Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings, string patterns, or regular expression. See: https://expressjs.com/en/guide/routing.html
  * @property {Number} requestTimeWindow The window of time in milliseconds within which the number of requests set in `requestCount` can be made before the rate limit is applied.
- * @property {String} zone The type of rate limit to apply. The following types are supported:<br><br>- `global`: rate limit based on the number of requests made by all users <br>- `ip`: rate limit based on the IP address of the request <br>- `user`: rate limit based on the user ID of the request <br>- `session`: rate limit based on the session token of the request <br><br><br>:default: 'ip'
+ * @property {String} zone The type of rate limit to apply. The following types are supported:<ul><li>`global`: rate limit based on the number of requests made by all users</li><li>`ip`: rate limit based on the IP address of the request</li><li>`user`: rate limit based on the user ID of the request</li><li>`session`: rate limit based on the session token of the request</li></ul>
  */
 
 /**

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -122,7 +122,7 @@
  * @property {String[]} requestMethods Optional, the HTTP request methods to which the rate limit should be applied, default is all methods.
  * @property {String} requestPath The path of the API route to be rate limited. Route paths, in combination with a request method, define the endpoints at which requests can be made. Route paths can be strings, string patterns, or regular expression. See: https://expressjs.com/en/guide/routing.html
  * @property {Number} requestTimeWindow The window of time in milliseconds within which the number of requests set in `requestCount` can be made before the rate limit is applied.
- * @property {String} zone The type of rate limit to apply. The following types are supported:<ul><li>`global`: rate limit based on the number of requests made by all users</li><li>`ip`: rate limit based on the IP address of the request</li><li>`user`: rate limit based on the user ID of the request</li><li>`session`: rate limit based on the session token of the request</li></ul>
+ * @property {String} zone The type of rate limit to apply. The following types are supported:<ul><li>`global`: rate limit based on the number of requests made by all users</li><li>`ip`: rate limit based on the IP address of the request</li><li>`user`: rate limit based on the user ID of the request</li><li>`session`: rate limit based on the session token of the request</li></ul>Default is `ip`.
  */
 
 /**

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -370,16 +370,14 @@ export interface RateLimitOptions {
   /* Optional, the URL of the Redis server to store rate limit data. This allows to rate limit requests for multiple servers by calculating the sum of all requests across all servers. This is useful if multiple servers are processing requests behind a load balancer. For example, the limit of 10 requests is reached if each of 2 servers processed 5 requests.
    */
   redisUrl: ?string;
-  /*
-  The type of rate limit to apply. The following types are supported:
-  <br><br>
-  - `global`: rate limit based on the number of requests made by all users <br>
-  - `ip`: rate limit based on the IP address of the request <br>
-  - `user`: rate limit based on the user ID of the request <br>
-  - `session`: rate limit based on the session token of the request <br>
-  <br><br>
-  :default: 'ip'
-  */
+  /* The type of rate limit to apply. The following types are supported:
+  <ul>
+  <li>`global`: rate limit based on the number of requests made by all users</li>
+  <li>`ip`: rate limit based on the IP address of the request</li>
+  <li>`user`: rate limit based on the user ID of the request</li>
+  <li>`session`: rate limit based on the session token of the request</li>
+  </ul>
+  :DEFAULT: ip */
   zone: ?string;
 }
 

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -377,6 +377,7 @@ export interface RateLimitOptions {
   <li>`user`: rate limit based on the user ID of the request</li>
   <li>`session`: rate limit based on the session token of the request</li>
   </ul>
+  Default is `ip`.
   :DEFAULT: ip */
   zone: ?string;
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

Parse Server option `rateLimit.zone` does not use default value `ip`. Due to typos in the code comment the parser doesn't recognize the default value.

## Approach

Fix code comment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limit zone configuration now has an explicit default value ("ip").

* **Documentation**
  * Rate limit option help text reformatted from inline HTML breaks to semantic bulleted lists and now notes the default clearly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->