### PR TITLE
perf: Replace `deepcopy` with Node-native `structuredClone` for faster object-cloning throughout the codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "bcryptjs": "3.0.2",
         "commander": "13.1.0",
         "cors": "2.8.5",
-        "deepcopy": "2.1.0",
         "express": "5.2.1",
         "express-rate-limit": "7.5.1",
         "follow-redirects": "1.15.9",
@@ -175,6 +174,7 @@
       "integrity": "sha512-YM9lQpm0VfVco4DSyKooHS/fDTiKQcCHfxr7i3iL6a0kP/jNO5+4NFK6vtRDxaYisd5BrwOZHLJpPBnvRVpKPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -876,6 +876,7 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -4070,6 +4071,7 @@
       "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -4570,6 +4572,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
       "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -4639,6 +4642,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5351,6 +5355,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5470,6 +5475,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.12.tgz",
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -6448,6 +6454,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -6601,6 +6608,7 @@
       "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.33.1",
@@ -6699,6 +6707,7 @@
       "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.33.1",
         "@typescript-eslint/types": "8.33.1",
@@ -7491,6 +7500,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8113,6 +8123,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -9539,14 +9550,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deepcopy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz",
-      "integrity": "sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==",
-      "dependencies": {
-        "type-detect": "^4.0.8"
-      }
-    },
     "node_modules/default-require-extensions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
@@ -10266,6 +10269,7 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10768,6 +10772,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
       "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -11704,7 +11709,6 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -11719,7 +11723,6 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -11736,7 +11739,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11757,16 +11759,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/gcp-metadata/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/gcp-metadata/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -11774,7 +11774,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -12260,6 +12259,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -12862,8 +12862,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
       "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -13462,6 +13461,7 @@
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
       "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
@@ -14706,6 +14706,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -14733,6 +14734,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -18914,6 +18916,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -18954,7 +18957,6 @@
       "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
       "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "pg": "^8"
       }
@@ -19237,6 +19239,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -20315,6 +20318,7 @@
       "integrity": "sha512-9xV49HNY8C0/WmPWxTlaNleiXhWb//qfMzG2c5X8/k7tuWcu8RssbuS+sujb/h7PiWSXv53mrQvV9hrO9b7vuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -21083,32 +21087,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
       }
     },
     "node_modules/source-map": {
@@ -22151,14 +22129,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/type-fest": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.21.0.tgz",
@@ -22234,6 +22204,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23236,6 +23207,7 @@
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.8.tgz",
       "integrity": "sha512-YM9lQpm0VfVco4DSyKooHS/fDTiKQcCHfxr7i3iL6a0kP/jNO5+4NFK6vtRDxaYisd5BrwOZHLJpPBnvRVpKPg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -23744,6 +23716,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -25879,6 +25852,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
       "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -26285,6 +26259,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
       "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "peer": true,
       "requires": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -26340,6 +26315,7 @@
           "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
           "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@octokit/auth-token": "^4.0.0",
             "@octokit/graphql": "^7.1.0",
@@ -26849,7 +26825,8 @@
           "version": "9.1.6",
           "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
           "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "marked-terminal": {
           "version": "6.2.0",
@@ -26918,6 +26895,7 @@
           "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.12.tgz",
           "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@semantic-release/commit-analyzer": "^11.0.0",
             "@semantic-release/error": "^4.0.0",
@@ -27583,6 +27561,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -27730,6 +27709,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
       "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.33.1",
@@ -27784,6 +27764,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
       "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.33.1",
         "@typescript-eslint/types": "8.33.1",
@@ -28284,7 +28265,8 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -28741,6 +28723,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -29741,14 +29724,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "deepcopy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz",
-      "integrity": "sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==",
-      "requires": {
-        "type-detect": "^4.0.8"
-      }
-    },
     "default-require-extensions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
@@ -30266,6 +30241,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -30637,6 +30613,7 @@
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
       "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "peer": true,
       "requires": {}
     },
     "extend": {
@@ -31243,7 +31220,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "optional": true,
-      "peer": true,
       "requires": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -31254,7 +31230,6 @@
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
           "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
           "optional": true,
-          "peer": true,
           "requires": {
             "extend": "^3.0.2",
             "https-proxy-agent": "^5.0.0",
@@ -31267,7 +31242,6 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
           "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "optional": true,
-          "peer": true,
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -31276,22 +31250,19 @@
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "optional": true,
-          "peer": true
+          "optional": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "optional": true,
-          "peer": true
+          "optional": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
           "optional": true,
-          "peer": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -31653,7 +31624,8 @@
     "graphql": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "peer": true
     },
     "graphql-list-fields": {
       "version": "2.0.4",
@@ -32060,11 +32032,9 @@
       }
     },
     "ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
       "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -32502,6 +32472,7 @@
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
       "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
@@ -33427,6 +33398,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -33447,7 +33419,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "marked-terminal": {
       "version": "7.3.0",
@@ -36276,6 +36249,7 @@
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "peer": true,
       "requires": {
         "pg-cloudflare": "^1.2.7",
         "pg-connection-string": "^2.9.1",
@@ -36300,7 +36274,6 @@
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
       "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
-      "peer": true,
       "requires": {}
     },
     "pg-int8": {
@@ -36486,6 +36459,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
       "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -37261,6 +37235,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.5.tgz",
       "integrity": "sha512-9xV49HNY8C0/WmPWxTlaNleiXhWb//qfMzG2c5X8/k7tuWcu8RssbuS+sujb/h7PiWSXv53mrQvV9hrO9b7vuQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -37781,24 +37756,6 @@
           "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
           "dev": true
         }
-      }
-    },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "optional": true,
-      "peer": true
-    },
-    "socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
       }
     },
     "source-map": {
@@ -38566,11 +38523,6 @@
         "prelude-ls": "^1.2.1"
       }
     },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-    },
     "type-fest": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.21.0.tgz",
@@ -38625,7 +38577,8 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "typescript-eslint": {
       "version": "8.33.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "bcryptjs": "3.0.2",
     "commander": "13.1.0",
     "cors": "2.8.5",
-    "deepcopy": "2.1.0",
     "express": "5.2.1",
     "express-rate-limit": "7.5.1",
     "follow-redirects": "1.15.9",

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -9,7 +9,6 @@ import _ from 'lodash';
 // @flow-disable-next
 import intersect from 'intersect';
 // @flow-disable-next
-import deepcopy from 'deepcopy';
 import logger from '../logger';
 import Utils from '../Utils';
 import * as SchemaController from './SchemaController';
@@ -502,7 +501,7 @@ class DatabaseController {
     const originalQuery = query;
     const originalUpdate = update;
     // Make a copy of the object, so we don't mutate the incoming data.
-    update = deepcopy(update);
+    update = structuredClone(update);
     var relationUpdates = [];
     var isMaster = acl === undefined;
     var aclGroup = acl || [];
@@ -1092,7 +1091,7 @@ class DatabaseController {
           this.addInObjectIdsIds(ids, query);
           return this.reduceRelationKeys(className, query, queryOptions);
         })
-        .then(() => {});
+        .then(() => { });
     }
   }
 
@@ -1543,8 +1542,8 @@ class DatabaseController {
         const fieldDescriptor = schema.getExpectedType(className, key);
         const fieldType =
           fieldDescriptor &&
-          typeof fieldDescriptor === 'object' &&
-          Object.prototype.hasOwnProperty.call(fieldDescriptor, 'type')
+            typeof fieldDescriptor === 'object' &&
+            Object.prototype.hasOwnProperty.call(fieldDescriptor, 'type')
             ? fieldDescriptor.type
             : null;
 

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -22,7 +22,6 @@ import DatabaseController from './DatabaseController';
 import Config from '../Config';
 import { createSanitizedError } from '../Error';
 // @flow-disable-next
-import deepcopy from 'deepcopy';
 import type {
   Schema,
   SchemaFields,
@@ -573,7 +572,7 @@ class SchemaData {
           if (!this.__data[schema.className]) {
             const data = {};
             data.fields = injectDefaultSchema(schema).fields;
-            data.classLevelPermissions = deepcopy(schema.classLevelPermissions);
+            data.classLevelPermissions = structuredClone(schema.classLevelPermissions);
             data.indexes = schema.indexes;
 
             const classProtectedFields = this.__protectedFields[schema.className];
@@ -768,7 +767,7 @@ export default class SchemaController {
           throw err;
         }
       )
-      .then(() => {});
+      .then(() => { });
     return this.reloadDataPromise;
   }
 

--- a/src/GraphQL/loaders/functionsMutations.js
+++ b/src/GraphQL/loaders/functionsMutations.js
@@ -1,5 +1,4 @@
 import { GraphQLNonNull, GraphQLEnumType } from 'graphql';
-import deepcopy from 'deepcopy';
 import { mutationWithClientMutationId } from 'graphql-relay';
 import { FunctionsRouter } from '../../Routers/FunctionsRouter';
 import * as defaultGraphQLTypes from './defaultGraphQLTypes';
@@ -44,7 +43,7 @@ const load = parseGraphQLSchema => {
       },
       mutateAndGetPayload: async (args, context) => {
         try {
-          const { functionName, params } = deepcopy(args);
+          const { functionName, params } = structuredClone(args);
           const { config, auth, info } = context;
 
           return {

--- a/src/GraphQL/loaders/parseClassMutations.js
+++ b/src/GraphQL/loaders/parseClassMutations.js
@@ -1,7 +1,6 @@
 import { GraphQLNonNull } from 'graphql';
 import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay';
 import getFieldNames from 'graphql-list-fields';
-import deepcopy from 'deepcopy';
 import * as defaultGraphQLTypes from './defaultGraphQLTypes';
 import { extractKeysAndInclude, getParseClassMutationConfig } from '../parseGraphQLUtils';
 import * as objectsMutations from '../helpers/objectsMutations';
@@ -75,7 +74,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
       },
       mutateAndGetPayload: async (args, context, mutationInfo) => {
         try {
-          let { fields } = deepcopy(args);
+          let { fields } = structuredClone(args);
           if (!fields) { fields = {}; }
           const { config, auth, info } = context;
 
@@ -178,7 +177,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
       },
       mutateAndGetPayload: async (args, context, mutationInfo) => {
         try {
-          let { id, fields } = deepcopy(args);
+          let { id, fields } = structuredClone(args);
           if (!fields) { fields = {}; }
           const { config, auth, info } = context;
 
@@ -284,7 +283,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
       },
       mutateAndGetPayload: async (args, context, mutationInfo) => {
         try {
-          let { id } = deepcopy(args);
+          let { id } = structuredClone(args);
           const { config, auth, info } = context;
 
           const globalIdObject = fromGlobalId(id);

--- a/src/GraphQL/loaders/parseClassQueries.js
+++ b/src/GraphQL/loaders/parseClassQueries.js
@@ -1,7 +1,6 @@
 import { GraphQLNonNull } from 'graphql';
 import { fromGlobalId } from 'graphql-relay';
 import getFieldNames from 'graphql-list-fields';
-import deepcopy from 'deepcopy';
 import pluralize from 'pluralize';
 import * as defaultGraphQLTypes from './defaultGraphQLTypes';
 import * as objectsQueries from '../helpers/objectsQueries';
@@ -75,7 +74,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
           return await getQuery(
             parseClass,
             _source,
-            deepcopy(args),
+            structuredClone(args),
             context,
             queryInfo,
             parseGraphQLSchema.parseClasses
@@ -99,7 +98,7 @@ const load = function (parseGraphQLSchema, parseClass, parseClassConfig: ?ParseG
       async resolve(_source, args, context, queryInfo) {
         try {
           // Deep copy args to avoid internal re assign issue
-          const { where, order, skip, first, after, last, before, options } = deepcopy(args);
+          const { where, order, skip, first, after, last, before, options } = structuredClone(args);
           const { readPreference, includeReadPreference, subqueryReadPreference } = options || {};
           const { config, auth, info } = context;
           const selectedFields = getFieldNames(queryInfo);

--- a/src/GraphQL/loaders/schemaMutations.js
+++ b/src/GraphQL/loaders/schemaMutations.js
@@ -1,6 +1,5 @@
 import Parse from 'parse/node';
 import { GraphQLNonNull } from 'graphql';
-import deepcopy from 'deepcopy';
 import { mutationWithClientMutationId } from 'graphql-relay';
 import * as schemaTypes from './schemaTypes';
 import { transformToParse, transformToGraphQL } from '../transformers/schemaFields';
@@ -28,7 +27,7 @@ const load = parseGraphQLSchema => {
     },
     mutateAndGetPayload: async (args, context) => {
       try {
-        const { name, schemaFields } = deepcopy(args);
+        const { name, schemaFields } = structuredClone(args);
         const { config, auth } = context;
 
         enforceMasterKeyAccess(auth, config);
@@ -78,7 +77,7 @@ const load = parseGraphQLSchema => {
     },
     mutateAndGetPayload: async (args, context) => {
       try {
-        const { name, schemaFields } = deepcopy(args);
+        const { name, schemaFields } = structuredClone(args);
         const { config, auth } = context;
 
         enforceMasterKeyAccess(auth, config);
@@ -130,7 +129,7 @@ const load = parseGraphQLSchema => {
     },
     mutateAndGetPayload: async (args, context) => {
       try {
-        const { name } = deepcopy(args);
+        const { name } = structuredClone(args);
         const { config, auth } = context;
 
         enforceMasterKeyAccess(auth, config);

--- a/src/GraphQL/loaders/schemaQueries.js
+++ b/src/GraphQL/loaders/schemaQueries.js
@@ -1,5 +1,4 @@
 import Parse from 'parse/node';
-import deepcopy from 'deepcopy';
 import { GraphQLNonNull, GraphQLList } from 'graphql';
 import { transformToGraphQL } from '../transformers/schemaFields';
 import * as schemaTypes from './schemaTypes';
@@ -28,7 +27,7 @@ const load = parseGraphQLSchema => {
       type: new GraphQLNonNull(schemaTypes.CLASS),
       resolve: async (_source, args, context) => {
         try {
-          const { name } = deepcopy(args);
+          const { name } = structuredClone(args);
           const { config, auth } = context;
 
           enforceMasterKeyAccess(auth, config);

--- a/src/GraphQL/loaders/usersMutations.js
+++ b/src/GraphQL/loaders/usersMutations.js
@@ -1,6 +1,5 @@
 import { GraphQLNonNull, GraphQLString, GraphQLBoolean, GraphQLInputObjectType } from 'graphql';
 import { mutationWithClientMutationId } from 'graphql-relay';
-import deepcopy from 'deepcopy';
 import UsersRouter from '../../Routers/UsersRouter';
 import * as objectsMutations from '../helpers/objectsMutations';
 import { OBJECT } from './defaultGraphQLTypes';
@@ -32,7 +31,7 @@ const load = parseGraphQLSchema => {
     },
     mutateAndGetPayload: async (args, context, mutationInfo) => {
       try {
-        const { fields } = deepcopy(args);
+        const { fields } = structuredClone(args);
         const { config, auth, info } = context;
 
         const parseFields = await transformTypes('create', fields, {
@@ -109,7 +108,7 @@ const load = parseGraphQLSchema => {
     },
     mutateAndGetPayload: async (args, context, mutationInfo) => {
       try {
-        const { fields, authData } = deepcopy(args);
+        const { fields, authData } = structuredClone(args);
         const { config, auth, info } = context;
 
         const parseFields = await transformTypes('create', fields, {
@@ -173,7 +172,7 @@ const load = parseGraphQLSchema => {
     },
     mutateAndGetPayload: async (args, context, mutationInfo) => {
       try {
-        const { username, password, authData } = deepcopy(args);
+        const { username, password, authData } = structuredClone(args);
         const { config, auth, info } = context;
 
         const { sessionToken, objectId, authDataResponse } = (

--- a/src/LiveQuery/ParseLiveQueryServer.ts
+++ b/src/LiveQuery/ParseLiveQueryServer.ts
@@ -24,7 +24,6 @@ import { LRUCache as LRU } from 'lru-cache';
 import UserRouter from '../Routers/UsersRouter';
 import DatabaseController from '../Controllers/DatabaseController';
 import { isDeepStrictEqual } from 'util';
-import deepcopy from 'deepcopy';
 
 class ParseLiveQueryServer {
   server: any;
@@ -256,7 +255,7 @@ class ParseLiveQueryServer {
             Client.pushError(client.parseWebSocket, error.code, error.message, false, requestId);
             logger.error(
               `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
-                JSON.stringify(error)
+              JSON.stringify(error)
             );
           }
         });
@@ -417,7 +416,7 @@ class ParseLiveQueryServer {
             Client.pushError(client.parseWebSocket, error.code, error.message, false, requestId);
             logger.error(
               `Failed running afterLiveQueryEvent on class ${className} for event ${res.event} with session ${res.sessionToken} with:\n Error: ` +
-                JSON.stringify(error)
+              JSON.stringify(error)
             );
           }
         });
@@ -524,7 +523,7 @@ class ParseLiveQueryServer {
     if (!parseObject) {
       return false;
     }
-    return matchesQuery(deepcopy(parseObject), subscription.query);
+    return matchesQuery(structuredClone(parseObject), subscription.query);
   }
 
   async _clearCachedRoles(userId: string) {
@@ -821,7 +820,7 @@ class ParseLiveQueryServer {
       Client.pushError(parseWebsocket, error.code, error.message, false);
       logger.error(
         `Failed running beforeConnect for session ${request.sessionToken} with:\n Error: ` +
-          JSON.stringify(error)
+        JSON.stringify(error)
       );
     }
   }
@@ -964,7 +963,7 @@ class ParseLiveQueryServer {
       Client.pushError(parseWebsocket, error.code, error.message, false, request.requestId);
       logger.error(
         `Failed running beforeSubscribe on ${className} for session ${request.sessionToken} with:\n Error: ` +
-          JSON.stringify(error)
+        JSON.stringify(error)
       );
     }
   }
@@ -994,8 +993,8 @@ class ParseLiveQueryServer {
         parseWebsocket,
         2,
         'Cannot find client with clientId ' +
-          parseWebsocket.clientId +
-          '. Make sure you connect to live query server before unsubscribing.'
+        parseWebsocket.clientId +
+        '. Make sure you connect to live query server before unsubscribing.'
       );
       logger.error('Can not find this client ' + parseWebsocket.clientId);
       return;
@@ -1007,16 +1006,16 @@ class ParseLiveQueryServer {
         parseWebsocket,
         2,
         'Cannot find subscription with clientId ' +
-          parseWebsocket.clientId +
-          ' subscriptionId ' +
-          requestId +
-          '. Make sure you subscribe to live query server before unsubscribing.'
+        parseWebsocket.clientId +
+        ' subscriptionId ' +
+        requestId +
+        '. Make sure you subscribe to live query server before unsubscribing.'
       );
       logger.error(
         'Can not find subscription with clientId ' +
-          parseWebsocket.clientId +
-          ' subscriptionId ' +
-          requestId
+        parseWebsocket.clientId +
+        ' subscriptionId ' +
+        requestId
       );
       return;
     }

--- a/src/Push/PushWorker.js
+++ b/src/Push/PushWorker.js
@@ -1,6 +1,5 @@
 // @flow
 // @flow-disable-next
-import deepcopy from 'deepcopy';
 import AdaptableController from '../Controllers/AdaptableController';
 import { master } from '../Auth';
 import Config from '../Config';
@@ -91,7 +90,7 @@ export class PushWorker {
 
     // Map the on the badges count and return the send result
     const promises = Object.keys(badgeInstallationsMap).map(badge => {
-      const payload = deepcopy(body);
+      const payload = structuredClone(body);
       payload.data.badge = parseInt(badge);
       const installations = badgeInstallationsMap[badge];
       return this.sendToAdapter(payload, installations, pushStatus, config, UTCOffset);

--- a/src/Push/utils.js
+++ b/src/Push/utils.js
@@ -1,5 +1,4 @@
 import Parse from 'parse/node';
-import deepcopy from 'deepcopy';
 
 export function isPushIncrementing(body) {
   if (!body.data || !body.data.badge) {
@@ -45,7 +44,7 @@ export function transformPushBodyForLocale(body, locale) {
   if (!data) {
     return body;
   }
-  body = deepcopy(body);
+  body = structuredClone(body);
   localizableKeys.forEach(key => {
     const localeValue = body.data[`${key}-${locale}`];
     if (localeValue) {
@@ -128,7 +127,7 @@ export function validatePushType(where = {}, validPushTypes = []) {
 }
 
 export function applyDeviceTokenExists(where) {
-  where = deepcopy(where);
+  where = structuredClone(where);
   if (!Object.prototype.hasOwnProperty.call(where, 'deviceToken')) {
     where['deviceToken'] = { $exists: true };
   }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -3,7 +3,7 @@
 // This could be either a "create" or an "update".
 
 var SchemaController = require('./Controllers/SchemaController');
-var deepcopy = require('deepcopy');
+
 
 const Auth = require('./Auth');
 const Utils = require('./Utils');
@@ -75,8 +75,8 @@ function RestWrite(config, auth, className, query, data, originalData, clientSDK
 
   // Processing this operation may mutate our data, so we operate on a
   // copy
-  this.query = deepcopy(query);
-  this.data = deepcopy(data);
+  this.query = structuredClone(query);
+  this.data = structuredClone(data);
   // We never change originalData, so we do not need a deep copy
   this.originalData = originalData;
 
@@ -375,12 +375,12 @@ RestWrite.prototype.setRequiredFieldsIfNeeded = function () {
         schema?.classLevelPermissions?.ACL &&
         !this.data.ACL &&
         JSON.stringify(schema.classLevelPermissions.ACL) !==
-          JSON.stringify({ '*': { read: true, write: true } })
+        JSON.stringify({ '*': { read: true, write: true } })
       ) {
-        const acl = deepcopy(schema.classLevelPermissions.ACL);
+        const acl = structuredClone(schema.classLevelPermissions.ACL);
         if (acl.currentUser) {
           if (this.auth.user?.id) {
-            acl[this.auth.user?.id] = deepcopy(acl.currentUser);
+            acl[this.auth.user?.id] = structuredClone(acl.currentUser);
           }
           delete acl.currentUser;
         }
@@ -599,7 +599,7 @@ RestWrite.prototype.handleAuthData = async function (authData) {
         // Run beforeLogin hook before storing any updates
         // to authData on the db; changes to userResult
         // will be ignored.
-        await this.runBeforeLoginTrigger(deepcopy(userResult));
+        await this.runBeforeLoginTrigger(structuredClone(userResult));
 
         // If we are in login operation via authData
         // we need to be sure that the user has provided
@@ -867,18 +867,18 @@ RestWrite.prototype._validatePasswordRequirements = function () {
   if (this.config.passwordPolicy.doNotAllowUsername === true) {
     if (this.data.username) {
       // username is not passed during password reset
-      if (this.data.password.indexOf(this.data.username) >= 0)
-      { return Promise.reject(new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)); }
+      if (this.data.password.indexOf(this.data.username) >= 0) { return Promise.reject(new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)); }
     } else {
       // retrieve the User object using objectId during password reset
       return this.config.database.find('_User', { objectId: this.objectId() }).then(results => {
         if (results.length != 1) {
           throw undefined;
         }
-        if (this.data.password.indexOf(results[0].username) >= 0)
-        { return Promise.reject(
-          new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)
-        ); }
+        if (this.data.password.indexOf(results[0].username) >= 0) {
+          return Promise.reject(
+            new Parse.Error(Parse.Error.VALIDATION_ERROR, containsUsernameError)
+          );
+        }
         return Promise.resolve();
       });
     }
@@ -902,11 +902,12 @@ RestWrite.prototype._validatePasswordHistory = function () {
         }
         const user = results[0];
         let oldPasswords = [];
-        if (user._password_history)
-        { oldPasswords = _.take(
-          user._password_history,
-          this.config.passwordPolicy.maxPasswordHistory - 1
-        ); }
+        if (user._password_history) {
+          oldPasswords = _.take(
+            user._password_history,
+            this.config.passwordPolicy.maxPasswordHistory - 1
+          );
+        }
         oldPasswords.push(user.password);
         const newPassword = this.data.password;
         // compare the new password hash with all old password hashes
@@ -926,12 +927,14 @@ RestWrite.prototype._validatePasswordHistory = function () {
           .catch(err => {
             if (err === 'REPEAT_PASSWORD')
             // a match was found
-            { return Promise.reject(
-              new Parse.Error(
-                Parse.Error.VALIDATION_ERROR,
-                `New password should not be the same as last ${this.config.passwordPolicy.maxPasswordHistory} passwords.`
-              )
-            ); }
+            {
+              return Promise.reject(
+                new Parse.Error(
+                  Parse.Error.VALIDATION_ERROR,
+                  `New password should not be the same as last ${this.config.passwordPolicy.maxPasswordHistory} passwords.`
+                )
+              );
+            }
             throw err;
           });
       });
@@ -1331,7 +1334,7 @@ RestWrite.prototype.handleInstallation = function () {
           throw new Parse.Error(
             132,
             'Must specify installationId when deviceToken ' +
-              'matches multiple Installation objects'
+            'matches multiple Installation objects'
           );
         } else {
           // Multiple device token matches and we specified an installation ID,
@@ -1733,7 +1736,7 @@ RestWrite.prototype.sanitizedData = function () {
       delete data[key];
     }
     return data;
-  }, deepcopy(this.data));
+  }, structuredClone(this.data));
   return Parse._decode(undefined, data);
 };
 
@@ -1783,7 +1786,7 @@ RestWrite.prototype.buildParseObjects = function () {
       delete data[key];
     }
     return data;
-  }, deepcopy(this.data));
+  }, structuredClone(this.data));
 
   const sanitized = this.sanitizedData();
   for (const attribute of readOnlyAttributes) {


### PR DESCRIPTION
## 🔄 Replace `deepcopy` with Native `structuredClone`

### ✔️ Summary

This PR replaces all usages of the `deepcopy` package with the native `structuredClone` API.
It also removes the `deepcopy` dependency from `package.json` and `package-lock.json`.

### 🎯 Motivation

* `structuredClone` is now widely supported in Node.js and provides faster deep-copy operations.
* Removing the external dependency reduces package size, maintenance overhead, and potential security risks.
* Ensures more consistent behavior by using a built-in native API.

### 🔍 Changes Included

* Replaced all `deepcopy(...)` calls with `structuredClone(...)`
* Removed `deepcopy` from dependency lists
* Updated any related utility code to match the new cloning behavior

### 🧪 What to Review

* Verify that all object-cloning operations still behave as expected
  (especially nested objects, arrays, and edge cases).
* Confirm all tests pass and no regressions occur.
* Check for any remaining unused imports or references to `deepcopy`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the external `deepcopy` package dependency and replaced all cloning operations with the native JavaScript `structuredClone` method across the application, reducing external dependencies while maintaining equivalent functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->