### PR TITLE
fix: Remove elevated permissions in GitHub CI performance benchmark

### DIFF
--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -1,6 +1,6 @@
 name: ci-performance
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - alpha
       - beta
@@ -17,8 +17,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   performance-check:
@@ -172,23 +170,6 @@ jobs:
           echo "baseline.json size: $(wc -c < baseline.json) bytes"
           echo "pr.json size: $(wc -c < pr.json) bytes"
 
-      - name: Store benchmark result (PR)
-        uses: benchmark-action/github-action-benchmark@v1
-        if: github.event_name == 'pull_request' && hashFiles('pr.json') != ''
-        continue-on-error: true
-        with:
-          name: Parse Server Performance
-          tool: 'customSmallerIsBetter'
-          output-file-path: pr.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-          save-data-file: false
-          alert-threshold: '110%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@parse-community/maintainers'
-          summary-always: true
-
       - name: Compare benchmark results
         id: compare
         run: |
@@ -277,43 +258,6 @@ jobs:
           name: benchmark-comparison
           path: comparison.md
           retention-days: 30
-
-      - name: Prepare comment body
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "## Performance Impact Report" > comment.md
-          echo "" >> comment.md
-          if [ -f comparison.md ]; then
-            cat comparison.md >> comment.md
-          else
-            echo "⚠️ Could not generate performance comparison." >> comment.md
-          fi
-          echo "" >> comment.md
-          echo "<details>" >> comment.md
-          echo "<summary>📊 View detailed results</summary>" >> comment.md
-          echo "" >> comment.md
-          echo "### Baseline Results" >> comment.md
-          echo "\`\`\`json" >> comment.md
-          cat baseline.json >> comment.md
-          echo "\`\`\`" >> comment.md
-          echo "" >> comment.md
-          echo "### PR Results" >> comment.md
-          echo "\`\`\`json" >> comment.md
-          cat pr.json >> comment.md
-          echo "\`\`\`" >> comment.md
-          echo "" >> comment.md
-          echo "</details>" >> comment.md
-          echo "" >> comment.md
-          echo "> **Note:** Thresholds: ⚠️ >25%, ❌ >50%." >> comment.md
-
-      - name: Comment PR with results
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v2
-        continue-on-error: true
-        with:
-          filePath: comment.md
-          comment_tag: performance-benchmark
-          mode: recreate
 
       - name: Generate job summary
         if: always()

--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -1,11 +1,4 @@
 name: ci-performance
-# SECURITY: This workflow runs performance benchmarks on PRs.
-# To prevent malicious code execution:
-# 1. Uses 'pull_request' trigger (read-only permissions, no secrets exposed)
-# 2. Always uses benchmark script from BASE branch (trusted code only)
-# 3. Tests the trusted benchmark script against both base and PR implementations
-# This means: If a PR modifies the benchmark script, those changes won't be
-# tested until AFTER the PR is merged (security over convenience).
 on:
   pull_request:
     branches:
@@ -32,11 +25,31 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Checkout PR branch (for benchmark script)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Save PR benchmark script
+        run: |
+          mkdir -p /tmp/pr-benchmark
+          cp -r benchmark /tmp/pr-benchmark/ || echo "No benchmark directory"
+          cp package.json /tmp/pr-benchmark/ || true
+
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 1
+          clean: true
+
+      - name: Restore PR benchmark script
+        run: |
+          if [ -d "/tmp/pr-benchmark/benchmark" ]; then
+            rm -rf benchmark
+            cp -r /tmp/pr-benchmark/benchmark .
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -1,4 +1,11 @@
 name: ci-performance
+# SECURITY: This workflow runs performance benchmarks on PRs.
+# To prevent malicious code execution:
+# 1. Uses 'pull_request' trigger (read-only permissions, no secrets exposed)
+# 2. Always uses benchmark script from BASE branch (trusted code only)
+# 3. Tests the trusted benchmark script against both base and PR implementations
+# This means: If a PR modifies the benchmark script, those changes won't be
+# tested until AFTER the PR is merged (security over convenience).
 on:
   pull_request:
     branches:
@@ -25,31 +32,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout PR branch (for benchmark script)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 1
-
-      - name: Save PR benchmark script
-        run: |
-          mkdir -p /tmp/pr-benchmark
-          cp -r benchmark /tmp/pr-benchmark/ || echo "No benchmark directory"
-          cp package.json /tmp/pr-benchmark/ || true
-
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 1
-          clean: true
-
-      - name: Restore PR benchmark script
-        run: |
-          if [ -d "/tmp/pr-benchmark/benchmark" ]; then
-            rm -rf benchmark
-            cp -r /tmp/pr-benchmark/benchmark .
-          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

CI performance benchmark runs with elevated permissions.

## Approach
<!-- Describe the changes in this PR. -->

Remove  elevated permissions in CI performance benchmark.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Performance benchmarking workflow now triggers on pull requests (expanded branch set: alpha, beta, release, release-*, next-major) with existing path-ignore filters.
  * Workflow permissions reduced to read-only.
  * PR-specific artifact uploads and automatic PR comments removed; benchmarking still generates baseline vs. PR comparison summaries and final reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->