### PR TITLE
feat: Increase required minimum MongoDB version to `7.0.16`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: MongoDB 6, ReplicaSet
-            MONGODB_VERSION: 6.0.19
-            MONGODB_TOPOLOGY: replset
-            NODE_VERSION: 24.11.0
           - name: MongoDB 7, ReplicaSet
             MONGODB_VERSION: 7.0.16
             MONGODB_TOPOLOGY: replset

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
 [![Node Version](https://img.shields.io/badge/nodejs-18,_20,_22,_24-green.svg?logo=node.js&style=flat)](https://nodejs.org)
-[![MongoDB Version](https://img.shields.io/badge/mongodb-6,_7,_8-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
+[![MongoDB Version](https://img.shields.io/badge/mongodb-7,_8-green.svg?logo=mongodb&style=flat)](https://www.mongodb.com)
 [![Postgres Version](https://img.shields.io/badge/postgresql-13,_14,_15,_16,_17,_18-green.svg?logo=postgresql&style=flat)](https://www.postgresql.org)
 
 [![npm latest version](https://img.shields.io/npm/v/parse-server/latest.svg)](https://www.npmjs.com/package/parse-server)

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "build:types": "tsc",
     "watch": "babel --watch src/ -d lib/ --copy-files",
     "watch:ts": "tsc --watch",
-    "test:mongodb:6.0.19": "MONGODB_VERSION=6.0.19 npm run test",
     "test:mongodb:7.0.16": "MONGODB_VERSION=7.0.16 npm run test",
     "test:mongodb:8.0.4": "MONGODB_VERSION=8.0.4 npm run test",
     "test:postgres:testonly": "cross-env PARSE_SERVER_TEST_DB=postgres PARSE_SERVER_TEST_DATABASE_URI=postgres://postgres:password@localhost:5432/parse_server_postgres_adapter_test_database npm run testonly",

--- a/spec/ParseQuery.hint.spec.js
+++ b/spec/ParseQuery.hint.spec.js
@@ -79,30 +79,6 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     });
   });
 
-  it_only_mongodb_version('<7')('query aggregate with hint string', async () => {
-    const object = new TestObject({ foo: 'bar' });
-    await object.save();
-
-    const collection = await config.database.adapter._adaptiveCollection('TestObject');
-    let result = await collection.aggregate([{ $group: { _id: '$foo' } }], {
-      explain: true,
-    });
-    let queryPlanner = result[0].stages[0].$cursor.queryPlanner;
-    expect(queryPlanner.winningPlan.stage).toBe('PROJECTION_SIMPLE');
-    expect(queryPlanner.winningPlan.inputStage.stage).toBe('COLLSCAN');
-    expect(queryPlanner.winningPlan.inputStage.inputStage).toBeUndefined();
-
-    result = await collection.aggregate([{ $group: { _id: '$foo' } }], {
-      hint: '_id_',
-      explain: true,
-    });
-    queryPlanner = result[0].stages[0].$cursor.queryPlanner;
-    expect(queryPlanner.winningPlan.stage).toBe('PROJECTION_SIMPLE');
-    expect(queryPlanner.winningPlan.inputStage.stage).toBe('FETCH');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.stage).toBe('IXSCAN');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.indexName).toBe('_id_');
-  });
-
   it_only_mongodb_version('>=7')('query aggregate with hint string', async () => {
     const object = new TestObject({ foo: 'bar' });
     await object.save();
@@ -125,31 +101,6 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(queryPlanner.winningPlan.queryPlan.inputStage.stage).toBe('FETCH');
     expect(queryPlanner.winningPlan.queryPlan.inputStage.inputStage.stage).toBe('IXSCAN');
     expect(queryPlanner.winningPlan.queryPlan.inputStage.inputStage.indexName).toBe('_id_');
-  });
-
-  it_only_mongodb_version('<7')('query aggregate with hint object', async () => {
-    const object = new TestObject({ foo: 'bar' });
-    await object.save();
-
-    const collection = await config.database.adapter._adaptiveCollection('TestObject');
-    let result = await collection.aggregate([{ $group: { _id: '$foo' } }], {
-      explain: true,
-    });
-    let queryPlanner = result[0].stages[0].$cursor.queryPlanner;
-    expect(queryPlanner.winningPlan.stage).toBe('PROJECTION_SIMPLE');
-    expect(queryPlanner.winningPlan.inputStage.stage).toBe('COLLSCAN');
-    expect(queryPlanner.winningPlan.inputStage.inputStage).toBeUndefined();
-
-    result = await collection.aggregate([{ $group: { _id: '$foo' } }], {
-      hint: { _id: 1 },
-      explain: true,
-    });
-    queryPlanner = result[0].stages[0].$cursor.queryPlanner;
-    expect(queryPlanner.winningPlan.stage).toBe('PROJECTION_SIMPLE');
-    expect(queryPlanner.winningPlan.inputStage.stage).toBe('FETCH');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.stage).toBe('IXSCAN');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.indexName).toBe('_id_');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.keyPattern).toEqual({ _id: 1 });
   });
 
   it_only_mongodb_version('>=7')('query aggregate with hint object', async () => {
@@ -200,39 +151,6 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     response = await request(options);
     explain = response.data.results;
     expect(explain.queryPlanner.winningPlan.inputStage.inputStage.indexName).toBe('_id_');
-  });
-
-  it_only_mongodb_version('<7')('query aggregate with hint (rest)', async () => {
-    const object = new TestObject({ foo: 'bar' });
-    await object.save();
-    let options = Object.assign({}, masterKeyOptions, {
-      url: Parse.serverURL + '/aggregate/TestObject',
-      qs: {
-        explain: true,
-        $group: JSON.stringify({ _id: '$foo' }),
-      },
-    });
-    let response = await request(options);
-    let queryPlanner = response.data.results[0].stages[0].$cursor.queryPlanner;
-    expect(queryPlanner.winningPlan.stage).toBe('PROJECTION_SIMPLE');
-    expect(queryPlanner.winningPlan.inputStage.stage).toBe('COLLSCAN');
-    expect(queryPlanner.winningPlan.inputStage.inputStage).toBeUndefined();
-
-    options = Object.assign({}, masterKeyOptions, {
-      url: Parse.serverURL + '/aggregate/TestObject',
-      qs: {
-        explain: true,
-        hint: '_id_',
-        $group: JSON.stringify({ _id: '$foo' }),
-      },
-    });
-    response = await request(options);
-    queryPlanner = response.data.results[0].stages[0].$cursor.queryPlanner;
-    expect(queryPlanner.winningPlan.stage).toBe('PROJECTION_SIMPLE');
-    expect(queryPlanner.winningPlan.inputStage.stage).toBe('FETCH');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.stage).toBe('IXSCAN');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.indexName).toBe('_id_');
-    expect(queryPlanner.winningPlan.inputStage.inputStage.keyPattern).toEqual({ _id: 1 });
   });
 
   it_only_mongodb_version('>=7')('query aggregate with hint (rest)', async () => {


### PR DESCRIPTION
BREAKING CHANGE: This releases increases the required minimum MongoDB version to `7.0.16`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed MongoDB 6.x from CI test matrix and eliminated the MongoDB 6 test script from available test targets.
  * Removed MongoDB 6-specific tests related to aggregation hints; retained tests for MongoDB 7+.
  * Updated README to indicate MongoDB 7+ as the supported versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->