### PR TITLE
feat: Add custom http status code and headers support for cloud funct…

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,55 @@ Logs are also viewable in Parse Dashboard.
 
 **Want new line delimited JSON error logs (for consumption by CloudWatch, Google Cloud Logging, etc)?** Pass the `JSON_LOGS` environment variable when starting `parse-server`. Usage :- `JSON_LOGS='1' parse-server --appId APPLICATION_ID --masterKey MASTER_KEY`
 
+## Cloud Functions HTTP Response
+
+Cloud functions support an Express-like `(req, res)` pattern to customize HTTP response status codes and headers.
+
+### Basic Usage
+
+```js
+// Set custom status code
+Parse.Cloud.define('createItem', (req, res) => {
+  res.status(201);
+  return { id: 'abc123', message: 'Created' };
+});
+
+// Set custom headers
+Parse.Cloud.define('apiEndpoint', (req, res) => {
+  res.set('X-Request-Id', 'req-123');
+  res.set('Cache-Control', 'no-cache');
+  return { success: true };
+});
+
+// Chain methods
+Parse.Cloud.define('authenticate', (req, res) => {
+  if (!isValid(req.params.token)) {
+    res.status(401).set('WWW-Authenticate', 'Bearer');
+    return { error: 'Unauthorized' };
+  }
+  return { user: 'john' };
+});
+```
+
+### Response Methods
+
+| Method | Description |
+|--------|-------------|
+| `res.status(code)` | Set HTTP status code (e.g., 201, 400, 404). Returns `res` for chaining. |
+| `res.set(name, value)` | Set HTTP header. Returns `res` for chaining. |
+
+### Backwards Compatibility
+
+The `res` argument is optional. Existing cloud functions using only `(req) => {}` continue to work unchanged.
+
+### Security Considerations
+
+The `set()` method allows setting arbitrary HTTP headers. Be cautious when setting security-sensitive headers such as:
+- CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`)
+- `Set-Cookie`
+- `Location` (redirects)
+- Authentication headers (`WWW-Authenticate`)
+
 # Deprecations
 
 See the [Deprecation Plan](https://github.com/parse-community/parse-server/blob/master/DEPRECATIONS.md) for an overview of deprecations and planned breaking changes.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A big _thank you_ 🙏 to our [sponsors](#sponsors) and [backers](#backers) who 
       - [Reserved Keys](#reserved-keys)
       - [Parameters](#parameters-1)
   - [Logging](#logging)
+  - [Cloud Function Custom HTTP Response](#cloud-functions-http-response)
 - [Deprecations](#deprecations)
 - [Live Query](#live-query)
 - [GraphQL](#graphql)

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -93,6 +93,111 @@ describe('Cloud Code', () => {
     });
   });
 
+  it('can return custom HTTP status code', async () => {
+    Parse.Cloud.define('customStatus', () => {
+      return {
+        __httpResponse: true,
+        status: 201,
+        result: { message: 'Created' },
+      };
+    });
+
+    const response = await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/functions/customStatus',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(response.status).toEqual(201);
+    expect(response.data.result.message).toEqual('Created');
+  });
+
+  it('can return custom HTTP headers', async () => {
+    Parse.Cloud.define('customHeaders', () => {
+      return {
+        __httpResponse: true,
+        headers: {
+          'X-Custom-Header': 'custom-value',
+          'X-Another-Header': 'another-value',
+        },
+        result: { success: true },
+      };
+    });
+
+    const response = await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/functions/customHeaders',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+    expect(response.headers['x-another-header']).toEqual('another-value');
+    expect(response.data.result.success).toEqual(true);
+  });
+
+  it('can return custom HTTP status code and headers together', async () => {
+    Parse.Cloud.define('customStatusAndHeaders', () => {
+      return {
+        __httpResponse: true,
+        status: 401,
+        headers: {
+          'WWW-Authenticate': 'Bearer realm="api"',
+        },
+        result: { error: 'Authentication required' },
+      };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/customStatusAndHeaders',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to reject with 401');
+    } catch (response) {
+      expect(response.status).toEqual(401);
+      expect(response.headers['www-authenticate']).toEqual('Bearer realm="api"');
+      expect(response.data.result.error).toEqual('Authentication required');
+    }
+  });
+
+  it('returns normal response when __httpResponse is not set', async () => {
+    Parse.Cloud.define('normalResponse', () => {
+      return { status: 201, result: 'this should be the result' };
+    });
+
+    const response = await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/functions/normalResponse',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.data.result.status).toEqual(201);
+    expect(response.data.result.result).toEqual('this should be the result');
+  });
+
   it('can get config', () => {
     const config = Parse.Server;
     let currentConfig = Config.get('test');

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -184,6 +184,142 @@ describe('Cloud Code', () => {
     expect(response.data.result.result).toEqual('this should be the result');
   });
 
+  it('res.status() called multiple times uses last value', async () => {
+    Parse.Cloud.define('multipleStatus', (req, res) => {
+      res.status(201);
+      res.status(202);
+      res.status(203);
+      return { message: 'ok' };
+    });
+
+    const response = await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/functions/multipleStatus',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(response.status).toEqual(203);
+  });
+
+  it('res.set() called multiple times for same header uses last value', async () => {
+    Parse.Cloud.define('multipleHeaders', (req, res) => {
+      res.set('X-Custom-Header', 'first');
+      res.set('X-Custom-Header', 'second');
+      res.set('X-Custom-Header', 'third');
+      return { message: 'ok' };
+    });
+
+    const response = await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/functions/multipleHeaders',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(response.headers['x-custom-header']).toEqual('third');
+  });
+
+  it('res.status() throws error for non-number status code', async () => {
+    Parse.Cloud.define('invalidStatusType', (req, res) => {
+      res.status('200');
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/invalidStatusType',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.set() throws error for non-string header name', async () => {
+    Parse.Cloud.define('invalidHeaderName', (req, res) => {
+      res.set(123, 'value');
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/invalidHeaderName',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.status() throws error for out of range status code', async () => {
+    Parse.Cloud.define('outOfRangeStatus', (req, res) => {
+      res.status(50);
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/outOfRangeStatus',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.set() throws error for undefined header value', async () => {
+    Parse.Cloud.define('undefinedHeaderValue', (req, res) => {
+      res.set('X-Custom-Header', undefined);
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/undefinedHeaderValue',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
   it('can get config', () => {
     const config = Parse.Server;
     let currentConfig = Config.get('test');

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -228,7 +228,7 @@ describe('Cloud Code', () => {
     expect(response.headers['x-custom-header']).toEqual('third');
   });
 
-  it('res.status() throws error for non-number status code', async () => {
+  it('res.status() throws error for non-integer status code', async () => {
     Parse.Cloud.define('invalidStatusType', (req, res) => {
       res.status('200');
       return { message: 'ok' };
@@ -238,6 +238,29 @@ describe('Cloud Code', () => {
       await request({
         method: 'POST',
         url: 'http://localhost:8378/1/functions/invalidStatusType',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.status() throws error for NaN status code', async () => {
+    Parse.Cloud.define('nanStatus', (req, res) => {
+      res.status(NaN);
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/nanStatus',
         headers: {
           'X-Parse-Application-Id': 'test',
           'X-Parse-REST-API-Key': 'rest',
@@ -307,6 +330,75 @@ describe('Cloud Code', () => {
       await request({
         method: 'POST',
         url: 'http://localhost:8378/1/functions/undefinedHeaderValue',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.set() throws error for empty header name', async () => {
+    Parse.Cloud.define('emptyHeaderName', (req, res) => {
+      res.set('   ', 'value');
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/emptyHeaderName',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.set() throws error for prototype pollution header names', async () => {
+    Parse.Cloud.define('protoHeaderName', (req, res) => {
+      res.set('__proto__', 'value');
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/protoHeaderName',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      });
+      fail('Expected request to fail');
+    } catch (response) {
+      expect(response.status).toEqual(400);
+    }
+  });
+
+  it('res.set() throws error for CRLF in header value', async () => {
+    Parse.Cloud.define('crlfHeaderValue', (req, res) => {
+      res.set('X-Custom-Header', 'value\r\nX-Injected: bad');
+      return { message: 'ok' };
+    });
+
+    try {
+      await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/functions/crlfHeaderValue',
         headers: {
           'X-Parse-Application-Id': 'test',
           'X-Parse-REST-API-Key': 'rest',

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -94,12 +94,9 @@ describe('Cloud Code', () => {
   });
 
   it('can return custom HTTP status code', async () => {
-    Parse.Cloud.define('customStatus', () => {
-      return {
-        __httpResponse: true,
-        status: 201,
-        result: { message: 'Created' },
-      };
+    Parse.Cloud.define('customStatus', (req, res) => {
+      res.status(201);
+      return { message: 'Created' };
     });
 
     const response = await request({
@@ -118,15 +115,10 @@ describe('Cloud Code', () => {
   });
 
   it('can return custom HTTP headers', async () => {
-    Parse.Cloud.define('customHeaders', () => {
-      return {
-        __httpResponse: true,
-        headers: {
-          'X-Custom-Header': 'custom-value',
-          'X-Another-Header': 'another-value',
-        },
-        result: { success: true },
-      };
+    Parse.Cloud.define('customHeaders', (req, res) => {
+      res.set('X-Custom-Header', 'custom-value');
+      res.set('X-Another-Header', 'another-value');
+      return { success: true };
     });
 
     const response = await request({
@@ -147,15 +139,9 @@ describe('Cloud Code', () => {
   });
 
   it('can return custom HTTP status code and headers together', async () => {
-    Parse.Cloud.define('customStatusAndHeaders', () => {
-      return {
-        __httpResponse: true,
-        status: 401,
-        headers: {
-          'WWW-Authenticate': 'Bearer realm="api"',
-        },
-        result: { error: 'Authentication required' },
-      };
+    Parse.Cloud.define('customStatusAndHeaders', (req, res) => {
+      res.status(401).set('WWW-Authenticate', 'Bearer realm="api"');
+      return { error: 'Authentication required' };
     });
 
     try {
@@ -177,7 +163,7 @@ describe('Cloud Code', () => {
     }
   });
 
-  it('returns normal response when __httpResponse is not set', async () => {
+  it('returns normal response when response object is not used', async () => {
     Parse.Cloud.define('normalResponse', () => {
       return { status: 201, result: 'this should be the result' };
     });

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -12,12 +12,12 @@ import { logger } from '../logger';
 class CloudResponse {
   constructor() {
     this._status = null;
-    this._headers = {};
+    this._headers = Object.create(null);
   }
 
   status(code) {
-    if (typeof code !== 'number') {
-      throw new Error('Status code must be a number');
+    if (!Number.isInteger(code)) {
+      throw new Error('Status code must be an integer');
     }
     if (code < 100 || code > 599) {
       throw new Error('Status code must be between 100 and 599');
@@ -30,10 +30,22 @@ class CloudResponse {
     if (typeof name !== 'string') {
       throw new Error('Header name must be a string');
     }
+    const headerName = name.trim();
+    if (!headerName) {
+      throw new Error('Header name must not be empty');
+    }
+    if (headerName === '__proto__' || headerName === 'constructor' || headerName === 'prototype') {
+      throw new Error('Invalid header name');
+    }
     if (value === undefined || value === null) {
       throw new Error('Header value must be defined');
     }
-    this._headers[name] = value;
+    const headerValue = Array.isArray(value) ? value.map(v => String(v)) : String(value);
+    const values = Array.isArray(headerValue) ? headerValue : [headerValue];
+    if (values.some(v => /[\r\n]/.test(v))) {
+      throw new Error('Header value must not contain CRLF');
+    }
+    this._headers[headerName] = headerValue;
     return this;
   }
 

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -19,6 +19,9 @@ class CloudResponse {
     if (typeof code !== 'number') {
       throw new Error('Status code must be a number');
     }
+    if (code < 100 || code > 599) {
+      throw new Error('Status code must be between 100 and 599');
+    }
     this._status = code;
     return this;
   }
@@ -26,6 +29,9 @@ class CloudResponse {
   set(name, value) {
     if (typeof name !== 'string') {
       throw new Error('Header name must be a string');
+    }
+    if (value === undefined || value === null) {
+      throw new Error('Header value must be defined');
     }
     this._headers[name] = value;
     return this;
@@ -153,7 +159,7 @@ export class FunctionsRouter extends PromiseRouter {
             response.status = status;
           }
           if (Object.keys(headers).length > 0) {
-            response.headers = headers;
+            response.headers = { ...headers };
           }
         }
         resolve(response);

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -9,6 +9,41 @@ import { jobStatusHandler } from '../StatusHandler';
 import _ from 'lodash';
 import { logger } from '../logger';
 
+class CloudResponse {
+  constructor() {
+    this._status = null;
+    this._headers = {};
+  }
+
+  status(code) {
+    if (typeof code !== 'number') {
+      throw new Error('Status code must be a number');
+    }
+    this._status = code;
+    return this;
+  }
+
+  set(name, value) {
+    if (typeof name !== 'string') {
+      throw new Error('Header name must be a string');
+    }
+    this._headers[name] = value;
+    return this;
+  }
+
+  hasCustomResponse() {
+    return this._status !== null || Object.keys(this._headers).length > 0;
+  }
+
+  getStatus() {
+    return this._status;
+  }
+
+  getHeaders() {
+    return this._headers;
+  }
+}
+
 function parseObject(obj, config) {
   if (Array.isArray(obj)) {
     return obj.map(item => {
@@ -103,29 +138,25 @@ export class FunctionsRouter extends PromiseRouter {
     });
   }
 
-  static createResponseObject(resolve, reject) {
+  static createResponseObject(resolve, reject, cloudResponse) {
     return {
       success: function (result) {
-        if (result && typeof result === 'object' && result.__httpResponse === true) {
-          const response = {
-            response: {
-              result: Parse._encode(result.result),
-            },
-          };
-          if (typeof result.status === 'number') {
-            response.status = result.status;
+        const response = {
+          response: {
+            result: Parse._encode(result),
+          },
+        };
+        if (cloudResponse && cloudResponse.hasCustomResponse()) {
+          const status = cloudResponse.getStatus();
+          const headers = cloudResponse.getHeaders();
+          if (status !== null) {
+            response.status = status;
           }
-          if (result.headers && typeof result.headers === 'object') {
-            response.headers = result.headers;
+          if (Object.keys(headers).length > 0) {
+            response.headers = headers;
           }
-          resolve(response);
-        } else {
-          resolve({
-            response: {
-              result: Parse._encode(result),
-            },
-          });
         }
+        resolve(response);
       },
       error: function (message) {
         const error = triggers.resolveError(message);
@@ -143,6 +174,7 @@ export class FunctionsRouter extends PromiseRouter {
     }
     let params = Object.assign({}, req.body, req.query);
     params = parseParams(params, req.config);
+    const cloudResponse = new CloudResponse();
     const request = {
       params: params,
       config: req.config,
@@ -197,14 +229,15 @@ export class FunctionsRouter extends PromiseRouter {
           } catch (e) {
             reject(e);
           }
-        }
+        },
+        cloudResponse
       );
       return Promise.resolve()
         .then(() => {
           return triggers.maybeRunValidator(request, functionName, req.auth);
         })
         .then(() => {
-          return theFunction(request);
+          return theFunction(request, cloudResponse);
         })
         .then(success, error);
     });

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -106,11 +106,26 @@ export class FunctionsRouter extends PromiseRouter {
   static createResponseObject(resolve, reject) {
     return {
       success: function (result) {
-        resolve({
-          response: {
-            result: Parse._encode(result),
-          },
-        });
+        if (result && typeof result === 'object' && result.__httpResponse === true) {
+          const response = {
+            response: {
+              result: Parse._encode(result.result),
+            },
+          };
+          if (typeof result.status === 'number') {
+            response.status = result.status;
+          }
+          if (result.headers && typeof result.headers === 'object') {
+            response.headers = result.headers;
+          }
+          resolve(response);
+        } else {
+          resolve({
+            response: {
+              result: Parse._encode(result),
+            },
+          });
+        }
       },
       error: function (message) {
         const error = triggers.resolveError(message);


### PR DESCRIPTION
## Pull Request

  - Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
  - Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
  - Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

  ## Issue

  Closes: #9479

  ## Approach

  Modified `FunctionsRouter.createResponseObject` to detect `__httpResponse: true` in cloud function return values and pass through `status` and `headers` to the existing PromiseRouter infrastructure. Fully backwards compatible.
  
  edited new approach:
  
Added CloudResponse class and pass it as second argument to cloud functions (req, res). When res.status() or res.set() are called, FunctionsRouter.createResponseObject passes status and headers to the existing PromiseRouter infrastructure. The res argument is optional - existing functions using only (req) continue to work unchanged.

  ## Tasks

  - [x] Add tests
  - [x] Add changes to documentation (guides, repository pages, code comments)
  - [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
  - [ ] Add new Parse Error codes to Parse JS SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud Functions can optionally customize HTTP responses (set status codes and headers via an Express-like response object).

* **Documentation**
  * README updated with usage examples, chaining behavior, and security considerations for response headers; note that the response argument is optional.

* **Tests**
  * Extensive new tests covering status/header setting, validation, combined responses, error paths, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->