### PR TITLE
feat: Deprecation DEPPS113: Config option `enableInsecureAuthAdapters` defaults to `false`

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,6 +16,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS10 | Encode `Parse.Object` in Cloud Function and remove option `encodeParseObjectInCloudFunction` | [#8634](https://github.com/parse-community/parse-server/issues/8634) | 6.2.0 (2023)                    | 9.0.0 (2026)                    | removed               | -     |
 | DEPPS11 | Replace `PublicAPIRouter` with `PagesRouter`                                                 | [#7625](https://github.com/parse-community/parse-server/issues/7625) | 8.0.0 (2025)                    | 9.0.0 (2026)                    | removed               | -     |
 | DEPPS12 | Database option `allowPublicExplain` defaults to `false`                                     | [#7519](https://github.com/parse-community/parse-server/issues/7519) | 8.5.0 (2025)                    | 9.0.0 (2026)                    | removed               | -     |
+| DEPPS13 | Config option `enableInsecureAuthAdapters` defaults to `false`                               | [#9667](https://github.com/parse-community/parse-server/pull/9667)   | 8.0.0 (2025)                    | 9.0.0 (2026)                    | removed               | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_removal]: ## "The version and date of the planned removal."

--- a/spec/SecurityCheckGroups.spec.js
+++ b/spec/SecurityCheckGroups.spec.js
@@ -49,6 +49,7 @@ describe('Security Check Groups', () => {
       config.masterKey = 'insecure';
       config.security.enableCheckLog = true;
       config.allowClientClassCreation = true;
+      config.enableInsecureAuthAdapters = true;
       config.graphQLPublicIntrospection = true;
       await reconfigureServer(config);
 

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -15,6 +15,4 @@
  *
  * If there are no deprecations, this must return an empty array.
  */
-module.exports = [
-  { optionKey: 'enableInsecureAuthAdapters', changeNewDefault: 'false' },
-];
+module.exports = [];

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -244,9 +244,9 @@ module.exports.ParseServerOptions = {
   enableInsecureAuthAdapters: {
     env: 'PARSE_SERVER_ENABLE_INSECURE_AUTH_ADAPTERS',
     help:
-      'Enable (or disable) insecure auth adapters, defaults to true. Insecure auth adapters are deprecated and it is recommended to disable them.',
+      'Optional. Enables insecure authentication adapters. Insecure auth adapters are deprecated and will be removed in a future version. Defaults to `false`.',
     action: parsers.booleanParser,
-    default: true,
+    default: false,
   },
   enableSanitizedErrorResponse: {
     env: 'PARSE_SERVER_ENABLE_SANITIZED_ERROR_RESPONSE',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -44,7 +44,7 @@
  * @property {Boolean} enableAnonymousUsers Enable (or disable) anonymous users, defaults to true
  * @property {Boolean} enableCollationCaseComparison Optional. If set to `true`, the collation rule of case comparison for queries and indexes is enabled. Enable this option to run Parse Server with MongoDB Atlas Serverless or AWS Amazon DocumentDB. If `false`, the collation rule of case comparison is disabled. Default is `false`.
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
- * @property {Boolean} enableInsecureAuthAdapters Enable (or disable) insecure auth adapters, defaults to true. Insecure auth adapters are deprecated and it is recommended to disable them.
+ * @property {Boolean} enableInsecureAuthAdapters Optional. Enables insecure authentication adapters. Insecure auth adapters are deprecated and will be removed in a future version. Defaults to `false`.
  * @property {Boolean} enableSanitizedErrorResponse If set to `true`, error details are removed from error messages in responses to client requests, and instead a generic error message is sent. Default is `true`.
  * @property {String} encryptionKey Key for encrypting your files
  * @property {Boolean} enforcePrivateUsers Set to true if new users should be created without public read and write access.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -167,9 +167,9 @@ export interface ParseServerOptions {
   /* Configuration for your authentication providers, as stringified JSON. See http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
   :ENV: PARSE_SERVER_AUTH_PROVIDERS */
   auth: ?{ [string]: AuthAdapter };
-  /* Enable (or disable) insecure auth adapters, defaults to true. Insecure auth adapters are deprecated and it is recommended to disable them.
+  /* Optional. Enables insecure authentication adapters. Insecure auth adapters are deprecated and will be removed in a future version. Defaults to `false`.
   :ENV: PARSE_SERVER_ENABLE_INSECURE_AUTH_ADAPTERS
-  :DEFAULT: true */
+  :DEFAULT: false */
   enableInsecureAuthAdapters: ?boolean;
   /* Max file size for uploads, defaults to 20mb
   :DEFAULT: 20mb */


### PR DESCRIPTION
BREAKING CHANGE: This release changes the config option `enableInsecureAuthAdapters` default to `false` (Deprecation DEPPS13).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * The enableInsecureAuthAdapters option is now deprecated and defaults to false (previously true); it will be removed in a future release.

* **Documentation**
  * Docs and option descriptions updated to mark insecure adapters as deprecated and reflect the new default.

* **Tests**
  * Security tests adjusted to exercise behavior when insecure adapters are explicitly enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->