### PR TITLE
fix: Server-Side Request Forgery (SSRF) in Instagram auth adapter

### DIFF
--- a/spec/Adapters/Auth/instagram.spec.js
+++ b/spec/Adapters/Auth/instagram.spec.js
@@ -101,6 +101,31 @@ describe('InstagramAdapter', function () {
         'Instagram auth is invalid for this user.'
       );
     });
+
+    it('should ignore client-provided apiURL and use hardcoded endpoint', async () => {
+      const accessToken = 'mockAccessToken';
+      const authData = {
+        id: 'mockUserId',
+        apiURL: 'https://example.com/',
+      };
+
+      mockFetch([
+        {
+          url: 'https://graph.instagram.com/me?fields=id&access_token=mockAccessToken',
+          method: 'GET',
+          response: {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                id: 'mockUserId',
+              }),
+          },
+        },
+      ]);
+
+      const user = await adapter.getUserFromAccessToken(accessToken, authData);
+      expect(user).toEqual({ id: 'mockUserId' });
+    });
   });
 
   describe('InstagramAdapter E2E Test', function () {

--- a/src/Adapters/Auth/instagram.js
+++ b/src/Adapters/Auth/instagram.js
@@ -96,8 +96,7 @@ class InstagramAdapter extends BaseAuthCodeAdapter {
   }
 
   async getUserFromAccessToken(accessToken, authData) {
-    const defaultURL = 'https://graph.instagram.com/';
-    const apiURL = authData.apiURL || defaultURL;
+    const apiURL = 'https://graph.instagram.com/';
     const path = `${apiURL}me?fields=id&access_token=${accessToken}`;
 
     const response = await fetch(path);


### PR DESCRIPTION
Fixes security vulnerability [GHSA-3f5f-xgrj-97pf](https://github.com/parse-community/parse-server/security/advisories/GHSA-3f5f-xgrj-97pf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Instagram authentication now consistently uses the official Graph API endpoint, preventing potential endpoint misconfigurations.

* **Tests**
  * Added test coverage for Instagram authentication endpoint handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->