### PR TITLE
feat: Add metadata to mongodb client

### DIFF
--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -1,7 +1,6 @@
 const GridFSBucketAdapter = require('../lib/Adapters/Files/GridFSBucketAdapter')
   .GridFSBucketAdapter;
 const { randomString } = require('../lib/cryptoUtils');
-const { MongoClient } = require('mongodb');
 const databaseURI = 'mongodb://localhost:27017/parse';
 const request = require('../lib/request');
 
@@ -479,11 +478,9 @@ describe_only_db('mongo')('GridFSBucket', () => {
 
   it('pass metadata to MongoClient', async () => {
     const pkg = require('../package.json');
-    spyOn(MongoClient.prototype, 'appendMetadata').and.callThrough();
-
     const gfsAdapter = new GridFSBucketAdapter(databaseURI);
     await gfsAdapter._connect();
-    expect(MongoClient.prototype.appendMetadata).toHaveBeenCalledWith({
+    expect(gfsAdapter._client.s.options.driverInfo).toEqual({
       name: 'Parse Server',
       version: pkg.version,
     });

--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -1,6 +1,7 @@
 const GridFSBucketAdapter = require('../lib/Adapters/Files/GridFSBucketAdapter')
   .GridFSBucketAdapter;
 const { randomString } = require('../lib/cryptoUtils');
+const { MongoClient } = require('mongodb');
 const databaseURI = 'mongodb://localhost:27017/parse';
 const request = require('../lib/request');
 
@@ -474,5 +475,17 @@ describe_only_db('mongo')('GridFSBucket', () => {
     } catch (e) {
       expect(e.message).toEqual('Client must be connected before running operations');
     }
+  });
+
+  it('pass metadata to MongoClient', async () => {
+    const pkg = require('../package.json');
+    spyOn(MongoClient.prototype, 'appendMetadata').and.callThrough();
+
+    const gfsAdapter = new GridFSBucketAdapter(databaseURI);
+    await gfsAdapter._connect();
+    expect(MongoClient.prototype.appendMetadata).toHaveBeenCalledWith({
+      name: 'Parse Server',
+      version: pkg.version,
+    });
   });
 });

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -449,6 +449,18 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     expect(schemaAfterDeletion.fields.test).toBeUndefined();
   });
 
+  it('pass metadata to MongoClient', async () => {
+    const pkg = require('../package.json');
+    spyOn(MongoClient.prototype, 'appendMetadata').and.callThrough();
+
+    const adapter = new MongoStorageAdapter({ uri: databaseURI });
+    await adapter.connect();
+    expect(adapter.client.appendMetadata).toHaveBeenCalledWith({
+      name: 'Parse Server',
+      version: pkg.version,
+    });
+  });
+
   if (process.env.MONGODB_TOPOLOGY === 'replicaset') {
     describe('transactions', () => {
       const headers = {

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -451,11 +451,9 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
 
   it('pass metadata to MongoClient', async () => {
     const pkg = require('../package.json');
-    spyOn(MongoClient.prototype, 'appendMetadata').and.callThrough();
-
     const adapter = new MongoStorageAdapter({ uri: databaseURI });
     await adapter.connect();
-    expect(adapter.client.appendMetadata).toHaveBeenCalledWith({
+    expect(adapter.client.s.options.driverInfo).toEqual({
       name: 'Parse Server',
       version: pkg.version,
     });

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -10,6 +10,7 @@
 import { MongoClient, GridFSBucket, Db } from 'mongodb';
 import { FilesAdapter, validateFilename } from './FilesAdapter';
 import defaults, { ParseServerDatabaseOptions } from '../../defaults';
+import pkg from '../../../package.json';
 const crypto = require('crypto');
 
 export class GridFSBucketAdapter extends FilesAdapter {
@@ -47,6 +48,10 @@ export class GridFSBucketAdapter extends FilesAdapter {
     if (!this._connectionPromise) {
       this._connectionPromise = MongoClient.connect(this._databaseURI, this._mongoOptions).then(
         client => {
+          client.appendMetadata?.({
+            name: 'Parse Server',
+            version: pkg.version,
+          });
           this._client = client;
           return client.db(client.s.options.dbName);
         }

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -51,9 +51,7 @@ export class GridFSBucketAdapter extends FilesAdapter {
         name: 'Parse Server',
         version: pkg.version,
       };
-      const mongoclient = new MongoClient(this._databaseURI, this._mongoOptions);
-      mongoclient.appendMetadata(driverInfo);
-      this._connectionPromise = mongoclient.connect().then(
+      this._connectionPromise = MongoClient.connect(this._databaseURI, { ...this._mongoOptions, driverInfo }).then(
         client => {
           this._client = client;
           return client.db(client.s.options.dbName);

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -46,12 +46,15 @@ export class GridFSBucketAdapter extends FilesAdapter {
 
   _connect() {
     if (!this._connectionPromise) {
-      this._connectionPromise = MongoClient.connect(this._databaseURI, this._mongoOptions).then(
+      // Add wrapping library metadata.
+      const driverInfo = {
+        name: 'Parse Server',
+        version: pkg.version,
+      };
+      const mongoclient = new MongoClient(this._databaseURI, this._mongoOptions);
+      mongoclient.appendMetadata(driverInfo);
+      this._connectionPromise = mongoclient.connect().then(
         client => {
-          client.appendMetadata?.({
-            name: 'Parse Server',
-            version: pkg.version,
-          });
           this._client = client;
           return client.db(client.s.options.dbName);
         }

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -180,15 +180,18 @@ export class MongoStorageAdapter implements StorageAdapter {
     // parsing and re-formatting causes the auth value (if there) to get URI
     // encoded
     const encodedUri = formatUrl(parseUrl(this._uri));
-    this.connectionPromise = MongoClient.connect(encodedUri, this._mongoOptions)
+    // Add wrapping library metadata.
+    const driverInfo = {
+      name: 'Parse Server',
+      version: pkg.version,
+    }
+    const mongoclient = new MongoClient(encodedUri, this._mongoOptions)
+    mongoclient.appendMetadata(driverInfo);
+    this.connectionPromise = mongoclient.connect()
       .then(client => {
         // Starting mongoDB 3.0, the MongoClient.connect don't return a DB anymore but a client
         // Fortunately, we can get back the options and use them to select the proper DB.
         // https://github.com/mongodb/node-mongodb-native/blob/2c35d76f08574225b8db02d7bef687123e6bb018/lib/mongo_client.js#L885
-        client.appendMetadata?.({
-          name: 'Parse Server',
-          version: pkg.version,
-        });
         const options = client.s.options;
         const database = client.db(options.dbName);
         if (!database) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -19,6 +19,7 @@ import _ from 'lodash';
 import defaults, { ParseServerDatabaseOptions } from '../../../defaults';
 import logger from '../../../logger';
 import Utils from '../../../Utils';
+import pkg from '../../../../package.json';
 
 // @flow-disable-next
 const mongodb = require('mongodb');
@@ -184,6 +185,10 @@ export class MongoStorageAdapter implements StorageAdapter {
         // Starting mongoDB 3.0, the MongoClient.connect don't return a DB anymore but a client
         // Fortunately, we can get back the options and use them to select the proper DB.
         // https://github.com/mongodb/node-mongodb-native/blob/2c35d76f08574225b8db02d7bef687123e6bb018/lib/mongo_client.js#L885
+        client.appendMetadata?.({
+          name: 'Parse Server',
+          version: pkg.version,
+        });
         const options = client.s.options;
         const database = client.db(options.dbName);
         if (!database) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -185,9 +185,7 @@ export class MongoStorageAdapter implements StorageAdapter {
       name: 'Parse Server',
       version: pkg.version,
     }
-    const mongoclient = new MongoClient(encodedUri, this._mongoOptions)
-    mongoclient.appendMetadata(driverInfo);
-    this.connectionPromise = mongoclient.connect()
+    this.connectionPromise = MongoClient.connect(encodedUri, { ...this._mongoOptions, driverInfo })
       .then(client => {
         // Starting mongoDB 3.0, the MongoClient.connect don't return a DB anymore but a client
         // Fortunately, we can get back the options and use them to select the proper DB.


### PR DESCRIPTION
## Pull Request

- [x] Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- [x] Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- [x] Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #9996 

## Approach
<!-- Describe the changes in this PR. -->
Added a call to `MongoClient.appendMetadata()` before calling `MongoClient.connect()` inside `MongoStorageAdapter` and `GridFSBucketAdapter` classes so that medatata is appended from the moment a connection is opened to MongoDB.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] ~Add changes to documentation (guides, repository pages, code comments)~
- [ ] ~Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)~
- [ ] ~Add new Parse Error codes to Parse JS SDK~ <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improve MongoDB client connections by attaching consistent driver metadata (name and version) so the server is identifiable to the driver.
* **Tests**
  * Added tests verifying that the driver metadata is included when storage adapters establish MongoDB connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->