### PR TITLE
fix: MongoDB timeout errors unhandled and potentially revealing internal data

### DIFF
--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -1063,4 +1063,127 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       await adapter.handleShutdown();
     });
   });
+
+  describe('transient error handling', () => {
+    it('should transform MongoWaitQueueTimeoutError to Parse.Error.INTERNAL_SERVER_ERROR', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      // Create a mock error with the MongoWaitQueueTimeoutError name
+      const mockError = new Error('Timed out while checking out a connection from connection pool');
+      mockError.name = 'MongoWaitQueueTimeoutError';
+
+      try {
+        adapter.handleError(mockError);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error instanceof Parse.Error).toBe(true);
+        expect(error.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+        expect(error.message).toBe('Database error');
+      }
+    });
+
+    it('should transform MongoServerSelectionError to Parse.Error.INTERNAL_SERVER_ERROR', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      const mockError = new Error('Server selection timed out');
+      mockError.name = 'MongoServerSelectionError';
+
+      try {
+        adapter.handleError(mockError);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error instanceof Parse.Error).toBe(true);
+        expect(error.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+        expect(error.message).toBe('Database error');
+      }
+    });
+
+    it('should transform MongoNetworkTimeoutError to Parse.Error.INTERNAL_SERVER_ERROR', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      const mockError = new Error('Network timeout');
+      mockError.name = 'MongoNetworkTimeoutError';
+
+      try {
+        adapter.handleError(mockError);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error instanceof Parse.Error).toBe(true);
+        expect(error.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+        expect(error.message).toBe('Database error');
+      }
+    });
+
+    it('should transform MongoNetworkError to Parse.Error.INTERNAL_SERVER_ERROR', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      const mockError = new Error('Network error');
+      mockError.name = 'MongoNetworkError';
+
+      try {
+        adapter.handleError(mockError);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error instanceof Parse.Error).toBe(true);
+        expect(error.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+        expect(error.message).toBe('Database error');
+      }
+    });
+
+    it('should transform TransientTransactionError to Parse.Error.INTERNAL_SERVER_ERROR', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      const mockError = new Error('Transient transaction error');
+      mockError.hasErrorLabel = label => label === 'TransientTransactionError';
+
+      try {
+        adapter.handleError(mockError);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error instanceof Parse.Error).toBe(true);
+        expect(error.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+        expect(error.message).toBe('Database error');
+      }
+    });
+
+    it('should not transform non-transient errors', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      const mockError = new Error('Some other error');
+      mockError.name = 'SomeOtherError';
+
+      try {
+        adapter.handleError(mockError);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error instanceof Parse.Error).toBe(false);
+        expect(error.message).toBe('Some other error');
+      }
+    });
+
+    it('should handle null/undefined errors', async () => {
+      const adapter = new MongoStorageAdapter({ uri: databaseURI });
+      await adapter.connect();
+
+      try {
+        adapter.handleError(null);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error).toBeNull();
+      }
+
+      try {
+        adapter.handleError(undefined);
+        fail('Expected handleError to throw');
+      } catch (error) {
+        expect(error).toBeUndefined();
+      }
+    });
+  });
 });

--- a/spec/ParseServer.spec.js
+++ b/spec/ParseServer.spec.js
@@ -55,7 +55,7 @@ describe('Server Url Checks', () => {
     parseServerProcess.on('close', async code => {
       expect(code).toEqual(1);
       expect(stdout).not.toContain('UnhandledPromiseRejectionWarning');
-      expect(stderr).toContain('MongoServerSelectionError');
+      expect(stderr).toContain('Database error');
       await reconfigureServer();
       done();
     });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -73,7 +73,7 @@ describe('server', () => {
       }),
     });
     const error = await server.start().catch(e => e);
-    expect(`${error}`.includes('MongoServerSelectionError')).toBeTrue();
+    expect(`${error}`.includes('Database error')).toBeTrue();
     await reconfigureServer();
   });
 

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -32,7 +32,9 @@ const MongoSchemaCollectionName = '_SCHEMA';
  * (connection pool, network, server selection) as opposed to a query-level error.
  */
 function isTransientError(error) {
-  if (!error) return false;
+  if (!error) {
+    return false;
+  }
 
   // Connection pool, network, and server selection errors
   const transientErrorNames = [
@@ -41,11 +43,15 @@ function isTransientError(error) {
     'MongoNetworkTimeoutError',
     'MongoNetworkError',
   ];
-  if (transientErrorNames.includes(error.name)) return true;
+  if (transientErrorNames.includes(error.name)) {
+    return true;
+  }
 
   // Check for MongoDB's transient transaction error label
   if (typeof error.hasErrorLabel === 'function') {
-    if (error.hasErrorLabel('TransientTransactionError')) return true;
+    if (error.hasErrorLabel('TransientTransactionError')) {
+      return true;
+    }
   }
 
   return false;

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -27,6 +27,30 @@ const ReadPreference = mongodb.ReadPreference;
 
 const MongoSchemaCollectionName = '_SCHEMA';
 
+/**
+ * Determines if a MongoDB error is a transient infrastructure error
+ * (connection pool, network, server selection) as opposed to a query-level error.
+ */
+function isTransientError(error) {
+  if (!error) return false;
+
+  // Connection pool, network, and server selection errors
+  const transientErrorNames = [
+    'MongoWaitQueueTimeoutError',
+    'MongoServerSelectionError',
+    'MongoNetworkTimeoutError',
+    'MongoNetworkError',
+  ];
+  if (transientErrorNames.includes(error.name)) return true;
+
+  // Check for MongoDB's transient transaction error label
+  if (typeof error.hasErrorLabel === 'function') {
+    if (error.hasErrorLabel('TransientTransactionError')) return true;
+  }
+
+  return false;
+}
+
 const storageAdapterAllCollections = mongoAdapter => {
   return mongoAdapter
     .connect()
@@ -240,6 +264,13 @@ export class MongoStorageAdapter implements StorageAdapter {
       delete this.connectionPromise;
       logger.error('Received unauthorized error', { error: error });
     }
+
+    // Transform infrastructure/transient errors into Parse.Error.INTERNAL_SERVER_ERROR
+    if (isTransientError(error)) {
+      logger.error('Database transient error', error);
+      throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'Database error');
+    }
+
     throw error;
   }
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -378,9 +378,9 @@ export const handleParseSession = async (req, res, next) => {
       next(error);
       return;
     }
-    // TODO: Determine the correct error scenario.
+    // Log full error details internally, but don't expose to client
     req.config.loggerController.error('error getting auth for sessionToken', error);
-    throw new Parse.Error(Parse.Error.UNKNOWN_ERROR, error);
+    next(new Parse.Error(Parse.Error.UNKNOWN_ERROR, 'Unknown error'));
   }
 };
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

## Issue

If MongoDB driver timeout parameters are set, and a timeout occurs, the error crashes with an uncaught exception, like this:

> Uncaught internal server error. Timed out while checking out a connection from connection pool.

Original code:

```js
throw new Parse.Error(Parse.Error.UNKNOWN_ERROR, error);
```

Crashing on database connection errors could be intentional, but wrapping it in `Parse.Error` suggests the intent was to send an error response to the client, not to crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Convert certain database connectivity errors into a generic "Database error" message for clients.
  * Better classify and handle transient database connectivity failures.
  * Sanitize client-facing error responses while preserving internal logging for diagnostics.

* **Tests**
  * Added tests covering transient database error translation, non-transient cases, and null/undefined error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->