### PR TITLE
refactor: Upgrade pg-promise from 12.2.0 to 12.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "parse": "8.0.3",
         "path-to-regexp": "8.3.0",
         "pg-monitor": "3.0.0",
-        "pg-promise": "12.2.0",
+        "pg-promise": "12.5.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
         "rate-limit-redis": "4.2.0",
@@ -18343,14 +18343,14 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.16.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.9.1",
-        "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.3",
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -18358,7 +18358,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.2.7"
+        "pg-cloudflare": "^1.3.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -18370,22 +18370,22 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
       "license": "MIT"
     },
     "node_modules/pg-cursor": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
-      "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.17.0.tgz",
+      "integrity": "sha512-2Uio3Xfl5ldwJfls+RgGL+YbPcKQncWACWjYQFqlamvHZ4HJFjZhhZBbqd7jQ2LIkZYSvU90bm2dNW0rno+QFQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -18423,46 +18423,46 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-promise": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.2.0.tgz",
-      "integrity": "sha512-th+GB7ftaRv5gAjSVslURSaYr5gf8d+T9/h5dZTJ/uyMqnQV8lJ8cDo3p5Crv3rprLC8ZCav9yLFcMKnobib+g==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.5.0.tgz",
+      "integrity": "sha512-cPnMogC9to0xQ8kJZ8Dyn5W+QgvqrvB108QHQaJrRJL++R2+2jkjonXaOqS5OOQM1O0JT040PUyn5ruyNnaI1A==",
       "license": "MIT",
       "dependencies": {
         "assert-options": "0.8.3",
-        "pg": "8.16.3",
+        "pg": "8.18.0",
         "pg-minify": "1.8.0",
-        "spex": "4.0.2"
+        "spex": "4.1.0"
       },
       "engines": {
         "node": ">=16.0"
       },
       "peerDependencies": {
-        "pg-query-stream": "4.10.3"
+        "pg-query-stream": "4.12.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
       "license": "MIT"
     },
     "node_modules/pg-query-stream": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.10.3.tgz",
-      "integrity": "sha512-h2utrzpOIzeT9JfaqfvBbVuvCfBjH86jNfVrGGTbyepKAIOyTfDew0lAt8bbJjs9n/I5bGDl7S2sx6h5hPyJxw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.12.0.tgz",
+      "integrity": "sha512-H97oiVPQ0+eRqIFOeYMUnjDcv9od7vHHMjiVDAhg2SEzAUr3M/dT83UEV1B+fm+tcVnymI8j2LSp57/+yjF6Fg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "pg-cursor": "^2.15.3"
+        "pg-cursor": "^2.17.0"
       },
       "peerDependencies": {
         "pg": "^8"
@@ -18712,9 +18712,9 @@
       }
     },
     "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20531,12 +20531,12 @@
       "dev": true
     },
     "node_modules/spex": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-4.0.2.tgz",
-      "integrity": "sha512-/8VnouFOkRlkfj/sDN6GYnRKCutBHjUndkg6oAgv374VvjYQRzzR2gTEXRsmFmgd1SrbI8W948iTDnkEkUieCw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-4.1.0.tgz",
+      "integrity": "sha512-ktgNAQ1X9x1A3IMChM6XBDeVjhGPbLgPQ8aEzGOaUIhZTnLeJSBApvi3gXT789hee6h73N3jOeWkXDwoPbYT/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/split2": {
@@ -35204,33 +35204,33 @@
       "dev": true
     },
     "pg": {
-      "version": "8.16.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "requires": {
-        "pg-cloudflare": "^1.2.7",
-        "pg-connection-string": "^2.9.1",
-        "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.3",
+        "pg-cloudflare": "^1.3.0",
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       }
     },
     "pg-cloudflare": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ=="
     },
     "pg-cursor": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
-      "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.17.0.tgz",
+      "integrity": "sha512-2Uio3Xfl5ldwJfls+RgGL+YbPcKQncWACWjYQFqlamvHZ4HJFjZhhZBbqd7jQ2LIkZYSvU90bm2dNW0rno+QFQ==",
       "peer": true,
       "requires": {}
     },
@@ -35253,34 +35253,34 @@
       }
     },
     "pg-pool": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
       "requires": {}
     },
     "pg-promise": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.2.0.tgz",
-      "integrity": "sha512-th+GB7ftaRv5gAjSVslURSaYr5gf8d+T9/h5dZTJ/uyMqnQV8lJ8cDo3p5Crv3rprLC8ZCav9yLFcMKnobib+g==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.5.0.tgz",
+      "integrity": "sha512-cPnMogC9to0xQ8kJZ8Dyn5W+QgvqrvB108QHQaJrRJL++R2+2jkjonXaOqS5OOQM1O0JT040PUyn5ruyNnaI1A==",
       "requires": {
         "assert-options": "0.8.3",
-        "pg": "8.16.3",
+        "pg": "8.18.0",
         "pg-minify": "1.8.0",
-        "spex": "4.0.2"
+        "spex": "4.1.0"
       }
     },
     "pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="
     },
     "pg-query-stream": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.10.3.tgz",
-      "integrity": "sha512-h2utrzpOIzeT9JfaqfvBbVuvCfBjH86jNfVrGGTbyepKAIOyTfDew0lAt8bbJjs9n/I5bGDl7S2sx6h5hPyJxw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.12.0.tgz",
+      "integrity": "sha512-H97oiVPQ0+eRqIFOeYMUnjDcv9od7vHHMjiVDAhg2SEzAUr3M/dT83UEV1B+fm+tcVnymI8j2LSp57/+yjF6Fg==",
       "peer": true,
       "requires": {
-        "pg-cursor": "^2.15.3"
+        "pg-cursor": "^2.17.0"
       }
     },
     "pg-types": {
@@ -35448,9 +35448,9 @@
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
     "postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="
     },
     "postgres-date": {
       "version": "1.0.7",
@@ -36726,9 +36726,9 @@
       "dev": true
     },
     "spex": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-4.0.2.tgz",
-      "integrity": "sha512-/8VnouFOkRlkfj/sDN6GYnRKCutBHjUndkg6oAgv374VvjYQRzzR2gTEXRsmFmgd1SrbI8W948iTDnkEkUieCw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-4.1.0.tgz",
+      "integrity": "sha512-ktgNAQ1X9x1A3IMChM6XBDeVjhGPbLgPQ8aEzGOaUIhZTnLeJSBApvi3gXT789hee6h73N3jOeWkXDwoPbYT/A=="
     },
     "split2": {
       "version": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "parse": "8.0.3",
         "path-to-regexp": "8.3.0",
         "pg-monitor": "3.0.0",
-        "pg-promise": "12.5.0",
+        "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
         "rate-limit-redis": "4.2.0",
@@ -18432,9 +18432,9 @@
       }
     },
     "node_modules/pg-promise": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.5.0.tgz",
-      "integrity": "sha512-cPnMogC9to0xQ8kJZ8Dyn5W+QgvqrvB108QHQaJrRJL++R2+2jkjonXaOqS5OOQM1O0JT040PUyn5ruyNnaI1A==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.6.0.tgz",
+      "integrity": "sha512-ZnfNn7c0U2p1OWYqoENcke8eSTe+yCGOpuMurExTuot/pe3POodbakE9Sj5MWUsyPpyreARUUPwe4j/5Dfs9Dw==",
       "license": "MIT",
       "dependencies": {
         "assert-options": "0.8.3",
@@ -35259,9 +35259,9 @@
       "requires": {}
     },
     "pg-promise": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.5.0.tgz",
-      "integrity": "sha512-cPnMogC9to0xQ8kJZ8Dyn5W+QgvqrvB108QHQaJrRJL++R2+2jkjonXaOqS5OOQM1O0JT040PUyn5ruyNnaI1A==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-12.6.0.tgz",
+      "integrity": "sha512-ZnfNn7c0U2p1OWYqoENcke8eSTe+yCGOpuMurExTuot/pe3POodbakE9Sj5MWUsyPpyreARUUPwe4j/5Dfs9Dw==",
       "requires": {
         "assert-options": "0.8.3",
         "pg": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "parse": "8.0.3",
     "path-to-regexp": "8.3.0",
     "pg-monitor": "3.0.0",
-    "pg-promise": "12.5.0",
+    "pg-promise": "12.6.0",
     "pluralize": "8.0.0",
     "punycode": "2.3.1",
     "rate-limit-redis": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "parse": "8.0.3",
     "path-to-regexp": "8.3.0",
     "pg-monitor": "3.0.0",
-    "pg-promise": "12.2.0",
+    "pg-promise": "12.5.0",
     "pluralize": "8.0.0",
     "punycode": "2.3.1",
     "rate-limit-redis": "4.2.0",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
<!-- Describe the issue. -->
The bot doesn't seem to be updating pg-promise as a [newer version than 12.2.0](https://github.com/vitaly-t/pg-promise/releases), 12.3.0, came out in 11/2025.

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->
Update manually using `npm i -E pg-promise@12.6.0`

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pg-promise database library to version 12.6.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->