### PR TITLE
fix: Default HTML pages for password reset, email verification not found

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -326,9 +326,7 @@ export class Config {
     } else if (!isBoolean(pages.forceRedirect)) {
       throw 'Parse Server option pages.forceRedirect must be a boolean.';
     }
-    if (pages.pagesPath === undefined) {
-      pages.pagesPath = PagesOptions.pagesPath.default;
-    } else if (!isString(pages.pagesPath)) {
+    if (pages.pagesPath !== undefined && !isString(pages.pagesPath)) {
       throw 'Parse Server option pages.pagesPath must be a string.';
     }
     if (pages.pagesEndpoint === undefined) {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -772,8 +772,7 @@ module.exports.PagesOptions = {
   pagesPath: {
     env: 'PARSE_SERVER_PAGES_PAGES_PATH',
     help:
-      "The path to the pages directory; this also defines where the static endpoint '/apps' points to. Default is the './public/' directory.",
-    default: './public',
+      "The path to the pages directory; this also defines where the static endpoint '/apps' points to. Default is the './public/' directory of the parse-server module.",
   },
   placeholders: {
     env: 'PARSE_SERVER_PAGES_PLACEHOLDERS',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -142,7 +142,7 @@
  * @property {String} localizationFallbackLocale The fallback locale for localization if no matching translation is provided for the given locale. This is only relevant when providing translation resources via JSON file.
  * @property {String} localizationJsonPath The path to the JSON file for localization; the translations will be used to fill template placeholders according to the locale.
  * @property {String} pagesEndpoint The API endpoint for the pages. Default is 'apps'.
- * @property {String} pagesPath The path to the pages directory; this also defines where the static endpoint '/apps' points to. Default is the './public/' directory.
+ * @property {String} pagesPath The path to the pages directory; this also defines where the static endpoint '/apps' points to. Default is the './public/' directory of the parse-server module.
  * @property {Object} placeholders The placeholder keys and values which will be filled in pages; this can be a simple object or a callback function.
  */
 

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -437,8 +437,7 @@ export interface PagesOptions {
   /* Is true if responses should always be redirects and never content, false if the response type should depend on the request type (GET request -> content response; POST request -> redirect response).
   :DEFAULT: false */
   forceRedirect: ?boolean;
-  /* The path to the pages directory; this also defines where the static endpoint '/apps' points to. Default is the './public/' directory.
-  :DEFAULT: ./public */
+  /* The path to the pages directory; this also defines where the static endpoint '/apps' points to. Default is the './public/' directory of the parse-server module. */
   pagesPath: ?string;
   /* The API endpoint for the pages. Default is 'apps'.
   :DEFAULT: apps */


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Default HTML pages for password reset, email verification not found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom pages endpoints and route configuration
  * Added ability to customize URLs for password reset and email verification flows

* **Documentation**
  * Clarified that the default pages directory is the `./public/` directory of the Parse Server module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->