### PR TITLE
feat: Add `Parse.File.url` validation with config `fileUpload.allowedFileUrlDomains` against SSRF attacks

### DIFF
--- a/spec/Deprecator.spec.js
+++ b/spec/Deprecator.spec.js
@@ -70,4 +70,37 @@ describe('Deprecator', () => {
     Deprecator.scanParseServerOptions({ databaseOptions: { testOption: true } });
     expect(logSpy).not.toHaveBeenCalled();
   });
+
+  it('logs deprecation for allowedFileUrlDomains when not set', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    // Pass a fresh fileUpload object without allowedFileUrlDomains to avoid
+    // inheriting the mutated default from a previous reconfigureServer() call.
+    await reconfigureServer({
+      fileUpload: {
+        enableForPublic: true,
+        enableForAnonymousUser: true,
+        enableForAuthenticatedUser: true,
+      },
+    });
+    expect(logSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        optionKey: 'fileUpload.allowedFileUrlDomains',
+        changeNewDefault: '[]',
+      })
+    );
+  });
+
+  it('does not log deprecation for allowedFileUrlDomains when explicitly set', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    await reconfigureServer({
+      fileUpload: { allowedFileUrlDomains: ['*'] },
+    });
+    expect(logSpy).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        optionKey: 'fileUpload.allowedFileUrlDomains',
+      })
+    );
+  });
 });

--- a/spec/FileUrlValidator.spec.js
+++ b/spec/FileUrlValidator.spec.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { validateFileUrl, validateFileUrlsInObject } = require('../src/FileUrlValidator');
+
+describe('FileUrlValidator', () => {
+  describe('validateFileUrl', () => {
+    it('allows null, undefined, and empty string URLs', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: [] } };
+      expect(() => validateFileUrl(null, config)).not.toThrow();
+      expect(() => validateFileUrl(undefined, config)).not.toThrow();
+      expect(() => validateFileUrl('', config)).not.toThrow();
+    });
+
+    it('allows any URL when allowedFileUrlDomains contains wildcard', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['*'] } };
+      expect(() => validateFileUrl('http://malicious.example.com/file.txt', config)).not.toThrow();
+      expect(() => validateFileUrl('http://malicious.example.com/leak', config)).not.toThrow();
+    });
+
+    it('allows any URL when allowedFileUrlDomains is not an array', () => {
+      expect(() => validateFileUrl('http://example.com/file', {})).not.toThrow();
+      expect(() => validateFileUrl('http://example.com/file', { fileUpload: {} })).not.toThrow();
+      expect(() => validateFileUrl('http://example.com/file', null)).not.toThrow();
+    });
+
+    it('rejects all URLs when allowedFileUrlDomains is empty', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: [] } };
+      expect(() => validateFileUrl('http://example.com/file', config)).toThrowError(
+        /not allowed/
+      );
+    });
+
+    it('allows URLs matching exact hostname', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['cdn.example.com'] } };
+      expect(() => validateFileUrl('https://cdn.example.com/files/test.txt', config)).not.toThrow();
+    });
+
+    it('rejects URLs not matching any allowed hostname', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['cdn.example.com'] } };
+      expect(() => validateFileUrl('http://malicious.example.com/file', config)).toThrowError(
+        /not allowed/
+      );
+    });
+
+    it('supports wildcard subdomain matching', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['*.example.com'] } };
+      expect(() => validateFileUrl('https://cdn.example.com/file.txt', config)).not.toThrow();
+      expect(() => validateFileUrl('https://us-east.cdn.example.com/file.txt', config)).not.toThrow();
+      expect(() => validateFileUrl('https://example.net/file.txt', config)).toThrowError(
+        /not allowed/
+      );
+    });
+
+    it('performs case-insensitive hostname matching', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['CDN.Example.COM'] } };
+      expect(() => validateFileUrl('https://cdn.example.com/file.txt', config)).not.toThrow();
+    });
+
+    it('throws on invalid URL strings', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['example.com'] } };
+      expect(() => validateFileUrl('not-a-url', config)).toThrowError(
+        /Invalid file URL/
+      );
+    });
+
+    it('supports multiple allowed domains', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['cdn1.example.com', 'cdn2.example.com'] } };
+      expect(() => validateFileUrl('https://cdn1.example.com/file.txt', config)).not.toThrow();
+      expect(() => validateFileUrl('https://cdn2.example.com/file.txt', config)).not.toThrow();
+      expect(() => validateFileUrl('https://cdn3.example.com/file.txt', config)).toThrowError(
+        /not allowed/
+      );
+    });
+
+    it('does not allow partial hostname matches', () => {
+      const config = { fileUpload: { allowedFileUrlDomains: ['example.com'] } };
+      expect(() => validateFileUrl('https://notexample.com/file.txt', config)).toThrowError(
+        /not allowed/
+      );
+      expect(() => validateFileUrl('https://example.com.malicious.example.com/file.txt', config)).toThrowError(
+        /not allowed/
+      );
+    });
+  });
+
+  describe('validateFileUrlsInObject', () => {
+    const config = { fileUpload: { allowedFileUrlDomains: ['example.com'] } };
+
+    it('validates file URLs in flat objects', () => {
+      expect(() =>
+        validateFileUrlsInObject(
+          { file: { __type: 'File', name: 'test.txt', url: 'http://malicious.example.com/file' } },
+          config
+        )
+      ).toThrowError(/not allowed/);
+    });
+
+    it('validates file URLs in nested objects', () => {
+      expect(() =>
+        validateFileUrlsInObject(
+          { nested: { deep: { file: { __type: 'File', name: 'test.txt', url: 'http://malicious.example.com/file' } } } },
+          config
+        )
+      ).toThrowError(/not allowed/);
+    });
+
+    it('validates file URLs in arrays', () => {
+      expect(() =>
+        validateFileUrlsInObject(
+          [{ __type: 'File', name: 'test.txt', url: 'http://malicious.example.com/file' }],
+          config
+        )
+      ).toThrowError(/not allowed/);
+    });
+
+    it('allows files without URLs', () => {
+      expect(() =>
+        validateFileUrlsInObject(
+          { file: { __type: 'File', name: 'test.txt' } },
+          config
+        )
+      ).not.toThrow();
+    });
+
+    it('allows files with permitted URLs', () => {
+      expect(() =>
+        validateFileUrlsInObject(
+          { file: { __type: 'File', name: 'test.txt', url: 'http://example.com/file.txt' } },
+          config
+        )
+      ).not.toThrow();
+    });
+
+    it('handles null, undefined, and primitive values', () => {
+      expect(() => validateFileUrlsInObject(null, config)).not.toThrow();
+      expect(() => validateFileUrlsInObject(undefined, config)).not.toThrow();
+      expect(() => validateFileUrlsInObject('string', config)).not.toThrow();
+      expect(() => validateFileUrlsInObject(42, config)).not.toThrow();
+    });
+  });
+});

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1368,6 +1368,20 @@ describe('Parse.File testing', () => {
           },
         })
       ).toBeRejectedWith('fileUpload.fileExtensions must be an array.');
+      await expectAsync(
+        reconfigureServer({
+          fileUpload: {
+            allowedFileUrlDomains: 'not-an-array',
+          },
+        })
+      ).toBeRejectedWith('fileUpload.allowedFileUrlDomains must be an array.');
+      await expectAsync(
+        reconfigureServer({
+          fileUpload: {
+            allowedFileUrlDomains: ['example.com'],
+          },
+        })
+      ).toBeResolved();
     });
   });
 
@@ -1753,6 +1767,70 @@ describe('Parse.File testing', () => {
         },
       });
       expect(result.status).toBe(201);
+    });
+
+    it('allows REST API create with file URL when default wildcard is used', async () => {
+      const result = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/classes/TestObject',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        body: {
+          file: {
+            __type: 'File',
+            name: 'test.txt',
+            url: 'http://example.com/file.txt',
+          },
+        },
+      });
+      expect(result.status).toBe(201);
+    });
+
+    it('allows cloud function with name-only file when domains are restricted', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: [],
+        },
+      });
+
+      Parse.Cloud.define('processFile', req => req.params.file.name());
+
+      const result = await Parse.Cloud.run('processFile', {
+        file: { __type: 'File', name: 'test.txt' },
+      });
+      expect(result).toBe('test.txt');
+    });
+
+    it('rejects disallowed file URL in array field', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: [],
+        },
+      });
+
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/classes/TestObject',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          body: {
+            files: [
+              {
+                __type: 'File',
+                name: 'test.txt',
+                url: 'http://malicious.example.com/file',
+              },
+            ],
+          },
+        })
+      ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
     });
 
     it('rejects disallowed file URL nested in object', async () => {

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1625,4 +1625,165 @@ describe('Parse.File testing', () => {
       expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.html$/);
     });
   });
+
+  describe('File URL domain validation for SSRF prevention', () => {
+    it('rejects cloud function call with disallowed file URL', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: [],
+        },
+      });
+
+      Parse.Cloud.define('setUserIcon', () => {});
+
+      await expectAsync(
+        Parse.Cloud.run('setUserIcon', {
+          file: { __type: 'File', name: 'file.txt', url: 'http://malicious.example.com/leak' },
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({ message: jasmine.stringMatching(/not allowed/) })
+      );
+    });
+
+    it('rejects REST API create with disallowed file URL', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: [],
+        },
+      });
+
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/classes/TestObject',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          body: {
+            file: {
+              __type: 'File',
+              name: 'test.txt',
+              url: 'http://malicious.example.com/file',
+            },
+          },
+        })
+      ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+    });
+
+    it('rejects REST API update with disallowed file URL', async () => {
+      const obj = new Parse.Object('TestObject');
+      await obj.save();
+
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: [],
+        },
+      });
+
+      await expectAsync(
+        request({
+          method: 'PUT',
+          url: `http://localhost:8378/1/classes/TestObject/${obj.id}`,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          body: {
+            file: {
+              __type: 'File',
+              name: 'test.txt',
+              url: 'http://malicious.example.com/file',
+            },
+          },
+        })
+      ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+    });
+
+    it('allows file URLs matching configured domains', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: ['cdn.example.com'],
+        },
+      });
+
+      Parse.Cloud.define('setUserIcon', () => 'ok');
+
+      const result = await Parse.Cloud.run('setUserIcon', {
+        file: { __type: 'File', name: 'file.txt', url: 'http://cdn.example.com/file.txt' },
+      });
+      expect(result).toBe('ok');
+    });
+
+    it('allows file URLs when default wildcard is used', async () => {
+      Parse.Cloud.define('setUserIcon', () => 'ok');
+
+      const result = await Parse.Cloud.run('setUserIcon', {
+        file: { __type: 'File', name: 'file.txt', url: 'http://example.com/file.txt' },
+      });
+      expect(result).toBe('ok');
+    });
+
+    it('allows files with server-hosted URLs even when domains are restricted', async () => {
+      const file = new Parse.File('test.txt', [1, 2, 3]);
+      await file.save();
+
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: ['localhost'],
+        },
+      });
+
+      const result = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/classes/TestObject',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        body: {
+          file: {
+            __type: 'File',
+            name: file.name(),
+            url: file.url(),
+          },
+        },
+      });
+      expect(result.status).toBe(201);
+    });
+
+    it('rejects disallowed file URL nested in object', async () => {
+      await reconfigureServer({
+        fileUpload: {
+          allowedFileUrlDomains: [],
+        },
+      });
+
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/classes/TestObject',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          body: {
+            data: {
+              nested: {
+                file: {
+                  __type: 'File',
+                  name: 'test.txt',
+                  url: 'http://malicious.example.com/file',
+                },
+              },
+            },
+          },
+        })
+      ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+    });
+  });
 });

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1378,6 +1378,20 @@ describe('Parse.File testing', () => {
       await expectAsync(
         reconfigureServer({
           fileUpload: {
+            allowedFileUrlDomains: [123],
+          },
+        })
+      ).toBeRejectedWith('fileUpload.allowedFileUrlDomains must contain only non-empty strings.');
+      await expectAsync(
+        reconfigureServer({
+          fileUpload: {
+            allowedFileUrlDomains: [''],
+          },
+        })
+      ).toBeRejectedWith('fileUpload.allowedFileUrlDomains must contain only non-empty strings.');
+      await expectAsync(
+        reconfigureServer({
+          fileUpload: {
             allowedFileUrlDomains: ['example.com'],
           },
         })

--- a/src/Config.js
+++ b/src/Config.js
@@ -550,6 +550,11 @@ export class Config {
     } else if (!Array.isArray(fileUpload.fileExtensions)) {
       throw 'fileUpload.fileExtensions must be an array.';
     }
+    if (fileUpload.allowedFileUrlDomains === undefined) {
+      fileUpload.allowedFileUrlDomains = FileUploadOptions.allowedFileUrlDomains.default;
+    } else if (!Array.isArray(fileUpload.allowedFileUrlDomains)) {
+      throw 'fileUpload.allowedFileUrlDomains must be an array.';
+    }
   }
 
   static validateIps(field, masterKeyIps) {

--- a/src/Config.js
+++ b/src/Config.js
@@ -554,6 +554,12 @@ export class Config {
       fileUpload.allowedFileUrlDomains = FileUploadOptions.allowedFileUrlDomains.default;
     } else if (!Array.isArray(fileUpload.allowedFileUrlDomains)) {
       throw 'fileUpload.allowedFileUrlDomains must be an array.';
+    } else {
+      for (const domain of fileUpload.allowedFileUrlDomains) {
+        if (typeof domain !== 'string' || domain === '') {
+          throw 'fileUpload.allowedFileUrlDomains must contain only non-empty strings.';
+        }
+      }
     }
   }
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -499,6 +499,12 @@ class DatabaseController {
     } catch (error) {
       return Promise.reject(new Parse.Error(Parse.Error.INVALID_KEY_NAME, error));
     }
+    try {
+      const { validateFileUrlsInObject } = require('../FileUrlValidator');
+      validateFileUrlsInObject(update, this.options);
+    } catch (error) {
+      return Promise.reject(error instanceof Parse.Error ? error : new Parse.Error(Parse.Error.FILE_SAVE_ERROR, error.message || error));
+    }
     const originalQuery = query;
     const originalUpdate = update;
     // Make a copy of the object, so we don't mutate the incoming data.
@@ -835,6 +841,12 @@ class DatabaseController {
       Utils.checkProhibitedKeywords(this.options, object);
     } catch (error) {
       return Promise.reject(new Parse.Error(Parse.Error.INVALID_KEY_NAME, error));
+    }
+    try {
+      const { validateFileUrlsInObject } = require('../FileUrlValidator');
+      validateFileUrlsInObject(object, this.options);
+    } catch (error) {
+      return Promise.reject(error instanceof Parse.Error ? error : new Parse.Error(Parse.Error.FILE_SAVE_ERROR, error.message || error));
     }
     // Make a copy of the object, so we don't mutate the incoming data.
     const originalObject = object;

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -15,4 +15,10 @@
  *
  * If there are no deprecations, this must return an empty array.
  */
-module.exports = [];
+module.exports = [
+  {
+    optionKey: 'fileUpload.allowedFileUrlDomains',
+    changeNewDefault: '[]',
+    solution: "Set 'fileUpload.allowedFileUrlDomains' to the domains you want to allow, or to '[]' to block all file URLs.",
+  },
+];

--- a/src/FileUrlValidator.js
+++ b/src/FileUrlValidator.js
@@ -1,0 +1,68 @@
+const Parse = require('parse/node').Parse;
+
+/**
+ * Validates whether a File URL is allowed based on the configured allowed domains.
+ * @param {string} fileUrl - The URL to validate.
+ * @param {Object} config - The Parse Server config object.
+ * @throws {Parse.Error} If the URL is not allowed.
+ */
+function validateFileUrl(fileUrl, config) {
+  if (fileUrl == null || fileUrl === '') {
+    return;
+  }
+
+  const domains = config?.fileUpload?.allowedFileUrlDomains;
+  if (!Array.isArray(domains) || domains.includes('*')) {
+    return;
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(fileUrl);
+  } catch (_) {
+    throw new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `Invalid file URL.`);
+  }
+
+  const fileHostname = parsedUrl.hostname.toLowerCase();
+  for (const domain of domains) {
+    const d = domain.toLowerCase();
+    if (fileHostname === d) {
+      return;
+    }
+    if (d.startsWith('*.') && fileHostname.endsWith(d.slice(1))) {
+      return;
+    }
+  }
+
+  throw new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `File URL domain '${parsedUrl.hostname}' is not allowed.`);
+}
+
+/**
+ * Recursively scans an object for File type fields and validates their URLs.
+ * @param {any} obj - The object to scan.
+ * @param {Object} config - The Parse Server config object.
+ * @throws {Parse.Error} If any File URL is not allowed.
+ */
+function validateFileUrlsInObject(obj, config) {
+  if (obj == null || typeof obj !== 'object') {
+    return;
+  }
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      validateFileUrlsInObject(item, config);
+    }
+    return;
+  }
+  if (obj.__type === 'File' && obj.url) {
+    validateFileUrl(obj.url, config);
+    return;
+  }
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    if (value && typeof value === 'object') {
+      validateFileUrlsInObject(value, config);
+    }
+  }
+}
+
+module.exports = { validateFileUrl, validateFileUrlsInObject };

--- a/src/FileUrlValidator.js
+++ b/src/FileUrlValidator.js
@@ -19,7 +19,7 @@ function validateFileUrl(fileUrl, config) {
   let parsedUrl;
   try {
     parsedUrl = new URL(fileUrl);
-  } catch (_) {
+  } catch {
     throw new Parse.Error(Parse.Error.FILE_SAVE_ERROR, `Invalid file URL.`);
   }
 

--- a/src/GraphQL/transformers/mutation.js
+++ b/src/GraphQL/transformers/mutation.js
@@ -97,6 +97,10 @@ const transformers = {
       const { fileInfo } = await handleUpload(upload, config);
       return { ...fileInfo, __type: 'File' };
     } else if (file && file.name) {
+      if (file.url) {
+        const { validateFileUrl } = require('../../FileUrlValidator');
+        validateFileUrl(file.url, config);
+      }
       return { name: file.name, __type: 'File', url: file.url };
     }
     throw new Parse.Error(Parse.Error.FILE_SAVE_ERROR, 'Invalid file upload.');

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -982,6 +982,12 @@ module.exports.PasswordPolicyOptions = {
   },
 };
 module.exports.FileUploadOptions = {
+  allowedFileUrlDomains: {
+    env: 'PARSE_SERVER_FILE_UPLOAD_ALLOWED_FILE_URL_DOMAINS',
+    help: "Sets the allowed hostnames for file URLs referenced in Parse objects. When a File object includes a URL, its hostname must match one of these entries to be accepted. Supports exact hostnames (e.g., `'cdn.example.com'`) and wildcard subdomains (e.g., `'*.example.com'`). Use `['*']` to allow any domain. Use `[]` to block all file URLs (only name-based files allowed).",
+    action: parsers.arrayParser,
+    default: ['*'],
+  },
   enableForAnonymousUser: {
     env: 'PARSE_SERVER_FILE_UPLOAD_ENABLE_FOR_ANONYMOUS_USER',
     help: 'Is true if file upload should be allowed for anonymous users.',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -232,6 +232,7 @@
 
 /**
  * @interface FileUploadOptions
+ * @property {String[]} allowedFileUrlDomains Sets the allowed hostnames for file URLs referenced in Parse objects. When a File object includes a URL, its hostname must match one of these entries to be accepted. Supports exact hostnames (e.g., `'cdn.example.com'`) and wildcard subdomains (e.g., `'*.example.com'`). Use `['*']` to allow any domain. Use `[]` to block all file URLs (only name-based files allowed).
  * @property {Boolean} enableForAnonymousUser Is true if file upload should be allowed for anonymous users.
  * @property {Boolean} enableForAuthenticatedUser Is true if file upload should be allowed for authenticated users.
  * @property {Boolean} enableForPublic Is true if file upload should be allowed for anyone, regardless of user authentication.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -630,6 +630,9 @@ export interface FileUploadOptions {
   /* Is true if file upload should be allowed for anyone, regardless of user authentication.
   :DEFAULT: false */
   enableForPublic: ?boolean;
+  /* Sets the allowed hostnames for file URLs referenced in Parse objects. When a File object includes a URL, its hostname must match one of these entries to be accepted. Supports exact hostnames (e.g., `'cdn.example.com'`) and wildcard subdomains (e.g., `'*.example.com'`). Use `['*']` to allow any domain. Use `[]` to block all file URLs (only name-based files allowed).
+  :DEFAULT: ["*"] */
+  allowedFileUrlDomains: ?(string[]);
 }
 
 /* The available log levels for Parse Server logging. Valid values are:<br>- `'error'` - Error level (highest priority)<br>- `'warn'` - Warning level<br>- `'info'` - Info level (default)<br>- `'verbose'` - Verbose level<br>- `'debug'` - Debug level<br>- `'silly'` - Silly level (lowest priority) */

--- a/src/ParseServer.ts
+++ b/src/ParseServer.ts
@@ -532,7 +532,7 @@ class ParseServer {
         let url;
         try {
           url = new URL(string);
-        } catch (_) {
+        } catch {
           return false;
         }
         return url.protocol === 'http:' || url.protocol === 'https:';

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -17,6 +17,10 @@ function parseObject(obj, config) {
   } else if (obj && obj.__type == 'Date') {
     return Object.assign(new Date(obj.iso), obj);
   } else if (obj && obj.__type == 'File') {
+    if (obj.url) {
+      const { validateFileUrl } = require('../FileUrlValidator');
+      validateFileUrl(obj.url, config);
+    }
     return Parse.File.fromJSON(obj);
   } else if (obj && obj.__type == 'Pointer') {
     return Parse.Object.fromJSON({

--- a/types/Options/index.d.ts
+++ b/types/Options/index.d.ts
@@ -236,6 +236,7 @@ export interface PasswordPolicyOptions {
     resetPasswordSuccessOnInvalidEmail?: boolean;
 }
 export interface FileUploadOptions {
+    allowedFileUrlDomains?: string[];
     fileExtensions?: (string[]);
     enableForAnonymousUser?: boolean;
     enableForAuthenticatedUser?: boolean;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

A developer can introduce a SSRF vulnerability if an attacker passes a crafted `Parse.File` with an arbitrary URL (e.g., `{__type: "File", name: "file.txt", url: "http://malicious.example.com"}`) as a Cloud Function parameter or save it to the database in a `Parse.Object` field of type Object or Array. When cloud code or clients call `Parse.File.getData()`, the Parse JS SDK makes an HTTP request to the attacker-controlled URL, leaking the server/client IP and potentially accessing internal services.

Note that this is not a vulnerability of Parse Server itself, as developers should not trust client-provided data they don't fully control, but instead validate it. This PR introduces a feature that allows to easily validate the `Parse.File.url` whenever JSON data is instantiated as `Parse.File`, specifically in the following scenarios:

- `Parse.File` as item in `Parse.Object` field of type Array.
- `Parse.File` as key value in `Parse.Object` field of type Object.
- `Parse.File` as parameter in a Cloud Function call.

This is not a breaking change, as the default configuration in this PR allows *any* URL. However, the default is deprecated and Parse Server logs a warning about a future change of the default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable file URL domain restrictions via fileUpload.allowedFileUrlDomains; enforced on file creation/update across REST, GraphQL, and cloud function paths. Includes validation of config values.

* **Tests**
  * Extensive coverage for URL validation: wildcards, exact/case-insensitive matches, nested/array fields, invalid URLs, and SSRF scenarios; deprecation-related tests added.

* **Documentation**
  * Added docs and config entry with examples, defaults, and usage guidance.

* **Chores**
  * Added deprecation notice for the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->