### PR TITLE
fix: Unlinking auth provider triggers auth data validation

### DIFF
--- a/spec/Adapters/Auth/BaseCodeAdapter.spec.js
+++ b/spec/Adapters/Auth/BaseCodeAdapter.spec.js
@@ -157,10 +157,15 @@ describe('BaseAuthCodeAdapter', function () {
   });
 
   describe('validateSetUp', function () {
-    it('should return user id from authData', function () {
-      const authData = { id: 'validUserId' };
+    it('should return user id from authData with access_token', function () {
+      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
       const result = adapter.validateSetUp(authData);
       expect(result).toEqual({ id: 'validUserId' });
+    });
+
+    it('should throw if access_token is missing', function () {
+      const authData = { id: 'validUserId' };
+      expect(() => adapter.validateSetUp(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 

--- a/spec/Adapters/Auth/BaseCodeAdapter.spec.js
+++ b/spec/Adapters/Auth/BaseCodeAdapter.spec.js
@@ -173,10 +173,15 @@ describe('BaseAuthCodeAdapter', function () {
   });
 
   describe('validateUpdate', function () {
-    it('should return user id from authData', function () {
-      const authData = { id: 'validUserId' };
+    it('should return user id from authData with access_token', function () {
+      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
       const result = adapter.validateUpdate(authData);
       expect(result).toEqual({ id: 'validUserId' });
+    });
+
+    it('should throw if access_token is missing', function () {
+      const authData = { id: 'validUserId' };
+      expect(() => adapter.validateUpdate(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 });

--- a/spec/Adapters/Auth/BaseCodeAdapter.spec.js
+++ b/spec/Adapters/Auth/BaseCodeAdapter.spec.js
@@ -157,15 +157,10 @@ describe('BaseAuthCodeAdapter', function () {
   });
 
   describe('validateSetUp', function () {
-    it('should return user id from authData with access_token', function () {
-      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
+    it('should return user id from authData', function () {
+      const authData = { id: 'validUserId' };
       const result = adapter.validateSetUp(authData);
       expect(result).toEqual({ id: 'validUserId' });
-    });
-
-    it('should throw if access_token is missing', function () {
-      const authData = { id: 'validUserId' };
-      expect(() => adapter.validateSetUp(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 

--- a/spec/Adapters/Auth/BaseCodeAdapter.spec.js
+++ b/spec/Adapters/Auth/BaseCodeAdapter.spec.js
@@ -150,27 +150,17 @@ describe('BaseAuthCodeAdapter', function () {
 
   describe('validateLogin', function () {
     it('should return user id from authData', function () {
-      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
+      const authData = { id: 'validUserId' };
       const result = adapter.validateLogin(authData);
       expect(result).toEqual({ id: 'validUserId' });
-    });
-
-    it('should throw if access_token is missing', function () {
-      const authData = { id: 'validUserId' };
-      expect(() => adapter.validateLogin(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 
   describe('validateSetUp', function () {
     it('should return user id from authData', function () {
-      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
+      const authData = { id: 'validUserId' };
       const result = adapter.validateSetUp(authData);
       expect(result).toEqual({ id: 'validUserId' });
-    });
-
-    it('should throw if access_token is missing', function () {
-      const authData = { id: 'validUserId' };
-      expect(() => adapter.validateSetUp(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 
@@ -184,14 +174,9 @@ describe('BaseAuthCodeAdapter', function () {
 
   describe('validateUpdate', function () {
     it('should return user id from authData', function () {
-      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
+      const authData = { id: 'validUserId' };
       const result = adapter.validateUpdate(authData);
       expect(result).toEqual({ id: 'validUserId' });
-    });
-
-    it('should throw if access_token is missing', function () {
-      const authData = { id: 'validUserId' };
-      expect(() => adapter.validateUpdate(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 });

--- a/spec/Adapters/Auth/BaseCodeAdapter.spec.js
+++ b/spec/Adapters/Auth/BaseCodeAdapter.spec.js
@@ -150,17 +150,27 @@ describe('BaseAuthCodeAdapter', function () {
 
   describe('validateLogin', function () {
     it('should return user id from authData', function () {
-      const authData = { id: 'validUserId' };
+      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
       const result = adapter.validateLogin(authData);
       expect(result).toEqual({ id: 'validUserId' });
+    });
+
+    it('should throw if access_token is missing', function () {
+      const authData = { id: 'validUserId' };
+      expect(() => adapter.validateLogin(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 
   describe('validateSetUp', function () {
     it('should return user id from authData', function () {
-      const authData = { id: 'validUserId' };
+      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
       const result = adapter.validateSetUp(authData);
       expect(result).toEqual({ id: 'validUserId' });
+    });
+
+    it('should throw if access_token is missing', function () {
+      const authData = { id: 'validUserId' };
+      expect(() => adapter.validateSetUp(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 
@@ -174,9 +184,14 @@ describe('BaseAuthCodeAdapter', function () {
 
   describe('validateUpdate', function () {
     it('should return user id from authData', function () {
-      const authData = { id: 'validUserId' };
+      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
       const result = adapter.validateUpdate(authData);
       expect(result).toEqual({ id: 'validUserId' });
+    });
+
+    it('should throw if access_token is missing', function () {
+      const authData = { id: 'validUserId' };
+      expect(() => adapter.validateUpdate(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 });

--- a/spec/Adapters/Auth/BaseCodeAdapter.spec.js
+++ b/spec/Adapters/Auth/BaseCodeAdapter.spec.js
@@ -173,15 +173,10 @@ describe('BaseAuthCodeAdapter', function () {
   });
 
   describe('validateUpdate', function () {
-    it('should return user id from authData with access_token', function () {
-      const authData = { id: 'validUserId', access_token: 'validAccessToken' };
+    it('should return user id from authData', function () {
+      const authData = { id: 'validUserId' };
       const result = adapter.validateUpdate(authData);
       expect(result).toEqual({ id: 'validUserId' });
-    });
-
-    it('should throw if access_token is missing', function () {
-      const authData = { id: 'validUserId' };
-      expect(() => adapter.validateUpdate(authData)).toThrowError('TestAdapter code is required.');
     });
   });
 });

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1342,6 +1342,11 @@ describe('Auth Adapter features', () => {
     const mockUserId = 'gpgamesUser123';
     const mockAccessToken = 'mockAccessToken';
 
+    const otherAdapter = {
+      validateAppId: () => Promise.resolve(),
+      validateAuthData: () => Promise.resolve(),
+    };
+
     mockFetch([
       {
         url: 'https://oauth2.googleapis.com/token',
@@ -1367,14 +1372,16 @@ describe('Auth Adapter features', () => {
           clientId: 'testClientId',
           clientSecret: 'testClientSecret',
         },
+        otherAdapter,
       },
     });
 
-    // Sign up with gpgames code-based provider
+    // Sign up with gpgames code-based provider and a second provider
     const user = new Parse.User();
     await user.save({
       authData: {
         gpgames: { id: mockUserId, code: 'authCode123', redirect_uri: 'https://example.com/callback' },
+        otherAdapter: { id: 'other1' },
       },
     });
     const sessionToken = user.getSessionToken();
@@ -1382,15 +1389,18 @@ describe('Auth Adapter features', () => {
     // Reset fetch spy to track calls during unlink
     global.fetch.calls.reset();
 
-    // Unlink by setting authData to null; should not call beforeFind / external APIs
+    // Unlink gpgames by setting authData to null; should not call beforeFind / external APIs
     await user.save({ authData: { gpgames: null } }, { sessionToken });
 
     // No external HTTP calls should have been made during unlink
     expect(global.fetch.calls.count()).toBe(0);
 
-    // Verify provider was removed
+    // Verify gpgames was removed while the other provider remains
     const reloaded = await new Parse.Query(Parse.User).get(user.id, { useMasterKey: true });
-    expect((reloaded.get('authData') || {}).gpgames).toBeUndefined();
+    const authData = reloaded.get('authData');
+    expect(authData).toBeDefined();
+    expect(authData.gpgames).toBeUndefined();
+    expect(authData.otherAdapter).toEqual({ id: 'other1' });
   });
 
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1553,29 +1553,6 @@ describe('Auth Adapter features', () => {
     );
   });
 
-  it('should reject linking a new code-based provider with only an id and no credentials', async () => {
-    await reconfigureServer({
-      auth: {
-        gpgames: {
-          clientId: 'testClientId',
-          clientSecret: 'testClientSecret',
-        },
-      },
-    });
-
-    // Sign up with username/password (no gpgames linked)
-    const user = new Parse.User();
-    await user.signUp({ username: 'linkTestUser', password: 'password123' });
-    const sessionToken = user.getSessionToken();
-
-    // Attempt to link gpgames with only { id } — no code or access_token
-    await expectAsync(
-      user.save({ authData: { gpgames: { id: 'victimUserId' } } }, { sessionToken })
-    ).toBeRejectedWith(
-      jasmine.objectContaining({ message: jasmine.stringContaining('code is required') })
-    );
-  });
-
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1338,6 +1338,61 @@ describe('Auth Adapter features', () => {
     expect(user.get('authData')).toEqual({ adapterB: { id: 'test' } });
   });
 
+  it('should unlink a code-based auth provider without triggering adapter validation', async () => {
+    const mockUserId = 'gpgamesUser123';
+    const mockAccessToken = 'mockAccessToken';
+
+    mockFetch([
+      {
+        url: 'https://oauth2.googleapis.com/token',
+        method: 'POST',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ access_token: mockAccessToken }),
+        },
+      },
+      {
+        url: `https://www.googleapis.com/games/v1/players/${mockUserId}`,
+        method: 'GET',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ playerId: mockUserId }),
+        },
+      },
+    ]);
+
+    await reconfigureServer({
+      auth: {
+        gpgames: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+        },
+      },
+    });
+
+    // Sign up with gpgames code-based provider
+    const user = new Parse.User();
+    await user.save({
+      authData: {
+        gpgames: { id: mockUserId, code: 'authCode123', redirect_uri: 'https://example.com/callback' },
+      },
+    });
+    const sessionToken = user.getSessionToken();
+
+    // Reset fetch spy to track calls during unlink
+    global.fetch.calls.reset();
+
+    // Unlink by setting authData to null; should not call beforeFind / external APIs
+    await user.save({ authData: { gpgames: null } }, { sessionToken });
+
+    // No external HTTP calls should have been made during unlink
+    expect(global.fetch.calls.count()).toBe(0);
+
+    // Verify provider was removed
+    const reloaded = await new Parse.Query(Parse.User).get(user.id, { useMasterKey: true });
+    expect((reloaded.get('authData') || {}).gpgames).toBeUndefined();
+  });
+
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1376,28 +1376,33 @@ describe('Auth Adapter features', () => {
       },
     });
 
-    // Sign up with gpgames code-based provider and a second provider
+    // Sign up with username/password, then link providers
     const user = new Parse.User();
+    await user.signUp({ username: 'gpgamesTestUser', password: 'password123' });
+
+    // Link gpgames code-based provider
     await user.save({
       authData: {
         gpgames: { id: mockUserId, code: 'authCode123', redirect_uri: 'https://example.com/callback' },
-        otherAdapter: { id: 'other1' },
       },
     });
-    const sessionToken = user.getSessionToken();
+
+    // Link a second provider
+    await user.save({ authData: { otherAdapter: { id: 'other1' } } });
 
     // Reset fetch spy to track calls during unlink
     global.fetch.calls.reset();
 
     // Unlink gpgames by setting authData to null; should not call beforeFind / external APIs
+    const sessionToken = user.getSessionToken();
     await user.save({ authData: { gpgames: null } }, { sessionToken });
 
     // No external HTTP calls should have been made during unlink
     expect(global.fetch.calls.count()).toBe(0);
 
     // Verify gpgames was removed while the other provider remains
-    const reloaded = await new Parse.Query(Parse.User).get(user.id, { useMasterKey: true });
-    const authData = reloaded.get('authData');
+    await user.fetch({ useMasterKey: true });
+    const authData = user.get('authData');
     expect(authData).toBeDefined();
     expect(authData.gpgames).toBeUndefined();
     expect(authData.otherAdapter).toEqual({ id: 'other1' });

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1553,6 +1553,29 @@ describe('Auth Adapter features', () => {
     );
   });
 
+  it('should reject linking a new code-based provider with only an id and no credentials', async () => {
+    await reconfigureServer({
+      auth: {
+        gpgames: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+        },
+      },
+    });
+
+    // Sign up with username/password (no gpgames linked)
+    const user = new Parse.User();
+    await user.signUp({ username: 'linkTestUser', password: 'password123' });
+    const sessionToken = user.getSessionToken();
+
+    // Attempt to link gpgames with only { id } — no code or access_token
+    await expectAsync(
+      user.save({ authData: { gpgames: { id: 'victimUserId' } } }, { sessionToken })
+    ).toBeRejectedWith(
+      jasmine.objectContaining({ message: jasmine.stringContaining('code is required') })
+    );
+  });
+
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1504,55 +1504,6 @@ describe('Auth Adapter features', () => {
     expect(finalAuthData.instagram.id).toBe(instagramUserId);
   });
 
-  it('should reject updating a code-based provider with only an id and no credentials', async () => {
-    const mockUserId = 'gpgamesUser123';
-    const mockAccessToken = 'mockAccessToken';
-
-    mockFetch([
-      {
-        url: 'https://oauth2.googleapis.com/token',
-        method: 'POST',
-        response: {
-          ok: true,
-          json: () => Promise.resolve({ access_token: mockAccessToken }),
-        },
-      },
-      {
-        url: `https://www.googleapis.com/games/v1/players/${mockUserId}`,
-        method: 'GET',
-        response: {
-          ok: true,
-          json: () => Promise.resolve({ playerId: mockUserId }),
-        },
-      },
-    ]);
-
-    await reconfigureServer({
-      auth: {
-        gpgames: {
-          clientId: 'testClientId',
-          clientSecret: 'testClientSecret',
-        },
-      },
-    });
-
-    // Sign up and link gpgames with valid credentials
-    const user = new Parse.User();
-    await user.save({
-      authData: {
-        gpgames: { id: mockUserId, code: 'authCode123', redirect_uri: 'https://example.com/callback' },
-      },
-    });
-    const sessionToken = user.getSessionToken();
-
-    // Attempt to change gpgames id without credentials (no code or access_token)
-    await expectAsync(
-      user.save({ authData: { gpgames: { id: 'differentUserId' } } }, { sessionToken })
-    ).toBeRejectedWith(
-      jasmine.objectContaining({ message: jasmine.stringContaining('code is required') })
-    );
-  });
-
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1504,6 +1504,55 @@ describe('Auth Adapter features', () => {
     expect(finalAuthData.instagram.id).toBe(instagramUserId);
   });
 
+  it('should reject updating a code-based provider with only an id and no credentials', async () => {
+    const mockUserId = 'gpgamesUser123';
+    const mockAccessToken = 'mockAccessToken';
+
+    mockFetch([
+      {
+        url: 'https://oauth2.googleapis.com/token',
+        method: 'POST',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ access_token: mockAccessToken }),
+        },
+      },
+      {
+        url: `https://www.googleapis.com/games/v1/players/${mockUserId}`,
+        method: 'GET',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ playerId: mockUserId }),
+        },
+      },
+    ]);
+
+    await reconfigureServer({
+      auth: {
+        gpgames: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+        },
+      },
+    });
+
+    // Sign up and link gpgames with valid credentials
+    const user = new Parse.User();
+    await user.save({
+      authData: {
+        gpgames: { id: mockUserId, code: 'authCode123', redirect_uri: 'https://example.com/callback' },
+      },
+    });
+    const sessionToken = user.getSessionToken();
+
+    // Attempt to change gpgames id without credentials (no code or access_token)
+    await expectAsync(
+      user.save({ authData: { gpgames: { id: 'differentUserId' } } }, { sessionToken })
+    ).toBeRejectedWith(
+      jasmine.objectContaining({ message: jasmine.stringContaining('code is required') })
+    );
+  });
+
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1408,7 +1408,7 @@ describe('Auth Adapter features', () => {
     expect(authData.otherAdapter).toEqual({ id: 'other1' });
   });
 
-  fit('should unlink one code-based provider while echoing back another unchanged', async () => {
+  it('should unlink one code-based provider while echoing back another unchanged', async () => {
     const gpgamesUserId = 'gpgamesUser1';
     const instagramUserId = 'igUser1';
 

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1408,6 +1408,102 @@ describe('Auth Adapter features', () => {
     expect(authData.otherAdapter).toEqual({ id: 'other1' });
   });
 
+  fit('should unlink one code-based provider while echoing back another unchanged', async () => {
+    const gpgamesUserId = 'gpgamesUser1';
+    const instagramUserId = 'igUser1';
+
+    // Mock gpgames API for initial login
+    mockFetch([
+      {
+        url: 'https://oauth2.googleapis.com/token',
+        method: 'POST',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'gpgamesToken' }),
+        },
+      },
+      {
+        url: `https://www.googleapis.com/games/v1/players/${gpgamesUserId}`,
+        method: 'GET',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ playerId: gpgamesUserId }),
+        },
+      },
+    ]);
+
+    await reconfigureServer({
+      auth: {
+        gpgames: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+        },
+        instagram: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+          redirectUri: 'https://example.com/callback',
+        },
+      },
+    });
+
+    // Login with gpgames
+    const user = await Parse.User.logInWith('gpgames', {
+      authData: { id: gpgamesUserId, code: 'gpCode1' },
+    });
+    const sessionToken = user.getSessionToken();
+
+    // Mock instagram API for linking
+    mockFetch([
+      {
+        url: 'https://api.instagram.com/oauth/access_token',
+        method: 'POST',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'igToken' }),
+        },
+      },
+      {
+        url: `https://graph.instagram.com/me?fields=id&access_token=igToken`,
+        method: 'GET',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ id: instagramUserId }),
+        },
+      },
+    ]);
+
+    // Link instagram as second provider
+    await user.save(
+      { authData: { instagram: { id: instagramUserId, code: 'igCode1' } } },
+      { sessionToken }
+    );
+
+    // Fetch to get current authData (afterFind strips credentials, leaving only { id })
+    await user.fetch({ sessionToken });
+    const currentAuthData = user.get('authData');
+    expect(currentAuthData.gpgames).toBeDefined();
+    expect(currentAuthData.instagram).toBeDefined();
+
+    // Reset fetch spy
+    global.fetch.calls.reset();
+
+    // Unlink gpgames while echoing back instagram unchanged — the common client pattern:
+    // fetch current state, spread it, set the one to unlink to null
+    user.set('authData', { ...currentAuthData, gpgames: null });
+    await user.save(null, { sessionToken });
+
+    // No external HTTP calls during unlink (no code exchange for unchanged instagram)
+    expect(global.fetch.calls.count()).toBe(0);
+
+    // Verify gpgames removed, instagram preserved
+    await user.fetch({ useMasterKey: true });
+    const finalAuthData = user.get('authData');
+    expect(finalAuthData).toBeDefined();
+    expect(finalAuthData.gpgames).toBeUndefined();
+    expect(finalAuthData.instagram).toBeDefined();
+    expect(finalAuthData.instagram.id).toBe(instagramUserId);
+  });
+
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1504,6 +1504,78 @@ describe('Auth Adapter features', () => {
     expect(finalAuthData.instagram.id).toBe(instagramUserId);
   });
 
+  it('should reject changing an existing code-based provider id without credentials', async () => {
+    const mockUserId = 'gpgamesUser123';
+    const mockAccessToken = 'mockAccessToken';
+
+    mockFetch([
+      {
+        url: 'https://oauth2.googleapis.com/token',
+        method: 'POST',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ access_token: mockAccessToken }),
+        },
+      },
+      {
+        url: `https://www.googleapis.com/games/v1/players/${mockUserId}`,
+        method: 'GET',
+        response: {
+          ok: true,
+          json: () => Promise.resolve({ playerId: mockUserId }),
+        },
+      },
+    ]);
+
+    await reconfigureServer({
+      auth: {
+        gpgames: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+        },
+      },
+    });
+
+    // Sign up and link gpgames with valid credentials
+    const user = new Parse.User();
+    await user.save({
+      authData: {
+        gpgames: { id: mockUserId, code: 'authCode123', redirect_uri: 'https://example.com/callback' },
+      },
+    });
+    const sessionToken = user.getSessionToken();
+
+    // Attempt to change gpgames id without credentials (no code or access_token)
+    await expectAsync(
+      user.save({ authData: { gpgames: { id: 'differentUserId' } } }, { sessionToken })
+    ).toBeRejectedWith(
+      jasmine.objectContaining({ message: jasmine.stringContaining('code is required') })
+    );
+  });
+
+  it('should reject linking a new code-based provider with only an id and no credentials', async () => {
+    await reconfigureServer({
+      auth: {
+        gpgames: {
+          clientId: 'testClientId',
+          clientSecret: 'testClientSecret',
+        },
+      },
+    });
+
+    // Sign up with username/password (no gpgames linked)
+    const user = new Parse.User();
+    await user.signUp({ username: 'linkTestUser', password: 'password123' });
+    const sessionToken = user.getSessionToken();
+
+    // Attempt to link gpgames with only { id } — no code or access_token
+    await expectAsync(
+      user.save({ authData: { gpgames: { id: 'victimUserId' } } }, { sessionToken })
+    ).toBeRejectedWith(
+      jasmine.objectContaining({ message: jasmine.stringContaining('code is required') })
+    );
+  });
+
   it('should handle multiple providers: add one while another remains unchanged (code-based)', async () => {
     await reconfigureServer({
       auth: {

--- a/spec/AuthenticationAdaptersV2.spec.js
+++ b/spec/AuthenticationAdaptersV2.spec.js
@@ -1448,7 +1448,7 @@ describe('Auth Adapter features', () => {
 
     // Login with gpgames
     const user = await Parse.User.logInWith('gpgames', {
-      authData: { id: gpgamesUserId, code: 'gpCode1' },
+      authData: { id: gpgamesUserId, code: 'gpCode1', redirect_uri: 'https://example.com/callback' },
     });
     const sessionToken = user.getSessionToken();
 

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -73,8 +73,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on login. `beforeFind` always runs first and validates
-   * credentials, so no additional credential check is needed here.
+   * Validates auth data on login. In the standard auth flows (login, signup,
+   * update), `beforeFind` runs first and validates credentials, so no
+   * additional credential check is needed here.
    */
   validateLogin(authData) {
     return {
@@ -84,8 +85,8 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
 
   /**
    * Validates auth data on first setup or when linking a new provider.
-   * `beforeFind` always runs first and validates credentials, so no additional
-   * credential check is needed here.
+   * In the standard auth flows, `beforeFind` runs first and validates
+   * credentials, so no additional credential check is needed here.
    */
   validateSetUp(authData) {
     return {
@@ -103,10 +104,10 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on update. `beforeFind` runs first for any changed
-   * auth data and validates credentials, so no additional credential check
-   * is needed here. Unchanged (echoed-back) data skips both `beforeFind`
-   * and validation entirely.
+   * Validates auth data on update. In the standard auth flows, `beforeFind`
+   * runs first for any changed auth data and validates credentials, so no
+   * additional credential check is needed here. Unchanged (echoed-back) data
+   * skips both `beforeFind` and validation entirely.
    */
   validateUpdate(authData) {
     return {

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -107,9 +107,12 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
    * authData has no credentials (e.g. echoed-back `{ id }` from `afterFind`).
    * Non-mutated echoed-back data is not validated at all. Mutated data without
    * credentials (e.g. a changed `id`) will reach this method without prior
-   * `beforeFind` validation.
+   * `beforeFind` validation, so an explicit credential check is required here.
    */
   validateUpdate(authData) {
+    if (!authData?.access_token) {
+      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
+    }
     return {
       id: authData.id,
     }

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -73,10 +73,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on login. No credential check is needed as `beforeFind`
-   * already validated credentials before this method is called. `beforeFind`
-   * exchanges the auth code for an access_token and verifies user identity; it
-   * rejects requests with missing credentials before these methods are called.
+   * Validates auth data on login. On login, `beforeFind` always runs first and
+   * validates credentials (exchanges code for access_token, verifies identity),
+   * so no additional credential check is needed here.
    */
   validateLogin(authData) {
     return {
@@ -85,10 +84,8 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on first setup. No credential check is needed as `beforeFind`
-   * already validated credentials before this method is called. `beforeFind`
-   * exchanges the auth code for an access_token and verifies user identity; it
-   * rejects requests with missing credentials before these methods are called.
+   * Validates auth data on first setup. On signup, `beforeFind` always runs first
+   * and validates credentials, so no additional credential check is needed here.
    */
   validateSetUp(authData) {
     return {
@@ -106,10 +103,11 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on update. No credential check is needed as `beforeFind`
-   * already validated credentials before this method is called. `beforeFind`
-   * exchanges the auth code for an access_token and verifies user identity; it
-   * rejects requests with missing credentials before these methods are called.
+   * Validates auth data on update. On update, `beforeFind` is skipped when
+   * authData has no credentials (e.g. echoed-back `{ id }` from `afterFind`).
+   * Non-mutated echoed-back data is not validated at all. Mutated data without
+   * credentials (e.g. a changed `id`) will reach this method without prior
+   * `beforeFind` validation.
    */
   validateUpdate(authData) {
     return {

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -73,9 +73,8 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on login. On login, `beforeFind` always runs first and
-   * validates credentials (exchanges code for access_token, verifies identity),
-   * so no additional credential check is needed here.
+   * Validates auth data on login. `beforeFind` always runs first and validates
+   * credentials, so no additional credential check is needed here.
    */
   validateLogin(authData) {
     return {
@@ -84,8 +83,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on first setup. On signup, `beforeFind` always runs first
-   * and validates credentials, so no additional credential check is needed here.
+   * Validates auth data on first setup or when linking a new provider.
+   * `beforeFind` always runs first and validates credentials, so no additional
+   * credential check is needed here.
    */
   validateSetUp(authData) {
     return {
@@ -103,11 +103,10 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   /**
-   * Validates auth data on update. On update, `beforeFind` is skipped when
-   * authData has no credentials (e.g. echoed-back `{ id }` from `afterFind`).
-   * Non-mutated echoed-back data is not validated at all. Mutated data without
-   * credentials (e.g. a changed `id`) will reach this method without prior
-   * `beforeFind` validation.
+   * Validates auth data on update. `beforeFind` runs first for any changed
+   * auth data and validates credentials, so no additional credential check
+   * is needed here. Unchanged (echoed-back) data skips both `beforeFind`
+   * and validation entirely.
    */
   validateUpdate(authData) {
     return {

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -72,24 +72,45 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
     throw new Error('getAccessTokenFromCode is not implemented');
   }
 
+  /**
+   * Validates auth data on login. No credential check is needed as `beforeFind`
+   * already validated credentials before this method is called. `beforeFind`
+   * exchanges the auth code for an access_token and verifies user identity; it
+   * rejects requests with missing credentials before these methods are called.
+   */
   validateLogin(authData) {
     return {
       id: authData.id,
     }
   }
 
+  /**
+   * Validates auth data on first setup. No credential check is needed as `beforeFind`
+   * already validated credentials before this method is called. `beforeFind`
+   * exchanges the auth code for an access_token and verifies user identity; it
+   * rejects requests with missing credentials before these methods are called.
+   */
   validateSetUp(authData) {
     return {
       id: authData.id,
     }
   }
 
+  /**
+   * Returns the auth data to expose to the client after a query.
+   */
   afterFind(authData) {
     return {
       id: authData.id,
     }
   }
 
+  /**
+   * Validates auth data on update. No credential check is needed as `beforeFind`
+   * already validated credentials before this method is called. `beforeFind`
+   * exchanges the auth code for an access_token and verifies user identity; it
+   * rejects requests with missing credentials before these methods are called.
+   */
   validateUpdate(authData) {
     return {
       id: authData.id,

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -107,12 +107,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
    * authData has no credentials (e.g. echoed-back `{ id }` from `afterFind`).
    * Non-mutated echoed-back data is not validated at all. Mutated data without
    * credentials (e.g. a changed `id`) will reach this method without prior
-   * `beforeFind` validation, so an explicit credential check is required here.
+   * `beforeFind` validation.
    */
   validateUpdate(authData) {
-    if (!authData?.access_token) {
-      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
-    }
     return {
       id: authData.id,
     }

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -85,9 +85,14 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
 
   /**
    * Validates auth data on first setup. On signup, `beforeFind` always runs first
-   * and validates credentials, so no additional credential check is needed here.
+   * and validates credentials. On update (linking a new provider), `beforeFind`
+   * may be skipped when authData has no credentials, so an explicit credential
+   * check is required here.
    */
   validateSetUp(authData) {
+    if (!authData?.access_token) {
+      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
+    }
     return {
       id: authData.id,
     }

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -29,13 +29,6 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   async beforeFind(authData) {
-    // If id is already resolved and no credentials are provided, there's nothing
-    // to process. This handles echoed-back authData from afterFind during updates,
-    // e.g. when a client fetches authData { id: '...' } and sends it back unchanged.
-    if (authData?.id && !authData?.code && !authData?.access_token) {
-      return;
-    }
-
     if (this.enableInsecureAuth && !authData?.code) {
       if (!authData?.access_token) {
         throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, `${this.adapterName} auth is invalid for this user.`);
@@ -80,14 +73,18 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   validateLogin(authData) {
-    // User validation is already done in beforeFind
+    if (!authData?.access_token) {
+      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
+    }
     return {
       id: authData.id,
     }
   }
 
   validateSetUp(authData) {
-    // User validation is already done in beforeFind
+    if (!authData?.access_token) {
+      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
+    }
     return {
       id: authData.id,
     }
@@ -100,7 +97,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   validateUpdate(authData) {
-    // User validation is already done in beforeFind
+    if (!authData?.access_token) {
+      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
+    }
     return {
       id: authData.id,
     }

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -29,6 +29,13 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   async beforeFind(authData) {
+    // If id is already resolved and no credentials are provided, there's nothing
+    // to process. This handles echoed-back authData from afterFind during updates,
+    // e.g. when a client fetches authData { id: '...' } and sends it back unchanged.
+    if (authData?.id && !authData?.code && !authData?.access_token) {
+      return;
+    }
+
     if (this.enableInsecureAuth && !authData?.code) {
       if (!authData?.access_token) {
         throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, `${this.adapterName} auth is invalid for this user.`);

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -85,14 +85,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
 
   /**
    * Validates auth data on first setup. On signup, `beforeFind` always runs first
-   * and validates credentials. On update (linking a new provider), `beforeFind`
-   * may be skipped when authData has no credentials, so an explicit credential
-   * check is required here.
+   * and validates credentials, so no additional credential check is needed here.
    */
   validateSetUp(authData) {
-    if (!authData?.access_token) {
-      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
-    }
     return {
       id: authData.id,
     }

--- a/src/Adapters/Auth/BaseCodeAuthAdapter.js
+++ b/src/Adapters/Auth/BaseCodeAuthAdapter.js
@@ -73,18 +73,12 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   validateLogin(authData) {
-    if (!authData?.access_token) {
-      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
-    }
     return {
       id: authData.id,
     }
   }
 
   validateSetUp(authData) {
-    if (!authData?.access_token) {
-      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
-    }
     return {
       id: authData.id,
     }
@@ -97,13 +91,9 @@ export default class BaseAuthCodeAdapter extends AuthAdapter {
   }
 
   validateUpdate(authData) {
-    if (!authData?.access_token) {
-      throw new Parse.Error(Parse.Error.VALIDATION_ERROR, `${this.adapterName} code is required.`);
-    }
     return {
       id: authData.id,
     }
-
   }
 
   parseResponseData(data) {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -417,7 +417,7 @@ Auth.prototype._getAllRolesNamesForRoleIds = function (roleIDs, names = [], quer
     });
 };
 
-const findUsersWithAuthData = async (config, authData, beforeFind, isUpdate) => {
+const findUsersWithAuthData = async (config, authData, beforeFind, currentUserAuthData) => {
   const providers = Object.keys(authData);
 
   const queries = await Promise.all(
@@ -429,16 +429,18 @@ const findUsersWithAuthData = async (config, authData, beforeFind, isUpdate) => 
         return null;
       }
 
-      const providerKeys = Object.keys(providerAuthData || {});
-      const hasCredentials = providerKeys.some(key => key !== 'id');
+      // Skip beforeFind only when incoming data is confirmed unchanged from stored data.
+      // This handles echoed-back authData from afterFind (e.g. client sends back { id: 'x' }
+      // alongside a provider unlink). On login/signup, currentUserAuthData is undefined so
+      // beforeFind always runs, preserving it as the security gate for missing credentials.
+      const storedProviderData = currentUserAuthData?.[provider];
+      const incomingKeys = Object.keys(providerAuthData || {});
+      const isUnchanged = storedProviderData && incomingKeys.length > 0 &&
+        !incomingKeys.some(key => !isDeepStrictEqual(providerAuthData[key], storedProviderData[key]));
 
-      // On update, skip beforeFind for echoed-back authData (no credentials to process).
-      // On login/signup, always call beforeFind so it can reject missing credentials.
       const adapter = config.authDataManager.getValidatorForProvider(provider)?.adapter;
-      if (beforeFind && typeof adapter?.beforeFind === 'function') {
-        if (hasCredentials || !isUpdate) {
-          await adapter.beforeFind(providerAuthData);
-        }
+      if (beforeFind && typeof adapter?.beforeFind === 'function' && !isUnchanged) {
+        await adapter.beforeFind(providerAuthData);
       }
 
       if (!providerAuthData?.id) {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -417,7 +417,7 @@ Auth.prototype._getAllRolesNamesForRoleIds = function (roleIDs, names = [], quer
     });
 };
 
-const findUsersWithAuthData = async (config, authData, beforeFind) => {
+const findUsersWithAuthData = async (config, authData, beforeFind, isUpdate) => {
   const providers = Object.keys(authData);
 
   const queries = await Promise.all(
@@ -429,15 +429,16 @@ const findUsersWithAuthData = async (config, authData, beforeFind) => {
         return null;
       }
 
-      // Skip beforeFind when authData has no credentials to process (only id or empty).
-      // This handles echoed-back authData from afterFind during updates, e.g. when a
-      // client sends back unchanged provider data alongside a provider unlink.
       const providerKeys = Object.keys(providerAuthData || {});
       const hasCredentials = providerKeys.some(key => key !== 'id');
 
+      // On update, skip beforeFind for echoed-back authData (no credentials to process).
+      // On login/signup, always call beforeFind so it can reject missing credentials.
       const adapter = config.authDataManager.getValidatorForProvider(provider)?.adapter;
-      if (beforeFind && hasCredentials && typeof adapter?.beforeFind === 'function') {
-        await adapter.beforeFind(providerAuthData);
+      if (beforeFind && typeof adapter?.beforeFind === 'function') {
+        if (hasCredentials || !isUpdate) {
+          await adapter.beforeFind(providerAuthData);
+        }
       }
 
       if (!providerAuthData?.id) {

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -424,6 +424,11 @@ const findUsersWithAuthData = async (config, authData, beforeFind) => {
     providers.map(async provider => {
       const providerAuthData = authData[provider];
 
+      // Skip providers being unlinked (null value)
+      if (providerAuthData === null) {
+        return null;
+      }
+
       const adapter = config.authDataManager.getValidatorForProvider(provider)?.adapter;
       if (beforeFind && typeof adapter?.beforeFind === 'function') {
         await adapter.beforeFind(providerAuthData);

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -429,8 +429,14 @@ const findUsersWithAuthData = async (config, authData, beforeFind) => {
         return null;
       }
 
+      // Skip beforeFind when authData has no credentials to process (only id or empty).
+      // This handles echoed-back authData from afterFind during updates, e.g. when a
+      // client sends back unchanged provider data alongside a provider unlink.
+      const providerKeys = Object.keys(providerAuthData || {});
+      const hasCredentials = providerKeys.some(key => key !== 'id');
+
       const adapter = config.authDataManager.getValidatorForProvider(provider)?.adapter;
-      if (beforeFind && typeof adapter?.beforeFind === 'function') {
+      if (beforeFind && hasCredentials && typeof adapter?.beforeFind === 'function') {
         await adapter.beforeFind(providerAuthData);
       }
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -541,7 +541,8 @@ RestWrite.prototype.ensureUniqueAuthDataId = async function () {
 };
 
 RestWrite.prototype.handleAuthData = async function (authData) {
-  const r = await Auth.findUsersWithAuthData(this.config, authData, true);
+  const isUpdate = !!this.query;
+  const r = await Auth.findUsersWithAuthData(this.config, authData, true, isUpdate);
   const results = this.filteredObjectsByACL(r);
 
   const userId = this.getUserId();

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -541,8 +541,15 @@ RestWrite.prototype.ensureUniqueAuthDataId = async function () {
 };
 
 RestWrite.prototype.handleAuthData = async function (authData) {
-  const isUpdate = !!this.query;
-  const r = await Auth.findUsersWithAuthData(this.config, authData, true, isUpdate);
+  let currentUserAuthData;
+  if (this.query?.objectId) {
+    const [currentUser] = await this.config.database.find(
+      '_User',
+      { objectId: this.query.objectId }
+    );
+    currentUserAuthData = currentUser?.authData;
+  }
+  const r = await Auth.findUsersWithAuthData(this.config, authData, true, currentUserAuthData);
   const results = this.filteredObjectsByACL(r);
 
   const userId = this.getUserId();


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Unlinking auth provider triggers auth data validation.

Closes: https://github.com/parse-community/parse-server/pull/9856
Closes: https://github.com/parse-community/parse-server/issues/9855

## Approach

Without the fix, the added test fails:

```
1) Auth Adapter features should unlink a code-based auth provider without triggering adapter validation
  Message:
    Error: gpgames code is required.
  Stack:
    error properties: Object({ code: 142 })
        at handleError (parse-server/node_modules/parse/lib/node/RESTController.js:327:15)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

This is a significant simplification over https://github.com/parse-community/parse-server/pull/9856.

The change in `src/Adapters/Storage/Postgres/PostgresStorageAdapter.js` also fixes a bug for Postgres (unrelated to the issue reported in #9855, but apparent with the fix implemented here). The change fixes unlinking auth data in Postgres by properly removing JSON keys instead of setting them to null. Before, when auth data had `__op: 'Delete'`, it set the value to `null` in the JSONB field using json_object_set_key — the key remained with a `null` value. After, it uses a new `generateRemove` helper that uses Postgres's operator (jsonb - key) to actually remove the key from the JSONB object. Both explicit `__op: 'Delete'` and `null` values trigger key removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for unlinking code-based authentication providers.

* **Tests**
  * Added tests for unlink flows in multi-provider scenarios, verifying safe removal without external network calls and preserving other providers.

* **Improvements**
  * Unlink operations no longer trigger external validation or network calls.
  * Auth data updates correctly remove provider credentials and avoid unnecessary validation when provider data is unchanged.

* **Documentation**
  * Clarified adapter validation and after-find behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->