### PR TITLE
fix: `Parse.Query.select('authData')` for `_User` class doesn't return auth data

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1395,6 +1395,19 @@ describe('Parse.User testing', () => {
     });
   });
 
+  it('should return authData when select authData with masterKey', async () => {
+    const provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    const user = await Parse.User._logInWith('facebook');
+    const query = new Parse.Query(Parse.User);
+    query.select('authData');
+    const result = await query.get(user.id, { useMasterKey: true });
+    expect(result.get('authData')).toBeDefined();
+    expect(result.get('authData').facebook).toBeDefined();
+    expect(result.get('authData').facebook.id).toBe('8675309');
+    expect(result.get('authData').facebook.access_token).toBe('jenny');
+  });
+
   it('only creates a single session for an installation / user pair (#2885)', async done => {
     Parse.Object.disableSingleInstance();
     const provider = getMockFacebookProvider();

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -264,7 +264,7 @@ module.exports = function (authOptions = {}, enableAnonymousUsers = true) {
     return [...allProviders].filter(provider => {
       try {
         return !!loadAuthAdapter(provider, authOptions);
-      } catch (e) {
+      } catch {
         return false;
       }
     });

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -254,8 +254,25 @@ module.exports = function (authOptions = {}, enableAnonymousUsers = true) {
     );
   };
 
+  // Returns the list of auth provider names that have a valid adapter configured.
+  // This includes both built-in providers and custom providers from authOptions.
+  const getProviders = function () {
+    const allProviders = new Set([...Object.keys(providers), ...Object.keys(authOptions)]);
+    if (!_enableAnonymousUsers) {
+      allProviders.delete('anonymous');
+    }
+    return [...allProviders].filter(provider => {
+      try {
+        return !!loadAuthAdapter(provider, authOptions);
+      } catch (e) {
+        return false;
+      }
+    });
+  };
+
   return Object.freeze({
     getValidatorForProvider,
+    getProviders,
     setEnableAnonymousUsers,
     runAfterFind,
   });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -751,12 +751,17 @@ _UnsafeRestQuery.prototype.runFind = async function (options = {}) {
     findOptions.keys = this.keys.map(key => {
       return key.split('.')[0];
     });
-    // When selecting authData on _User, also add the internal auth data fields
-    // (e.g. _auth_data_facebook) for each configured auth provider. In MongoDB,
-    // authData is stored as individual _auth_data_<provider> fields, so the
-    // projection for 'authData' alone won't match them. Adding both ensures it
-    // works across all database adapters: Mongo uses _auth_data_* fields,
-    // Postgres uses the authData column directly.
+    // When selecting `authData` on `_User`, also add the internal auth data fields
+    // (e.g. `_auth_data_facebook`) for each configured auth provider. In MongoDB,
+    // `authData` is stored as individual `_auth_data_<provider>` fields, so the
+    // projection for `authData` alone won't match them. Adding both ensures it
+    // works across all database adapters: Mongo uses `_auth_data_*` fields,
+    // Postgres uses the `authData` column directly.
+    //
+    // Note: When selecting `authData`, only auth data of currently configured
+    // providers is returned. Auth data entries of providers that are no longer
+    // configured won't be included. To return all auth data regardless of the
+    // provider configuration, do not use `authData` as a selected key.
     if (this.className === '_User' && findOptions.keys.includes('authData')) {
       const providers = this.config.authDataManager.getProviders();
       for (const provider of providers) {

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -751,6 +751,21 @@ _UnsafeRestQuery.prototype.runFind = async function (options = {}) {
     findOptions.keys = this.keys.map(key => {
       return key.split('.')[0];
     });
+    // When selecting authData on _User, also add the internal auth data fields
+    // (e.g. _auth_data_facebook) for each configured auth provider. In MongoDB,
+    // authData is stored as individual _auth_data_<provider> fields, so the
+    // projection for 'authData' alone won't match them. Adding both ensures it
+    // works across all database adapters: Mongo uses _auth_data_* fields,
+    // Postgres uses the authData column directly.
+    if (this.className === '_User' && findOptions.keys.includes('authData')) {
+      const providers = this.config.authDataManager.getProviders();
+      for (const provider of providers) {
+        const key = `_auth_data_${provider}`;
+        if (!findOptions.keys.includes(key)) {
+          findOptions.keys.push(key);
+        }
+      }
+    }
   }
   if (options.op) {
     findOptions.op = options.op;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

`Parse.Query.select('authData')` for `_User` class doesn't return auth data. The reason is that the `authData` field is synthesized and actually stored as `_auth_data_<PROVIDER>` in the `_User` obj. So setting `authData` as selected key for MongoDB won't find a field of such name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve a user’s authentication data when explicitly selected in queries using the master key.
  * Add a function to list configured authentication providers (built-in and custom).

* **Tests**
  * Added a test verifying retrieval of authData via master-key queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->