### PR TITLE
fix: Incorrect dependency chain of `Parse` uses browser build instead of Node build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@graphql-tools/schema": "10.0.23",
         "@graphql-tools/utils": "10.8.6",
         "@parse/fs-files-adapter": "3.0.0",
-        "@parse/push-adapter": "8.3.0",
+        "@parse/push-adapter": "8.3.1",
         "bcryptjs": "3.0.3",
         "commander": "14.0.3",
         "cors": "2.8.6",
@@ -4155,9 +4155,9 @@
       }
     },
     "node_modules/@parse/push-adapter": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.3.0.tgz",
-      "integrity": "sha512-snHVH0j5pqleU3uBUjHCzTR1ex8FFnAaDbKX3Bz+L6w2mLT2Zio2e7fxxrDCorluVBVJvorSsSjgZQsWCXL+Cg==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.3.1.tgz",
+      "integrity": "sha512-UOkL0bTOtUx4R866XtBwGGYvkNLQrQPrPWC4uzpbd9vR8tbfYIQQvBDT7eg58GryLb4EG+NOP8enm/VkhbwMVw==",
       "license": "MIT",
       "dependencies": {
         "@parse/node-apn": "7.1.0",
@@ -25584,9 +25584,9 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.3.0.tgz",
-      "integrity": "sha512-snHVH0j5pqleU3uBUjHCzTR1ex8FFnAaDbKX3Bz+L6w2mLT2Zio2e7fxxrDCorluVBVJvorSsSjgZQsWCXL+Cg==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.3.1.tgz",
+      "integrity": "sha512-UOkL0bTOtUx4R866XtBwGGYvkNLQrQPrPWC4uzpbd9vR8tbfYIQQvBDT7eg58GryLb4EG+NOP8enm/VkhbwMVw==",
       "requires": {
         "@parse/node-apn": "7.1.0",
         "expo-server-sdk": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@graphql-tools/schema": "10.0.23",
     "@graphql-tools/utils": "10.8.6",
     "@parse/fs-files-adapter": "3.0.0",
-    "@parse/push-adapter": "8.3.0",
+    "@parse/push-adapter": "8.3.1",
     "bcryptjs": "3.0.3",
     "commander": "14.0.3",
     "cors": "2.8.6",

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -3,7 +3,7 @@ import { randomHexString } from '../cryptoUtils';
 import AdaptableController from './AdaptableController';
 import { validateFilename, FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path from 'path';
-const Parse = require('parse').Parse;
+const Parse = require('parse/node').Parse;
 
 const legacyFilesRegex = new RegExp(
   '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-.*'


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Incorrect dependency chain of `Parse` uses browser build instead of Node build. This causes all kinds of difficult to debug bugs because `Parse` builds for browser and Node are imported, may or not be initialized and overwrite each other due to a globally pinned `Parse` object. The fundamental fix will be https://github.com/parse-community/parse-server/issues/8787 in the future. This PR fixed an immediate issue that causes CI fails and can cause production code issues. Part of the fix is the update to `@parse/push-adapter` 8.3.1 which also imports the browser build of `Parse` instead of the Node build. This and the import in Parse Server's FilesController produce this strange interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->