### PR TITLE
fix: File creation and deletion bypasses `readOnlyMasterKey` write restriction (GHSA-xfh7-phr7-gr2x)

### DIFF
--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -1307,6 +1307,63 @@ describe('read-only masterKey', () => {
     });
     expect(Array.isArray(res.data)).toBe(true);
   });
+
+  it('should throw when trying to delete a file with readOnlyMasterKey', async () => {
+    // Create a file with the real master key
+    const uploadRes = await request({
+      method: 'POST',
+      url: `${Parse.serverURL}/files/readonly-delete-test.txt`,
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': Parse.masterKey,
+        'Content-Type': 'text/plain',
+      },
+      body: 'file content',
+    });
+    const filename = uploadRes.data.name;
+    expect(filename).toBeDefined();
+
+    // Attempt delete with readOnlyMasterKey — should be rejected
+    loggerErrorSpy.calls.reset();
+    try {
+      await request({
+        method: 'DELETE',
+        url: `${Parse.serverURL}/files/${filename}`,
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-Master-Key': 'read-only-test',
+        },
+      });
+      fail('should have thrown');
+    } catch (res) {
+      expect(res.status).toBe(403);
+      expect(res.data.error).toBe('Permission denied');
+    }
+
+    // Verify file still exists
+    const getRes = await request({ url: uploadRes.data.url });
+    expect(getRes.status).toBe(200);
+  });
+
+  it('should throw when trying to create a file with readOnlyMasterKey', async () => {
+    loggerErrorSpy.calls.reset();
+    try {
+      await request({
+        method: 'POST',
+        url: `${Parse.serverURL}/files/readonly-create-test.txt`,
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-Master-Key': 'read-only-test',
+          'Content-Type': 'text/plain',
+        },
+        body: 'file content',
+      });
+      fail('should have thrown');
+    } catch (res) {
+      expect(res.status).toBe(403);
+      expect(res.data.error).toBe('Permission denied');
+    }
+  });
 });
 
 describe('rest context', () => {

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -5,6 +5,7 @@ import Config from '../Config';
 import logger from '../logger';
 const triggers = require('../triggers');
 const Utils = require('../Utils');
+import { createSanitizedHttpError } from '../Error';
 
 export class FilesRouter {
   expressRouter({ maxUploadSize = '20Mb' } = {}) {
@@ -112,6 +113,12 @@ export class FilesRouter {
   }
 
   async createHandler(req, res, next) {
+    if (req.auth.isReadOnly) {
+      const error = createSanitizedHttpError(403, "read-only masterKey isn't allowed to create a file.", req.config);
+      res.status(error.status);
+      res.end(`{"error":"${error.message}"}`);
+      return;
+    }
     const config = req.config;
     const user = req.auth.user;
     const isMaster = req.auth.isMaster;
@@ -266,6 +273,12 @@ export class FilesRouter {
   }
 
   async deleteHandler(req, res, next) {
+    if (req.auth.isReadOnly) {
+      const error = createSanitizedHttpError(403, "read-only masterKey isn't allowed to delete a file.", req.config);
+      res.status(error.status);
+      res.end(`{"error":"${error.message}"}`);
+      return;
+    }
     try {
       const { filesController } = req.config;
       const { filename } = req.params;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

File creation and deletion bypasses `readOnlyMasterKey` write restriction ([GHSA-xfh7-phr7-gr2x](https://github.com/parse-community/parse-server/security/advisories/GHSA-xfh7-phr7-gr2x))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
