### PR TITLE
feat: Handle deeply nested dot notation, e.g., 'x.y.z'

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1737,15 +1737,34 @@ RestWrite.prototype.buildParseObjects = function () {
           updatedObject.set(key, data[key]);
         }
       } else {
-        // subdocument key with dot notation { 'x.y': v } => { 'x': { 'y' : v } })
-        const splittedKey = key.split('.');
-        const parentProp = splittedKey[0];
-        let parentVal = updatedObject.get(parentProp);
-        if (typeof parentVal !== 'object') {
-          parentVal = {};
+        // Handle deeply nested dot notation, e.g., 'x.y.z', { 'x.y.z': v } => { 'x': { 'y' : {'z': v} } }
+        const keys = key.split('.');
+        const rootProp = keys[0];
+
+        // Get a deep copy of the root object
+        let rootObj = updatedObject.get(rootProp);
+        if (rootObj && typeof rootObj === 'object') {
+          rootObj = deepcopy(rootObj);
+        } else {
+          rootObj = {};
         }
-        parentVal[splittedKey[1]] = data[key];
-        updatedObject.set(parentProp, parentVal);
+
+        // Recursively set nested properties
+        let current = rootObj;
+        for (let i = 1; i < keys.length - 1; i++) {
+          const prop = keys[i];
+          if (!current[prop] || typeof current[prop] !== 'object') {
+            current[prop] = {};
+          } else {
+            // Ensure we're working with a copy rather than the original reference
+            current[prop] = deepcopy(current[prop]);
+          }
+          current = current[prop];
+        }
+
+        // Set the final value
+        current[keys[keys.length - 1]] = data[key];
+        updatedObject.set(rootProp, rootObj);
       }
       delete data[key];
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE). 

## Issue
#7384 Deeply nested keys are not passed correctly to afterSave triggers 

## Approach
This PR addresses a critical issue with LiveQuery notifications when deeply nested objects are updated. The changes in RestWrite.js include:

Fixed LiveQuery notification problems during deep nested updates: Previously, when objects with deeply nested structures were updated, LiveQuery subscribers would not receive proper notifications due to incomplete change detection.


