### PR TITLE
fix: Endpoint `/loginAs` allows `readOnlyMasterKey` to gain full read and write access as any user (GHSA-79wj-8rqv-jvp5)

### DIFF
--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -1364,6 +1364,32 @@ describe('read-only masterKey', () => {
       expect(res.data.error).toBe('Permission denied');
     }
   });
+
+  it('should throw when trying to loginAs with readOnlyMasterKey', async () => {
+    // Create a target user
+    await Parse.User.signUp('readonly-loginas-test', 'password123');
+    const userId = Parse.User.current().id;
+    await Parse.User.logOut();
+
+    // Attempt loginAs with readOnlyMasterKey — should be rejected
+    loggerErrorSpy.calls.reset();
+    try {
+      await request({
+        method: 'POST',
+        url: `${Parse.serverURL}/loginAs`,
+        headers: {
+          'X-Parse-Application-Id': Parse.applicationId,
+          'X-Parse-Master-Key': 'read-only-test',
+          'Content-Type': 'application/json',
+        },
+        body: { userId },
+      });
+      fail('should have thrown');
+    } catch (res) {
+      expect(res.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
+      expect(res.data.error).toBe('Permission denied');
+    }
+  });
 });
 
 describe('rest context', () => {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -344,6 +344,13 @@ export class UsersRouter extends ClassesRouter {
         req.config
       );
     }
+    if (req.auth.isReadOnly) {
+      throw createSanitizedError(
+        Parse.Error.OPERATION_FORBIDDEN,
+        "read-only masterKey isn't allowed to login as another user.",
+        req.config
+      );
+    }
 
     const userId = req.body?.userId || req.query.userId;
     if (!userId) {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Endpoint `/loginAs` allows `readOnlyMasterKey` to gain full read and write access as any user ([GHSA-79wj-8rqv-jvp5](https://github.com/parse-community/parse-server/security/advisories/GHSA-79wj-8rqv-jvp5))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent login-as operations when using a read-only master key, now returns a permission denied error.

* **Tests**
  * Added test coverage for read-only master key rejection in login-as operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->