### PR TITLE
feat: Allow to identify `readOnlyMasterKey` invocation of Cloud Function via `request.isReadOnly`

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ The client keys used with Parse are no longer necessary with Parse Server. If yo
 
 <sub>(1) `Parse.Object.createdAt`, `Parse.Object.updatedAt`.</sub>
 
+> [!NOTE]
+> In Cloud Code, both `masterKey` and `readOnlyMasterKey` set `request.master` to `true`. To distinguish between them, check `request.isReadOnly`. For example, use `request.master && !request.isReadOnly` to ensure full master key access.
+
 ## Email Verification and Password Reset
 
 Verifying user email addresses and enabling password reset via email requires an email adapter. There are many email adapters provided and maintained by the community. The following is an example configuration with an example email adapter. See the [Parse Server Options][server-options] for more details and a full list of available options.

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -1438,6 +1438,30 @@ describe('read-only masterKey', () => {
     expect(receivedMaster).toBe(true);
     expect(receivedIsReadOnly).toBe(false);
   });
+
+  it('should expose isReadOnly in beforeFind trigger when using readOnlyMasterKey', async () => {
+    let receivedMaster;
+    let receivedIsReadOnly;
+    Parse.Cloud.beforeFind('ReadOnlyTriggerTest', req => {
+      receivedMaster = req.master;
+      receivedIsReadOnly = req.isReadOnly;
+    });
+
+    const obj = new Parse.Object('ReadOnlyTriggerTest');
+    await obj.save(null, { useMasterKey: true });
+
+    await request({
+      method: 'GET',
+      url: `${Parse.serverURL}/classes/ReadOnlyTriggerTest`,
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': 'read-only-test',
+      },
+    });
+
+    expect(receivedMaster).toBe(true);
+    expect(receivedIsReadOnly).toBe(true);
+  });
 });
 
 describe('rest context', () => {

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -1390,6 +1390,54 @@ describe('read-only masterKey', () => {
       expect(res.data.error).toBe('Permission denied');
     }
   });
+
+  it('should expose isReadOnly in Cloud Function request when using readOnlyMasterKey', async () => {
+    let receivedMaster;
+    let receivedIsReadOnly;
+    Parse.Cloud.define('checkReadOnly', req => {
+      receivedMaster = req.master;
+      receivedIsReadOnly = req.isReadOnly;
+      return 'ok';
+    });
+
+    await request({
+      method: 'POST',
+      url: `${Parse.serverURL}/functions/checkReadOnly`,
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': 'read-only-test',
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(receivedMaster).toBe(true);
+    expect(receivedIsReadOnly).toBe(true);
+  });
+
+  it('should not set isReadOnly in Cloud Function request when using masterKey', async () => {
+    let receivedMaster;
+    let receivedIsReadOnly;
+    Parse.Cloud.define('checkNotReadOnly', req => {
+      receivedMaster = req.master;
+      receivedIsReadOnly = req.isReadOnly;
+      return 'ok';
+    });
+
+    await request({
+      method: 'POST',
+      url: `${Parse.serverURL}/functions/checkNotReadOnly`,
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': Parse.masterKey,
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    });
+
+    expect(receivedMaster).toBe(true);
+    expect(receivedIsReadOnly).toBe(false);
+  });
 });
 
 describe('rest context', () => {

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -1462,6 +1462,30 @@ describe('read-only masterKey', () => {
     expect(receivedMaster).toBe(true);
     expect(receivedIsReadOnly).toBe(true);
   });
+
+  it('should not set isReadOnly in beforeFind trigger when using masterKey', async () => {
+    let receivedMaster;
+    let receivedIsReadOnly;
+    Parse.Cloud.beforeFind('ReadOnlyTriggerTestNeg', req => {
+      receivedMaster = req.master;
+      receivedIsReadOnly = req.isReadOnly;
+    });
+
+    const obj = new Parse.Object('ReadOnlyTriggerTestNeg');
+    await obj.save(null, { useMasterKey: true });
+
+    await request({
+      method: 'GET',
+      url: `${Parse.serverURL}/classes/ReadOnlyTriggerTestNeg`,
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Master-Key': Parse.masterKey,
+      },
+    });
+
+    expect(receivedMaster).toBe(true);
+    expect(receivedIsReadOnly).toBe(false);
+  });
 });
 
 describe('rest context', () => {

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -176,6 +176,7 @@ export class FunctionsRouter extends PromiseRouter {
       params: params,
       config: req.config,
       master: req.auth && req.auth.isMaster,
+      isReadOnly: !!(req.auth && req.auth.isReadOnly),
       user: req.auth && req.auth.user,
       installationId: req.info.installationId,
       log: req.config.loggerController,

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -730,7 +730,8 @@ module.exports = ParseCloud;
 /**
  * @interface Parse.Cloud.TriggerRequest
  * @property {String} installationId If set, the installationId triggering the request.
- * @property {Boolean} master If true, means the master key was used.
+ * @property {Boolean} master If true, means the master key or the read-only master key was used.
+ * @property {Boolean} isReadOnly If true, means the read-only master key was used. This is a subset of `master`, so `master` will also be true. Use `master && !isReadOnly` to check for full master key access.
  * @property {Boolean} isChallenge If true, means the current request is originally triggered by an auth challenge.
  * @property {Parse.User} user If set, the user that made the request.
  * @property {Parse.Object} object The object triggering the hook.
@@ -745,7 +746,8 @@ module.exports = ParseCloud;
 /**
  * @interface Parse.Cloud.FileTriggerRequest
  * @property {String} installationId If set, the installationId triggering the request.
- * @property {Boolean} master If true, means the master key was used.
+ * @property {Boolean} master If true, means the master key or the read-only master key was used.
+ * @property {Boolean} isReadOnly If true, means the read-only master key was used. This is a subset of `master`, so `master` will also be true. Use `master && !isReadOnly` to check for full master key access.
  * @property {Parse.User} user If set, the user that made the request.
  * @property {Parse.File} file The file that triggered the hook.
  * @property {Integer} fileSize The size of the file in bytes.
@@ -784,7 +786,8 @@ module.exports = ParseCloud;
 /**
  * @interface Parse.Cloud.BeforeFindRequest
  * @property {String} installationId If set, the installationId triggering the request.
- * @property {Boolean} master If true, means the master key was used.
+ * @property {Boolean} master If true, means the master key or the read-only master key was used.
+ * @property {Boolean} isReadOnly If true, means the read-only master key was used. This is a subset of `master`, so `master` will also be true. Use `master && !isReadOnly` to check for full master key access.
  * @property {Parse.User} user If set, the user that made the request.
  * @property {Parse.Query} query The query triggering the hook.
  * @property {String} ip The IP address of the client making the request.
@@ -798,7 +801,8 @@ module.exports = ParseCloud;
 /**
  * @interface Parse.Cloud.AfterFindRequest
  * @property {String} installationId If set, the installationId triggering the request.
- * @property {Boolean} master If true, means the master key was used.
+ * @property {Boolean} master If true, means the master key or the read-only master key was used.
+ * @property {Boolean} isReadOnly If true, means the read-only master key was used. This is a subset of `master`, so `master` will also be true. Use `master && !isReadOnly` to check for full master key access.
  * @property {Parse.User} user If set, the user that made the request.
  * @property {Parse.Query} query The query triggering the hook.
  * @property {Array<Parse.Object>} results The results the query yielded.
@@ -812,7 +816,8 @@ module.exports = ParseCloud;
 /**
  * @interface Parse.Cloud.FunctionRequest
  * @property {String} installationId If set, the installationId triggering the request.
- * @property {Boolean} master If true, means the master key was used.
+ * @property {Boolean} master If true, means the master key or the read-only master key was used.
+ * @property {Boolean} isReadOnly If true, means the read-only master key was used. This is a subset of `master`, so `master` will also be true. Use `master && !isReadOnly` to check for full master key access.
  * @property {Parse.User} user If set, the user that made the request.
  * @property {Object} params The params passed to the cloud function.
  * @property {String} ip The IP address of the client making the request.

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -1027,6 +1027,7 @@ export function getRequestFileObject(triggerType, auth, fileObject, config) {
     ...fileObject,
     triggerName: triggerType,
     master: false,
+    isReadOnly: false,
     log: config.loggerController,
     headers: config.headers,
     ip: config.ip,

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -268,6 +268,7 @@ export function getRequestObject(
     triggerName: triggerType,
     object: parseObject,
     master: false,
+    isReadOnly: false,
     log: config.loggerController,
     headers: config.headers,
     ip: config.ip,
@@ -301,6 +302,9 @@ export function getRequestObject(
   if (auth.isMaster) {
     request['master'] = true;
   }
+  if (auth.isReadOnly) {
+    request['isReadOnly'] = true;
+  }
   if (auth.user) {
     request['user'] = auth.user;
   }
@@ -317,6 +321,7 @@ export function getRequestQueryObject(triggerType, auth, query, count, config, c
     triggerName: triggerType,
     query,
     master: false,
+    isReadOnly: false,
     count,
     log: config.loggerController,
     isGet,
@@ -331,6 +336,9 @@ export function getRequestQueryObject(triggerType, auth, query, count, config, c
   }
   if (auth.isMaster) {
     request['master'] = true;
+  }
+  if (auth.isReadOnly) {
+    request['isReadOnly'] = true;
   }
   if (auth.user) {
     request['user'] = auth.user;
@@ -1030,6 +1038,9 @@ export function getRequestFileObject(triggerType, auth, fileObject, config) {
   }
   if (auth.isMaster) {
     request['master'] = true;
+  }
+  if (auth.isReadOnly) {
+    request['isReadOnly'] = true;
   }
   if (auth.user) {
     request['user'] = auth.user;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Cloud Functions and triggers receive `request.master === true` when called with `readOnlyMasterKey`, with no way to distinguish it from a full `masterKey` call. Developers gating logic on `request.master` unknowingly allow read-only credentials to execute master-only code paths.

## Approach

The `readOnlyMasterKey` is represented throughout the codebase as `isMaster: true` + `isReadOnly: true`. The original design in #4297 intended to rely on `RestWrite` as the safety net for blocking write operations — and that safety net works here, since Cloud Function data operations go through `RestWrite`. This is unlike [files](https://github.com/parse-community/parse-server/pull/10095) or [loginAs](https://github.com/parse-community/parse-server/pull/10098), where operations bypass `RestWrite` entirely and require explicit blocks.

Rather than hard-blocking Cloud Function execution for `readOnlyMasterKey` (which would break the established model and prevent legitimate read-only use cases), this change exposes `request.isReadOnly` in Cloud Function and trigger request objects. This gives developers the information to enforce their own policy, e.g. `if (request.master && !request.isReadOnly)`.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud Functions and triggers now expose an isReadOnly flag on request objects so handlers can detect read-only master key usage.

* **Documentation**
  * Docs and public Cloud Code interface updated to document isReadOnly and how to require full master access (master && !isReadOnly).

* **Tests**
  * New tests verify isReadOnly is set for read-only master key and not set for full master key (Cloud Function and beforeFind scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->