### PR TITLE
fix: Malformed `$regex` query leaks database error details in API response (GHSA-9cp7-3q5w-j92g)

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -508,7 +508,7 @@ describe('Malformed $regex information disclosure', () => {
       expect(JSON.stringify(e.data)).not.toContain('errorResponse');
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Sanitized error:',
-        jasmine.stringContaining('Regular expression is invalid')
+        jasmine.stringMatching(/[Rr]egular expression/i)
       );
     }
   });
@@ -526,7 +526,7 @@ describe('Malformed $regex information disclosure', () => {
           'X-Parse-REST-API-Key': 'rest',
         },
         qs: {
-          where: JSON.stringify({ name: { $regex: 'a(' } }),
+          where: JSON.stringify({ name: { $regex: '[abc' } }),
         },
       });
       fail('Request should have failed');
@@ -539,7 +539,7 @@ describe('Malformed $regex information disclosure', () => {
       expect(JSON.stringify(e.data)).not.toContain('errorResponse');
       expect(loggerErrorSpy).toHaveBeenCalledWith(
         'Sanitized error:',
-        jasmine.stringContaining('Regular expression is invalid')
+        jasmine.stringMatching(/[Rr]egular expression/i)
       );
     }
   });

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -516,6 +516,8 @@ describe('Malformed $regex information disclosure', () => {
   it('should not leak database error internals for invalid regex pattern in role query', async () => {
     const logger = require('../lib/logger').default;
     const loggerErrorSpy = spyOn(logger, 'error').and.callThrough();
+    const role = new Parse.Role('testrole', new Parse.ACL());
+    await role.save(null, { useMasterKey: true });
     try {
       await request({
         method: 'GET',

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -478,6 +478,73 @@ describe('Vulnerabilities', () => {
   });
 });
 
+describe('Malformed $regex information disclosure', () => {
+  it('should not leak database error internals for invalid regex pattern in class query', async () => {
+    const logger = require('../lib/logger').default;
+    const loggerErrorSpy = spyOn(logger, 'error').and.callThrough();
+    const obj = new Parse.Object('TestObject');
+    await obj.save({ field: 'value' });
+
+    try {
+      await request({
+        method: 'GET',
+        url: `http://localhost:8378/1/classes/TestObject`,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        qs: {
+          where: JSON.stringify({ field: { $regex: '[abc' } }),
+        },
+      });
+      fail('Request should have failed');
+    } catch (e) {
+      expect(e.data.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+      expect(e.data.error).toBe('An internal server error occurred');
+      expect(typeof e.data.error).toBe('string');
+      expect(JSON.stringify(e.data)).not.toContain('errmsg');
+      expect(JSON.stringify(e.data)).not.toContain('codeName');
+      expect(JSON.stringify(e.data)).not.toContain('errorResponse');
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Sanitized error:',
+        jasmine.stringContaining('Regular expression is invalid')
+      );
+    }
+  });
+
+  it('should not leak database error internals for invalid regex pattern in role query', async () => {
+    const logger = require('../lib/logger').default;
+    const loggerErrorSpy = spyOn(logger, 'error').and.callThrough();
+    try {
+      await request({
+        method: 'GET',
+        url: `http://localhost:8378/1/roles`,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        qs: {
+          where: JSON.stringify({ name: { $regex: 'a(' } }),
+        },
+      });
+      fail('Request should have failed');
+    } catch (e) {
+      expect(e.data.code).toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+      expect(e.data.error).toBe('An internal server error occurred');
+      expect(typeof e.data.error).toBe('string');
+      expect(JSON.stringify(e.data)).not.toContain('errmsg');
+      expect(JSON.stringify(e.data)).not.toContain('codeName');
+      expect(JSON.stringify(e.data)).not.toContain('errorResponse');
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Sanitized error:',
+        jasmine.stringContaining('Regular expression is invalid')
+      );
+    }
+  });
+});
+
 describe('Postgres regex sanitizater', () => {
   it('sanitizes the regex correctly to prevent Injection', async () => {
     const user = new Parse.User();

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -20,6 +20,7 @@ import SchemaCache from '../Adapters/Cache/SchemaCache';
 import type { LoadSchemaOptions } from './types';
 import type { ParseServerOptions } from '../Options';
 import type { QueryOptions, FullQueryOptions } from '../Adapters/Storage/StorageAdapter';
+import { createSanitizedError } from '../Error';
 
 function addWriteACL(query, acl) {
   const newQuery = _.cloneDeep(query);
@@ -1366,7 +1367,19 @@ class DatabaseController {
                     })
                   )
                   .catch(error => {
-                    throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, error);
+                    if (error instanceof Parse.Error) {
+                      throw error;
+                    }
+                    const detailedMessage =
+                      typeof error === 'string'
+                        ? error
+                        : error?.message || 'An internal server error occurred';
+                    throw createSanitizedError(
+                      Parse.Error.INTERNAL_SERVER_ERROR,
+                      detailedMessage,
+                      this.options,
+                      'An internal server error occurred'
+                    );
                   });
               }
             });

--- a/src/Error.js
+++ b/src/Error.js
@@ -6,9 +6,11 @@ import defaultLogger from './logger';
  *
  * @param {number} errorCode - The Parse.Error code (e.g., Parse.Error.OPERATION_FORBIDDEN)
  * @param {string} detailedMessage - The detailed error message to log server-side
+ * @param {object} config - Parse Server config with enableSanitizedErrorResponse
+ * @param {string} [sanitizedMessage='Permission denied'] - The sanitized message to return to clients
  * @returns {Parse.Error} A Parse.Error with sanitized message
  */
-function createSanitizedError(errorCode, detailedMessage, config) {
+function createSanitizedError(errorCode, detailedMessage, config, sanitizedMessage = 'Permission denied') {
   // On testing we need to add a prefix to the message to allow to find the correct call in the TestUtils.js file
   if (process.env.TESTING) {
     defaultLogger.error('Sanitized error:', detailedMessage);
@@ -16,7 +18,7 @@ function createSanitizedError(errorCode, detailedMessage, config) {
     defaultLogger.error(detailedMessage);
   }
 
-  return new Parse.Error(errorCode, config?.enableSanitizedErrorResponse !== false ? 'Permission denied' : detailedMessage);
+  return new Parse.Error(errorCode, config?.enableSanitizedErrorResponse !== false ? sanitizedMessage : detailedMessage);
 }
 
 /**


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Malformed `$regex` query leaks database error details in API response ([GHSA-9cp7-3q5w-j92g](https://github.com/parse-community/parse-server/security/advisories/GHSA-9cp7-3q5w-j92g))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure unexpected internal errors are returned as sanitized, generic server errors; the client-facing sanitized message is now configurable.

* **Tests**
  * Added tests verifying invalid regex queries yield generic sanitized errors without exposing internal details and that logs indicate a sanitized error occurrence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->