### PR TITLE
feat: Add security check for server option `mountPlayground` for GraphQL development

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongo
 
 After starting the server, you can visit http://localhost:1337/playground in your browser to start playing with your GraphQL API.
 
-**_Note:_** Do **_NOT_** use --mountPlayground option in production. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and it is the recommended option for production apps.
+**_Note:_** Do **_NOT_** use --mountPlayground option in production. The GraphQL Playground exposes the master key in the browser page. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and is the recommended option for production apps.
 
 ### Using Docker
 
@@ -845,7 +845,7 @@ $ docker run --name my-parse-server --link my-mongo:mongo -v config-vol:/parse-s
 
 After starting the server, you can visit http://localhost:1337/playground in your browser to start playing with your GraphQL API.
 
-**_Note:_** Do **_NOT_** use --mountPlayground option in production. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and it is the recommended option for production apps.
+**_Note:_** Do **_NOT_** use --mountPlayground option in production. The GraphQL Playground exposes the master key in the browser page. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and is the recommended option for production apps.
 
 ### Using Express.js
 
@@ -899,7 +899,7 @@ $ node index.js
 
 After starting the app, you can visit http://localhost:1337/playground in your browser to start playing with your GraphQL API.
 
-**_Note:_** Do **_NOT_** mount the GraphQL Playground in production. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and it is the recommended option for production apps.
+**_Note:_** Do **_NOT_** mount the GraphQL Playground in production. The GraphQL Playground exposes the master key in the browser page. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and is the recommended option for production apps.
 
 ## Checking the API health
 

--- a/spec/SecurityCheckGroups.spec.js
+++ b/spec/SecurityCheckGroups.spec.js
@@ -34,6 +34,7 @@ describe('Security Check Groups', () => {
       config.allowClientClassCreation = false;
       config.enableInsecureAuthAdapters = false;
       config.graphQLPublicIntrospection = false;
+      config.mountPlayground = false;
       await reconfigureServer(config);
 
       const group = new CheckGroupServerConfig();
@@ -43,6 +44,7 @@ describe('Security Check Groups', () => {
       expect(group.checks()[2].checkState()).toBe(CheckState.success);
       expect(group.checks()[4].checkState()).toBe(CheckState.success);
       expect(group.checks()[5].checkState()).toBe(CheckState.success);
+      expect(group.checks()[6].checkState()).toBe(CheckState.success);
     });
 
     it('checks fail correctly', async () => {
@@ -51,6 +53,7 @@ describe('Security Check Groups', () => {
       config.allowClientClassCreation = true;
       config.enableInsecureAuthAdapters = true;
       config.graphQLPublicIntrospection = true;
+      config.mountPlayground = true;
       await reconfigureServer(config);
 
       const group = new CheckGroupServerConfig();
@@ -60,6 +63,7 @@ describe('Security Check Groups', () => {
       expect(group.checks()[2].checkState()).toBe(CheckState.fail);
       expect(group.checks()[4].checkState()).toBe(CheckState.fail);
       expect(group.checks()[5].checkState()).toBe(CheckState.fail);
+      expect(group.checks()[6].checkState()).toBe(CheckState.fail);
     });
 
     it_only_db('mongo')('checks succeed correctly (MongoDB specific)', async () => {
@@ -69,7 +73,7 @@ describe('Security Check Groups', () => {
 
       const group = new CheckGroupServerConfig();
       await group.run();
-      expect(group.checks()[6].checkState()).toBe(CheckState.success);
+      expect(group.checks()[7].checkState()).toBe(CheckState.success);
     });
 
     it_only_db('mongo')('checks fail correctly (MongoDB specific)', async () => {
@@ -79,7 +83,7 @@ describe('Security Check Groups', () => {
 
       const group = new CheckGroupServerConfig();
       await group.run();
-      expect(group.checks()[6].checkState()).toBe(CheckState.fail);
+      expect(group.checks()[7].checkState()).toBe(CheckState.fail);
     });
   });
 

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -404,7 +404,7 @@ module.exports.ParseServerOptions = {
   },
   mountPlayground: {
     env: 'PARSE_SERVER_MOUNT_PLAYGROUND',
-    help: 'Mounts the GraphQL Playground - never use this option in production',
+    help: 'Mounts the GraphQL Playground which exposes the master key in the browser - never use this option in production',
     action: parsers.booleanParser,
     default: false,
   },

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -77,7 +77,7 @@
  * @property {Union} middleware middleware for express server, can be string or function
  * @property {Boolean} mountGraphQL Mounts the GraphQL endpoint
  * @property {String} mountPath Mount path for the server, defaults to /parse
- * @property {Boolean} mountPlayground Mounts the GraphQL Playground - never use this option in production
+ * @property {Boolean} mountPlayground Mounts the GraphQL Playground which exposes the master key in the browser - never use this option in production
  * @property {Number} objectIdSize Sets the number of characters in generated object id's, default 10
  * @property {PagesOptions} pages The options for pages such as password reset and email verification.
  * @property {PasswordPolicyOptions} passwordPolicy The password policy for enforcing password related rules.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -339,7 +339,7 @@ export interface ParseServerOptions {
   :ENV: PARSE_SERVER_GRAPHQL_PUBLIC_INTROSPECTION
   :DEFAULT: false */
   graphQLPublicIntrospection: ?boolean;
-  /* Mounts the GraphQL Playground - never use this option in production
+  /* Mounts the GraphQL Playground which exposes the master key in the browser - never use this option in production
   :ENV: PARSE_SERVER_MOUNT_PLAYGROUND
   :DEFAULT: false */
   mountPlayground: ?boolean;

--- a/src/ParseServer.ts
+++ b/src/ParseServer.ts
@@ -458,6 +458,9 @@ class ParseServer {
 
       if (options.mountPlayground) {
         parseGraphQLServer.applyPlayground(app);
+        console.warn(
+          `\nWARNING, GraphQL Playground is enabled and exposes the master key in the browser. The playground is a developer tool and should not be used in production. Use Parse Dashboard for production environments.\n`
+        );
       }
     }
     const server = await new Promise(resolve => {

--- a/src/ParseServer.ts
+++ b/src/ParseServer.ts
@@ -458,8 +458,8 @@ class ParseServer {
 
       if (options.mountPlayground) {
         parseGraphQLServer.applyPlayground(app);
-        console.warn(
-          `\nWARNING, GraphQL Playground is enabled and exposes the master key in the browser. The playground is a developer tool and should not be used in production. Use Parse Dashboard for production environments.\n`
+        logging.getLogger().warn(
+          'GraphQL Playground is enabled and exposes the master key in the browser. The playground is a developer tool and should not be used in production. Use Parse Dashboard for production environments.'
         );
       }
     }

--- a/src/Security/CheckGroups/CheckGroupServerConfig.js
+++ b/src/Security/CheckGroups/CheckGroupServerConfig.js
@@ -91,6 +91,18 @@ class CheckGroupServerConfig extends CheckGroup {
         },
       }),
       new Check({
+        title: 'GraphQL Playground disabled',
+        warning:
+          'GraphQL Playground is enabled and exposes the master key in the browser page.',
+        solution:
+          "Change Parse Server configuration to 'mountPlayground: false'. Use Parse Dashboard for GraphQL exploration in production.",
+        check: () => {
+          if (config.mountPlayground) {
+            throw 1;
+          }
+        },
+      }),
+      new Check({
         title: 'Public database explain disabled',
         warning:
           'Database explain queries are publicly accessible, which may expose sensitive database performance information and schema details.',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

- Add security check for server option `mountPlayground`.
- Improve docs to highlight that the API exposes the `masterKey` when enabled.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime warning when GraphQL Playground is mounted to warn that the master key is exposed in the browser.
  * Added a security check that detects and warns if GraphQL Playground is enabled in production.

* **Documentation**
  * Clarified warnings about GraphQL Playground exposing the master key across docs and help text.
  * Documented new playgroundPath and port options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->