### PR TITLE
fix: File metadata endpoint bypasses `beforeFind` / `afterFind` trigger authorization (GHSA-hwx8-q9cg-mqmc)

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -4473,6 +4473,21 @@ describe('Parse.File hooks', () => {
     });
     expect(response.headers['content-disposition']).toBe(`attachment;filename=${file._name}`);
   });
+
+  it('beforeFind blocks metadata endpoint', async () => {
+    const file = new Parse.File('popeye.txt', [1, 2, 3], 'text/plain');
+    await file.save({ useMasterKey: true });
+    Parse.Cloud.beforeFind(Parse.File, () => {
+      throw 'unauthorized';
+    });
+    await expectAsync(
+      request({
+        url: `http://localhost:8378/1/files/test/metadata/${file._name}`,
+      }).catch(e => {
+        throw new Parse.Error(e.data.code, e.data.error);
+      })
+    ).toBeRejectedWith(new Parse.Error(Parse.Error.SCRIPT_FAILED, 'unauthorized'));
+  });
 });
 
 describe('Cloud Config hooks', () => {

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -323,14 +323,17 @@ export class FilesRouter {
         return;
       }
       const { filesController } = config;
-      const { filename } = req.params;
+      let { filename } = req.params;
       const file = new Parse.File(filename, { base64: '' });
-      await triggers.maybeRunFileTrigger(
+      const triggerResult = await triggers.maybeRunFileTrigger(
         triggers.Types.beforeFind,
         { file },
         config,
         req.auth
       );
+      if (triggerResult?.file?._name) {
+        filename = triggerResult.file._name;
+      }
       const data = await filesController.getMetadata(filename).catch(() => {
         res.status(200);
         res.json({});

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -317,14 +317,36 @@ export class FilesRouter {
   async metadataHandler(req, res) {
     try {
       const config = Config.get(req.params.appId);
+      if (!config) {
+        res.status(200);
+        res.json({});
+        return;
+      }
       const { filesController } = config;
       const { filename } = req.params;
+      const file = new Parse.File(filename, { base64: '' });
+      await triggers.maybeRunFileTrigger(
+        triggers.Types.beforeFind,
+        { file },
+        config,
+        req.auth
+      );
       const data = await filesController.getMetadata(filename);
+      await triggers.maybeRunFileTrigger(
+        triggers.Types.afterFind,
+        { file },
+        config,
+        req.auth
+      );
       res.status(200);
       res.json(data);
-    } catch {
-      res.status(200);
-      res.json({});
+    } catch (e) {
+      const err = triggers.resolveError(e, {
+        code: Parse.Error.SCRIPT_FAILED,
+        message: 'Could not get file metadata.',
+      });
+      res.status(403);
+      res.json({ code: err.code, error: err.message });
     }
   }
 }

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -331,7 +331,13 @@ export class FilesRouter {
         config,
         req.auth
       );
-      const data = await filesController.getMetadata(filename);
+      const data = await filesController.getMetadata(filename).catch(() => {
+        res.status(200);
+        res.json({});
+      });
+      if (!data) {
+        return;
+      }
       await triggers.maybeRunFileTrigger(
         triggers.Types.afterFind,
         { file },


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

File metadata endpoint bypasses `beforeFind` / `afterFind` trigger authorization ([GHSA-hwx8-q9cg-mqmc](https://github.com/parse-community/parse-server/security/advisories/GHSA-hwx8-q9cg-mqmc))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->
