### PR TITLE
refactor: Add poisoned object ID guard to legacy session auth path

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -47,6 +47,34 @@ describe('Vulnerabilities', () => {
         ).toBeRejectedWith(new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'Invalid object ID.'));
         await new Parse.Query(Parse.User).find({ sessionToken: innocentUser.getSessionToken() });
       });
+
+    });
+
+    describe('legacy session upgrade for user with poisoned object ID', () => {
+      it('refuses legacy session upgrade for user with poisoned object ID', async () => {
+        const parseServer = await global.reconfigureServer();
+        const databaseController = parseServer.config.databaseController;
+        const poisonedId = 'role:legacy';
+        const legacyToken = 'legacy-poisoned-token';
+        // Create user with poisoned ID and legacy session token directly in DB
+        await databaseController.create('_User', {
+          objectId: poisonedId,
+          _session_token: legacyToken,
+        });
+        await expectAsync(
+          request({
+            method: 'POST',
+            url: 'http://localhost:8378/1/upgradeToRevocableSession',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Parse-Application-Id': 'test',
+              'X-Parse-REST-API-Key': 'rest',
+              'X-Parse-Session-Token': legacyToken,
+            },
+            body: JSON.stringify({}),
+          })
+        ).toBeRejected();
+      });
     });
   });
 

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -51,7 +51,8 @@ describe('Vulnerabilities', () => {
     });
 
     describe('legacy session upgrade for user with poisoned object ID', () => {
-      it('refuses legacy session upgrade for user with poisoned object ID', async () => {
+      // Legacy session tokens (_session_token on _User) are a MongoDB-only legacy feature
+      it_only_db('mongo')('refuses legacy session upgrade for user with poisoned object ID', async () => {
         const parseServer = await global.reconfigureServer();
         const databaseController = parseServer.config.databaseController;
         const poisonedId = 'role:legacy';

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -228,6 +228,11 @@ var getAuthForLegacySessionToken = async function ({ config, sessionToken, insta
       throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid legacy session token');
     }
     const obj = results[0];
+
+    if (typeof obj['objectId'] === 'string' && obj['objectId'].startsWith('role:')) {
+      throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'Invalid object ID.');
+    }
+
     obj.className = '_User';
     const userObject = Parse.Object.fromJSON(obj);
     return new Auth({


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

The `role:` object ID guard added in [GHSA-8xq9-g7ch-35hg](https://github.com/parse-community/parse-server/security/advisories/GHSA-8xq9-g7ch-35hg) was missing from `getAuthForLegacySessionToken`, which is used by `/upgradeToRevocableSession`. This allowed a poisoned legacy session to be upgraded and a revocable token to be minted for an invalid `role:*` identity.

This is not an exploitable vulnerability because the minted revocable token is immediately rejected by `getAuthForSessionToken` on any subsequent API call, so there is no privilege escalation or data access. This change aligns the validation for consistency and defense-in-depth.


## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject authentication for legacy sessions when invalid or malformed identifiers are present, preventing unauthorized access and improving security.

* **Tests**
  * Added test coverage to ensure legacy session upgrade requests are properly rejected for accounts with invalid identifiers, verifying validation behavior in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->