### PR TITLE
ci: Add performance benchmark for regex in `Parse.Query`

### DIFF
--- a/benchmark/performance.js
+++ b/benchmark/performance.js
@@ -23,6 +23,7 @@ const LOG_ITERATIONS = false;
 
 // Parse Server instance
 let parseServer;
+let httpServer;
 let mongoClient;
 let core;
 
@@ -48,6 +49,7 @@ async function initializeParseServer() {
     allowClientClassCreation: true,
     logLevel: 'error', // Minimal logging for performance
     verbose: false,
+    liveQuery: { classNames: ['BenchmarkLiveQuery'] },
   });
 
   app.use('/parse', parseServer.app);
@@ -703,6 +705,55 @@ async function benchmarkConcurrentQueryMemory(name) {
 }
 
 /**
+ * Benchmark: LiveQuery $regex end-to-end
+ *
+ * Measures the full round-trip of a LiveQuery subscription with a $regex constraint:
+ * subscribe with a unique regex pattern, save an object that matches, and measure
+ * the time until the LiveQuery event fires. Each iteration uses a different regex
+ * to avoid cache hits on the RE2JS compile step.
+ */
+async function benchmarkLiveQueryRegex(name) {
+  // Enable LiveQuery on the running server
+  const { default: ParseServer } = require('../lib/index.js');
+  await ParseServer.createLiveQueryServer(httpServer, {
+    appId: APP_ID,
+    masterKey: MASTER_KEY,
+    serverURL: SERVER_URL,
+  });
+  Parse.liveQueryServerURL = 'ws://localhost:1337';
+
+  let counter = 0;
+
+  // Cycle through different regex patterns to avoid RE2JS cache hits
+  const patterns = [
+    { base: '^BenchLQ_', fieldValue: i => `BenchLQ_${i} data` },
+    { base: 'benchfield_', fieldValue: i => `some benchfield_${i} here` },
+    { base: '[a-z]+_benchclass_', fieldValue: i => `abc_benchclass_${i}` },
+  ];
+
+  return measureOperation({
+    name,
+    iterations: 30,
+    operation: async () => {
+      const idx = counter++;
+      const pattern = patterns[idx % patterns.length];
+      const regex = pattern.base + idx;
+      const query = new Parse.Query('BenchmarkLiveQuery');
+      query._addCondition('field', '$regex', regex);
+      const subscription = await query.subscribe();
+      const eventPromise = new Promise(resolve => {
+        subscription.on('create', () => resolve());
+      });
+      const obj = new Parse.Object('BenchmarkLiveQuery');
+      obj.set('field', pattern.fieldValue(idx));
+      await obj.save();
+      await eventPromise;
+      subscription.unsubscribe();
+    },
+  });
+}
+
+/**
  * Run all benchmarks
  */
 async function runBenchmarks() {
@@ -715,6 +766,7 @@ async function runBenchmarks() {
     // Initialize Parse Server
     logInfo('Initializing Parse Server...');
     server = await initializeParseServer();
+    httpServer = server;
 
     // Wait for server to be ready
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -734,6 +786,7 @@ async function runBenchmarks() {
       { name: 'Query.include (nested pointers)', fn: benchmarkQueryWithIncludeNested },
       { name: 'Query.find (large result, GC pressure)', fn: benchmarkLargeResultMemory },
       { name: 'Query.find (concurrent, GC pressure)', fn: benchmarkConcurrentQueryMemory },
+      { name: 'LiveQuery $regex', fn: benchmarkLiveQueryRegex },
     ];
 
     // Run each benchmark with database cleanup

--- a/benchmark/performance.js
+++ b/benchmark/performance.js
@@ -705,6 +705,39 @@ async function benchmarkConcurrentQueryMemory(name) {
 }
 
 /**
+ * Benchmark: Query $regex
+ *
+ * Measures a standard Parse.Query.find() with a $regex constraint.
+ * Each iteration uses a different regex to avoid database query cache hits.
+ */
+async function benchmarkQueryRegex(name) {
+  // Seed objects that will match the various regex patterns
+  const objects = [];
+  for (let i = 0; i < 1_000; i++) {
+    const obj = new Parse.Object('BenchmarkRegex');
+    obj.set('field', `BenchRegex_${i} data`);
+    objects.push(obj);
+  }
+  await Parse.Object.saveAll(objects);
+
+  let counter = 0;
+
+  const bases = ['^BenchRegex_', 'BenchRegex_', '[a-z]+_'];
+
+  return measureOperation({
+    name,
+    iterations: 1_000,
+    operation: async () => {
+      const idx = counter++;
+      const regex = bases[idx % bases.length] + idx;
+      const query = new Parse.Query('BenchmarkRegex');
+      query._addCondition('field', '$regex', regex);
+      await query.find();
+    },
+  });
+}
+
+/**
  * Benchmark: LiveQuery $regex end-to-end
  *
  * Measures the full round-trip of a LiveQuery subscription with a $regex constraint:
@@ -733,7 +766,7 @@ async function benchmarkLiveQueryRegex(name) {
 
   return measureOperation({
     name,
-    iterations: 30,
+    iterations: 500,
     operation: async () => {
       const idx = counter++;
       const pattern = patterns[idx % patterns.length];
@@ -786,6 +819,7 @@ async function runBenchmarks() {
       { name: 'Query.include (nested pointers)', fn: benchmarkQueryWithIncludeNested },
       { name: 'Query.find (large result, GC pressure)', fn: benchmarkLargeResultMemory },
       { name: 'Query.find (concurrent, GC pressure)', fn: benchmarkConcurrentQueryMemory },
+      { name: 'Query $regex', fn: benchmarkQueryRegex },
       { name: 'LiveQuery $regex', fn: benchmarkLiveQueryRegex },
     ];
 

--- a/benchmark/performance.js
+++ b/benchmark/performance.js
@@ -748,7 +748,7 @@ async function benchmarkQueryRegex(name) {
 async function benchmarkLiveQueryRegex(name) {
   // Enable LiveQuery on the running server
   const { default: ParseServer } = require('../lib/index.js');
-  await ParseServer.createLiveQueryServer(httpServer, {
+  const liveQueryServer = await ParseServer.createLiveQueryServer(httpServer, {
     appId: APP_ID,
     masterKey: MASTER_KEY,
     serverURL: SERVER_URL,
@@ -764,26 +764,31 @@ async function benchmarkLiveQueryRegex(name) {
     { base: '[a-z]+_benchclass_', fieldValue: i => `abc_benchclass_${i}` },
   ];
 
-  return measureOperation({
-    name,
-    iterations: 500,
-    operation: async () => {
-      const idx = counter++;
-      const pattern = patterns[idx % patterns.length];
-      const regex = pattern.base + idx;
-      const query = new Parse.Query('BenchmarkLiveQuery');
-      query._addCondition('field', '$regex', regex);
-      const subscription = await query.subscribe();
-      const eventPromise = new Promise(resolve => {
-        subscription.on('create', () => resolve());
-      });
-      const obj = new Parse.Object('BenchmarkLiveQuery');
-      obj.set('field', pattern.fieldValue(idx));
-      await obj.save();
-      await eventPromise;
-      subscription.unsubscribe();
-    },
-  });
+  try {
+    return await measureOperation({
+      name,
+      iterations: 500,
+      operation: async () => {
+        const idx = counter++;
+        const pattern = patterns[idx % patterns.length];
+        const regex = pattern.base + idx;
+        const query = new Parse.Query('BenchmarkLiveQuery');
+        query._addCondition('field', '$regex', regex);
+        const subscription = await query.subscribe();
+        const eventPromise = new Promise(resolve => {
+          subscription.on('create', () => resolve());
+        });
+        const obj = new Parse.Object('BenchmarkLiveQuery');
+        obj.set('field', pattern.fieldValue(idx));
+        await obj.save();
+        await eventPromise;
+        subscription.unsubscribe();
+      },
+    });
+  } finally {
+    await liveQueryServer.shutdown();
+    Parse.liveQueryServerURL = undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Add performance benchmark for regex in `Parse.Query`

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regex-pattern performance benchmark for standard queries (1,000 seeded objects, 1,000 iterations).
  * Added LiveQuery end-to-end performance benchmark exercising real-time subscription, create-event delivery, and unsubscribe flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->