### PR TITLE
ci: Performance benchmark job not failing on regression

### DIFF
--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -245,6 +245,7 @@ jobs:
           console.log('');
           if (hasRegression) {
             console.log('⚠️ **Performance regressions detected.** Please review the changes.');
+            process.exitCode = 1;
           } else if (hasImprovement) {
             console.log('🚀 **Performance improvements detected!** Great work!');
           } else {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Performance benchmark job not failing on regression.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced performance regression detection in CI pipeline to explicitly signal job failure when regressions are identified, enabling better control flow for automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->