### PR TITLE
ci: Performance benchmark job not failing on regression

### DIFF
--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Compare benchmark results
         id: compare
         run: |
+          set -o pipefail
           node -e "
           const fs = require('fs');
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Performance benchmark job not failing on regression

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in the CI/CD performance benchmark pipeline to better propagate and detect failures during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->