### PR TITLE
fix: Parse Server role escalation and CLP bypass via direct `_Join` table write (GHSA-5f92-jrq3-28rc)

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -258,6 +258,9 @@ global.afterEachFn = async () => {
         if (!className.startsWith('_')) {
           return true;
         }
+        if (className.startsWith('_Join:')) {
+          return true;
+        }
         return [
           '_User',
           '_Installation',

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -953,6 +953,117 @@ describe('rest update', () => {
   });
 });
 
+describe('_Join table security', () => {
+  let config;
+
+  beforeEach(() => {
+    config = Config.get('test');
+  });
+
+  it('cannot create object in _Join table without masterKey', () => {
+    expect(() =>
+      rest.create(config, auth.nobody(config), '_Join:users:_Role', {
+        relatedId: 'someUserId',
+        owningId: 'someRoleId',
+      })
+    ).toThrowError(/Permission denied/);
+  });
+
+  it('cannot find objects in _Join table without masterKey', async () => {
+    await expectAsync(
+      rest.find(config, auth.nobody(config), '_Join:users:_Role', {})
+    ).toBeRejectedWith(
+      jasmine.objectContaining({
+        code: Parse.Error.OPERATION_FORBIDDEN,
+      })
+    );
+  });
+
+  it('cannot update object in _Join table without masterKey', () => {
+    expect(() =>
+      rest.update(config, auth.nobody(config), '_Join:users:_Role', { relatedId: 'someUserId' }, { owningId: 'newRoleId' })
+    ).toThrowError(/Permission denied/);
+  });
+
+  it('cannot delete object in _Join table without masterKey', () => {
+    expect(() =>
+      rest.del(config, auth.nobody(config), '_Join:users:_Role', 'someObjectId')
+    ).toThrowError(/Permission denied/);
+  });
+
+  it('cannot get object in _Join table without masterKey', async () => {
+    await expectAsync(
+      rest.get(config, auth.nobody(config), '_Join:users:_Role', 'someObjectId')
+    ).toBeRejectedWith(
+      jasmine.objectContaining({
+        code: Parse.Error.OPERATION_FORBIDDEN,
+      })
+    );
+  });
+
+  it('can find objects in _Join table with masterKey', async () => {
+    await expectAsync(
+      rest.find(config, auth.master(config), '_Join:users:_Role', {})
+    ).toBeResolved();
+  });
+
+  it('can find objects in _Join table with maintenance key', async () => {
+    await expectAsync(
+      rest.find(config, auth.maintenance(config), '_Join:users:_Role', {})
+    ).toBeResolved();
+  });
+
+  it('legitimate relation operations still work', async () => {
+    const role = new Parse.Role('admin', new Parse.ACL());
+    const user = await Parse.User.signUp('testuser', 'password123');
+    role.getUsers().add(user);
+    await role.save(null, { useMasterKey: true });
+    const result = await rest.find(config, auth.master(config), '_Join:users:_Role', {});
+    expect(result.results.length).toBe(1);
+  });
+
+  it('blocks _Join table access for any relation, not just _Role', () => {
+    expect(() =>
+      rest.create(config, auth.nobody(config), '_Join:viewers:ConfidentialDoc', {
+        relatedId: 'someUserId',
+        owningId: 'someDocId',
+      })
+    ).toThrowError(/Permission denied/);
+  });
+
+  it('cannot escalate role via direct _Join table write', async () => {
+    const role = new Parse.Role('superadmin', new Parse.ACL());
+    await role.save(null, { useMasterKey: true });
+    const user = await Parse.User.signUp('attacker', 'password123');
+    const sessionToken = user.getSessionToken();
+    const userAuth = await auth.getAuthForSessionToken({
+      config,
+      sessionToken,
+    });
+    expect(() =>
+      rest.create(config, userAuth, '_Join:users:_Role', {
+        relatedId: user.id,
+        owningId: role.id,
+      })
+    ).toThrowError(/Permission denied/);
+  });
+
+  it('cannot write to _Join table with read-only masterKey', () => {
+    expect(() =>
+      rest.create(config, auth.readOnly(config), '_Join:users:_Role', {
+        relatedId: 'someUserId',
+        owningId: 'someRoleId',
+      })
+    ).toThrowError(/Permission denied/);
+  });
+
+  it('can read _Join table with read-only masterKey', async () => {
+    await expectAsync(
+      rest.find(config, auth.readOnly(config), '_Join:users:_Role', {})
+    ).toBeResolved();
+  });
+});
+
 describe('read-only masterKey', () => {
   let loggerErrorSpy;
   let logger;

--- a/src/SharedRest.js
+++ b/src/SharedRest.js
@@ -33,6 +33,15 @@ function enforceRoleSecurity(method, className, auth, config) {
     );
   }
 
+  // _Join tables are internal and must only be modified through relation operations
+  if (className.startsWith('_Join:') && !auth.isMaster && !auth.isMaintenance) {
+    throw createSanitizedError(
+      Parse.Error.OPERATION_FORBIDDEN,
+      `Clients aren't allowed to perform the ${method} operation on the ${className} collection.`,
+      config
+    );
+  }
+
   // readOnly masterKey is not allowed
   if (auth.isReadOnly && (method === 'delete' || method === 'create' || method === 'update')) {
     throw createSanitizedError(


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Parse Server role escalation and CLP bypass via direct `_Join table write ([GHSA-5f92-jrq3-28rc](https://github.com/parse-community/parse-server/security/advisories/GHSA-5f92-jrq3-28rc))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced access controls for internal join tables to restrict unauthorized operations
  * Improved permission validation to ensure only authorized users can modify or access join table structures

* **Tests**
  * Added comprehensive test suite validating join table security and permission enforcement across various user roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->