### PR TITLE
fix:  LiveQuery `regexTimeout` default value not applied

### DIFF
--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -557,6 +557,16 @@ describe('matchesQuery', function () {
     expect(matchesQuery(player, q)).toBe(true);
   });
 
+  it('applies default regexTimeout when liveQuery is configured without explicit regexTimeout', async () => {
+    await reconfigureServer({
+      liveQuery: { classNames: ['Player'] },
+    });
+    // Verify the default value is applied by checking the config
+    const Config = require('../lib/Config');
+    const config = Config.get('test');
+    expect(config.liveQuery.regexTimeout).toBe(100);
+  });
+
   it('matches $nearSphere queries', function () {
     let q = new Parse.Query('Checkin');
     q.near('location', new Parse.GeoPoint(20, 20));

--- a/src/Config.js
+++ b/src/Config.js
@@ -14,6 +14,7 @@ import {
   DatabaseOptions,
   FileUploadOptions,
   IdempotencyOptions,
+  LiveQueryOptions,
   LogLevels,
   PagesOptions,
   ParseServerOptions,
@@ -136,6 +137,7 @@ export class Config {
     extendSessionOnUse,
     allowClientClassCreation,
     requestComplexity,
+    liveQuery,
   }) {
     if (masterKey === readOnlyMasterKey) {
       throw new Error('masterKey and readOnlyMasterKey should be different');
@@ -179,6 +181,7 @@ export class Config {
     this.validateCustomPages(customPages);
     this.validateAllowClientClassCreation(allowClientClassCreation);
     this.validateRequestComplexity(requestComplexity);
+    this.validateLiveQueryOptions(liveQuery);
   }
 
   static validateCustomPages(customPages) {
@@ -703,6 +706,17 @@ export class Config {
       databaseOptions.allowPublicExplain = DatabaseOptions.allowPublicExplain.default;
     } else if (typeof databaseOptions.allowPublicExplain !== 'boolean') {
       throw `Parse Server option 'databaseOptions.allowPublicExplain' must be a boolean.`;
+    }
+  }
+
+  static validateLiveQueryOptions(liveQuery) {
+    if (liveQuery == undefined) {
+      return;
+    }
+    if (liveQuery.regexTimeout === undefined) {
+      liveQuery.regexTimeout = LiveQueryOptions.regexTimeout.default;
+    } else if (typeof liveQuery.regexTimeout !== 'number') {
+      throw `liveQuery.regexTimeout must be a number`;
     }
   }
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

LiveQuery `regexTimeout` default value not applied.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LiveQuery configuration now applies a default regexTimeout value of 100 when not explicitly configured.
  * Enhanced validation for LiveQuery options to ensure proper regexTimeout values.

* **Tests**
  * Added test case to verify default regexTimeout behavior in LiveQuery configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->