### PR TITLE
feat: Add `X-Content-Type-Options: nosniff` header and customizable response headers for files via `Parse.Cloud.afterFind(Parse.File)`

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -4453,6 +4453,39 @@ describe('Parse.File hooks', () => {
     expect(response.headers['content-disposition']).toBe(`attachment;filename=${file._name}`);
   });
 
+  it('can set custom response headers in afterFind', async () => {
+    const file = new Parse.File('popeye.txt', [1, 2, 3], 'text/plain');
+    await file.save({ useMasterKey: true });
+    Parse.Cloud.afterFind(Parse.File, req => {
+      req.responseHeaders['X-Custom-Header'] = 'custom-value';
+    });
+    const response = await request({
+      url: file.url(),
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+      },
+    });
+    expect(response.headers['x-custom-header']).toBe('custom-value');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('can override default response headers in afterFind', async () => {
+    const file = new Parse.File('popeye.txt', [1, 2, 3], 'text/plain');
+    await file.save({ useMasterKey: true });
+    Parse.Cloud.afterFind(Parse.File, req => {
+      delete req.responseHeaders['X-Content-Type-Options'];
+    });
+    const response = await request({
+      url: file.url(),
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+      },
+    });
+    expect(response.headers['x-content-type-options']).toBeUndefined();
+  });
+
   it('beforeFind blocks metadata endpoint', async () => {
     const file = new Parse.File('popeye.txt', [1, 2, 3], 'text/plain');
     await file.save({ useMasterKey: true });

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -858,8 +858,9 @@ describe('(GHSA-mf3j-86qx-cq5j) ReDoS via $regex in LiveQuery subscription', () 
     expect(elapsed).toBeLessThan(timeout + 1000);
     client.close();
   });
+});
 
-  describe('(GHSA-3jmq-rrxf-gqrg) Stored XSS via file serving', () => {
+describe('(GHSA-3jmq-rrxf-gqrg) Stored XSS via file serving', () => {
     it('sets X-Content-Type-Options: nosniff on file GET response', async () => {
       const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
       await file.save({ useMasterKey: true });
@@ -886,6 +887,4 @@ describe('(GHSA-mf3j-86qx-cq5j) ReDoS via $regex in LiveQuery subscription', () 
       });
       expect(response.headers['x-content-type-options']).toBe('nosniff');
     });
-
-  });
 });

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -858,4 +858,34 @@ describe('(GHSA-mf3j-86qx-cq5j) ReDoS via $regex in LiveQuery subscription', () 
     expect(elapsed).toBeLessThan(timeout + 1000);
     client.close();
   });
+
+  describe('(GHSA-3jmq-rrxf-gqrg) Stored XSS via file serving', () => {
+    it('sets X-Content-Type-Options: nosniff on file GET response', async () => {
+      const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
+      await file.save({ useMasterKey: true });
+      const response = await request({
+        url: file.url(),
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+      });
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+    });
+
+    it('sets X-Content-Type-Options: nosniff on streaming file GET response', async () => {
+      const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
+      await file.save({ useMasterKey: true });
+      const response = await request({
+        url: file.url(),
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Range': 'bytes=0-2',
+        },
+      });
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+    });
+
+  });
 });

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -861,30 +861,30 @@ describe('(GHSA-mf3j-86qx-cq5j) ReDoS via $regex in LiveQuery subscription', () 
 });
 
 describe('(GHSA-3jmq-rrxf-gqrg) Stored XSS via file serving', () => {
-    it('sets X-Content-Type-Options: nosniff on file GET response', async () => {
-      const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
-      await file.save({ useMasterKey: true });
-      const response = await request({
-        url: file.url(),
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-REST-API-Key': 'rest',
-        },
-      });
-      expect(response.headers['x-content-type-options']).toBe('nosniff');
+  it('sets X-Content-Type-Options: nosniff on file GET response', async () => {
+    const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
+    await file.save({ useMasterKey: true });
+    const response = await request({
+      url: file.url(),
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+      },
     });
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+  });
 
-    it('sets X-Content-Type-Options: nosniff on streaming file GET response', async () => {
-      const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
-      await file.save({ useMasterKey: true });
-      const response = await request({
-        url: file.url(),
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-REST-API-Key': 'rest',
-          'Range': 'bytes=0-2',
-        },
-      });
-      expect(response.headers['x-content-type-options']).toBe('nosniff');
+  it('sets X-Content-Type-Options: nosniff on streaming file GET response', async () => {
+    const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');
+    await file.save({ useMasterKey: true });
+    const response = await request({
+      url: file.url(),
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'Range': 'bytes=0-2',
+      },
     });
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+  });
 });

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -188,7 +188,12 @@ export class FilesRouter {
         contentType = mime.getType(filename);
       }
 
+      const defaultResponseHeaders = { 'X-Content-Type-Options': 'nosniff' };
+
       if (isFileStreamable(req, filesController)) {
+        for (const [key, value] of Object.entries(defaultResponseHeaders)) {
+          res.set(key, value);
+        }
         filesController.handleFileStream(config, filename, req, res, contentType).catch(() => {
           res.status(404);
           res.set('Content-Type', 'text/plain');
@@ -208,7 +213,7 @@ export class FilesRouter {
       file = new Parse.File(filename, { base64: data.toString('base64') }, contentType);
       const afterFind = await triggers.maybeRunFileTrigger(
         triggers.Types.afterFind,
-        { file, forceDownload: false },
+        { file, forceDownload: false, responseHeaders: { ...defaultResponseHeaders } },
         config,
         req.auth
       );
@@ -223,6 +228,11 @@ export class FilesRouter {
       res.set('Content-Length', data.length);
       if (afterFind.forceDownload) {
         res.set('Content-Disposition', `attachment;filename=${afterFind.file._name}`);
+      }
+      if (afterFind.responseHeaders) {
+        for (const [key, value] of Object.entries(afterFind.responseHeaders)) {
+          res.set(key, value);
+        }
       }
       res.end(data);
     } catch (e) {

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -757,6 +757,8 @@ module.exports = ParseCloud;
  * @property {String} triggerName The name of the trigger (`beforeSave`, `afterSave`)
  * @property {Object} log The current logger inside Parse Server.
  * @property {Object} config The Parse Server config.
+ * @property {Boolean} forceDownload (afterFind only) If set to `true`, the file response will include a `Content-Disposition: attachment` header, prompting the browser to download the file instead of displaying it inline.
+ * @property {Object} responseHeaders (afterFind only) The headers that will be set on the file response. By default contains `{ 'X-Content-Type-Options': 'nosniff' }`. Modify this object to add, change, or remove response headers.
  */
 
 /**

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -1076,6 +1076,9 @@ export async function maybeRunFileTrigger(triggerType, fileObject, config, auth)
       if (request.forceDownload) {
         fileObject.forceDownload = true;
       }
+      if (request.responseHeaders) {
+        fileObject.responseHeaders = request.responseHeaders;
+      }
       logTriggerSuccessBeforeHook(
         triggerType,
         'Parse.File',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Add `X-Content-Type-Options: nosniff` header and customizable response headers for file responses.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File response triggers (afterFind) can set or override HTTP response headers.
  * New forceDownload option to prompt file download.
  * X-Content-Type-Options: nosniff applied to file responses by default.

* **Tests**
  * Added tests for custom/overridden response headers in afterFind hooks.
  * Added tests ensuring nosniff is present for normal and ranged/streamed file responses.

* **Documentation**
  * Trigger request docs updated to include forceDownload and responseHeaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->