### PR TITLE
fix: SQL injection via dot-notation field name in PostgreSQL (GHSA-qpr4-jrj4-6f27)

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -884,7 +884,7 @@ describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name',
     }).catch(() => {});
 
     // Verify the data was not modified by injected SQL
-    const verify = await new Parse.Query('InjectionTest').first();
+    const verify = await new Parse.Query('InjectionTest').get(obj.id);
     expect(verify.get('name')).toBe('original');
   });
 

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -924,7 +924,7 @@ describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name',
       },
     }).catch(() => {});
 
-    const verify = await new Parse.Query('InjectionTest').first();
+    const verify = await new Parse.Query('InjectionTest').get(obj.id);
     expect(verify.get('name')).toBe('original');
   });
 
@@ -944,7 +944,7 @@ describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name',
       },
     }).catch(() => {});
 
-    const verify = await new Parse.Query('InjectionTest').first();
+    const verify = await new Parse.Query('InjectionTest').get(obj.id);
     expect(verify.get('name')).toBe('original');
   });
 
@@ -964,7 +964,7 @@ describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name',
       },
     }).catch(() => {});
 
-    const verify = await new Parse.Query('InjectionTest').first();
+    const verify = await new Parse.Query('InjectionTest').get(obj.id);
     expect(verify.get('name')).toBe('original');
   });
 
@@ -984,7 +984,7 @@ describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name',
       },
     }).catch(() => {});
 
-    const verify = await new Parse.Query('InjectionTest').first();
+    const verify = await new Parse.Query('InjectionTest').get(obj.id);
     expect(verify.get('name')).toBe('original');
   });
 

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -860,6 +860,87 @@ describe('(GHSA-mf3j-86qx-cq5j) ReDoS via $regex in LiveQuery subscription', () 
   });
 });
 
+describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name', () => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Parse-Application-Id': 'test',
+    'X-Parse-REST-API-Key': 'rest',
+  };
+
+  it_only_db('postgres')('does not execute injected SQL via sort order dot-notation', async () => {
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    obj.set('name', 'original');
+    await obj.save();
+
+    // This payload would execute a stacked query if single quotes are not escaped
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: "data.x' ASC; UPDATE \"InjectionTest\" SET name = 'hacked' WHERE true--",
+      },
+    }).catch(() => {});
+
+    // Verify the data was not modified by injected SQL
+    const verify = await new Parse.Query('InjectionTest').first();
+    expect(verify.get('name')).toBe('original');
+  });
+
+  it_only_db('postgres')('does not execute injected SQL via sort order with pg_sleep', async () => {
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    await obj.save();
+
+    const start = Date.now();
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: "data.x' ASC; SELECT pg_sleep(3)--",
+      },
+    }).catch(() => {});
+    const elapsed = Date.now() - start;
+
+    // If injection succeeded, query would take >= 3 seconds
+    expect(elapsed).toBeLessThan(3000);
+  });
+
+  it('allows valid dot-notation sort on object field', async () => {
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    await obj.save();
+
+    const response = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: 'data.key',
+      },
+    });
+    expect(response.status).toBe(200);
+  });
+
+  it('allows valid dot-notation with special characters in sub-field', async () => {
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { 'my-field': 'value' });
+    await obj.save();
+
+    const response = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: 'data.my-field',
+      },
+    });
+    expect(response.status).toBe(200);
+  });
+});
+
 describe('(GHSA-3jmq-rrxf-gqrg) Stored XSS via file serving', () => {
   it('sets X-Content-Type-Options: nosniff on file GET response', async () => {
     const file = new Parse.File('hello.txt', [1, 2, 3], 'text/plain');

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -908,6 +908,86 @@ describe('(GHSA-qpr4-jrj4-6f27) SQL Injection via sort dot-notation field name',
     expect(elapsed).toBeLessThan(3000);
   });
 
+  it_only_db('postgres')('does not execute injection via dollar-sign quoting bypass', async () => {
+    // PostgreSQL supports $$string$$ as alternative to 'string'
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    obj.set('name', 'original');
+    await obj.save();
+
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: "data.x' ASC; UPDATE \"InjectionTest\" SET name = $$hacked$$ WHERE true--",
+      },
+    }).catch(() => {});
+
+    const verify = await new Parse.Query('InjectionTest').first();
+    expect(verify.get('name')).toBe('original');
+  });
+
+  it_only_db('postgres')('does not execute injection via tagged dollar quoting bypass', async () => {
+    // PostgreSQL supports $tag$string$tag$ as alternative to 'string'
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    obj.set('name', 'original');
+    await obj.save();
+
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: "data.x' ASC; UPDATE \"InjectionTest\" SET name = $t$hacked$t$ WHERE true--",
+      },
+    }).catch(() => {});
+
+    const verify = await new Parse.Query('InjectionTest').first();
+    expect(verify.get('name')).toBe('original');
+  });
+
+  it_only_db('postgres')('does not execute injection via CHR() concatenation bypass', async () => {
+    // CHR(104)||CHR(97)||... builds 'hacked' without quotes
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    obj.set('name', 'original');
+    await obj.save();
+
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: "data.x' ASC; UPDATE \"InjectionTest\" SET name = CHR(104)||CHR(97)||CHR(99)||CHR(107) WHERE true--",
+      },
+    }).catch(() => {});
+
+    const verify = await new Parse.Query('InjectionTest').first();
+    expect(verify.get('name')).toBe('original');
+  });
+
+  it_only_db('postgres')('does not execute injection via backslash escape bypass', async () => {
+    // Backslash before quote could interact with '' escaping in some configurations
+    const obj = new Parse.Object('InjectionTest');
+    obj.set('data', { key: 'value' });
+    obj.set('name', 'original');
+    await obj.save();
+
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/InjectionTest',
+      headers,
+      qs: {
+        order: "data.x\\' ASC; UPDATE \"InjectionTest\" SET name = 'hacked' WHERE true--",
+      },
+    }).catch(() => {});
+
+    const verify = await new Parse.Query('InjectionTest').first();
+    expect(verify.get('name')).toBe('original');
+  });
+
   it('allows valid dot-notation sort on object field', async () => {
     const obj = new Parse.Object('InjectionTest');
     obj.set('data', { key: 'value' });

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -211,12 +211,12 @@ const handleDotFields = object => {
 const transformDotFieldToComponents = fieldName => {
   return fieldName.split('.').map((cmpt, index) => {
     if (index === 0) {
-      return `"${cmpt}"`;
+      return `"${cmpt.replace(/"/g, '""')}"`;
     }
     if (isArrayIndex(cmpt)) {
       return Number(cmpt);
     } else {
-      return `'${cmpt}'`;
+      return `'${cmpt.replace(/'/g, "''")}'`;
     }
   });
 };


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

SQL injection via dot-notation field name in PostgreSQL ([GHSA-qpr4-jrj4-6f27](https://github.com/parse-community/parse-server/security/advisories/GHSA-qpr4-jrj4-6f27))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive PostgreSQL tests validating that malicious sort parameters cannot perform SQL-injection or timing-based attacks; includes checks for varied payload encodings (note: test suite was duplicated).
* **Bug Fixes**
  * Improved escaping of quotation characters in field identifiers used in queries, preventing malformed identifiers and reducing injection risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->