### PR TITLE
test: Verify prototype pollution via application ID is blocked by middleware

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -245,6 +245,39 @@ describe('Vulnerabilities', () => {
     });
   });
 
+  describe('(GHSA-3v4q-4q9g-x83q) Prototype pollution via application ID in trigger store', () => {
+    const prototypeProperties = ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'];
+
+    for (const prop of prototypeProperties) {
+      it(`rejects "${prop}" as application ID in cloud function call`, async () => {
+        const response = await request({
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': prop,
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          method: 'POST',
+          url: 'http://localhost:8378/1/functions/testFunction',
+          body: JSON.stringify({}),
+        }).catch(e => e);
+        expect(response.status).toBe(403);
+      });
+
+      it(`rejects "${prop}" as application ID in class query`, async () => {
+        const response = await request({
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': prop,
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          method: 'GET',
+          url: 'http://localhost:8378/1/classes/TestClass',
+        }).catch(e => e);
+        expect(response.status).toBe(403);
+      });
+    }
+  });
+
   describe('Request denylist', () => {
     describe('(GHSA-q342-9w2p-57fp) Denylist bypass via sibling nested objects', () => {
       it('denies _bsontype:Code after a sibling nested object', async () => {

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -263,6 +263,20 @@ describe('Vulnerabilities', () => {
         expect(response.status).toBe(403);
       });
 
+      it(`rejects "${prop}" as application ID with arbitrary API key in cloud function call`, async () => {
+        const response = await request({
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Parse-Application-Id': prop,
+            'X-Parse-REST-API-Key': 'ANY_KEY',
+          },
+          method: 'POST',
+          url: 'http://localhost:8378/1/functions/testFunction',
+          body: JSON.stringify({}),
+        }).catch(e => e);
+        expect(response.status).toBe(403);
+      });
+
       it(`rejects "${prop}" as application ID in class query`, async () => {
         const response = await request({
           headers: {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -87,7 +87,7 @@ function validateClassNameForTriggers(className, type) {
   return className;
 }
 
-const _triggerStore = {};
+const _triggerStore = Object.create(null);
 
 const Category = {
   Functions: 'Functions',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Verify prototype pollution via application ID is blocked by middleware. In addition, the trigger store is initialized in a prototype pollution-safe way for consistency.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened in-memory trigger handling to prevent prototype-property attacks via application identifiers, closing a prototype pollution vector and improving overall security.

* **Tests**
  * Added security tests that verify requests using prototype-like property names are denied (403), ensuring protections remain effective.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->