### PR TITLE
docs: Clarify user lockout when setting empty ACL

### DIFF
--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -54,7 +54,7 @@ module.exports.SchemaOptions = {
 module.exports.ParseServerOptions = {
   accountLockout: {
     env: 'PARSE_SERVER_ACCOUNT_LOCKOUT',
-    help: 'The account lockout policy for failed login attempts.',
+    help: "The account lockout policy for failed login attempts.<br><br>Note: Setting a user's ACL to an empty object `{}` via master key is a separate mechanism that only prevents new logins; it does not invalidate existing session tokens. To immediately revoke a user's access, destroy their sessions via master key in addition to setting the ACL.",
     action: parsers.objectParser,
     type: 'AccountLockoutOptions',
   },

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -12,7 +12,7 @@
 
 /**
  * @interface ParseServerOptions
- * @property {AccountLockoutOptions} accountLockout The account lockout policy for failed login attempts.
+ * @property {AccountLockoutOptions} accountLockout The account lockout policy for failed login attempts.<br><br>Note: Setting a user's ACL to an empty object `{}` via master key is a separate mechanism that only prevents new logins; it does not invalidate existing session tokens. To immediately revoke a user's access, destroy their sessions via master key in addition to setting the ACL.
  * @property {Boolean} allowClientClassCreation Enable (or disable) client class creation, defaults to false
  * @property {Boolean} allowCustomObjectId Enable (or disable) custom objectId
  * @property {Boolean} allowExpiredAuthDataToken Allow a user to log in even if the 3rd party authentication token that was used to sign in to their account has expired. If this is set to `false`, then the token will be validated every time the user signs in to their account. This refers to the token that is stored in the `_User.authData` field. Defaults to `false`.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -251,7 +251,9 @@ export interface ParseServerOptions {
     | boolean
     | (SendEmailVerificationRequest => boolean | Promise<boolean>)
   );
-  /* The account lockout policy for failed login attempts. */
+  /* The account lockout policy for failed login attempts.
+  <br><br>
+  Note: Setting a user's ACL to an empty object `{}` via master key is a separate mechanism that only prevents new logins; it does not invalidate existing session tokens. To immediately revoke a user's access, destroy their sessions via master key in addition to setting the ACL. */
   accountLockout: ?AccountLockoutOptions;
   /* The password policy for enforcing password related rules. */
   passwordPolicy: ?PasswordPolicyOptions;

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -132,10 +132,10 @@ export class UsersRouter extends ClassesRouter {
           if (!isValidPassword) {
             throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
           }
-          // Ensure the user isn't locked out
-          // A locked out user won't be able to login
-          // To lock a user out, just set the ACL to `masterKey` only  ({}).
-          // Empty ACL is OK
+          // A user with an empty ACL (master key only) is considered locked out and
+          // cannot log in. This only prevents new logins; existing session tokens
+          // remain valid. To immediately revoke access, also destroy the user's
+          // sessions via master key.
           if (!req.auth.isMaster && user.ACL && Object.keys(user.ACL).length == 0) {
             throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
           }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Clarify user lockout when setting empty ACL.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for account lockout settings to clarify ACL behavior with master key access and session token handling.
  * Enhanced inline guidance on login lockout behavior and the steps needed for immediate user access revocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->