### PR TITLE
SQL injection via query field name when using PostgreSQL (GHSA-c442-97qw-j6c6)

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -2112,3 +2112,219 @@ describe('(GHSA-w54v-hf9p-8856) User enumeration via email verification endpoint
     }
   });
 });
+
+describe('(GHSA-c442-97qw-j6c6) SQL Injection via $regex query operator field name in PostgreSQL adapter', () => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Parse-Application-Id': 'test',
+    'X-Parse-REST-API-Key': 'rest',
+    'X-Parse-Master-Key': 'test',
+  };
+  const serverURL = 'http://localhost:8378/1';
+
+  beforeEach(async () => {
+    const obj = new Parse.Object('TestClass');
+    obj.set('playerName', 'Alice');
+    obj.set('score', 100);
+    await obj.save(null, { useMasterKey: true });
+  });
+
+  it('rejects field names containing double quotes in $regex query with master key', async () => {
+    const maliciousField = 'playerName" OR 1=1 --';
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          [maliciousField]: { $regex: 'x' },
+        }),
+      },
+    }).catch(e => e);
+    expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
+  it('rejects field names containing single quotes in $regex query with master key', async () => {
+    const maliciousField = "playerName' OR '1'='1";
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          [maliciousField]: { $regex: 'x' },
+        }),
+      },
+    }).catch(e => e);
+    expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
+  it('rejects field names containing semicolons in $regex query with master key', async () => {
+    const maliciousField = 'playerName; DROP TABLE "TestClass" --';
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          [maliciousField]: { $regex: 'x' },
+        }),
+      },
+    }).catch(e => e);
+    expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
+  it('rejects field names containing parentheses in $regex query with master key', async () => {
+    const maliciousField = 'playerName" ~ \'x\' OR (SELECT 1) --';
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          [maliciousField]: { $regex: 'x' },
+        }),
+      },
+    }).catch(e => e);
+    expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
+  it('allows legitimate $regex query with master key', async () => {
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          playerName: { $regex: 'Ali' },
+        }),
+      },
+    });
+    expect(response.data.results.length).toBe(1);
+    expect(response.data.results[0].playerName).toBe('Alice');
+  });
+
+  it('allows legitimate $regex query with dot notation and master key', async () => {
+    const obj = new Parse.Object('TestClass');
+    obj.set('metadata', { tag: 'hello-world' });
+    await obj.save(null, { useMasterKey: true });
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          'metadata.tag': { $regex: 'hello' },
+        }),
+      },
+    });
+    expect(response.data.results.length).toBe(1);
+    expect(response.data.results[0].metadata.tag).toBe('hello-world');
+  });
+
+  it('allows legitimate $regex query without master key', async () => {
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+      },
+      qs: {
+        where: JSON.stringify({
+          playerName: { $regex: 'Ali' },
+        }),
+      },
+    });
+    expect(response.data.results.length).toBe(1);
+    expect(response.data.results[0].playerName).toBe('Alice');
+  });
+
+  it('rejects field names with SQL injection via non-$regex operators with master key', async () => {
+    const maliciousField = 'playerName" OR 1=1 --';
+    const response = await request({
+      method: 'GET',
+      url: `${serverURL}/classes/TestClass`,
+      headers,
+      qs: {
+        where: JSON.stringify({
+          [maliciousField]: { $exists: true },
+        }),
+      },
+    }).catch(e => e);
+    expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
+  describe('validateQuery key name enforcement', () => {
+    const maliciousField = 'field"; DROP TABLE test --';
+    const noMasterHeaders = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+    };
+
+    it('rejects malicious field name in find without master key', async () => {
+      const response = await request({
+        method: 'GET',
+        url: `${serverURL}/classes/TestClass`,
+        headers: noMasterHeaders,
+        qs: {
+          where: JSON.stringify({ [maliciousField]: 'value' }),
+        },
+      }).catch(e => e);
+      expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+    });
+
+    it('rejects malicious field name in find with master key', async () => {
+      const response = await request({
+        method: 'GET',
+        url: `${serverURL}/classes/TestClass`,
+        headers,
+        qs: {
+          where: JSON.stringify({ [maliciousField]: 'value' }),
+        },
+      }).catch(e => e);
+      expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+    });
+
+    it('allows master key to query whitelisted internal field _email_verify_token', async () => {
+      await reconfigureServer({
+        verifyUserEmails: true,
+        emailAdapter: {
+          sendVerificationEmail: () => Promise.resolve(),
+          sendPasswordResetEmail: () => Promise.resolve(),
+          sendMail: () => {},
+        },
+        appName: 'test',
+        publicServerURL: 'http://localhost:8378/1',
+      });
+      const user = new Parse.User();
+      user.setUsername('testuser');
+      user.setPassword('testpass');
+      user.setEmail('test@example.com');
+      await user.signUp();
+      const response = await request({
+        method: 'GET',
+        url: `${serverURL}/classes/_User`,
+        headers,
+        qs: {
+          where: JSON.stringify({ _email_verify_token: { $exists: true } }),
+        },
+      });
+      expect(response.data.results.length).toBeGreaterThan(0);
+    });
+
+    it('rejects non-master key querying internal field _email_verify_token', async () => {
+      const response = await request({
+        method: 'GET',
+        url: `${serverURL}/classes/_User`,
+        headers: noMasterHeaders,
+        qs: {
+          where: JSON.stringify({ _email_verify_token: { $exists: true } }),
+        },
+      }).catch(e => e);
+      expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+    });
+  });
+});

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -2326,5 +2326,44 @@ describe('(GHSA-c442-97qw-j6c6) SQL Injection via $regex query operator field na
       }).catch(e => e);
       expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
     });
+
+    describe('non-master key cannot update internal fields', () => {
+      const internalFields = [
+        '_rperm',
+        '_wperm',
+        '_hashed_password',
+        '_email_verify_token',
+        '_perishable_token',
+        '_perishable_token_expires_at',
+        '_email_verify_token_expires_at',
+        '_failed_login_count',
+        '_account_lockout_expires_at',
+        '_password_changed_at',
+        '_password_history',
+        '_tombstone',
+        '_session_token',
+      ];
+
+      for (const field of internalFields) {
+        it(`rejects non-master key updating ${field}`, async () => {
+          const user = new Parse.User();
+          user.setUsername(`updatetest_${field}`);
+          user.setPassword('password123');
+          await user.signUp();
+          const response = await request({
+            method: 'PUT',
+            url: `${serverURL}/classes/_User/${user.id}`,
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Parse-Application-Id': 'test',
+              'X-Parse-REST-API-Key': 'rest',
+              'X-Parse-Session-Token': user.getSessionToken(),
+            },
+            body: JSON.stringify({ [field]: 'malicious_value' }),
+          }).catch(e => e);
+          expect(response.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+        });
+      }
+    });
   });
 });

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -225,7 +225,7 @@ const transformDotFieldToComponents = fieldName => {
 
 const transformDotField = fieldName => {
   if (fieldName.indexOf('.') === -1) {
-    return `"${fieldName}"`;
+    return `"${fieldName.replace(/"/g, '""')}"`;
   }
   const components = transformDotFieldToComponents(fieldName);
   let name = components.slice(0, components.length - 1).join('->');
@@ -760,11 +760,16 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
         }
       }
 
-      const name = transformDotField(fieldName);
       regex = processRegexPattern(regex);
 
-      patterns.push(`$${index}:raw ${operator} '$${index + 1}:raw'`);
-      values.push(name, regex);
+      if (fieldName.indexOf('.') >= 0) {
+        const name = transformDotField(fieldName);
+        patterns.push(`$${index}:raw ${operator} '$${index + 1}:raw'`);
+        values.push(name, regex);
+      } else {
+        patterns.push(`$${index}:name ${operator} '$${index + 1}:raw'`);
+        values.push(fieldName, regex);
+      }
       index += 2;
     }
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -122,8 +122,8 @@ const validateQuery = (
     }
     if (
       !key.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/) &&
-      ((!specialQueryKeys.includes(key) && !isMaster && !update) ||
-        (update && isMaster && !specialMasterQueryKeys.includes(key)))
+      !specialQueryKeys.includes(key) &&
+      !(isMaster && specialMasterQueryKeys.includes(key))
     ) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${key}`);
     }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -56,17 +56,59 @@ const transformObjectACL = ({ ACL, ...result }) => {
   return result;
 };
 
-const specialQueryKeys = ['$and', '$or', '$nor', '_rperm', '_wperm'];
+// Query operators that always pass validation regardless of auth level.
+const queryOperators = ['$and', '$or', '$nor'];
+
+// Registry of internal fields with access permissions.
+// Internal fields are never directly writable by clients, so clientWrite is omitted.
+// - clientRead: any client can use this field in queries
+// - masterRead: master key can use this field in queries
+// - masterWrite: master key can use this field in updates
+const internalFields = {
+  _rperm:                         { clientRead: true,  masterRead: true,  masterWrite: true  },
+  _wperm:                         { clientRead: true,  masterRead: true,  masterWrite: true  },
+  _hashed_password:               { clientRead: false, masterRead: false, masterWrite: true  },
+  _email_verify_token:            { clientRead: false, masterRead: true,  masterWrite: true  },
+  _perishable_token:              { clientRead: false, masterRead: true,  masterWrite: true  },
+  _perishable_token_expires_at:   { clientRead: false, masterRead: true,  masterWrite: true  },
+  _email_verify_token_expires_at: { clientRead: false, masterRead: true,  masterWrite: true  },
+  _failed_login_count:            { clientRead: false, masterRead: true,  masterWrite: true  },
+  _account_lockout_expires_at:    { clientRead: false, masterRead: true,  masterWrite: true  },
+  _password_changed_at:           { clientRead: false, masterRead: true,  masterWrite: true  },
+  _password_history:              { clientRead: false, masterRead: true,  masterWrite: true  },
+  _tombstone:                     { clientRead: false, masterRead: true,  masterWrite: false },
+  _session_token:                 { clientRead: false, masterRead: true,  masterWrite: false },
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  // The following fields are not accessed by their _-prefixed name through the API;
+  // they are mapped to REST-level names in the adapter layer or handled through
+  // separate code paths.
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  // System fields (mapped to REST-level names):
+  // _id (objectId)
+  // _created_at (createdAt)
+  // _updated_at (updatedAt)
+  // _last_used (lastUsed)
+  // _expiresAt (expiresAt)
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  // Legacy ACL format: mapped to/from _rperm/_wperm
+  // _acl
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  // Schema metadata: not data fields, used only for schema configuration
+  // _metadata
+  // _client_permissions
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  // Dynamic auth data fields: used only in projections and updates, not in queries
+  // _auth_data_<provider>
+};
+
+// Derived access lists
+const specialQueryKeys = [
+  ...queryOperators,
+  ...Object.keys(internalFields).filter(k => internalFields[k].clientRead),
+];
 const specialMasterQueryKeys = [
-  ...specialQueryKeys,
-  '_email_verify_token',
-  '_perishable_token',
-  '_tombstone',
-  '_email_verify_token_expires_at',
-  '_failed_login_count',
-  '_account_lockout_expires_at',
-  '_password_changed_at',
-  '_password_history',
+  ...queryOperators,
+  ...Object.keys(internalFields).filter(k => internalFields[k].masterRead),
 ];
 
 const validateQuery = (
@@ -250,17 +292,7 @@ const filterSensitiveData = (
 //   acl:  a list of strings. If the object to be updated has an ACL,
 //         one of the provided strings must provide the caller with
 //         write permissions.
-const specialKeysForUpdate = [
-  '_hashed_password',
-  '_perishable_token',
-  '_email_verify_token',
-  '_email_verify_token_expires_at',
-  '_account_lockout_expires_at',
-  '_failed_login_count',
-  '_perishable_token_expires_at',
-  '_password_changed_at',
-  '_password_history',
-];
+const specialKeysForUpdate = Object.keys(internalFields).filter(k => internalFields[k].masterWrite);
 
 const isSpecialUpdateKey = key => {
   return specialKeysForUpdate.indexOf(key) >= 0;

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -22,40 +22,6 @@ import type { ParseServerOptions } from '../Options';
 import type { QueryOptions, FullQueryOptions } from '../Adapters/Storage/StorageAdapter';
 import { createSanitizedError } from '../Error';
 
-function addWriteACL(query, acl) {
-  const newQuery = _.cloneDeep(query);
-  //Can't be any existing '_wperm' query, we don't allow client queries on that, no need to $and
-  newQuery._wperm = { $in: [null, ...acl] };
-  return newQuery;
-}
-
-function addReadACL(query, acl) {
-  const newQuery = _.cloneDeep(query);
-  //Can't be any existing '_rperm' query, we don't allow client queries on that, no need to $and
-  newQuery._rperm = { $in: [null, '*', ...acl] };
-  return newQuery;
-}
-
-// Transforms a REST API formatted ACL object to our two-field mongo format.
-const transformObjectACL = ({ ACL, ...result }) => {
-  if (!ACL) {
-    return result;
-  }
-
-  result._wperm = [];
-  result._rperm = [];
-
-  for (const entry in ACL) {
-    if (ACL[entry].read) {
-      result._rperm.push(entry);
-    }
-    if (ACL[entry].write) {
-      result._wperm.push(entry);
-    }
-  }
-  return result;
-};
-
 // Query operators that always pass validation regardless of auth level.
 const queryOperators = ['$and', '$or', '$nor'];
 
@@ -110,6 +76,40 @@ const specialMasterQueryKeys = [
   ...queryOperators,
   ...Object.keys(internalFields).filter(k => internalFields[k].masterRead),
 ];
+
+function addWriteACL(query, acl) {
+  const newQuery = _.cloneDeep(query);
+  //Can't be any existing '_wperm' query, we don't allow client queries on that, no need to $and
+  newQuery._wperm = { $in: [null, ...acl] };
+  return newQuery;
+}
+
+function addReadACL(query, acl) {
+  const newQuery = _.cloneDeep(query);
+  //Can't be any existing '_rperm' query, we don't allow client queries on that, no need to $and
+  newQuery._rperm = { $in: [null, '*', ...acl] };
+  return newQuery;
+}
+
+// Transforms a REST API formatted ACL object to our two-field mongo format.
+const transformObjectACL = ({ ACL, ...result }) => {
+  if (!ACL) {
+    return result;
+  }
+
+  result._wperm = [];
+  result._rperm = [];
+
+  for (const entry in ACL) {
+    if (ACL[entry].read) {
+      result._rperm.push(entry);
+    }
+    if (ACL[entry].write) {
+      result._wperm.push(entry);
+    }
+  }
+  return result;
+};
 
 const validateQuery = (
   query: any,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

SQL injection via query field name when using PostgreSQL ([GHSA-c442-97qw-j6c6](https://github.com/parse-community/parse-server/security/advisories/GHSA-c442-97qw-j6c6))

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and escaping of query field names to prevent malformed or unsafe database queries.

* **Tests**
  * Added comprehensive tests for field-name and regex query validation, including nested/dotted fields, master-key behaviors, and protection of internal fields.

* **Refactor**
  * Centralized rule definitions for query validation and internal-field access for more consistent and predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->