### PR TITLE
fix: OAuth2 adapter app ID validation sends wrong token to introspection endpoint (GHSA-69xg-f649-w5g2)

### DIFF
--- a/spec/Adapters/Auth/oauth2.spec.js
+++ b/spec/Adapters/Auth/oauth2.spec.js
@@ -340,32 +340,36 @@ describe('OAuth2Adapter', () => {
     it('should send the correct access token to the introspection endpoint during app ID validation', async () => {
       const capturedTokens = [];
       const originalFetch = global.fetch;
-      global.fetch = async (url, options) => {
-        if (typeof url === 'string' && url === 'https://provider.com/introspect') {
-          const body = options?.body?.toString() || '';
-          const token = new URLSearchParams(body).get('token');
-          capturedTokens.push(token);
-          return {
-            ok: true,
-            json: () => Promise.resolve({
-              active: true,
-              sub: 'user123',
-              aud: 'valid-app-id',
-            }),
-          };
+      try {
+        global.fetch = async (url, options) => {
+          if (typeof url === 'string' && url === 'https://provider.com/introspect') {
+            const body = options?.body?.toString() || '';
+            const token = new URLSearchParams(body).get('token');
+            capturedTokens.push(token);
+            return {
+              ok: true,
+              json: () => Promise.resolve({
+                active: true,
+                sub: 'user123',
+                aud: 'valid-app-id',
+              }),
+            };
+          }
+          return originalFetch(url, options);
+        };
+
+        const authData = { access_token: 'myRealAccessToken', id: 'user123' };
+        const user = await Parse.User.logInWith('mockOauth', { authData });
+        expect(user.id).toBeDefined();
+
+        // With appidField configured, validateAppId and validateAuthData both call requestTokenInfo.
+        // Both should receive the actual access token, not 'undefined' from argument mismatch.
+        expect(capturedTokens.length).toBeGreaterThanOrEqual(2);
+        for (const token of capturedTokens) {
+          expect(token).toBe('myRealAccessToken');
         }
-        return originalFetch(url, options);
-      };
-
-      const authData = { access_token: 'myRealAccessToken', id: 'user123' };
-      const user = await Parse.User.logInWith('mockOauth', { authData });
-      expect(user.id).toBeDefined();
-
-      // With appidField configured, validateAppId and validateAuthData both call requestTokenInfo.
-      // Both should receive the actual access token, not 'undefined' from argument mismatch.
-      expect(capturedTokens.length).toBeGreaterThanOrEqual(2);
-      for (const token of capturedTokens) {
-        expect(token).toBe('myRealAccessToken');
+      } finally {
+        global.fetch = originalFetch;
       }
     });
 

--- a/spec/Adapters/Auth/oauth2.spec.js
+++ b/spec/Adapters/Auth/oauth2.spec.js
@@ -337,6 +337,38 @@ describe('OAuth2Adapter', () => {
       );
     });
 
+    it('should send the correct access token to the introspection endpoint during app ID validation', async () => {
+      const capturedTokens = [];
+      const originalFetch = global.fetch;
+      global.fetch = async (url, options) => {
+        if (typeof url === 'string' && url === 'https://provider.com/introspect') {
+          const body = options?.body?.toString() || '';
+          const token = new URLSearchParams(body).get('token');
+          capturedTokens.push(token);
+          return {
+            ok: true,
+            json: () => Promise.resolve({
+              active: true,
+              sub: 'user123',
+              aud: 'valid-app-id',
+            }),
+          };
+        }
+        return originalFetch(url, options);
+      };
+
+      const authData = { access_token: 'myRealAccessToken', id: 'user123' };
+      const user = await Parse.User.logInWith('mockOauth', { authData });
+      expect(user.id).toBeDefined();
+
+      // With appidField configured, validateAppId and validateAuthData both call requestTokenInfo.
+      // Both should receive the actual access token, not 'undefined' from argument mismatch.
+      expect(capturedTokens.length).toBeGreaterThanOrEqual(2);
+      for (const token of capturedTokens) {
+        expect(token).toBe('myRealAccessToken');
+      }
+    });
+
     it('should reject account takeover when useridField is omitted and attacker uses their own token with victim ID', async () => {
       await reconfigureServer({
         auth: {

--- a/src/Adapters/Auth/oauth2.js
+++ b/src/Adapters/Auth/oauth2.js
@@ -72,7 +72,7 @@ class OAuth2Adapter extends AuthAdapter {
     this.authorizationHeader = options.authorizationHeader;
   }
 
-  async validateAppId(authData) {
+  async validateAppId(appIds, authData) {
     if (!this.appidField) {
       return;
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

OAuth2 adapter app ID validation sends wrong token to introspection endpoint ([GHSA-69xg-f649-w5g2](https://github.com/parse-community/parse-server/security/advisories/GHSA-69xg-f649-w5g2))

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK