### PR TITLE
fix: Session token expiration unchecked on cache hit

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -3318,6 +3318,47 @@ describe('Parse.User testing', () => {
     expect(session.get('expiresAt')).toEqual(expiresAt);
   });
 
+  it('should reject expired session token even when served from cache', async () => {
+    // Use a 1-second session length with a 5-second cache TTL (default)
+    // so the session expires while the cache entry is still alive
+    await reconfigureServer({ sessionLength: 1 });
+
+    // Sign up user — creates a session with expiresAt = now + 1 second
+    const user = await Parse.User.signUp('cacheuser', 'somepass');
+    const sessionToken = user.getSessionToken();
+
+    // Make an authenticated request to prime the user cache
+    await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/users/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+
+    // Wait for the session to expire (1 second), but cache entry (5s TTL) is still alive
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // This request should be served from cache but still reject the expired session
+    try {
+      await request({
+        method: 'GET',
+        url: 'http://localhost:8378/1/users/me',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'X-Parse-Session-Token': sessionToken,
+        },
+      });
+      fail('Should have rejected expired session token from cache');
+    } catch (error) {
+      expect(error.data.code).toEqual(209);
+      expect(error.data.error).toEqual('Session token is expired.');
+    }
+  });
+
   it('should not create extraneous session tokens', done => {
     const config = Config.get(Parse.applicationId);
     config.database

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -133,8 +133,13 @@ const getAuthForSessionToken = async function ({
 }) {
   cacheController = cacheController || (config && config.cacheController);
   if (cacheController) {
-    const userJSON = await cacheController.user.get(sessionToken);
-    if (userJSON) {
+    const cached = await cacheController.user.get(sessionToken);
+    if (cached) {
+      const { expiresAt: cachedExpiresAt, ...userJSON } = cached;
+      if (cachedExpiresAt && new Date(cachedExpiresAt) < new Date()) {
+        cacheController.user.del(sessionToken);
+        throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'Session token is expired.');
+      }
       const cachedUser = Parse.Object.fromJSON(userJSON);
       renewSessionIfNeeded({ config, sessionToken });
       return Promise.resolve(
@@ -195,7 +200,7 @@ const getAuthForSessionToken = async function ({
   obj['className'] = '_User';
   obj['sessionToken'] = sessionToken;
   if (cacheController) {
-    cacheController.user.put(sessionToken, obj);
+    cacheController.user.put(sessionToken, { ...obj, expiresAt: expiresAt?.toISOString() });
   }
   renewSessionIfNeeded({ config, session, sessionToken });
   const userObject = Parse.Object.fromJSON(obj);


### PR DESCRIPTION
## Summary

- Stores `expiresAt` alongside user data in the session cache
- Checks `expiresAt` on cache hits and rejects expired sessions
- Evicts expired cache entries on detection

## Test plan

- [x] Added test: expired session token rejected even when served from cache
- [x] Verified existing expired session tests still pass
- [x] Tested on MongoDB and Postgres
- [x] Linter passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test verifying expired session tokens are rejected when retrieved from cache.

* **Bug Fixes**
  * Implemented session token expiration validation for cached sessions. Expired tokens are now detected and removed from cache, preventing unauthorized access with stale credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->