### PR TITLE
fix: RequestComplexity opt in and new defaults

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -21,7 +21,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS15 | Config option `readOnlyMasterKeyIps` defaults to `['127.0.0.1', '::1']`                      | [#10115](https://github.com/parse-community/parse-server/pull/10115)   | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS16 | Remove config option `mountPlayground`                                                       | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS17 | Remove config option `playgroundPath`                                                        | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
-| DEPPS18 | Config option `requestComplexity` defaults to enabled with limits                            | TBD                                                                     | 9.6.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
+| DEPPS18 | Config option `requestComplexity` defaults to enabled with limits                            | [#10204](https://github.com/parse-community/parse-server/pull/10204)   | 9.6.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_change]: ## "The version and date of the planned change."

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -21,6 +21,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS15 | Config option `readOnlyMasterKeyIps` defaults to `['127.0.0.1', '::1']`                      | [#10115](https://github.com/parse-community/parse-server/pull/10115)   | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS16 | Remove config option `mountPlayground`                                                       | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS17 | Remove config option `playgroundPath`                                                        | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
+| DEPPS18 | Config option `requestComplexity` defaults to enabled with limits                            | TBD                                                                     | 9.6.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_change]: ## "The version and date of the planned change."

--- a/spec/RequestComplexity.spec.js
+++ b/spec/RequestComplexity.spec.js
@@ -116,8 +116,30 @@ describe('request complexity', () => {
       expect(config.requestComplexity.graphQLFields).toBe(200);
     });
 
-    it('should apply full defaults when not configured', async () => {
+    it('should have requestComplexity undefined when not configured', async () => {
       await reconfigureServer({});
+      const config = Config.get('test');
+      expect(config.requestComplexity).toBeUndefined();
+    });
+
+    it('should apply no limits when requestComplexity is undefined', async () => {
+      await reconfigureServer({});
+      const config = Config.get('test');
+      expect(config.requestComplexity).toBeUndefined();
+
+      const where = buildNestedInQuery(15);
+      await expectAsync(
+        rest.find(config, auth.nobody(config), '_User', where)
+      ).toBeResolved();
+
+      const includes = Array.from({ length: 100 }, (_, i) => `field${i}`).join(',');
+      await expectAsync(
+        rest.find(config, auth.nobody(config), '_User', {}, { include: includes })
+      ).toBeResolved();
+    });
+
+    it('should apply full defaults when empty object is passed', async () => {
+      await reconfigureServer({ requestComplexity: {} });
       const config = Config.get('test');
       expect(config.requestComplexity).toEqual({
         includeDepth: 5,
@@ -126,6 +148,18 @@ describe('request complexity', () => {
         graphQLDepth: 50,
         graphQLFields: 200,
       });
+    });
+
+    it('should log deprecation warning when requestComplexity is not set', async () => {
+      const Deprecator = require('../lib/Deprecator/Deprecator');
+      const logSpy = spyOn(Deprecator, '_logOption').and.callThrough();
+      await reconfigureServer({});
+      expect(logSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          optionKey: 'requestComplexity',
+          changeNewDefault: jasmine.stringMatching(/includeDepth.*10/),
+        })
+      );
     });
   });
 

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -41,4 +41,9 @@ module.exports = [
     changeNewKey: '',
     solution: "Use Parse Dashboard as GraphQL IDE or configure a third-party GraphQL client such as Apollo Sandbox, GraphiQL, or Insomnia with custom request headers.",
   },
+  {
+    optionKey: 'requestComplexity',
+    changeNewDefault: '{"includeDepth":10,"includeCount":100,"subqueryDepth":10,"graphQLDepth":20,"graphQLFields":200}',
+    solution: "Set 'requestComplexity' to the limits you want to enforce, or to the above object to opt-in to the future default behavior.",
+  },
 ];

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -500,10 +500,10 @@ module.exports.ParseServerOptions = {
   },
   requestComplexity: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY',
-    help: 'Options to limit the complexity of requests to prevent denial-of-service attacks. Limits are enforced for all requests except those using the master or maintenance key. Each property can be set to `-1` to disable that specific limit. Disabled by default in the current version; will be enabled by default with specific limits in the next major version.',
+    help: 'Options to limit the complexity of requests to prevent denial-of-service attacks. Limits are enforced for all requests except those using the master or maintenance key. Each property can be set to `-1` to disable that specific limit.',
     action: parsers.objectParser,
     type: 'RequestComplexityOptions',
-    default: undefined,
+    default: {},
   },
   requestContextMiddleware: {
     env: 'PARSE_SERVER_REQUEST_CONTEXT_MIDDLEWARE',

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -500,10 +500,10 @@ module.exports.ParseServerOptions = {
   },
   requestComplexity: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY',
-    help: 'Options to limit the complexity of requests to prevent denial-of-service attacks. Limits are enforced for all requests except those using the master or maintenance key. Each property can be set to `-1` to disable that specific limit.',
+    help: 'Options to limit the complexity of requests to prevent denial-of-service attacks. Limits are enforced for all requests except those using the master or maintenance key. Each property can be set to `-1` to disable that specific limit. Disabled by default in the current version; will be enabled by default with specific limits in the next major version.',
     action: parsers.objectParser,
     type: 'RequestComplexityOptions',
-    default: {},
+    default: undefined,
   },
   requestContextMiddleware: {
     env: 'PARSE_SERVER_REQUEST_CONTEXT_MIDDLEWARE',

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -503,7 +503,6 @@ module.exports.ParseServerOptions = {
     help: 'Options to limit the complexity of requests to prevent denial-of-service attacks. Limits are enforced for all requests except those using the master or maintenance key. Each property can be set to `-1` to disable that specific limit.',
     action: parsers.objectParser,
     type: 'RequestComplexityOptions',
-    default: {},
   },
   requestContextMiddleware: {
     env: 'PARSE_SERVER_REQUEST_CONTEXT_MIDDLEWARE',

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -366,8 +366,7 @@ export interface ParseServerOptions {
   /* Callback when server has closed */
   serverCloseComplete: ?() => void;
   /* Options to limit the complexity of requests to prevent denial-of-service attacks. Limits are enforced for all requests except those using the master or maintenance key. Each property can be set to `-1` to disable that specific limit.
-  :ENV: PARSE_SERVER_REQUEST_COMPLEXITY
-  :DEFAULT: {} */
+  :ENV: PARSE_SERVER_REQUEST_COMPLEXITY */
   requestComplexity: ?RequestComplexityOptions;
   /* The security options to identify and report weak security settings.
   :DEFAULT: {} */

--- a/src/Security/CheckGroups/CheckGroupServerConfig.js
+++ b/src/Security/CheckGroups/CheckGroupServerConfig.js
@@ -143,7 +143,7 @@ class CheckGroupServerConfig extends CheckGroup {
         check: () => {
           const rc = config.requestComplexity;
           if (!rc) {
-            throw 1;
+            return;
           }
           const values = [rc.includeDepth, rc.includeCount, rc.subqueryDepth, rc.graphQLDepth, rc.graphQLFields];
           if (values.some(v => v === -1)) {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
<!-- Describe or link the issue that this PR closes. -->

## Approach
<!-- Describe the changes in this PR. -->

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * The requestComplexity option is now marked deprecated; it will be enabled by default with limits in the next major release and a deprecation warning is emitted when unset.

* **Documentation**
  * Help text updated to remove the prior default and reflect the upcoming default change.

* **Tests**
  * Tests updated to expect the deprecation warning and adjusted assertions for unset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->