### PR TITLE
fix: Revert accidental breaking default values for query complexity limits

### DIFF
--- a/spec/RequestComplexity.spec.js
+++ b/spec/RequestComplexity.spec.js
@@ -136,23 +136,23 @@ describe('request complexity', () => {
       });
       const config = Config.get('test');
       expect(config.requestComplexity.includeDepth).toBe(3);
-      expect(config.requestComplexity.includeCount).toBe(50);
-      expect(config.requestComplexity.subqueryDepth).toBe(5);
+      expect(config.requestComplexity.includeCount).toBe(-1);
+      expect(config.requestComplexity.subqueryDepth).toBe(-1);
       expect(config.requestComplexity.queryDepth).toBe(-1);
-      expect(config.requestComplexity.graphQLDepth).toBe(50);
-      expect(config.requestComplexity.graphQLFields).toBe(200);
+      expect(config.requestComplexity.graphQLDepth).toBe(-1);
+      expect(config.requestComplexity.graphQLFields).toBe(-1);
     });
 
     it('should apply full defaults when not configured', async () => {
       await reconfigureServer({});
       const config = Config.get('test');
       expect(config.requestComplexity).toEqual({
-        includeDepth: 5,
-        includeCount: 50,
-        subqueryDepth: 5,
+        includeDepth: -1,
+        includeCount: -1,
+        subqueryDepth: -1,
         queryDepth: -1,
-        graphQLDepth: 50,
-        graphQLFields: 200,
+        graphQLDepth: -1,
+        graphQLFields: -1,
       });
     });
   });

--- a/spec/SecurityCheckGroups.spec.js
+++ b/spec/SecurityCheckGroups.spec.js
@@ -37,7 +37,14 @@ describe('Security Check Groups', () => {
       config.mountPlayground = false;
       config.readOnlyMasterKey = 'someReadOnlyMasterKey';
       config.readOnlyMasterKeyIps = ['127.0.0.1', '::1'];
-      config.requestComplexity = { queryDepth: 10 };
+      config.requestComplexity = {
+        includeDepth: 5,
+        includeCount: 50,
+        subqueryDepth: 5,
+        queryDepth: 10,
+        graphQLDepth: 50,
+        graphQLFields: 200,
+      };
       await reconfigureServer(config);
 
       const group = new CheckGroupServerConfig();

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -670,27 +670,27 @@ module.exports.RateLimitOptions = {
 module.exports.RequestComplexityOptions = {
   graphQLDepth: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY_GRAPHQL_DEPTH',
-    help: 'Maximum depth of GraphQL field selections. Set to `-1` to disable. Default is `50`.',
+    help: 'Maximum depth of GraphQL field selections. Set to `-1` to disable. Default is `-1`.',
     action: parsers.numberParser('graphQLDepth'),
-    default: 50,
+    default: -1,
   },
   graphQLFields: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY_GRAPHQL_FIELDS',
-    help: 'Maximum number of field selections in a GraphQL query. Set to `-1` to disable. Default is `200`.',
+    help: 'Maximum number of field selections in a GraphQL query. Set to `-1` to disable. Default is `-1`.',
     action: parsers.numberParser('graphQLFields'),
-    default: 200,
+    default: -1,
   },
   includeCount: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY_INCLUDE_COUNT',
-    help: 'Maximum number of include paths in a single query. Set to `-1` to disable. Default is `50`.',
+    help: 'Maximum number of include paths in a single query. Set to `-1` to disable. Default is `-1`.',
     action: parsers.numberParser('includeCount'),
-    default: 50,
+    default: -1,
   },
   includeDepth: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY_INCLUDE_DEPTH',
-    help: 'Maximum depth of include pointer chains (e.g. `a.b.c` = depth 3). Set to `-1` to disable. Default is `5`.',
+    help: 'Maximum depth of include pointer chains (e.g. `a.b.c` = depth 3). Set to `-1` to disable. Default is `-1`.',
     action: parsers.numberParser('includeDepth'),
-    default: 5,
+    default: -1,
   },
   queryDepth: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY_QUERY_DEPTH',
@@ -700,9 +700,9 @@ module.exports.RequestComplexityOptions = {
   },
   subqueryDepth: {
     env: 'PARSE_SERVER_REQUEST_COMPLEXITY_SUBQUERY_DEPTH',
-    help: 'Maximum nesting depth of `$inQuery`, `$notInQuery`, `$select`, `$dontSelect` subqueries. Set to `-1` to disable. Default is `5`.',
+    help: 'Maximum nesting depth of `$inQuery`, `$notInQuery`, `$select`, `$dontSelect` subqueries. Set to `-1` to disable. Default is `-1`.',
     action: parsers.numberParser('subqueryDepth'),
-    default: 5,
+    default: -1,
   },
 };
 module.exports.SecurityOptions = {

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -130,12 +130,12 @@
 
 /**
  * @interface RequestComplexityOptions
- * @property {Number} graphQLDepth Maximum depth of GraphQL field selections. Set to `-1` to disable. Default is `50`.
- * @property {Number} graphQLFields Maximum number of field selections in a GraphQL query. Set to `-1` to disable. Default is `200`.
- * @property {Number} includeCount Maximum number of include paths in a single query. Set to `-1` to disable. Default is `50`.
- * @property {Number} includeDepth Maximum depth of include pointer chains (e.g. `a.b.c` = depth 3). Set to `-1` to disable. Default is `5`.
+ * @property {Number} graphQLDepth Maximum depth of GraphQL field selections. Set to `-1` to disable. Default is `-1`.
+ * @property {Number} graphQLFields Maximum number of field selections in a GraphQL query. Set to `-1` to disable. Default is `-1`.
+ * @property {Number} includeCount Maximum number of include paths in a single query. Set to `-1` to disable. Default is `-1`.
+ * @property {Number} includeDepth Maximum depth of include pointer chains (e.g. `a.b.c` = depth 3). Set to `-1` to disable. Default is `-1`.
  * @property {Number} queryDepth Maximum nesting depth of `$or`, `$and`, `$nor` query operators. Set to `-1` to disable. Default is `-1`.
- * @property {Number} subqueryDepth Maximum nesting depth of `$inQuery`, `$notInQuery`, `$select`, `$dontSelect` subqueries. Set to `-1` to disable. Default is `5`.
+ * @property {Number} subqueryDepth Maximum nesting depth of `$inQuery`, `$notInQuery`, `$select`, `$dontSelect` subqueries. Set to `-1` to disable. Default is `-1`.
  */
 
 /**

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -425,25 +425,25 @@ export interface RateLimitOptions {
 }
 
 export interface RequestComplexityOptions {
-  /* Maximum depth of include pointer chains (e.g. `a.b.c` = depth 3). Set to `-1` to disable. Default is `5`.
-  :DEFAULT: 5 */
+  /* Maximum depth of include pointer chains (e.g. `a.b.c` = depth 3). Set to `-1` to disable. Default is `-1`.
+  :DEFAULT: -1 */
   includeDepth: ?number;
-  /* Maximum number of include paths in a single query. Set to `-1` to disable. Default is `50`.
-  :DEFAULT: 50 */
+  /* Maximum number of include paths in a single query. Set to `-1` to disable. Default is `-1`.
+  :DEFAULT: -1 */
   includeCount: ?number;
-  /* Maximum nesting depth of `$inQuery`, `$notInQuery`, `$select`, `$dontSelect` subqueries. Set to `-1` to disable. Default is `5`.
-  :DEFAULT: 5 */
+  /* Maximum nesting depth of `$inQuery`, `$notInQuery`, `$select`, `$dontSelect` subqueries. Set to `-1` to disable. Default is `-1`.
+  :DEFAULT: -1 */
   subqueryDepth: ?number;
   /* Maximum nesting depth of `$or`, `$and`, `$nor` query operators. Set to `-1` to disable. Default is `-1`.
   :DEFAULT: -1 */
   queryDepth: ?number;
-  /* Maximum depth of GraphQL field selections. Set to `-1` to disable. Default is `50`.
+  /* Maximum depth of GraphQL field selections. Set to `-1` to disable. Default is `-1`.
   :ENV: PARSE_SERVER_REQUEST_COMPLEXITY_GRAPHQL_DEPTH
-  :DEFAULT: 50 */
+  :DEFAULT: -1 */
   graphQLDepth: ?number;
-  /* Maximum number of field selections in a GraphQL query. Set to `-1` to disable. Default is `200`.
+  /* Maximum number of field selections in a GraphQL query. Set to `-1` to disable. Default is `-1`.
   :ENV: PARSE_SERVER_REQUEST_COMPLEXITY_GRAPHQL_FIELDS
-  :DEFAULT: 200 */
+  :DEFAULT: -1 */
   graphQLFields: ?number;
 }
 


### PR DESCRIPTION
## Issue

Revert accidental breaking default values for query complexity limits that were introduced with the fix for [GHSA-cmj3-wx7h-ffvg](https://github.com/parse-community/parse-server/security/advisories/GHSA-cmj3-wx7h-ffvg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated default request complexity settings to be disabled by default. Previously configured limits for query depth, field counts, and include operations are now disabled until explicitly configured. Users can re-enable these constraints as needed.

* **Documentation**
  * Updated documentation to reflect new default configuration values for request complexity options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->