### PR TITLE
refactor: Deprecate disabled default values for query complexity limits

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -21,6 +21,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS15 | Config option `readOnlyMasterKeyIps` defaults to `['127.0.0.1', '::1']`                      | [#10115](https://github.com/parse-community/parse-server/pull/10115)   | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS16 | Remove config option `mountPlayground`                                                       | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS17 | Remove config option `playgroundPath`                                                        | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
+| DEPPS18 | Config option `requestComplexity` limits enabled by default                                  | [#10207](https://github.com/parse-community/parse-server/pull/10207)   | 9.6.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_change]: ## "The version and date of the planned change."

--- a/spec/Deprecator.spec.js
+++ b/spec/Deprecator.spec.js
@@ -149,4 +149,55 @@ describe('Deprecator', () => {
       })
     );
   });
+
+  it('logs deprecation for requestComplexity limits when not set', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    await reconfigureServer();
+    const keys = [
+      'requestComplexity.includeDepth',
+      'requestComplexity.includeCount',
+      'requestComplexity.subqueryDepth',
+      'requestComplexity.queryDepth',
+      'requestComplexity.graphQLDepth',
+      'requestComplexity.graphQLFields',
+    ];
+    for (const key of keys) {
+      expect(logSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          optionKey: key,
+        })
+      );
+    }
+  });
+
+  it('does not log deprecation for requestComplexity limits when explicitly set', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    await reconfigureServer({
+      requestComplexity: {
+        includeDepth: 10,
+        includeCount: 100,
+        subqueryDepth: 10,
+        queryDepth: 10,
+        graphQLDepth: 20,
+        graphQLFields: 200,
+      },
+    });
+    const keys = [
+      'requestComplexity.includeDepth',
+      'requestComplexity.includeCount',
+      'requestComplexity.subqueryDepth',
+      'requestComplexity.queryDepth',
+      'requestComplexity.graphQLDepth',
+      'requestComplexity.graphQLFields',
+    ];
+    for (const key of keys) {
+      expect(logSpy).not.toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          optionKey: key,
+        })
+      );
+    }
+  });
 });

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -41,4 +41,34 @@ module.exports = [
     changeNewKey: '',
     solution: "Use Parse Dashboard as GraphQL IDE or configure a third-party GraphQL client such as Apollo Sandbox, GraphiQL, or Insomnia with custom request headers.",
   },
+  {
+    optionKey: 'requestComplexity.includeDepth',
+    changeNewDefault: '10',
+    solution: "Set 'requestComplexity.includeDepth' to a positive integer appropriate for your app to limit include pointer chain depth, or to '-1' to disable.",
+  },
+  {
+    optionKey: 'requestComplexity.includeCount',
+    changeNewDefault: '100',
+    solution: "Set 'requestComplexity.includeCount' to a positive integer appropriate for your app to limit the number of include paths per query, or to '-1' to disable.",
+  },
+  {
+    optionKey: 'requestComplexity.subqueryDepth',
+    changeNewDefault: '10',
+    solution: "Set 'requestComplexity.subqueryDepth' to a positive integer appropriate for your app to limit subquery nesting depth, or to '-1' to disable.",
+  },
+  {
+    optionKey: 'requestComplexity.queryDepth',
+    changeNewDefault: '10',
+    solution: "Set 'requestComplexity.queryDepth' to a positive integer appropriate for your app to limit query condition nesting depth, or to '-1' to disable.",
+  },
+  {
+    optionKey: 'requestComplexity.graphQLDepth',
+    changeNewDefault: '20',
+    solution: "Set 'requestComplexity.graphQLDepth' to a positive integer appropriate for your app to limit GraphQL field selection depth, or to '-1' to disable.",
+  },
+  {
+    optionKey: 'requestComplexity.graphQLFields',
+    changeNewDefault: '200',
+    solution: "Set 'requestComplexity.graphQLFields' to a positive integer appropriate for your app to limit the number of GraphQL field selections, or to '-1' to disable.",
+  },
 ];


### PR DESCRIPTION
## Issue

The `requestComplexity` options (`includeDepth`, `includeCount`, `subqueryDepth`, `queryDepth`, `graphQLDepth`, `graphQLFields`) currently default to `-1` (disabled) to avoid a breaking change. In the next major version, these defaults will change to positive values that enforce query complexity limits. This adds deprecation warnings to inform developers to explicitly configure these options.

## Tasks

- [x] Add changes to documentation (guides, repository pages, code comments)
- [x] Add tests
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Six new request-complexity configuration options added (include depth, include count, subquery depth, query depth, GraphQL depth, GraphQL fields) with recommended defaults and guidance for tuning.
* **Documentation**
  * Deprecation notice added announcing default limits for requestComplexity and timeline for change.
* **Tests**
  * New tests cover deprecation logging behavior for the requestComplexity limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->