### PR TITLE
fix: Validate session in middleware for non-GET requests to `/sessions/me`

### DIFF
--- a/spec/ParseSession.spec.js
+++ b/spec/ParseSession.spec.js
@@ -256,4 +256,64 @@ describe('Parse.Session', () => {
     expect(newSession.createdWith.action).toBe('create');
     expect(newSession.createdWith.authProvider).toBeUndefined();
   });
+
+  describe('PUT /sessions/me', () => {
+    it('should return error with invalid session token', async () => {
+      const response = await request({
+        method: 'PUT',
+        url: 'http://localhost:8378/1/sessions/me',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'X-Parse-Session-Token': 'r:invalid-session-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      }).catch(e => e);
+      expect(response.status).not.toBe(500);
+      expect(response.data.code).toBe(Parse.Error.INVALID_SESSION_TOKEN);
+    });
+
+    it('should return error without session token', async () => {
+      const response = await request({
+        method: 'PUT',
+        url: 'http://localhost:8378/1/sessions/me',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      }).catch(e => e);
+      expect(response.status).not.toBe(500);
+    });
+  });
+
+  describe('DELETE /sessions/me', () => {
+    it('should return error with invalid session token', async () => {
+      const response = await request({
+        method: 'DELETE',
+        url: 'http://localhost:8378/1/sessions/me',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'X-Parse-Session-Token': 'r:invalid-session-token',
+        },
+      }).catch(e => e);
+      expect(response.status).not.toBe(500);
+      expect(response.data.code).toBe(Parse.Error.INVALID_SESSION_TOKEN);
+    });
+
+    it('should return error without session token', async () => {
+      const response = await request({
+        method: 'DELETE',
+        url: 'http://localhost:8378/1/sessions/me',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+      }).catch(e => e);
+      expect(response.status).not.toBe(500);
+    });
+  });
 });

--- a/spec/ParseSession.spec.js
+++ b/spec/ParseSession.spec.js
@@ -285,7 +285,9 @@ describe('Parse.Session', () => {
         },
         body: JSON.stringify({}),
       }).catch(e => e);
-      expect(response.status).not.toBe(500);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+      expect(response.data?.code).toBeDefined();
     });
   });
 
@@ -313,7 +315,9 @@ describe('Parse.Session', () => {
           'X-Parse-REST-API-Key': 'rest',
         },
       }).catch(e => e);
-      expect(response.status).not.toBe(500);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+      expect(response.data?.code).toBeDefined();
     });
   });
 });

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -377,7 +377,7 @@ const handleRateLimit = async (req, res, next) => {
 export const handleParseSession = async (req, res, next) => {
   try {
     const info = req.info;
-    if (req.auth || req.url === '/sessions/me') {
+    if (req.auth || (req.url === '/sessions/me' && req.method === 'GET')) {
       next();
       return;
     }


### PR DESCRIPTION
## Issue

Validate session in middleware for non-GET requests to `/sessions/me`