### PR TITLE
fix: Empty authData bypasses credential requirement on signup (GHSA-wjqw-r9x4-j59v)

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -2700,6 +2700,82 @@ describe('(GHSA-9xp9-j92r-p88v) Stack overflow process crash via deeply nested q
     );
   });
 
+  describe('(GHSA-wjqw-r9x4-j59v) Empty authData session issuance bypass', () => {
+    const signupHeaders = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+    };
+
+    it('rejects signup with empty authData and no credentials', async () => {
+      await reconfigureServer({ enableAnonymousUsers: false });
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/users',
+        headers: signupHeaders,
+        body: JSON.stringify({ authData: {} }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+      expect(res.data.code).toBe(Parse.Error.USERNAME_MISSING);
+    });
+
+    it('rejects signup with empty authData and no credentials when anonymous users enabled', async () => {
+      await reconfigureServer({ enableAnonymousUsers: true });
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/users',
+        headers: signupHeaders,
+        body: JSON.stringify({ authData: {} }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+      expect(res.data.code).toBe(Parse.Error.USERNAME_MISSING);
+    });
+
+    it('rejects signup with authData containing only empty provider data and no credentials', async () => {
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/users',
+        headers: signupHeaders,
+        body: JSON.stringify({ authData: { bogus: {} } }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+      expect(res.data.code).toBe(Parse.Error.USERNAME_MISSING);
+    });
+
+    it('rejects signup with authData containing null provider data and no credentials', async () => {
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/users',
+        headers: signupHeaders,
+        body: JSON.stringify({ authData: { bogus: null } }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+      expect(res.data.code).toBe(Parse.Error.USERNAME_MISSING);
+    });
+
+    it('rejects signup with non-object authData provider value even when credentials are provided', async () => {
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/users',
+        headers: signupHeaders,
+        body: JSON.stringify({ username: 'bogusauth', password: 'pass1234', authData: { bogus: 'x' } }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+      expect(res.data.code).toBe(Parse.Error.UNSUPPORTED_SERVICE);
+    });
+
+    it('allows signup with empty authData when username and password are provided', async () => {
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/users',
+        headers: signupHeaders,
+        body: JSON.stringify({ username: 'emptyauth', password: 'pass1234', authData: {} }),
+      });
+      expect(res.data.objectId).toBeDefined();
+      expect(res.data.sessionToken).toBeDefined();
+    });
+  });
+
   describe('(GHSA-r3xq-68wh-gwvh) Password reset single-use token bypass via concurrent requests', () => {
     let sendPasswordResetEmail;
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -453,8 +453,14 @@ RestWrite.prototype.validateAuthData = function () {
   const authData = this.data.authData;
   const hasUsernameAndPassword =
     typeof this.data.username === 'string' && typeof this.data.password === 'string';
+  const hasAuthData =
+    authData &&
+    Object.keys(authData).some(provider => {
+      const providerData = authData[provider];
+      return providerData && typeof providerData === 'object' && Object.keys(providerData).length;
+    });
 
-  if (!this.query && !authData) {
+  if (!this.query && !hasAuthData) {
     if (typeof this.data.username !== 'string' || _.isEmpty(this.data.username)) {
       throw new Parse.Error(Parse.Error.USERNAME_MISSING, 'bad or missing username');
     }
@@ -463,13 +469,10 @@ RestWrite.prototype.validateAuthData = function () {
     }
   }
 
-  if (
-    (authData && !Object.keys(authData).length) ||
-    !Object.prototype.hasOwnProperty.call(this.data, 'authData')
-  ) {
+  if (!Object.prototype.hasOwnProperty.call(this.data, 'authData')) {
     // Nothing to validate here
     return;
-  } else if (Object.prototype.hasOwnProperty.call(this.data, 'authData') && !this.data.authData) {
+  } else if (!this.data.authData) {
     // Handle saving authData to null
     throw new Parse.Error(
       Parse.Error.UNSUPPORTED_SERVICE,
@@ -478,14 +481,16 @@ RestWrite.prototype.validateAuthData = function () {
   }
 
   var providers = Object.keys(authData);
-  if (providers.length > 0) {
-    const canHandleAuthData = providers.some(provider => {
-      const providerAuthData = authData[provider] || {};
-      return !!Object.keys(providerAuthData).length;
-    });
-    if (canHandleAuthData || hasUsernameAndPassword || this.auth.isMaster || this.getUserId()) {
-      return this.handleAuthData(authData);
-    }
+  if (!providers.length) {
+    // Empty authData object, nothing to validate
+    return;
+  }
+  const canHandleAuthData = providers.some(provider => {
+    const providerAuthData = authData[provider] || {};
+    return !!Object.keys(providerAuthData).length;
+  });
+  if (canHandleAuthData || hasUsernameAndPassword || this.auth.isMaster || this.getUserId()) {
+    return this.handleAuthData(authData);
   }
   throw new Parse.Error(
     Parse.Error.UNSUPPORTED_SERVICE,


### PR DESCRIPTION
## Issue
Empty authData bypasses credential requirement on signup ([GHSA-wjqw-r9x4-j59v](https://github.com/parse-community/parse-server/security/advisories/GHSA-wjqw-r9x4-j59v))

## Tasks
- [x] Add tests
- [x] Add changes
- [ ] Add security check
- [ ] Add benchmark