### PR TITLE
fix: Validate authData input in dot-notation updates, login provider checks, and challenge endpoint

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -3075,6 +3075,7 @@ describe('(GHSA-fjxm-vhvc-gcmj) LiveQuery Operator Type Confusion', () => {
           challengeData: { anonymous: { token: '123456' } },
         }),
       }).catch(e => e);
+      expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
     });
 
@@ -3092,6 +3093,7 @@ describe('(GHSA-fjxm-vhvc-gcmj) LiveQuery Operator Type Confusion', () => {
           challengeData: { anonymous: { token: '123456' } },
         }),
       }).catch(e => e);
+      expect(res.status).toBeGreaterThanOrEqual(400);
       expect(res.status).toBeLessThan(500);
     });
   });

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -3010,6 +3010,92 @@ describe('(GHSA-fjxm-vhvc-gcmj) LiveQuery Operator Type Confusion', () => {
     });
   });
 
+  describe('(GHSA-g55g-hrp7-h6vq) Dotted authData provider injection', () => {
+    it('rejects dotted update key that targets authData sub-field', async () => {
+      const user = new Parse.User();
+      user.setUsername('dotuser');
+      user.setPassword('pass1234');
+      await user.signUp();
+
+      const res = await request({
+        method: 'PUT',
+        url: `http://localhost:8378/1/users/${user.id}`,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'X-Parse-Session-Token': user.getSessionToken(),
+        },
+        body: JSON.stringify({ 'authData.anonymous".id': 'injected' }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+    });
+
+    it('login does not crash when stored authData has unknown provider', async () => {
+      const user = new Parse.User();
+      user.setUsername('dotuser2');
+      user.setPassword('pass1234');
+      await user.signUp();
+      await Parse.User.logOut();
+
+      // Inject unknown provider directly in database to simulate corrupted data
+      const config = Config.get('test');
+      await config.database.update(
+        '_User',
+        { objectId: user.id },
+        { authData: { unknown_provider: { id: 'bad' } } }
+      );
+
+      // Login should not crash with 500
+      const login = await request({
+        method: 'GET',
+        url: `http://localhost:8378/1/login?username=dotuser2&password=pass1234`,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+      }).catch(e => e);
+      expect(login.status).toBe(200);
+      expect(login.data.sessionToken).toBeDefined();
+    });
+  });
+
+  describe('(GHSA-2c6m-7356-pw67) Challenge null authData dereference', () => {
+    it('rejects challenge request with null provider value without 500', async () => {
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/challenge',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        body: JSON.stringify({
+          authData: { anonymous: null },
+          challengeData: { anonymous: { token: '123456' } },
+        }),
+      }).catch(e => e);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    it('rejects challenge request with non-object provider value without 500', async () => {
+      const res = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/challenge',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+        body: JSON.stringify({
+          authData: { anonymous: 'string_value' },
+          challengeData: { anonymous: { token: '123456' } },
+        }),
+      }).catch(e => e);
+      expect(res.status).toBeLessThan(500);
+    });
+  });
+
   describe('(GHSA-r3xq-68wh-gwvh) Password reset single-use token bypass via concurrent requests', () => {
     let sendPasswordResetEmail;
 

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -526,7 +526,7 @@ const checkIfUserHasProvidedConfiguredProvidersForLogin = (
   const savedUserProviders = Object.keys(userAuthData)
     .map(provider => {
       const validator = config.authDataManager.getValidatorForProvider(provider);
-      if (!validator) {
+      if (!validator || !validator.adapter) {
         return null;
       }
       return { name: provider, adapter: validator.adapter };

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -523,10 +523,15 @@ const checkIfUserHasProvidedConfiguredProvidersForLogin = (
   userAuthData = {},
   config
 ) => {
-  const savedUserProviders = Object.keys(userAuthData).map(provider => ({
-    name: provider,
-    adapter: config.authDataManager.getValidatorForProvider(provider).adapter,
-  }));
+  const savedUserProviders = Object.keys(userAuthData)
+    .map(provider => {
+      const validator = config.authDataManager.getValidatorForProvider(provider);
+      if (!validator) {
+        return null;
+      }
+      return { name: provider, adapter: validator.adapter };
+    })
+    .filter(Boolean);
 
   const hasProvidedASoloProvider = savedUserProviders.some(
     provider =>

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -603,7 +603,7 @@ class DatabaseController {
             })
             .then(schema => {
               Object.keys(update).forEach(fieldName => {
-                if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
+                if (fieldName.match(/^authData\./)) {
                   throw new Parse.Error(
                     Parse.Error.INVALID_KEY_NAME,
                     `Invalid field name for update: ${fieldName}`

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -614,7 +614,16 @@ export class UsersRouter extends ClassesRouter {
         );
       }
 
-      if (Object.keys(authData).filter(key => authData[key].id).length > 1) {
+      for (const key of Object.keys(authData)) {
+        if (authData[key] !== null && (typeof authData[key] !== 'object' || Array.isArray(authData[key]))) {
+          throw new Parse.Error(
+            Parse.Error.OTHER_CAUSE,
+            `authData.${key} should be an object.`
+          );
+        }
+      }
+
+      if (Object.keys(authData).filter(key => authData[key] && authData[key].id).length > 1) {
         throw new Parse.Error(
           Parse.Error.OTHER_CAUSE,
           'You cannot provide more than one authData provider with an id.'
@@ -628,7 +637,7 @@ export class UsersRouter extends ClassesRouter {
           throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'User not found.');
         }
         // Find the provider used to find the user
-        const provider = Object.keys(authData).find(key => authData[key].id);
+        const provider = Object.keys(authData).find(key => authData[key] && authData[key].id);
 
         parseUser = Parse.User.fromJSON({ className: '_User', ...results[0] });
         request = getRequestObject(undefined, req.auth, parseUser, parseUser, req.config);


### PR DESCRIPTION
## Issue
Input validation bugs in authData handling:
- Dot-notation update keys bypass authData field name validation, allowing injection of malformed provider names
- Login crashes with null dereference when stored authData contains unknown providers
- Challenge endpoint crashes with null dereference when provider values are null or non-object

## Tasks
- [x] Add tests
- [x] Add changes
- [ ] Add security check
- [ ] Add benchmark