### PR TITLE
fix: Replace `instanceof Array` with `Array.isArray()`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,13 @@ module.exports = [
       curly: ["error", "all"],
       "block-spacing": ["error", "always"],
       "no-unused-vars": "off",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Array']",
+          message: "Use Array.isArray() instead of instanceof Array (cross-realm safe).",
+        },
+      ],
       "no-console": "warn"
     },
   },

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -1,6 +1,7 @@
 const Config = require('../lib/Config');
 const DatabaseController = require('../lib/Controllers/DatabaseController.js');
 const validateQuery = DatabaseController._validateQuery;
+const vm = require('vm');
 
 describe('DatabaseController', function () {
   describe('validateQuery', function () {
@@ -53,6 +54,33 @@ describe('DatabaseController', function () {
 
     it('should accept valid queries', done => {
       expect(() => validateQuery({ $or: [{ a: 1 }, { b: 2 }] })).not.toThrow();
+      done();
+    });
+
+    it('should accept cross-realm arrays for $or', done => {
+      const query = {
+        $or: vm.runInNewContext('[{ a: 1 }, { b: 2 }]'),
+      };
+      expect(Array.isArray(query.$or)).toBe(true);
+      expect(() => validateQuery(query)).not.toThrow();
+      done();
+    });
+
+    it('should accept cross-realm arrays for $and', done => {
+      const query = {
+        $and: vm.runInNewContext('[{ a: 1 }, { b: 2 }]'),
+      };
+      expect(Array.isArray(query.$and)).toBe(true);
+      expect(() => validateQuery(query)).not.toThrow();
+      done();
+    });
+
+    it('should accept cross-realm arrays for $nor', done => {
+      const query = {
+        $nor: vm.runInNewContext('[{ a: 1 }]'),
+      };
+      expect(Array.isArray(query.$nor)).toBe(true);
+      expect(() => validateQuery(query)).not.toThrow();
       done();
     });
   });

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -243,7 +243,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date instanceof Date).toBe(true);
         return adapter.find('MyClass', schema, {}, {});
@@ -251,7 +251,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date.__type).toBe('Date');
         expect(mob.date.iso).toBe('2016-05-26T20:55:01.154Z');
@@ -376,7 +376,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       })
       .then(results => {
         const mob = results;
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date.__type).toBe('Date');
         expect(mob.date.iso).toBe('2016-05-26T20:55:01.154Z');
@@ -385,7 +385,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date instanceof Date).toBe(true);
         done();

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -328,8 +328,8 @@ describe('miscellaneous', () => {
       })
       .then(obj2 => {
         expect(obj2.get('date') instanceof Date).toBe(true);
-        expect(obj2.get('array') instanceof Array).toBe(true);
-        expect(obj2.get('object') instanceof Array).toBe(false);
+        expect(Array.isArray(obj2.get('array'))).toBe(true);
+        expect(Array.isArray(obj2.get('object'))).toBe(false);
         expect(obj2.get('object') instanceof Object).toBe(true);
         done();
       });

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -63,6 +63,13 @@ module.exports = [
       curly: ["error", "all"],
       "block-spacing": ["error", "always"],
       "no-unused-vars": "off",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Array']",
+          message: "Use Array.isArray() instead of instanceof Array (cross-realm safe).",
+        },
+      ],
     },
   },
 ];

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -337,7 +337,7 @@ function normalize(obj) {
   if (obj === null || typeof obj !== 'object') {
     return JSON.stringify(obj);
   }
-  if (obj instanceof Array) {
+  if (Array.isArray(obj)) {
     return '[' + obj.map(normalize).join(', ') + ']';
   }
   let answer = '{';

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -278,7 +278,7 @@ describe('rest create', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date.__type).toBe('Date');
         expect(new Date(mob.date.iso).getTime()).toBe(now.getTime());

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -121,7 +121,7 @@ const transformKeyValueForUpdate = (className, restKey, restValue, parseFormatSc
   }
 
   // Handle arrays
-  if (restValue instanceof Array) {
+  if (Array.isArray(restValue)) {
     value = restValue.map(transformInteriorValue);
     return { key, value };
   }
@@ -192,7 +192,7 @@ const transformInteriorValue = restValue => {
       if (value instanceof Date) {
         return value;
       }
-      if (value instanceof Array) {
+      if (Array.isArray(value)) {
         value = value.map(transformInteriorValue);
       } else {
         value = mapValues(value, transformInteriorValue);
@@ -202,7 +202,7 @@ const transformInteriorValue = restValue => {
   }
 
   // Handle arrays
-  if (restValue instanceof Array) {
+  if (Array.isArray(restValue)) {
     return restValue.map(transformInteriorValue);
   }
 
@@ -338,7 +338,7 @@ function transformQueryKeyValue(className, key, value, schema, count = false) {
     return { key, value: transformedConstraint };
   }
 
-  if (expectedTypeIsArray && !(value instanceof Array)) {
+  if (expectedTypeIsArray && !Array.isArray(value)) {
     return { key, value: { $all: [transformInteriorAtom(value)] } };
   }
 
@@ -444,7 +444,7 @@ const parseObjectKeyValueToMongoObjectKeyValue = (restKey, restValue, schema) =>
   }
 
   // Handle arrays
-  if (restValue instanceof Array) {
+  if (Array.isArray(restValue)) {
     value = restValue.map(transformInteriorValue);
     return { key: restKey, value: value };
   }
@@ -721,7 +721,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
       case '$in':
       case '$nin': {
         const arr = constraint[key];
-        if (!(arr instanceof Array)) {
+        if (!Array.isArray(arr)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad ' + key + ' value');
         }
         answer[key] = _.flatMap(arr, value => {
@@ -737,7 +737,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
       }
       case '$all': {
         const arr = constraint[key];
-        if (!(arr instanceof Array)) {
+        if (!Array.isArray(arr)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad ' + key + ' value');
         }
         answer[key] = arr.map(transformInteriorAtom);
@@ -762,7 +762,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
 
       case '$containedBy': {
         const arr = constraint[key];
-        if (!(arr instanceof Array)) {
+        if (!Array.isArray(arr)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, `bad $containedBy: should be an array`);
         }
         answer.$elemMatch = {
@@ -872,7 +872,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
               );
             }
             points = polygon.coordinates;
-          } else if (polygon instanceof Array) {
+          } else if (Array.isArray(polygon)) {
             if (polygon.length < 3) {
               throw new Parse.Error(
                 Parse.Error.INVALID_JSON,
@@ -887,7 +887,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
             );
           }
           points = points.map(point => {
-            if (point instanceof Array && point.length === 2) {
+            if (Array.isArray(point) && point.length === 2) {
               Parse.GeoPoint._validate(point[1], point[0]);
               return point;
             }
@@ -902,7 +902,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
             $polygon: points,
           };
         } else if (centerSphere !== undefined) {
-          if (!(centerSphere instanceof Array) || centerSphere.length < 2) {
+          if (!Array.isArray(centerSphere) || centerSphere.length < 2) {
             throw new Parse.Error(
               Parse.Error.INVALID_JSON,
               'bad $geoWithin value; $centerSphere should be an array of Parse.GeoPoint and distance'
@@ -910,7 +910,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
           }
           // Get point, convert to geo point if necessary and validate
           let point = centerSphere[0];
-          if (point instanceof Array && point.length === 2) {
+          if (Array.isArray(point) && point.length === 2) {
             point = new Parse.GeoPoint(point[1], point[0]);
           } else if (!GeoPointCoder.isValidJSON(point)) {
             throw new Parse.Error(
@@ -999,7 +999,7 @@ function transformUpdateOperator({ __op, amount, objects }, flatten) {
 
     case 'Add':
     case 'AddUnique':
-      if (!(objects instanceof Array)) {
+      if (!Array.isArray(objects)) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
       }
       var toAdd = objects.map(transformInteriorAtom);
@@ -1014,7 +1014,7 @@ function transformUpdateOperator({ __op, amount, objects }, flatten) {
       }
 
     case 'Remove':
-      if (!(objects instanceof Array)) {
+      if (!Array.isArray(objects)) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to remove must be an array');
       }
       var toRemove = objects.map(transformInteriorAtom);
@@ -1053,7 +1053,7 @@ const nestedMongoObjectToNestedParseObject = mongoObject => {
       if (mongoObject === null) {
         return null;
       }
-      if (mongoObject instanceof Array) {
+      if (Array.isArray(mongoObject)) {
         return mongoObject.map(nestedMongoObjectToNestedParseObject);
       }
 
@@ -1116,7 +1116,7 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
       if (mongoObject === null) {
         return null;
       }
-      if (mongoObject instanceof Array) {
+      if (Array.isArray(mongoObject)) {
         return mongoObject.map(nestedMongoObjectToNestedParseObject);
       }
 
@@ -1347,7 +1347,7 @@ var GeoPointCoder = {
   },
 
   isValidDatabaseObject(object) {
-    return object instanceof Array && object.length == 2;
+    return Array.isArray(object) && object.length == 2;
   },
 
   JSONToDatabase(json) {
@@ -1373,7 +1373,7 @@ var PolygonCoder = {
 
   isValidDatabaseObject(object) {
     const coords = object.coordinates[0];
-    if (object.type !== 'Polygon' || !(coords instanceof Array)) {
+    if (object.type !== 'Polygon' || !Array.isArray(coords)) {
       return false;
     }
     for (let i = 0; i < coords.length; i++) {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -572,7 +572,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
 
     if (fieldValue.$containedBy) {
       const arr = fieldValue.$containedBy;
-      if (!(arr instanceof Array)) {
+      if (!Array.isArray(arr)) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, `bad $containedBy: should be an array`);
       }
 
@@ -654,7 +654,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
 
     if (fieldValue.$geoWithin && fieldValue.$geoWithin.$centerSphere) {
       const centerSphere = fieldValue.$geoWithin.$centerSphere;
-      if (!(centerSphere instanceof Array) || centerSphere.length < 2) {
+      if (!Array.isArray(centerSphere) || centerSphere.length < 2) {
         throw new Parse.Error(
           Parse.Error.INVALID_JSON,
           'bad $geoWithin value; $centerSphere should be an array of Parse.GeoPoint and distance'
@@ -662,7 +662,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
       }
       // Get point, convert to geo point if necessary and validate
       let point = centerSphere[0];
-      if (point instanceof Array && point.length === 2) {
+      if (Array.isArray(point) && point.length === 2) {
         point = new Parse.GeoPoint(point[1], point[0]);
       } else if (!GeoPointCoder.isValidJSON(point)) {
         throw new Parse.Error(
@@ -699,7 +699,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
           );
         }
         points = polygon.coordinates;
-      } else if (polygon instanceof Array) {
+      } else if (Array.isArray(polygon)) {
         if (polygon.length < 3) {
           throw new Parse.Error(
             Parse.Error.INVALID_JSON,
@@ -715,7 +715,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
       }
       points = points
         .map(point => {
-          if (point instanceof Array && point.length === 2) {
+          if (Array.isArray(point) && point.length === 2) {
             Parse.GeoPoint._validate(point[1], point[0]);
             return `(${point[0]}, ${point[1]})`;
           }

--- a/src/Config.js
+++ b/src/Config.js
@@ -346,7 +346,7 @@ export class Config {
     }
     if (pages.customRoutes === undefined) {
       pages.customRoutes = PagesOptions.customRoutes.default;
-    } else if (!(pages.customRoutes instanceof Array)) {
+    } else if (!Array.isArray(pages.customRoutes)) {
       throw 'Parse Server option pages.customRoutes must be an array.';
     }
     if (pages.encodePageParamHeaders === undefined) {
@@ -369,7 +369,7 @@ export class Config {
     }
     if (!idempotencyOptions.paths) {
       idempotencyOptions.paths = IdempotencyOptions.paths.default;
-    } else if (!(idempotencyOptions.paths instanceof Array)) {
+    } else if (!Array.isArray(idempotencyOptions.paths)) {
       throw 'idempotency paths must be of an array of strings';
     }
   }
@@ -536,7 +536,7 @@ export class Config {
 
   static validateFileUploadOptions(fileUpload) {
     try {
-      if (fileUpload == null || typeof fileUpload !== 'object' || fileUpload instanceof Array) {
+      if (fileUpload == null || typeof fileUpload !== 'object' || Array.isArray(fileUpload)) {
         throw 'fileUpload must be an object value.';
       }
     } catch (e) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -1,4 +1,4 @@
-﻿// @flow
+// @flow
 // A database adapter that works with data exported from the hosted
 // Parse database.
 
@@ -132,7 +132,7 @@ const validateQuery = (
   }
 
   if (query.$or) {
-    if (query.$or instanceof Array) {
+    if (Array.isArray(query.$or)) {
       query.$or.forEach(value => validateQuery(value, isMaster, isMaintenance, update, options, _depth + 1));
     } else {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Bad $or format - use an array value.');
@@ -140,7 +140,7 @@ const validateQuery = (
   }
 
   if (query.$and) {
-    if (query.$and instanceof Array) {
+    if (Array.isArray(query.$and)) {
       query.$and.forEach(value => validateQuery(value, isMaster, isMaintenance, update, options, _depth + 1));
     } else {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Bad $and format - use an array value.');
@@ -148,7 +148,7 @@ const validateQuery = (
   }
 
   if (query.$nor) {
-    if (query.$nor instanceof Array && query.$nor.length > 0) {
+    if (Array.isArray(query.$nor) && query.$nor.length > 0) {
       query.$nor.forEach(value => validateQuery(value, isMaster, isMaintenance, update, options, _depth + 1));
     } else {
       throw new Parse.Error(
@@ -323,19 +323,19 @@ const flattenUpdateOperatorsForCreate = object => {
           object[key] = object[key].amount;
           break;
         case 'Add':
-          if (!(object[key].objects instanceof Array)) {
+          if (!Array.isArray(object[key].objects)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
           }
           object[key] = object[key].objects;
           break;
         case 'AddUnique':
-          if (!(object[key].objects instanceof Array)) {
+          if (!Array.isArray(object[key].objects)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
           }
           object[key] = object[key].objects;
           break;
         case 'Remove':
-          if (!(object[key].objects instanceof Array)) {
+          if (!Array.isArray(object[key].objects)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
           }
           object[key] = [];

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -70,7 +70,7 @@ export class FilesController extends AdaptableController {
    * Object may be a single object or list of REST-format objects.
    */
   async expandFilesInObject(config, object) {
-    if (object instanceof Array) {
+    if (Array.isArray(object)) {
       const promises = object.map(obj => this.expandFilesInObject(config, obj));
       await Promise.all(promises);
       return;

--- a/src/Controllers/LiveQueryController.js
+++ b/src/Controllers/LiveQueryController.js
@@ -9,7 +9,7 @@ export class LiveQueryController {
     // If config is empty, we just assume no classs needs to be registered as LiveQuery
     if (!config || !config.classNames) {
       this.classNames = new Set();
-    } else if (config.classNames instanceof Array) {
+    } else if (Array.isArray(config.classNames)) {
       const classNames = config.classNames.map(name => {
         const _name = getClassName(name);
         return new RegExp(`^${_name}$`);

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -1579,7 +1579,7 @@ function getType(obj: any): ?(SchemaField | string) {
 // also gets the appropriate type for $ operators.
 // Returns null if the type is unknown.
 function getObjectType(obj): ?(SchemaField | string) {
-  if (obj instanceof Array) {
+  if (Array.isArray(obj)) {
     return 'Array';
   }
   if (obj.__type) {

--- a/src/GraphQL/transformers/query.js
+++ b/src/GraphQL/transformers/query.js
@@ -200,7 +200,7 @@ const transformQueryConstraintInputToParse = (
         }
         break;
       case 'polygon':
-        if (fieldValue instanceof Array) {
+        if (Array.isArray(fieldValue)) {
           fieldValue.forEach(geoPoint => {
             if (typeof geoPoint === 'object' && !geoPoint.__type) {
               geoPoint.__type = 'GeoPoint';

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -1223,7 +1223,7 @@ function includePath(config, auth, response, path, context, restOptions = {}) {
 // Path is a list of fields to search into.
 // Returns a list of pointers in REST format.
 function findPointers(object, path) {
-  if (object instanceof Array) {
+  if (Array.isArray(object)) {
     return object.map(x => findPointers(x, path)).flat();
   }
 
@@ -1252,7 +1252,7 @@ function findPointers(object, path) {
 // Returns something analogous to object, but with the appropriate
 // pointers inflated.
 function replacePointers(object, path, replace) {
-  if (object instanceof Array) {
+  if (Array.isArray(object)) {
     return object
       .map(obj => replacePointers(obj, path, replace))
       .filter(obj => typeof obj !== 'undefined');
@@ -1291,7 +1291,7 @@ function findObjectWithKey(root, key) {
   if (typeof root !== 'object') {
     return;
   }
-  if (root instanceof Array) {
+  if (Array.isArray(root)) {
     for (var item of root) {
       const answer = findObjectWithKey(item, key);
       if (answer) {

--- a/types/eslint.config.mjs
+++ b/types/eslint.config.mjs
@@ -19,6 +19,13 @@ export default tseslint.config({
     '@typescript-eslint/no-unsafe-call': 'off',
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unsafe-return": "off",
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: "BinaryExpression[operator='instanceof'][right.name='Array']",
+        message: 'Use Array.isArray() instead of instanceof Array (cross-realm safe).',
+      },
+    ],
   },
   languageOptions: {
     parser: tseslint.parser,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
<!-- Describe or link the issue that this PR closes. -->
instanceof Array is not realm safe, so in test frameworks like Jest or in advanced parse-server setup, many queries and parse-server features can break.

## Approach
<!-- Describe the changes in this PR. -->
Replacing instanceof Array with Array.isArray() which is realm safe, and official MDN recommendation

Added an eslint rule to prevent futur problem related to this kind of issue

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array type detection across the codebase for better cross-realm compatibility

* **Tests**
  * Added tests for cross-realm array handling in query validation and storage operations

* **Chores**
  * Updated ESLint configuration to enforce consistent array detection methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->