### PR TITLE
fix: Block dot-notation updates to authData sub-fields and harden login provider checks

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -3010,6 +3010,56 @@ describe('(GHSA-fjxm-vhvc-gcmj) LiveQuery Operator Type Confusion', () => {
     });
   });
 
+  describe('authData dot-notation injection and login crash', () => {
+    it('rejects dotted update key that targets authData sub-field', async () => {
+      const user = new Parse.User();
+      user.setUsername('dotuser');
+      user.setPassword('pass1234');
+      await user.signUp();
+
+      const res = await request({
+        method: 'PUT',
+        url: `http://localhost:8378/1/users/${user.id}`,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'X-Parse-Session-Token': user.getSessionToken(),
+        },
+        body: JSON.stringify({ 'authData.anonymous".id': 'injected' }),
+      }).catch(e => e);
+      expect(res.status).toBe(400);
+    });
+
+    it('login does not crash when stored authData has unknown provider', async () => {
+      const user = new Parse.User();
+      user.setUsername('dotuser2');
+      user.setPassword('pass1234');
+      await user.signUp();
+      await Parse.User.logOut();
+
+      // Inject unknown provider directly in database to simulate corrupted data
+      const config = Config.get('test');
+      await config.database.update(
+        '_User',
+        { objectId: user.id },
+        { authData: { unknown_provider: { id: 'bad' } } }
+      );
+
+      // Login should not crash with 500
+      const login = await request({
+        method: 'GET',
+        url: `http://localhost:8378/1/login?username=dotuser2&password=pass1234`,
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+        },
+      }).catch(e => e);
+      expect(login.status).toBe(200);
+      expect(login.data.sessionToken).toBeDefined();
+    });
+  });
+
   describe('(GHSA-r3xq-68wh-gwvh) Password reset single-use token bypass via concurrent requests', () => {
     let sendPasswordResetEmail;
 

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -523,10 +523,15 @@ const checkIfUserHasProvidedConfiguredProvidersForLogin = (
   userAuthData = {},
   config
 ) => {
-  const savedUserProviders = Object.keys(userAuthData).map(provider => ({
-    name: provider,
-    adapter: config.authDataManager.getValidatorForProvider(provider).adapter,
-  }));
+  const savedUserProviders = Object.keys(userAuthData)
+    .map(provider => {
+      const validator = config.authDataManager.getValidatorForProvider(provider);
+      if (!validator || !validator.adapter) {
+        return null;
+      }
+      return { name: provider, adapter: validator.adapter };
+    })
+    .filter(Boolean);
 
   const hasProvidedASoloProvider = savedUserProviders.some(
     provider =>

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -603,7 +603,7 @@ class DatabaseController {
             })
             .then(schema => {
               Object.keys(update).forEach(fieldName => {
-                if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
+                if (fieldName.match(/^authData\./)) {
                   throw new Parse.Error(
                     Parse.Error.INVALID_KEY_NAME,
                     `Invalid field name for update: ${fieldName}`


### PR DESCRIPTION
## Issue

Two related input validation bugs in authData handling:

1. **Dot-notation injection** (`src/Controllers/DatabaseController.js`): The field name guard only blocked `authData.<alphanumeric>.id` via regex `/^authData\.([a-zA-Z0-9_]+)\.id$/`. Special characters in provider names (e.g. `authData.anonymous".id`) bypassed the check. Fix: widen to `/^authData\./` to block all dot-notation updates to authData sub-fields. This is safe because authData is only updated as a top-level field internally, never via dot-notation.

2. **Login crash on unknown provider** (`src/Auth.js`): `checkIfUserHasProvidedConfiguredProvidersForLogin` calls `getValidatorForProvider(provider).adapter` for each stored provider. Unknown providers return `undefined`, causing a null dereference and 500 on login. Fix: filter out providers where the validator or adapter is missing.

## Tasks
- [x] Add tests
- [x] Add changes
- [ ] Add security check
- [ ] Add benchmark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of authentication data fields during updates to prevent injection attacks
  * Improved login stability when authentication data contains unconfigured providers
  * Strengthened protection against malicious authentication data modifications

* **Tests**
  * Added test coverage for authentication data validation and login resilience scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->