### PR TITLE
fix: Instance comparison with `instanceof` is not realm-safe

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,14 @@ module.exports = [
       curly: ["error", "all"],
       "block-spacing": ["error", "always"],
       "no-unused-vars": "off",
-      "no-console": "warn"
+      "no-console": "warn",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Date']",
+          message: "Use Utils.isDate() instead of instanceof Date (cross-realm safe).",
+        },
+      ]
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,6 +68,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Object']",
           message: "Use Utils.isObject() instead of instanceof Object (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Set']",
+          message: "Use Utils.isSet() instead of instanceof Set (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Date']",
           message: "Use Utils.isDate() instead of instanceof Date (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='RegExp']",
+          message: "Use Utils.isRegExp() instead of instanceof RegExp (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='RegExp']",
           message: "Use Utils.isRegExp() instead of instanceof RegExp (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
+          message: "Use Utils.isNativeError() instead of instanceof Error (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Set']",
           message: "Use Utils.isSet() instead of instanceof Set (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Buffer']",
+          message: "Use Buffer.isBuffer() instead of instanceof Buffer (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
           message: "Use Utils.isNativeError() instead of instanceof Error (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Promise']",
+          message: "Use Utils.isPromise() instead of instanceof Promise (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,6 +76,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Buffer']",
           message: "Use Buffer.isBuffer() instead of instanceof Buffer (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Array']",
+          message: "Use Array.isArray() instead of instanceof Array (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Promise']",
           message: "Use Utils.isPromise() instead of instanceof Promise (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Map']",
+          message: "Use Utils.isMap() instead of instanceof Map (cross-realm safe).",
+        },
       ]
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,6 +64,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Map']",
           message: "Use Utils.isMap() instead of instanceof Map (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Object']",
+          message: "Use Utils.isObject() instead of instanceof Object (cross-realm safe).",
+        },
       ]
     },
   },

--- a/spec/AdapterLoader.spec.js
+++ b/spec/AdapterLoader.spec.js
@@ -2,6 +2,7 @@ const { loadAdapter, loadModule } = require('../lib/Adapters/AdapterLoader');
 const FilesAdapter = require('@parse/fs-files-adapter').default;
 const MockFilesAdapter = require('mock-files-adapter');
 const Config = require('../lib/Config');
+const Utils = require('../lib/Utils');
 
 describe('AdapterLoader', () => {
   it('should instantiate an adapter from string in object', done => {
@@ -15,7 +16,7 @@ describe('AdapterLoader', () => {
       },
     });
 
-    expect(adapter instanceof Object).toBe(true);
+    expect(Utils.isObject(adapter)).toBe(true);
     expect(adapter.options.key).toBe('value');
     expect(adapter.options.foo).toBe('bar');
     done();
@@ -25,7 +26,7 @@ describe('AdapterLoader', () => {
     const adapterPath = require('path').resolve('./spec/support/MockAdapter');
     const adapter = loadAdapter(adapterPath);
 
-    expect(adapter instanceof Object).toBe(true);
+    expect(Utils.isObject(adapter)).toBe(true);
     done();
   });
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -5,6 +5,7 @@ const ParseServer = require('../lib/index').ParseServer;
 const request = require('../lib/request');
 const InMemoryCacheAdapter = require('../lib/Adapters/Cache/InMemoryCacheAdapter')
   .InMemoryCacheAdapter;
+const Utils = require('../lib/Utils');
 
 const mockAdapter = {
   createFile: async filename => ({
@@ -1272,15 +1273,15 @@ describe('Cloud Code', () => {
 
   it('test cloud function request params types', function (done) {
     Parse.Cloud.define('params', function (req) {
-      expect(req.params.date instanceof Date).toBe(true);
+      expect(Utils.isDate(req.params.date)).toBe(true);
       expect(req.params.date.getTime()).toBe(1463907600000);
-      expect(req.params.dateList[0] instanceof Date).toBe(true);
+      expect(Utils.isDate(req.params.dateList[0])).toBe(true);
       expect(req.params.dateList[0].getTime()).toBe(1463907600000);
-      expect(req.params.complexStructure.date[0] instanceof Date).toBe(true);
+      expect(Utils.isDate(req.params.complexStructure.date[0])).toBe(true);
       expect(req.params.complexStructure.date[0].getTime()).toBe(1463907600000);
-      expect(req.params.complexStructure.deepDate.date[0] instanceof Date).toBe(true);
+      expect(Utils.isDate(req.params.complexStructure.deepDate.date[0])).toBe(true);
       expect(req.params.complexStructure.deepDate.date[0].getTime()).toBe(1463907600000);
-      expect(req.params.complexStructure.deepDate2[0].date instanceof Date).toBe(true);
+      expect(Utils.isDate(req.params.complexStructure.deepDate2[0].date)).toBe(true);
       expect(req.params.complexStructure.deepDate2[0].date.getTime()).toBe(1463907600000);
       // Regression for #2294
       expect(req.params.file instanceof Parse.File).toBe(true);

--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -103,12 +103,12 @@ describe_only_db('mongo')('GridFSBucket', () => {
     ).toEqual(1);
     expect(notRotated.length).toEqual(0);
     let result = await encryptedAdapter.getFileData(fileName1);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data1);
     const encryptedData1 = await unencryptedAdapter.getFileData(fileName1);
     expect(encryptedData1.toString('utf-8')).not.toEqual(unencryptedResult1);
     result = await encryptedAdapter.getFileData(fileName2);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data2);
     const encryptedData2 = await unencryptedAdapter.getFileData(fileName2);
     expect(encryptedData2.toString('utf-8')).not.toEqual(unencryptedResult2);
@@ -146,7 +146,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
     ).toEqual(1);
     expect(notRotated.length).toEqual(0);
     let result = await encryptedAdapter.getFileData(fileName1);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data1);
     let decryptionError1;
     let encryptedData1;
@@ -158,7 +158,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
     expect(decryptionError1).toMatch('Error');
     expect(encryptedData1).toBeUndefined();
     result = await encryptedAdapter.getFileData(fileName2);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data2);
     let decryptionError2;
     let encryptedData2;
@@ -203,7 +203,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
     ).toEqual(1);
     expect(notRotated.length).toEqual(0);
     let result = await unEncryptedAdapter.getFileData(fileName1);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data1);
     let decryptionError1;
     let encryptedData1;
@@ -215,7 +215,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
     expect(decryptionError1).toMatch('Error');
     expect(encryptedData1).toBeUndefined();
     result = await unEncryptedAdapter.getFileData(fileName2);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data2);
     let decryptionError2;
     let encryptedData2;
@@ -271,7 +271,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
       }).length
     ).toEqual(0);
     let result = await encryptedAdapter.getFileData(fileName1);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data1);
     let decryptionError1;
     let encryptedData1;
@@ -283,7 +283,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
     expect(decryptionError1).toMatch('Error');
     expect(encryptedData1).toBeUndefined();
     result = await encryptedAdapter.getFileData(fileName2);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data2);
     let decryptionError2;
     let encryptedData2;
@@ -338,7 +338,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
       }).length
     ).toEqual(1);
     let result = await encryptedAdapter.getFileData(fileName1);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data1);
     let decryptionError1;
     let encryptedData1;
@@ -350,7 +350,7 @@ describe_only_db('mongo')('GridFSBucket', () => {
     expect(decryptionError1).toMatch('Error');
     expect(encryptedData1).toBeUndefined();
     result = await encryptedAdapter.getFileData(fileName2);
-    expect(result instanceof Buffer).toBe(true);
+    expect(Buffer.isBuffer(result)).toBe(true);
     expect(result.toString('utf-8')).toEqual(data2);
     let decryptionError2;
     let encryptedData2;

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -244,7 +244,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(Utils.isDate(mob.date)).toBe(true);
         return adapter.find('MyClass', schema, {}, {});
@@ -252,7 +252,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date.__type).toBe('Date');
         expect(mob.date.iso).toBe('2016-05-26T20:55:01.154Z');
@@ -377,7 +377,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       })
       .then(results => {
         const mob = results;
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date.__type).toBe('Date');
         expect(mob.date.iso).toBe('2016-05-26T20:55:01.154Z');
@@ -386,7 +386,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(Utils.isDate(mob.date)).toBe(true);
         done();

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -6,6 +6,7 @@ const databaseURI = 'mongodb://localhost:27017/parseServerMongoAdapterTestDataba
 const request = require('../lib/request');
 const Config = require('../lib/Config');
 const TestUtils = require('../lib/TestUtils');
+const Utils = require('../lib/Utils');
 
 const fakeClient = {
   s: { options: { dbName: null } },
@@ -245,7 +246,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
         const mob = results[0];
         expect(mob.array instanceof Array).toBe(true);
         expect(typeof mob.object).toBe('object');
-        expect(mob.date instanceof Date).toBe(true);
+        expect(Utils.isDate(mob.date)).toBe(true);
         return adapter.find('MyClass', schema, {}, {});
       })
       .then(results => {
@@ -278,9 +279,9 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     }).save();
     const adapter = Config.get(Parse.applicationId).database.adapter;
     const [object] = await adapter._rawFind('MyClass', {});
-    expect(object.date instanceof Date).toBeTrue();
-    expect(object.bar.date instanceof Date).toBeTrue();
-    expect(object.foo.test.date instanceof Date).toBeTrue();
+    expect(Utils.isDate(object.date)).toBeTrue();
+    expect(Utils.isDate(object.bar.date)).toBeTrue();
+    expect(Utils.isDate(object.foo.test.date)).toBeTrue();
   });
 
   it('handles nested dates in array ', async () => {
@@ -297,13 +298,13 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     }).save();
     const adapter = Config.get(Parse.applicationId).database.adapter;
     const [object] = await adapter._rawFind('MyClass', {});
-    expect(object.date[0] instanceof Date).toBeTrue();
-    expect(object.bar.date[0] instanceof Date).toBeTrue();
-    expect(object.foo.test.date[0] instanceof Date).toBeTrue();
+    expect(Utils.isDate(object.date[0])).toBeTrue();
+    expect(Utils.isDate(object.bar.date[0])).toBeTrue();
+    expect(Utils.isDate(object.foo.test.date[0])).toBeTrue();
     const obj = await new Parse.Query('MyClass').first({ useMasterKey: true });
-    expect(obj.get('date')[0] instanceof Date).toBeTrue();
-    expect(obj.get('bar').date[0] instanceof Date).toBeTrue();
-    expect(obj.get('foo').test.date[0] instanceof Date).toBeTrue();
+    expect(Utils.isDate(obj.get('date')[0])).toBeTrue();
+    expect(Utils.isDate(obj.get('bar').date[0])).toBeTrue();
+    expect(Utils.isDate(obj.get('foo').test.date[0])).toBeTrue();
   });
 
   it('upserts with $setOnInsert', async () => {
@@ -387,7 +388,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
         const mob = results[0];
         expect(mob.array instanceof Array).toBe(true);
         expect(typeof mob.object).toBe('object');
-        expect(mob.date instanceof Date).toBe(true);
+        expect(Utils.isDate(mob.date)).toBe(true);
         done();
       })
       .catch(error => {

--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -33,8 +33,8 @@ describe('parseObjectToMongoObjectForCreate', () => {
     const output = transform.parseObjectToMongoObjectForCreate(null, input, {
       fields: {},
     });
-    expect(output._created_at instanceof Date).toBe(true);
-    expect(output._updated_at instanceof Date).toBe(true);
+    expect(Utils.isDate(output._created_at)).toBe(true);
+    expect(Utils.isDate(output._updated_at)).toBe(true);
     done();
   });
 

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -329,8 +329,8 @@ describe('miscellaneous', () => {
       })
       .then(obj2 => {
         expect(Utils.isDate(obj2.get('date'))).toBe(true);
-        expect(obj2.get('array') instanceof Array).toBe(true);
-        expect(obj2.get('object') instanceof Array).toBe(false);
+        expect(Array.isArray(obj2.get('array'))).toBe(true);
+        expect(Array.isArray(obj2.get('object'))).toBe(false);
         expect(Utils.isObject(obj2.get('object'))).toBe(true);
         done();
       });

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -7,6 +7,7 @@ const Parse = require('parse/node');
 const Config = require('../lib/Config');
 const SchemaController = require('../lib/Controllers/SchemaController');
 const { destroyAllDataPermanently } = require('../lib/TestUtils');
+const Utils = require('../lib/Utils');
 
 const userSchema = SchemaController.convertSchemaToAdapterSchema({
   className: '_User',
@@ -327,7 +328,7 @@ describe('miscellaneous', () => {
         return obj2.fetch();
       })
       .then(obj2 => {
-        expect(obj2.get('date') instanceof Date).toBe(true);
+        expect(Utils.isDate(obj2.get('date'))).toBe(true);
         expect(obj2.get('array') instanceof Array).toBe(true);
         expect(obj2.get('object') instanceof Array).toBe(false);
         expect(obj2.get('object') instanceof Object).toBe(true);

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -331,7 +331,7 @@ describe('miscellaneous', () => {
         expect(Utils.isDate(obj2.get('date'))).toBe(true);
         expect(obj2.get('array') instanceof Array).toBe(true);
         expect(obj2.get('object') instanceof Array).toBe(false);
-        expect(obj2.get('object') instanceof Object).toBe(true);
+        expect(Utils.isObject(obj2.get('object'))).toBe(true);
         done();
       });
   });

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -5,6 +5,7 @@ const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fet
 const FormData = require('form-data');
 require('./helper');
 const { updateCLP } = require('./support/dev');
+const Utils = require('../lib/Utils');
 
 const pluralize = require('pluralize');
 const createUploadLink = (...args) => import('apollo-upload-client/createUploadLink.mjs').then(({ default: fn }) => fn(...args));
@@ -8476,15 +8477,15 @@ describe('ParseGraphQLServer', () => {
 
         it('should accept different params', done => {
           Parse.Cloud.define('hello', async req => {
-            expect(req.params.date instanceof Date).toBe(true);
+            expect(Utils.isDate(req.params.date)).toBe(true);
             expect(req.params.date.getTime()).toBe(1463907600000);
-            expect(req.params.dateList[0] instanceof Date).toBe(true);
+            expect(Utils.isDate(req.params.dateList[0])).toBe(true);
             expect(req.params.dateList[0].getTime()).toBe(1463907600000);
-            expect(req.params.complexStructure.date[0] instanceof Date).toBe(true);
+            expect(Utils.isDate(req.params.complexStructure.date[0])).toBe(true);
             expect(req.params.complexStructure.date[0].getTime()).toBe(1463907600000);
-            expect(req.params.complexStructure.deepDate.date[0] instanceof Date).toBe(true);
+            expect(Utils.isDate(req.params.complexStructure.deepDate.date[0])).toBe(true);
             expect(req.params.complexStructure.deepDate.date[0].getTime()).toBe(1463907600000);
-            expect(req.params.complexStructure.deepDate2[0].date instanceof Date).toBe(true);
+            expect(Utils.isDate(req.params.complexStructure.deepDate2[0].date)).toBe(true);
             expect(req.params.complexStructure.deepDate2[0].date.getTime()).toBe(1463907600000);
             // Regression for #2294
             expect(req.params.file instanceof Parse.File).toBe(true);

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -9,6 +9,7 @@ const request = require('../lib/request');
 const ParseServerRESTController = require('../lib/ParseServerRESTController').ParseServerRESTController;
 const ParseServer = require('../lib/ParseServer').default;
 const Deprecator = require('../lib/Deprecator/Deprecator').default;
+const Utils = require('../lib/Utils');
 
 const masterKeyHeaders = {
   'X-Parse-Application-Id': 'test',
@@ -1452,8 +1453,8 @@ describe('Parse.Query testing', () => {
         ok(result);
         equal(result.id, objectId);
         equal(result.get('foo'), 'bar');
-        ok(result.createdAt instanceof Date);
-        ok(result.updatedAt instanceof Date);
+        ok(Utils.isDate(result.createdAt));
+        ok(Utils.isDate(result.updatedAt));
         done();
       });
     });
@@ -3902,7 +3903,7 @@ describe('Parse.Query testing', () => {
         objs => {
           expect(objs.length).toBe(1);
           expect(objs[0].get('child').get('hello')).toEqual('world');
-          expect(objs[0].createdAt instanceof Date).toBe(true);
+          expect(Utils.isDate(objs[0].createdAt)).toBe(true);
           done();
         },
         () => {

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -12,6 +12,7 @@ const request = require('../lib/request');
 const passwordCrypto = require('../lib/password');
 const Config = require('../lib/Config');
 const cryptoUtils = require('../lib/cryptoUtils');
+const Utils = require('../lib/Utils');
 
 
 describe('allowExpiredAuthDataToken option', () => {
@@ -1128,9 +1129,9 @@ describe('Parse.User testing', () => {
 
           equal(userInMemory.id, id, 'id should be set');
 
-          expect(userInMemory.updatedAt instanceof Date).toBe(true);
+          expect(Utils.isDate(userInMemory.updatedAt)).toBe(true);
 
-          ok(userInMemory.createdAt instanceof Date);
+          ok(Utils.isDate(userInMemory.createdAt));
 
           ok(userInMemory.getSessionToken(), 'user should have a sessionToken after saving');
 
@@ -1167,9 +1168,9 @@ describe('Parse.User testing', () => {
 
           equal(userFromDisk.id, id, 'id should be set on userFromDisk');
 
-          ok(userFromDisk.updatedAt instanceof Date);
+          ok(Utils.isDate(userFromDisk.updatedAt));
 
-          ok(userFromDisk.createdAt instanceof Date);
+          ok(Utils.isDate(userFromDisk.createdAt));
 
           ok(userFromDisk.getSessionToken(), 'userFromDisk should have a sessionToken');
 

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -3,6 +3,7 @@ const PushController = require('../lib/Controllers/PushController').PushControll
 const StatusHandler = require('../lib/StatusHandler');
 const Config = require('../lib/Config');
 const validatePushType = require('../lib/Push/utils').validatePushType;
+const Utils = require('../lib/Utils');
 
 const successfulTransmissions = function (body, installations) {
   const promises = installations.map(device => {
@@ -454,8 +455,8 @@ describe('PushController', () => {
     const pushStatusId = await sendPush(payload, {}, config, auth);
     await pushCompleted(pushStatusId);
     const result = await Parse.Push.getPushStatus(pushStatusId);
-    expect(result.createdAt instanceof Date).toBe(true);
-    expect(result.updatedAt instanceof Date).toBe(true);
+    expect(Utils.isDate(result.createdAt)).toBe(true);
+    expect(Utils.isDate(result.updatedAt)).toBe(true);
     expect(result.id.length).toBe(10);
     expect(result.get('source')).toEqual('rest');
     expect(result.get('query')).toEqual(JSON.stringify({}));

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -430,6 +430,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm object', () => {
       const crossRealmObj = vm.runInNewContext('({ a: 1 })');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmObj instanceof Object).toBe(false);
       expect(Utils.isObject(crossRealmObj)).toBe(true);
     });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -315,6 +315,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm RegExp', () => {
       const crossRealmRegExp = vm.runInNewContext('/test/');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmRegExp instanceof RegExp).toBe(false);
       expect(Utils.isRegExp(crossRealmRegExp)).toBe(true);
     });
@@ -370,6 +371,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm Error', () => {
       const crossRealmError = vm.runInNewContext('new Error("test")');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmError instanceof Error).toBe(false);
       expect(Utils.isNativeError(crossRealmError)).toBe(true);
     });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -333,6 +333,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm Map', () => {
       const crossRealmMap = vm.runInNewContext('new Map()');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmMap instanceof Map).toBe(false);
       expect(Utils.isMap(crossRealmMap)).toBe(true);
     });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -295,6 +295,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm Date', () => {
       const crossRealmDate = vm.runInNewContext('new Date()');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmDate instanceof Date).toBe(false);
       expect(Utils.isDate(crossRealmDate)).toBe(true);
     });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -1,5 +1,6 @@
 const Utils = require('../lib/Utils');
 const { createSanitizedError, createSanitizedHttpError } = require("../lib/Error")
+const vm = require('vm');
 
 describe('Utils', () => {
   describe('encodeForUrl', () => {
@@ -285,6 +286,158 @@ describe('Utils', () => {
       const config = { enableSanitizedErrorResponse: false };
       const error = createSanitizedHttpError(403, 'Detailed error message', config);
       expect(error.message).toBe('Detailed error message');
+    });
+  });
+
+  describe('isDate', () => {
+    it('should return true for a Date', () => {
+      expect(Utils.isDate(new Date())).toBe(true);
+    });
+    it('should return true for a cross-realm Date', () => {
+      const crossRealmDate = vm.runInNewContext('new Date()');
+      expect(crossRealmDate instanceof Date).toBe(false);
+      expect(Utils.isDate(crossRealmDate)).toBe(true);
+    });
+    it('should return false for non-Date values', () => {
+      expect(Utils.isDate(null)).toBe(false);
+      expect(Utils.isDate(undefined)).toBe(false);
+      expect(Utils.isDate('2021-01-01')).toBe(false);
+      expect(Utils.isDate(123)).toBe(false);
+      expect(Utils.isDate({})).toBe(false);
+    });
+  });
+
+  describe('isRegExp', () => {
+    it('should return true for a RegExp', () => {
+      expect(Utils.isRegExp(/test/)).toBe(true);
+      expect(Utils.isRegExp(new RegExp('test'))).toBe(true);
+    });
+    it('should return true for a cross-realm RegExp', () => {
+      const crossRealmRegExp = vm.runInNewContext('/test/');
+      expect(crossRealmRegExp instanceof RegExp).toBe(false);
+      expect(Utils.isRegExp(crossRealmRegExp)).toBe(true);
+    });
+    it('should return false for non-RegExp values', () => {
+      expect(Utils.isRegExp(null)).toBe(false);
+      expect(Utils.isRegExp(undefined)).toBe(false);
+      expect(Utils.isRegExp('/test/')).toBe(false);
+      expect(Utils.isRegExp({})).toBe(false);
+    });
+  });
+
+  describe('isMap', () => {
+    it('should return true for a Map', () => {
+      expect(Utils.isMap(new Map())).toBe(true);
+    });
+    it('should return true for a cross-realm Map', () => {
+      const crossRealmMap = vm.runInNewContext('new Map()');
+      expect(crossRealmMap instanceof Map).toBe(false);
+      expect(Utils.isMap(crossRealmMap)).toBe(true);
+    });
+    it('should return false for non-Map values', () => {
+      expect(Utils.isMap(null)).toBe(false);
+      expect(Utils.isMap(undefined)).toBe(false);
+      expect(Utils.isMap({})).toBe(false);
+      expect(Utils.isMap(new Set())).toBe(false);
+    });
+  });
+
+  describe('isSet', () => {
+    it('should return true for a Set', () => {
+      expect(Utils.isSet(new Set())).toBe(true);
+    });
+    it('should return true for a cross-realm Set', () => {
+      const crossRealmSet = vm.runInNewContext('new Set()');
+      expect(crossRealmSet instanceof Set).toBe(false);
+      expect(Utils.isSet(crossRealmSet)).toBe(true);
+    });
+    it('should return false for non-Set values', () => {
+      expect(Utils.isSet(null)).toBe(false);
+      expect(Utils.isSet(undefined)).toBe(false);
+      expect(Utils.isSet({})).toBe(false);
+      expect(Utils.isSet(new Map())).toBe(false);
+    });
+  });
+
+  describe('isNativeError', () => {
+    it('should return true for an Error', () => {
+      expect(Utils.isNativeError(new Error('test'))).toBe(true);
+    });
+    it('should return true for Error subclasses', () => {
+      expect(Utils.isNativeError(new TypeError('test'))).toBe(true);
+      expect(Utils.isNativeError(new RangeError('test'))).toBe(true);
+    });
+    it('should return true for a cross-realm Error', () => {
+      const crossRealmError = vm.runInNewContext('new Error("test")');
+      expect(crossRealmError instanceof Error).toBe(false);
+      expect(Utils.isNativeError(crossRealmError)).toBe(true);
+    });
+    it('should return false for non-Error values', () => {
+      expect(Utils.isNativeError(null)).toBe(false);
+      expect(Utils.isNativeError(undefined)).toBe(false);
+      expect(Utils.isNativeError({ message: 'fake' })).toBe(false);
+      expect(Utils.isNativeError('error')).toBe(false);
+    });
+  });
+
+  describe('isPromise', () => {
+    it('should return true for a Promise', () => {
+      expect(Utils.isPromise(Promise.resolve())).toBe(true);
+    });
+    it('should return true for a cross-realm Promise', () => {
+      const crossRealmPromise = vm.runInNewContext('Promise.resolve()');
+      expect(crossRealmPromise instanceof Promise).toBe(false);
+      expect(Utils.isPromise(crossRealmPromise)).toBe(true);
+    });
+    it('should return true for a thenable', () => {
+      expect(Utils.isPromise({ then: () => {} })).toBe(true);
+    });
+    it('should return false for non-Promise values', () => {
+      expect(Utils.isPromise(null)).toBe(false);
+      expect(Utils.isPromise(undefined)).toBe(false);
+      expect(Utils.isPromise({})).toBe(false);
+      expect(Utils.isPromise(42)).toBe(false);
+    });
+    it('should return false for plain objects when Object.prototype.then is polluted', () => {
+      Object.prototype.then = () => {};
+      try {
+        expect(Utils.isPromise({})).toBe(false);
+        expect(Utils.isPromise({ a: 1 })).toBe(false);
+      } finally {
+        delete Object.prototype.then;
+      }
+    });
+    it('should return true for real thenables even when Object.prototype.then is polluted', () => {
+      Object.prototype.then = () => {};
+      try {
+        expect(Utils.isPromise({ then: () => {} })).toBe(true);
+        expect(Utils.isPromise(Promise.resolve())).toBe(true);
+      } finally {
+        delete Object.prototype.then;
+      }
+    });
+  });
+
+  describe('isObject', () => {
+    it('should return true for plain objects', () => {
+      expect(Utils.isObject({})).toBe(true);
+      expect(Utils.isObject({ a: 1 })).toBe(true);
+    });
+    it('should return true for a cross-realm object', () => {
+      const crossRealmObj = vm.runInNewContext('({ a: 1 })');
+      expect(crossRealmObj instanceof Object).toBe(false);
+      expect(Utils.isObject(crossRealmObj)).toBe(true);
+    });
+    it('should return true for arrays and other objects', () => {
+      expect(Utils.isObject([])).toBe(true);
+      expect(Utils.isObject(new Date())).toBe(true);
+    });
+    it('should return false for non-object values', () => {
+      expect(Utils.isObject(null)).toBe(false);
+      expect(Utils.isObject(undefined)).toBe(false);
+      expect(Utils.isObject(42)).toBe(false);
+      expect(Utils.isObject('string')).toBe(false);
+      expect(Utils.isObject(true)).toBe(false);
     });
   });
 });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -389,6 +389,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm Promise', () => {
       const crossRealmPromise = vm.runInNewContext('Promise.resolve()');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmPromise instanceof Promise).toBe(false);
       expect(Utils.isPromise(crossRealmPromise)).toBe(true);
     });

--- a/spec/Utils.spec.js
+++ b/spec/Utils.spec.js
@@ -351,6 +351,7 @@ describe('Utils', () => {
     });
     it('should return true for a cross-realm Set', () => {
       const crossRealmSet = vm.runInNewContext('new Set()');
+      // eslint-disable-next-line no-restricted-syntax -- intentional: proving instanceof fails cross-realm
       expect(crossRealmSet instanceof Set).toBe(false);
       expect(Utils.isSet(crossRealmSet)).toBe(true);
     });

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -73,6 +73,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='RegExp']",
           message: "Use Utils.isRegExp() instead of instanceof RegExp (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
+          message: "Use Utils.isNativeError() instead of instanceof Error (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -93,6 +93,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Set']",
           message: "Use Utils.isSet() instead of instanceof Set (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Buffer']",
+          message: "Use Buffer.isBuffer() instead of instanceof Buffer (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -63,6 +63,13 @@ module.exports = [
       curly: ["error", "all"],
       "block-spacing": ["error", "always"],
       "no-unused-vars": "off",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Date']",
+          message: "Use Utils.isDate() instead of instanceof Date (cross-realm safe).",
+        },
+      ],
     },
   },
 ];

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -69,6 +69,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Date']",
           message: "Use Utils.isDate() instead of instanceof Date (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='RegExp']",
+          message: "Use Utils.isRegExp() instead of instanceof RegExp (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -77,6 +77,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Error']",
           message: "Use Utils.isNativeError() instead of instanceof Error (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Promise']",
+          message: "Use Utils.isPromise() instead of instanceof Promise (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -81,6 +81,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Promise']",
           message: "Use Utils.isPromise() instead of instanceof Promise (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Map']",
+          message: "Use Utils.isMap() instead of instanceof Map (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -89,6 +89,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Object']",
           message: "Use Utils.isObject() instead of instanceof Object (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Set']",
+          message: "Use Utils.isSet() instead of instanceof Set (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -85,6 +85,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Map']",
           message: "Use Utils.isMap() instead of instanceof Map (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Object']",
+          message: "Use Utils.isObject() instead of instanceof Object (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/eslint.config.js
+++ b/spec/eslint.config.js
@@ -97,6 +97,10 @@ module.exports = [
           selector: "BinaryExpression[operator='instanceof'][right.name='Buffer']",
           message: "Use Buffer.isBuffer() instead of instanceof Buffer (cross-realm safe).",
         },
+        {
+          selector: "BinaryExpression[operator='instanceof'][right.name='Array']",
+          message: "Use Array.isArray() instead of instanceof Array (cross-realm safe).",
+        },
       ],
     },
   },

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -337,7 +337,7 @@ function normalize(obj) {
   if (obj === null || typeof obj !== 'object') {
     return JSON.stringify(obj);
   }
-  if (obj instanceof Array) {
+  if (Array.isArray(obj)) {
     return '[' + obj.map(normalize).join(', ') + ']';
   }
   let answer = '{';

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -278,7 +278,7 @@ describe('rest create', () => {
       .then(results => {
         expect(results.length).toEqual(1);
         const mob = results[0];
-        expect(mob.array instanceof Array).toBe(true);
+        expect(Array.isArray(mob.array)).toBe(true);
         expect(typeof mob.object).toBe('object');
         expect(mob.date.__type).toBe('Date');
         expect(new Date(mob.date.iso).getTime()).toBe(now.getTime());

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -2,6 +2,7 @@
 import { format as formatUrl, parse as parseUrl } from '../../../vendor/mongodbUrl';
 import type { QueryOptions, QueryType, SchemaType, StorageClass } from '../StorageAdapter';
 import { StorageAdapter } from '../StorageAdapter';
+import Utils from '../../../Utils';
 import MongoCollection from './MongoCollection';
 import MongoSchemaCollection from './MongoSchemaCollection';
 import {
@@ -18,7 +19,6 @@ import Parse from 'parse/node';
 import _ from 'lodash';
 import defaults, { ParseServerDatabaseOptions } from '../../../defaults';
 import logger from '../../../logger';
-import Utils from '../../../Utils';
 
 // @flow-disable-next
 const mongodb = require('mongodb');
@@ -1110,7 +1110,7 @@ export class MongoStorageAdapter implements StorageAdapter {
    * @returns {any} The original value if not convertible to Date, or a Date object if it is.
    */
   _convertToDate(value: any): any {
-    if (value instanceof Date) {
+    if (Utils.isDate(value)) {
       return value;
     }
     if (typeof value === 'string') {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -189,7 +189,7 @@ const transformInteriorValue = restValue => {
   var value = transformInteriorAtom(restValue);
   if (value !== CannotTransform) {
     if (value && typeof value === 'object') {
-      if (value instanceof Date) {
+      if (Utils.isDate(value)) {
         return value;
       }
       if (value instanceof Array) {
@@ -218,7 +218,7 @@ const transformInteriorValue = restValue => {
 const valueAsDate = value => {
   if (typeof value === 'string') {
     return new Date(value);
-  } else if (value instanceof Date) {
+  } else if (Utils.isDate(value)) {
     return value;
   }
   return false;
@@ -565,7 +565,7 @@ function CannotTransform() {}
 
 const transformInteriorAtom = atom => {
   // TODO: check validity harder for the __type-defined types
-  if (typeof atom === 'object' && atom && !(atom instanceof Date) && atom.__type === 'Pointer') {
+  if (typeof atom === 'object' && atom && !Utils.isDate(atom) && atom.__type === 'Pointer') {
     return {
       __type: 'Pointer',
       className: atom.className,
@@ -606,7 +606,7 @@ function transformTopLevelAtom(atom, field) {
     case 'function':
       throw new Parse.Error(Parse.Error.INVALID_JSON, `cannot transform value: ${atom}`);
     case 'object':
-      if (atom instanceof Date) {
+      if (Utils.isDate(atom)) {
         // Technically dates are not rest format, but, it seems pretty
         // clear what they should be transformed to, so let's just do it.
         return atom;
@@ -1057,7 +1057,7 @@ const nestedMongoObjectToNestedParseObject = mongoObject => {
         return mongoObject.map(nestedMongoObjectToNestedParseObject);
       }
 
-      if (mongoObject instanceof Date) {
+      if (Utils.isDate(mongoObject)) {
         return Parse._encode(mongoObject);
       }
 
@@ -1076,7 +1076,7 @@ const nestedMongoObjectToNestedParseObject = mongoObject => {
       if (
         Object.prototype.hasOwnProperty.call(mongoObject, '__type') &&
         mongoObject.__type == 'Date' &&
-        mongoObject.iso instanceof Date
+        Utils.isDate(mongoObject.iso)
       ) {
         mongoObject.iso = mongoObject.iso.toJSON();
         return mongoObject;
@@ -1120,7 +1120,7 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
         return mongoObject.map(nestedMongoObjectToNestedParseObject);
       }
 
-      if (mongoObject instanceof Date) {
+      if (Utils.isDate(mongoObject)) {
         return Parse._encode(mongoObject);
       }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -121,7 +121,7 @@ const transformKeyValueForUpdate = (className, restKey, restValue, parseFormatSc
   }
 
   // Handle arrays
-  if (restValue instanceof Array) {
+  if (Array.isArray(restValue)) {
     value = restValue.map(transformInteriorValue);
     return { key, value };
   }
@@ -192,7 +192,7 @@ const transformInteriorValue = restValue => {
       if (Utils.isDate(value)) {
         return value;
       }
-      if (value instanceof Array) {
+      if (Array.isArray(value)) {
         value = value.map(transformInteriorValue);
       } else {
         value = mapValues(value, transformInteriorValue);
@@ -202,7 +202,7 @@ const transformInteriorValue = restValue => {
   }
 
   // Handle arrays
-  if (restValue instanceof Array) {
+  if (Array.isArray(restValue)) {
     return restValue.map(transformInteriorValue);
   }
 
@@ -338,7 +338,7 @@ function transformQueryKeyValue(className, key, value, schema, count = false) {
     return { key, value: transformedConstraint };
   }
 
-  if (expectedTypeIsArray && !(value instanceof Array)) {
+  if (expectedTypeIsArray && !Array.isArray(value)) {
     return { key, value: { $all: [transformInteriorAtom(value)] } };
   }
 
@@ -444,7 +444,7 @@ const parseObjectKeyValueToMongoObjectKeyValue = (restKey, restValue, schema) =>
   }
 
   // Handle arrays
-  if (restValue instanceof Array) {
+  if (Array.isArray(restValue)) {
     value = restValue.map(transformInteriorValue);
     return { key: restKey, value: value };
   }
@@ -721,7 +721,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
       case '$in':
       case '$nin': {
         const arr = constraint[key];
-        if (!(arr instanceof Array)) {
+        if (!Array.isArray(arr)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad ' + key + ' value');
         }
         answer[key] = _.flatMap(arr, value => {
@@ -737,7 +737,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
       }
       case '$all': {
         const arr = constraint[key];
-        if (!(arr instanceof Array)) {
+        if (!Array.isArray(arr)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, 'bad ' + key + ' value');
         }
         answer[key] = arr.map(transformInteriorAtom);
@@ -762,7 +762,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
 
       case '$containedBy': {
         const arr = constraint[key];
-        if (!(arr instanceof Array)) {
+        if (!Array.isArray(arr)) {
           throw new Parse.Error(Parse.Error.INVALID_JSON, `bad $containedBy: should be an array`);
         }
         answer.$elemMatch = {
@@ -872,7 +872,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
               );
             }
             points = polygon.coordinates;
-          } else if (polygon instanceof Array) {
+          } else if (Array.isArray(polygon)) {
             if (polygon.length < 3) {
               throw new Parse.Error(
                 Parse.Error.INVALID_JSON,
@@ -887,7 +887,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
             );
           }
           points = points.map(point => {
-            if (point instanceof Array && point.length === 2) {
+            if (Array.isArray(point) && point.length === 2) {
               Parse.GeoPoint._validate(point[1], point[0]);
               return point;
             }
@@ -902,7 +902,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
             $polygon: points,
           };
         } else if (centerSphere !== undefined) {
-          if (!(centerSphere instanceof Array) || centerSphere.length < 2) {
+          if (!Array.isArray(centerSphere) || centerSphere.length < 2) {
             throw new Parse.Error(
               Parse.Error.INVALID_JSON,
               'bad $geoWithin value; $centerSphere should be an array of Parse.GeoPoint and distance'
@@ -910,7 +910,7 @@ function transformConstraint(constraint, field, queryKey, count = false) {
           }
           // Get point, convert to geo point if necessary and validate
           let point = centerSphere[0];
-          if (point instanceof Array && point.length === 2) {
+          if (Array.isArray(point) && point.length === 2) {
             point = new Parse.GeoPoint(point[1], point[0]);
           } else if (!GeoPointCoder.isValidJSON(point)) {
             throw new Parse.Error(
@@ -999,7 +999,7 @@ function transformUpdateOperator({ __op, amount, objects }, flatten) {
 
     case 'Add':
     case 'AddUnique':
-      if (!(objects instanceof Array)) {
+      if (!Array.isArray(objects)) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
       }
       var toAdd = objects.map(transformInteriorAtom);
@@ -1014,7 +1014,7 @@ function transformUpdateOperator({ __op, amount, objects }, flatten) {
       }
 
     case 'Remove':
-      if (!(objects instanceof Array)) {
+      if (!Array.isArray(objects)) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to remove must be an array');
       }
       var toRemove = objects.map(transformInteriorAtom);
@@ -1053,7 +1053,7 @@ const nestedMongoObjectToNestedParseObject = mongoObject => {
       if (mongoObject === null) {
         return null;
       }
-      if (mongoObject instanceof Array) {
+      if (Array.isArray(mongoObject)) {
         return mongoObject.map(nestedMongoObjectToNestedParseObject);
       }
 
@@ -1116,7 +1116,7 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
       if (mongoObject === null) {
         return null;
       }
-      if (mongoObject instanceof Array) {
+      if (Array.isArray(mongoObject)) {
         return mongoObject.map(nestedMongoObjectToNestedParseObject);
       }
 
@@ -1347,7 +1347,7 @@ var GeoPointCoder = {
   },
 
   isValidDatabaseObject(object) {
-    return object instanceof Array && object.length == 2;
+    return Array.isArray(object) && object.length == 2;
   },
 
   JSONToDatabase(json) {
@@ -1373,7 +1373,7 @@ var PolygonCoder = {
 
   isValidDatabaseObject(object) {
     const coords = object.coordinates[0];
-    if (object.type !== 'Polygon' || !(coords instanceof Array)) {
+    if (object.type !== 'Polygon' || !Array.isArray(coords)) {
       return false;
     }
     for (let i = 0; i < coords.length; i++) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -137,7 +137,7 @@ const transformKeyValueForUpdate = (className, restKey, restValue, parseFormatSc
 };
 
 const isRegex = value => {
-  return value && value instanceof RegExp;
+  return value && Utils.isRegExp(value);
 };
 
 const isStartsWithRegex = value => {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1696,7 +1696,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
         updatePatterns.push(`$${index}:name = $${index + 1}`);
         values.push(fieldName, toPostgresValue(fieldValue));
         index += 2;
-      } else if (fieldValue instanceof Date) {
+      } else if (Utils.isDate(fieldValue)) {
         updatePatterns.push(`$${index}:name = $${index + 1}`);
         values.push(fieldName, fieldValue);
         index += 2;
@@ -2057,7 +2057,7 @@ export class PostgresStorageAdapter implements StorageAdapter {
       if (object[fieldName] === null) {
         delete object[fieldName];
       }
-      if (object[fieldName] instanceof Date) {
+      if (Utils.isDate(object[fieldName])) {
         object[fieldName] = {
           __type: 'Date',
           iso: object[fieldName].toISOString(),

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -572,7 +572,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
 
     if (fieldValue.$containedBy) {
       const arr = fieldValue.$containedBy;
-      if (!(arr instanceof Array)) {
+      if (!Array.isArray(arr)) {
         throw new Parse.Error(Parse.Error.INVALID_JSON, `bad $containedBy: should be an array`);
       }
 
@@ -654,7 +654,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
 
     if (fieldValue.$geoWithin && fieldValue.$geoWithin.$centerSphere) {
       const centerSphere = fieldValue.$geoWithin.$centerSphere;
-      if (!(centerSphere instanceof Array) || centerSphere.length < 2) {
+      if (!Array.isArray(centerSphere) || centerSphere.length < 2) {
         throw new Parse.Error(
           Parse.Error.INVALID_JSON,
           'bad $geoWithin value; $centerSphere should be an array of Parse.GeoPoint and distance'
@@ -662,7 +662,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
       }
       // Get point, convert to geo point if necessary and validate
       let point = centerSphere[0];
-      if (point instanceof Array && point.length === 2) {
+      if (Array.isArray(point) && point.length === 2) {
         point = new Parse.GeoPoint(point[1], point[0]);
       } else if (!GeoPointCoder.isValidJSON(point)) {
         throw new Parse.Error(
@@ -699,7 +699,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
           );
         }
         points = polygon.coordinates;
-      } else if (polygon instanceof Array) {
+      } else if (Array.isArray(polygon)) {
         if (polygon.length < 3) {
           throw new Parse.Error(
             Parse.Error.INVALID_JSON,
@@ -715,7 +715,7 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
       }
       points = points
         .map(point => {
-          if (point instanceof Array && point.length === 2) {
+          if (Array.isArray(point) && point.length === 2) {
             Parse.GeoPoint._validate(point[1], point[0]);
             return `(${point[0]}, ${point[1]})`;
           }

--- a/src/Config.js
+++ b/src/Config.js
@@ -24,6 +24,7 @@ import {
 } from './Options/Definitions';
 import ParseServer from './cloud-code/Parse.Server';
 import Deprecator from './Deprecator/Deprecator';
+import Utils from './Utils';
 
 function removeTrailingSlash(str) {
   if (!str) {
@@ -420,7 +421,7 @@ export class Config {
       if (passwordPolicy.validatorPattern) {
         if (typeof passwordPolicy.validatorPattern === 'string') {
           passwordPolicy.validatorPattern = new RegExp(passwordPolicy.validatorPattern);
-        } else if (!(passwordPolicy.validatorPattern instanceof RegExp)) {
+        } else if (!Utils.isRegExp(passwordPolicy.validatorPattern)) {
           throw 'passwordPolicy.validatorPattern must be a regex string or RegExp object.';
         }
       }

--- a/src/Config.js
+++ b/src/Config.js
@@ -347,7 +347,7 @@ export class Config {
     }
     if (pages.customRoutes === undefined) {
       pages.customRoutes = PagesOptions.customRoutes.default;
-    } else if (!(pages.customRoutes instanceof Array)) {
+    } else if (!Array.isArray(pages.customRoutes)) {
       throw 'Parse Server option pages.customRoutes must be an array.';
     }
     if (pages.encodePageParamHeaders === undefined) {
@@ -370,7 +370,7 @@ export class Config {
     }
     if (!idempotencyOptions.paths) {
       idempotencyOptions.paths = IdempotencyOptions.paths.default;
-    } else if (!(idempotencyOptions.paths instanceof Array)) {
+    } else if (!Array.isArray(idempotencyOptions.paths)) {
       throw 'idempotency paths must be of an array of strings';
     }
   }
@@ -537,7 +537,7 @@ export class Config {
 
   static validateFileUploadOptions(fileUpload) {
     try {
-      if (fileUpload == null || typeof fileUpload !== 'object' || fileUpload instanceof Array) {
+      if (fileUpload == null || typeof fileUpload !== 'object' || Array.isArray(fileUpload)) {
         throw 'fileUpload must be an object value.';
       }
     } catch (e) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -132,7 +132,7 @@ const validateQuery = (
   }
 
   if (query.$or) {
-    if (query.$or instanceof Array) {
+    if (Array.isArray(query.$or)) {
       query.$or.forEach(value => validateQuery(value, isMaster, isMaintenance, update, options, _depth + 1));
     } else {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Bad $or format - use an array value.');
@@ -140,7 +140,7 @@ const validateQuery = (
   }
 
   if (query.$and) {
-    if (query.$and instanceof Array) {
+    if (Array.isArray(query.$and)) {
       query.$and.forEach(value => validateQuery(value, isMaster, isMaintenance, update, options, _depth + 1));
     } else {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Bad $and format - use an array value.');
@@ -148,7 +148,7 @@ const validateQuery = (
   }
 
   if (query.$nor) {
-    if (query.$nor instanceof Array && query.$nor.length > 0) {
+    if (Array.isArray(query.$nor) && query.$nor.length > 0) {
       query.$nor.forEach(value => validateQuery(value, isMaster, isMaintenance, update, options, _depth + 1));
     } else {
       throw new Parse.Error(
@@ -323,19 +323,19 @@ const flattenUpdateOperatorsForCreate = object => {
           object[key] = object[key].amount;
           break;
         case 'Add':
-          if (!(object[key].objects instanceof Array)) {
+          if (!Array.isArray(object[key].objects)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
           }
           object[key] = object[key].objects;
           break;
         case 'AddUnique':
-          if (!(object[key].objects instanceof Array)) {
+          if (!Array.isArray(object[key].objects)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
           }
           object[key] = object[key].objects;
           break;
         case 'Remove':
-          if (!(object[key].objects instanceof Array)) {
+          if (!Array.isArray(object[key].objects)) {
             throw new Parse.Error(Parse.Error.INVALID_JSON, 'objects to add must be an array');
           }
           object[key] = [];

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -70,7 +70,7 @@ export class FilesController extends AdaptableController {
    * Object may be a single object or list of REST-format objects.
    */
   async expandFilesInObject(config, object) {
-    if (object instanceof Array) {
+    if (Array.isArray(object)) {
       const promises = object.map(obj => this.expandFilesInObject(config, obj));
       await Promise.all(promises);
       return;

--- a/src/Controllers/LiveQueryController.js
+++ b/src/Controllers/LiveQueryController.js
@@ -9,7 +9,7 @@ export class LiveQueryController {
     // If config is empty, we just assume no classs needs to be registered as LiveQuery
     if (!config || !config.classNames) {
       this.classNames = new Set();
-    } else if (config.classNames instanceof Array) {
+    } else if (Array.isArray(config.classNames)) {
       const classNames = config.classNames.map(name => {
         const _name = getClassName(name);
         return new RegExp(`^${_name}$`);

--- a/src/Controllers/ParseGraphQLController.js
+++ b/src/Controllers/ParseGraphQLController.js
@@ -308,7 +308,7 @@ const isValidSimpleObject = function (obj): boolean {
     !Array.isArray(obj) &&
     obj !== null &&
     Utils.isDate(obj) !== true &&
-    obj instanceof Promise !== true
+    Utils.isPromise(obj) !== true
   );
 };
 

--- a/src/Controllers/ParseGraphQLController.js
+++ b/src/Controllers/ParseGraphQLController.js
@@ -1,4 +1,5 @@
 import requiredParameter from '../../lib/requiredParameter';
+import Utils from '../Utils';
 import DatabaseController from './DatabaseController';
 import CacheController from './CacheController';
 
@@ -306,7 +307,7 @@ const isValidSimpleObject = function (obj): boolean {
     typeof obj === 'object' &&
     !Array.isArray(obj) &&
     obj !== null &&
-    obj instanceof Date !== true &&
+    Utils.isDate(obj) !== true &&
     obj instanceof Promise !== true
   );
 };

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -1579,7 +1579,7 @@ function getType(obj: any): ?(SchemaField | string) {
 // also gets the appropriate type for $ operators.
 // Returns null if the type is unknown.
 function getObjectType(obj): ?(SchemaField | string) {
-  if (obj instanceof Array) {
+  if (Array.isArray(obj)) {
     return 'Array';
   }
   if (obj.__type) {

--- a/src/GraphQL/loaders/defaultGraphQLTypes.js
+++ b/src/GraphQL/loaders/defaultGraphQLTypes.js
@@ -16,6 +16,7 @@ import {
 } from 'graphql';
 import { toGlobalId } from 'graphql-relay';
 import GraphQLUpload from 'graphql-upload/GraphQLUpload.js';
+import Utils from '../../Utils';
 
 class TypeValidationError extends Error {
   constructor(value, type) {
@@ -149,7 +150,7 @@ const parseDateIsoValue = value => {
     if (!isNaN(date)) {
       return date;
     }
-  } else if (value instanceof Date) {
+  } else if (Utils.isDate(value)) {
     return value;
   }
 
@@ -160,7 +161,7 @@ const serializeDateIso = value => {
   if (typeof value === 'string') {
     return value;
   }
-  if (value instanceof Date) {
+  if (Utils.isDate(value)) {
     return value.toISOString();
   }
 
@@ -179,7 +180,7 @@ const DATE = new GraphQLScalarType({
   name: 'Date',
   description: 'The Date scalar type is used in operations and types that involve dates.',
   parseValue(value) {
-    if (typeof value === 'string' || value instanceof Date) {
+    if (typeof value === 'string' || Utils.isDate(value)) {
       return {
         __type: 'Date',
         iso: parseDateIsoValue(value),
@@ -194,7 +195,7 @@ const DATE = new GraphQLScalarType({
     throw new TypeValidationError(value, 'Date');
   },
   serialize(value) {
-    if (typeof value === 'string' || value instanceof Date) {
+    if (typeof value === 'string' || Utils.isDate(value)) {
       return serializeDateIso(value);
     } else if (typeof value === 'object' && value.__type === 'Date' && value.iso) {
       return serializeDateIso(value.iso);

--- a/src/GraphQL/transformers/query.js
+++ b/src/GraphQL/transformers/query.js
@@ -200,7 +200,7 @@ const transformQueryConstraintInputToParse = (
         }
         break;
       case 'polygon':
-        if (fieldValue instanceof Array) {
+        if (Array.isArray(fieldValue)) {
           fieldValue.forEach(geoPoint => {
             if (typeof geoPoint === 'object' && !geoPoint.__type) {
               geoPoint.__type = 'GeoPoint';

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -1223,7 +1223,7 @@ function includePath(config, auth, response, path, context, restOptions = {}) {
 // Path is a list of fields to search into.
 // Returns a list of pointers in REST format.
 function findPointers(object, path) {
-  if (object instanceof Array) {
+  if (Array.isArray(object)) {
     return object.map(x => findPointers(x, path)).flat();
   }
 
@@ -1252,7 +1252,7 @@ function findPointers(object, path) {
 // Returns something analogous to object, but with the appropriate
 // pointers inflated.
 function replacePointers(object, path, replace) {
-  if (object instanceof Array) {
+  if (Array.isArray(object)) {
     return object
       .map(obj => replacePointers(obj, path, replace))
       .filter(obj => typeof obj !== 'undefined');
@@ -1291,7 +1291,7 @@ function findObjectWithKey(root, key) {
   if (typeof root !== 'object') {
     return;
   }
-  if (root instanceof Array) {
+  if (Array.isArray(root)) {
     for (var item of root) {
       const answer = findObjectWithKey(item, key);
       if (answer) {

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -434,7 +434,7 @@ export class FilesRouter {
     }
 
     // Dispatch to the appropriate handler based on whether the body was buffered
-    if (req.body instanceof Buffer) {
+    if (Buffer.isBuffer(req.body)) {
       return this._handleBufferedUpload(req, res, next);
     }
     return this._handleStreamUpload(req, res, next);

--- a/src/Routers/PagesRouter.js
+++ b/src/Routers/PagesRouter.js
@@ -444,7 +444,7 @@ export class PagesRouter extends PromiseRouter {
         : Object.prototype.toString.call(this.pagesConfig.placeholders) === '[object Object]'
           ? this.pagesConfig.placeholders
           : {};
-    if (configPlaceholders instanceof Promise) {
+    if (Utils.isPromise(configPlaceholders)) {
       configPlaceholders = await configPlaceholders;
     }
 

--- a/src/Security/Check.js
+++ b/src/Security/Check.js
@@ -42,7 +42,7 @@ class Check {
 
   async run() {
     // Get check as synchronous or asynchronous function
-    const check = this.check instanceof Promise ? await this.check : this.check;
+    const check = Utils.isPromise(this.check) ? await this.check : this.check;
 
     // Run check
     try {

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -1,4 +1,5 @@
 import { md5Hash, newObjectId } from './cryptoUtils';
+import Utils from './Utils';
 import { KeyPromiseQueue } from './KeyPromiseQueue';
 import { logger } from './logger';
 import rest from './rest';
@@ -113,7 +114,7 @@ export function jobStatusHandler(config) {
     if (message && typeof message === 'string') {
       update.message = message;
     }
-    if (message instanceof Error && typeof message.message === 'string') {
+    if (Utils.isNativeError(message) && typeof message.message === 'string') {
       update.message = message.message;
     }
     return handler.update({ objectId }, update);

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -505,7 +505,7 @@ class Utils {
       if (Utils.isMap(value)) {
         return Object.fromEntries(value);
       }
-      if (value instanceof Set) {
+      if (Utils.isSet(value)) {
         return Array.from(value);
       }
       if (typeof value === 'object' && value !== null) {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -180,9 +180,13 @@ class Utils {
   }
 
   /**
-   * Realm-safe check for object (non-null, typeof object).
+   * Realm-safe check for object type. Uses `typeof` instead of `instanceof Object`
+   * which fails across realms. Returns true for any non-null value where
+   * `typeof` is `'object'`, including plain objects, arrays, dates, maps, sets,
+   * regex, and boxed primitives (e.g. `new String()`). Returns false for `null`,
+   * `undefined`, unboxed primitives, and functions.
    * @param {any} value The value to check.
-   * @returns {Boolean} Returns true if the value is a non-null object.
+   * @returns {Boolean} Returns true if the value is a non-null object type.
    */
   static isObject(value) {
     return typeof value === 'object' && value !== null;

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -6,6 +6,7 @@
 
 const path = require('path');
 const fs = require('fs').promises;
+const { types } = require('util');
 
 /**
  * The general purpose utilities.
@@ -120,12 +121,71 @@ class Utils {
   }
 
   /**
-   * Determines whether an object is a Promise.
-   * @param {any} object The object to validate.
-   * @returns {Boolean} Returns true if the object is a promise.
+   * Realm-safe check for Date.
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a Date.
    */
-  static isPromise(object) {
-    return object instanceof Promise;
+  static isDate(value) {
+    return types.isDate(value);
+  }
+
+  /**
+   * Realm-safe check for RegExp.
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a RegExp.
+   */
+  static isRegExp(value) {
+    return types.isRegExp(value);
+  }
+
+  /**
+   * Realm-safe check for Map.
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a Map.
+   */
+  static isMap(value) {
+    return types.isMap(value);
+  }
+
+  /**
+   * Realm-safe check for Set.
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a Set.
+   */
+  static isSet(value) {
+    return types.isSet(value);
+  }
+
+  /**
+   * Realm-safe check for native Error.
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a native Error.
+   */
+  static isNativeError(value) {
+    return types.isNativeError(value);
+  }
+
+  /**
+   * Realm-safe check for Promise (duck-typed as thenable).
+   * Guards against Object.prototype pollution by ensuring `then` is not
+   * inherited solely from Object.prototype.
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a Promise or thenable.
+   */
+  static isPromise(value) {
+    if (value == null || typeof value.then !== 'function') {
+      return false;
+    }
+    return Object.getPrototypeOf(value) !== Object.prototype || Object.prototype.hasOwnProperty.call(value, 'then');
+  }
+
+  /**
+   * Realm-safe check for object (non-null, typeof object).
+   * @param {any} value The value to check.
+   * @returns {Boolean} Returns true if the value is a non-null object.
+   */
+  static isObject(value) {
+    return typeof value === 'object' && value !== null;
   }
 
   /**

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -498,7 +498,7 @@ class Utils {
   static getCircularReplacer() {
     const seen = new WeakSet();
     return (key, value) => {
-      if (value instanceof Map) {
+      if (Utils.isMap(value)) {
         return Object.fromEntries(value);
       }
       if (value instanceof Set) {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -1,4 +1,5 @@
 import AppCache from './cache';
+import Utils from './Utils';
 import Parse from 'parse/node';
 import auth from './Auth';
 import Config from './Config';
@@ -178,7 +179,7 @@ export async function handleParseHeaders(req, res, next) {
         delete req.body._MasterKey;
       }
       if (req.body._context) {
-        if (req.body._context instanceof Object) {
+        if (Utils.isObject(req.body._context)) {
           info.context = req.body._context;
         } else {
           try {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -120,7 +120,7 @@ export async function handleParseHeaders(req, res, next) {
 
   if (!info.appId || !AppCache.get(info.appId)) {
     // See if we can find the app id on the body.
-    if (req.body instanceof Buffer) {
+    if (Buffer.isBuffer(req.body)) {
       // The only chance to find the app id is if this is a file
       // upload that actually is a JSON body. So try to parse it.
       // https://github.com/parse-community/parse-server/issues/6589

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -1,6 +1,7 @@
 // triggers.js
 import Parse from 'parse/node';
 import { logger } from './logger';
+import Utils from './Utils';
 
 export const Types = {
   beforeLogin: 'beforeLogin',
@@ -712,7 +713,7 @@ export function resolveError(message, defaultOpts) {
     return new Parse.Error(code, message);
   }
   const error = new Parse.Error(code, message.message || message);
-  if (message instanceof Error) {
+  if (Utils.isNativeError(message)) {
     error.stack = message.stack;
   }
   return error;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Instance comparison with `instanceof` is not realm-safe. This may cause issues in certain test or production setups.

## Approach

- Replace occurrences of `instanceof` with safe alternatives.
- Add lint rule to prevent future use of `instanceof`.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-realm-safe type-checking utilities for Date, RegExp, Map, Set, native Error, Promise/thenable, and generic object detection.

* **Improvements**
  * Replaced fragile instanceof checks with the new, safer utilities and Array.isArray/Buffer.isBuffer where appropriate for more reliable runtime behavior.

* **Tests**
  * Expanded unit tests to cover cross-realm, edge-case, and prototype-pollution scenarios.

* **Chores**
  * Added lint rules to enforce use of the safer type-check utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->