### PR TITLE
feat: Add `enableProductPurchaseLegacyApi` option to disable legacy IAP validation

### DIFF
--- a/spec/Deprecator.spec.js
+++ b/spec/Deprecator.spec.js
@@ -171,6 +171,29 @@ describe('Deprecator', () => {
     }
   });
 
+  it('logs deprecation for enableProductPurchaseLegacyApi when set', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    await reconfigureServer({ enableProductPurchaseLegacyApi: true });
+    expect(logSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        optionKey: 'enableProductPurchaseLegacyApi',
+        changeNewKey: '',
+      })
+    );
+  });
+
+  it('does not log deprecation for enableProductPurchaseLegacyApi when not set', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    await reconfigureServer();
+    expect(logSpy).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        optionKey: 'enableProductPurchaseLegacyApi',
+      })
+    );
+  });
+
   it('does not log deprecation for requestComplexity limits when explicitly set', async () => {
     const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
 

--- a/spec/PurchaseValidation.spec.js
+++ b/spec/PurchaseValidation.spec.js
@@ -186,6 +186,31 @@ describe('test validate_receipt endpoint', () => {
       });
   });
 
+  it('should disable validate_purchase endpoint when enableProductPurchaseLegacyApi is false', async () => {
+    await reconfigureServer({ enableProductPurchaseLegacyApi: false });
+    const ParseServer = require('../lib/ParseServer').default;
+    const routers = ParseServer.promiseRouter({
+      appId: 'test',
+      options: { enableProductPurchaseLegacyApi: false },
+    });
+    const hasValidatePurchase = routers.routes.some(
+      r => r.path === '/validate_purchase' && r.method === 'POST'
+    );
+    expect(hasValidatePurchase).toBe(false);
+  });
+
+  it('should enable validate_purchase endpoint by default', async () => {
+    const ParseServer = require('../lib/ParseServer').default;
+    const routers = ParseServer.promiseRouter({
+      appId: 'test',
+      options: {},
+    });
+    const hasValidatePurchase = routers.routes.some(
+      r => r.path === '/validate_purchase' && r.method === 'POST'
+    );
+    expect(hasValidatePurchase).toBe(true);
+  });
+
   it('should not be able to remove a require key in a _Product', done => {
     const query = new Parse.Query('_Product');
     query

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -71,4 +71,9 @@ module.exports = [
     changeNewDefault: '200',
     solution: "Set 'requestComplexity.graphQLFields' to a positive integer appropriate for your app to limit the number of GraphQL field selections, or to '-1' to disable.",
   },
+  {
+    optionKey: 'enableProductPurchaseLegacyApi',
+    changeNewKey: '',
+    solution: "The product purchase API is an undocumented, unmaintained legacy feature that may not function as expected and will be removed in a future major version. We strongly advise against using it. Set 'enableProductPurchaseLegacyApi' to 'false' to disable it, or remove the option to accept the future removal.",
+  },
 ];

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -238,6 +238,12 @@ module.exports.ParseServerOptions = {
     action: parsers.booleanParser,
     default: false,
   },
+  enableProductPurchaseLegacyApi: {
+    env: 'PARSE_SERVER_ENABLE_PRODUCT_PURCHASE_LEGACY_API',
+    help: 'Deprecated. Enables the legacy product purchase API including the `_Product` class and the `/validate_purchase` endpoint. This is an undocumented, unmaintained legacy feature inherited from the original Parse platform that may not function as expected. We strongly advise against using it. It will be removed in a future major version.',
+    action: parsers.booleanParser,
+    default: true,
+  },
   enableSanitizedErrorResponse: {
     env: 'PARSE_SERVER_ENABLE_SANITIZED_ERROR_RESPONSE',
     help: 'If set to `true`, error details are removed from error messages in responses to client requests, and instead a generic error message is sent. Default is `true`.',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -46,6 +46,7 @@
  * @property {Boolean} enableCollationCaseComparison Optional. If set to `true`, the collation rule of case comparison for queries and indexes is enabled. Enable this option to run Parse Server with MongoDB Atlas Serverless or AWS Amazon DocumentDB. If `false`, the collation rule of case comparison is disabled. Default is `false`.
  * @property {Boolean} enableExpressErrorHandler Enables the default express error handler for all errors
  * @property {Boolean} enableInsecureAuthAdapters Optional. Enables insecure authentication adapters. Insecure auth adapters are deprecated and will be removed in a future version. Defaults to `false`.
+ * @property {Boolean} enableProductPurchaseLegacyApi Deprecated. Enables the legacy product purchase API including the `_Product` class and the `/validate_purchase` endpoint. This is an undocumented, unmaintained legacy feature inherited from the original Parse platform that may not function as expected. We strongly advise against using it. It will be removed in a future major version.
  * @property {Boolean} enableSanitizedErrorResponse If set to `true`, error details are removed from error messages in responses to client requests, and instead a generic error message is sent. Default is `true`.
  * @property {String} encryptionKey Key for encrypting your files
  * @property {Boolean} enforcePrivateUsers Set to true if new users should be created without public read and write access.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -305,6 +305,10 @@ export interface ParseServerOptions {
   /* Enables the default express error handler for all errors
   :DEFAULT: false */
   enableExpressErrorHandler: ?boolean;
+  /* Deprecated. Enables the legacy product purchase API including the `_Product` class and the `/validate_purchase` endpoint. This is an undocumented, unmaintained legacy feature inherited from the original Parse platform that may not function as expected. We strongly advise against using it. It will be removed in a future major version.
+  :ENV: PARSE_SERVER_ENABLE_PRODUCT_PURCHASE_LEGACY_API
+  :DEFAULT: true */
+  enableProductPurchaseLegacyApi: ?boolean;
   /* Sets the number of characters in generated object id's, default 10
   :DEFAULT: 10 */
   objectIdSize: ?number;

--- a/src/ParseServer.ts
+++ b/src/ParseServer.ts
@@ -345,7 +345,7 @@ class ParseServer {
     }
     api.use(middlewares.handleParseSession);
     this.applyRequestContextMiddleware(api, options);
-    const appRouter = ParseServer.promiseRouter({ appId });
+    const appRouter = ParseServer.promiseRouter({ appId, options });
     api.use(appRouter.expressRouter());
 
     api.use(middlewares.handleParseErrors);
@@ -378,7 +378,7 @@ class ParseServer {
     return api;
   }
 
-  static promiseRouter({ appId }) {
+  static promiseRouter({ appId, options }) {
     const routers = [
       new ClassesRouter(),
       new UsersRouter(),
@@ -390,7 +390,6 @@ class ParseServer {
       new SchemasRouter(),
       new PushRouter(),
       new LogsRouter(),
-      new IAPValidationRouter(),
       new FeaturesRouter(),
       new GlobalConfigRouter(),
       new GraphQLRouter(),
@@ -401,6 +400,10 @@ class ParseServer {
       new AggregateRouter(),
       new SecurityRouter(),
     ];
+
+    if (options?.enableProductPurchaseLegacyApi !== false) {
+      routers.push(new IAPValidationRouter());
+    }
 
     const routes = routers.reduce((memo, router) => {
       return memo.concat(router.routes);


### PR DESCRIPTION
## Issue

Add server option `enableProductPurchaseLegacyApi` to control the legacy product purchase API (`_Product` class and `/validate_purchase` endpoint). The option defaults to `true` for backward compatibility and is immediately deprecated. The entire feature will be removed in a future major version.

## Tasks

- [x] Add new tests
- [x] Add changes to documentation (guides, changelogs, code comments, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice for the legacy product purchase API, warning it will be removed in a future major version.
  * Introduced configuration option `enableProductPurchaseLegacyApi` to control the legacy API behavior.

* **Tests**
  * Added test coverage for deprecation logging and endpoint enablement/disablement validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->