### PR TITLE
docs: Add DEPPS19 for `enableProductPurchaseLegacyApi` deprecation

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -22,6 +22,7 @@ The following is a list of deprecations, according to the [Deprecation Policy](h
 | DEPPS16 | Remove config option `mountPlayground`                                                       | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS17 | Remove config option `playgroundPath`                                                        | [#10110](https://github.com/parse-community/parse-server/issues/10110) | 9.5.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 | DEPPS18 | Config option `requestComplexity` limits enabled by default                                  | [#10207](https://github.com/parse-community/parse-server/pull/10207)   | 9.6.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
+| DEPPS19 | Remove config option `enableProductPurchaseLegacyApi`                                        | [#10228](https://github.com/parse-community/parse-server/pull/10228)   | 9.6.0 (2026)                    | 10.0.0 (2027)                   | deprecated            | -     |
 
 [i_deprecation]: ## "The version and date of the deprecation."
 [i_change]: ## "The version and date of the planned change."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated deprecation notices with a new entry documenting the removal timeline for a legacy API configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->