### PR TITLE
fix: Input type validation for query operators and batch path

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -5565,4 +5565,188 @@ describe('Parse.Query testing', () => {
       }
     );
   });
+
+  describe('query input type validation', () => {
+    const restHeaders = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+    };
+
+    describe('malformed where parameter', () => {
+      it('rejects invalid JSON in where parameter with proper error instead of 500', async () => {
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: 'http://localhost:8378/1/classes/TestClass?where=%7Bbad-json',
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects invalid JSON in where parameter for roles endpoint', async () => {
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: 'http://localhost:8378/1/roles?where=%7Bbad-json',
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects invalid JSON in where parameter for users endpoint', async () => {
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: 'http://localhost:8378/1/users?where=%7Bbad-json',
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects invalid JSON in where parameter for sessions endpoint', async () => {
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: 'http://localhost:8378/1/sessions?where=%7Bbad-json',
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('still accepts valid JSON in where parameter', async () => {
+        const result = await request({
+          method: 'GET',
+          url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(JSON.stringify({}))}`,
+          headers: restHeaders,
+        });
+        expect(result.data.results).toEqual([]);
+      });
+    });
+
+    describe('$regex type validation', () => {
+      it('rejects object $regex in query', async () => {
+        const where = JSON.stringify({ field: { $regex: { a: 1 } } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects numeric $regex in query', async () => {
+        const where = JSON.stringify({ field: { $regex: 123 } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects array $regex in query', async () => {
+        const where = JSON.stringify({ field: { $regex: ['test'] } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('still accepts valid string $regex in query', async () => {
+        const obj = new Parse.Object('TestClass');
+        obj.set('field', 'hello');
+        await obj.save();
+        const where = JSON.stringify({ field: { $regex: '^hello$' } });
+        const result = await request({
+          method: 'GET',
+          url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+          headers: restHeaders,
+        });
+        expect(result.data.results.length).toBe(1);
+      });
+    });
+
+    describe('$options type validation', () => {
+      it('rejects numeric $options in query', async () => {
+        const where = JSON.stringify({ field: { $regex: 'test', $options: 123 } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects object $options in query', async () => {
+        const where = JSON.stringify({ field: { $regex: 'test', $options: { a: 1 } } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('rejects boolean $options in query', async () => {
+        const where = JSON.stringify({ field: { $regex: 'test', $options: true } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('still accepts valid string $options in query', async () => {
+        const obj = new Parse.Object('TestClass');
+        obj.set('field', 'hello');
+        await obj.save();
+        const where = JSON.stringify({ field: { $regex: 'hello', $options: 'i' } });
+        const result = await request({
+          method: 'GET',
+          url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+          headers: restHeaders,
+        });
+        expect(result.data.results.length).toBe(1);
+      });
+    });
+
+    describe('$in type validation on text fields', () => {
+      it_only_db('postgres')('rejects non-matching type in $in for text field with proper error instead of 500', async () => {
+        const obj = new Parse.Object('TestClass');
+        obj.set('textField', 'hello');
+        await obj.save();
+        const where = JSON.stringify({ textField: { $in: [1, 2, 3] } });
+        await expectAsync(
+          request({
+            method: 'GET',
+            url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+            headers: restHeaders,
+          })
+        ).toBeRejectedWith(jasmine.objectContaining({ status: 400 }));
+      });
+
+      it('still accepts matching type in $in for text field', async () => {
+        const obj = new Parse.Object('TestClass');
+        obj.set('textField', 'hello');
+        await obj.save();
+        const where = JSON.stringify({ textField: { $in: ['hello', 'world'] } });
+        const result = await request({
+          method: 'GET',
+          url: `http://localhost:8378/1/classes/TestClass?where=${encodeURIComponent(where)}`,
+          headers: restHeaders,
+        });
+        expect(result.data.results.length).toBe(1);
+      });
+    });
+  });
 });

--- a/spec/batch.spec.js
+++ b/spec/batch.spec.js
@@ -593,4 +593,93 @@ describe('batch', () => {
       });
     });
   }
+
+  describe('subrequest path type validation', () => {
+    it('rejects object path in batch subrequest with proper error instead of 500', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [{ method: 'GET', path: { invalid: true } }],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({ status: 400 })
+      );
+    });
+
+    it('rejects numeric path in batch subrequest', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [{ method: 'GET', path: 123 }],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({ status: 400 })
+      );
+    });
+
+    it('rejects array path in batch subrequest', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [{ method: 'GET', path: ['/1/classes/Test'] }],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({ status: 400 })
+      );
+    });
+
+    it('rejects null path in batch subrequest', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [{ method: 'GET', path: null }],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({ status: 400 })
+      );
+    });
+
+    it('rejects boolean path in batch subrequest', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [{ method: 'GET', path: true }],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({ status: 400 })
+      );
+    });
+
+    it('still accepts valid string path in batch subrequest', async () => {
+      const result = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/batch',
+        headers,
+        body: JSON.stringify({
+          requests: [{ method: 'GET', path: '/1/classes/TestClass' }],
+        }),
+      });
+      expect(result.data).toEqual(jasmine.any(Array));
+    });
+  });
 });

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -486,6 +486,17 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
             if (fieldName.indexOf('.') >= 0) {
               return;
             }
+            const fieldType = schema.fields[fieldName]?.type;
+            if (fieldType === 'String') {
+              for (const elem of baseArray) {
+                if (elem != null && typeof elem !== 'string') {
+                  throw new Parse.Error(
+                    Parse.Error.INVALID_QUERY,
+                    `$in element type mismatch: expected string for field "${fieldName}"`
+                  );
+                }
+              }
+            }
             const inPatterns = [];
             values.push(fieldName);
             baseArray.forEach((listElem, listIndex) => {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -488,11 +488,12 @@ const buildWhereClause = ({ schema, query, index, caseInsensitive }): WhereClaus
             }
             const fieldType = schema.fields[fieldName]?.type;
             if (fieldType === 'String') {
+              const operatorName = notIn ? '$nin' : '$in';
               for (const elem of baseArray) {
                 if (elem != null && typeof elem !== 'string') {
                   throw new Parse.Error(
                     Parse.Error.INVALID_QUERY,
-                    `$in element type mismatch: expected string for field "${fieldName}"`
+                    `${operatorName} element type mismatch: expected string for field "${fieldName}"`
                   );
                 }
               }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -160,6 +160,12 @@ const validateQuery = (
 
   Object.keys(query).forEach(key => {
     if (query && query[key] && query[key].$regex) {
+      if (typeof query[key].$regex !== 'string') {
+        throw new Parse.Error(Parse.Error.INVALID_QUERY, '$regex value must be a string');
+      }
+      if (query[key].$options !== undefined && typeof query[key].$options !== 'string') {
+        throw new Parse.Error(Parse.Error.INVALID_QUERY, '$options value must be a string');
+      }
       if (typeof query[key].$options === 'string') {
         if (!query[key].$options.match(/^[imxsu]+$/)) {
           throw new Parse.Error(

--- a/src/Routers/AggregateRouter.js
+++ b/src/Routers/AggregateRouter.js
@@ -29,7 +29,11 @@ export class AggregateRouter extends ClassesRouter {
     }
     options.pipeline = AggregateRouter.getPipeline(body);
     if (typeof body.where === 'string') {
-      body.where = JSON.parse(body.where);
+      try {
+        body.where = JSON.parse(body.where);
+      } catch {
+        throw new Parse.Error(Parse.Error.INVALID_JSON, 'where parameter is not valid JSON');
+      }
     }
     try {
       const response = await rest.find(

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -30,7 +30,11 @@ export class ClassesRouter extends PromiseRouter {
       options.redirectClassNameForKey = String(body.redirectClassNameForKey);
     }
     if (typeof body.where === 'string') {
-      body.where = JSON.parse(body.where);
+      try {
+        body.where = JSON.parse(body.where);
+      } catch {
+        throw new Parse.Error(Parse.Error.INVALID_JSON, 'where parameter is not valid JSON');
+      }
     }
     return rest
       .find(

--- a/src/batch.js
+++ b/src/batch.js
@@ -67,6 +67,11 @@ async function handleBatch(router, req) {
   if (!Array.isArray(req.body?.requests)) {
     throw new Parse.Error(Parse.Error.INVALID_JSON, 'requests must be an array');
   }
+  for (const restRequest of req.body.requests) {
+    if (typeof restRequest.path !== 'string') {
+      throw new Parse.Error(Parse.Error.INVALID_JSON, 'batch request path must be a string');
+    }
+  }
 
   // The batch paths are all from the root of our domain.
   // That means they include the API prefix, that the API is mounted

--- a/src/batch.js
+++ b/src/batch.js
@@ -68,7 +68,7 @@ async function handleBatch(router, req) {
     throw new Parse.Error(Parse.Error.INVALID_JSON, 'requests must be an array');
   }
   for (const restRequest of req.body.requests) {
-    if (typeof restRequest.path !== 'string') {
+    if (!restRequest || typeof restRequest !== 'object' || typeof restRequest.path !== 'string') {
       throw new Parse.Error(Parse.Error.INVALID_JSON, 'batch request path must be a string');
     }
   }


### PR DESCRIPTION
## Issue

Input type validation for query operators and batch path

## Tasks

- [x] Add tests
- [x] Add changes
- [ ] Add entry to changelog