### PR TITLE
fix: Resolve flaky rest query internal field test by running queries …

### DIFF
--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -205,16 +205,14 @@ describe('rest query', () => {
       '_password_changed_at',
       '_password_history',
     ];
-    await Promise.all([
-      ...internalFields.map(field =>
-        expectAsync(new Parse.Query(Parse.User).exists(field).find()).toBeRejectedWith(
-          new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${field}`)
-        )
-      ),
-      ...internalFields.map(field =>
-        new Parse.Query(Parse.User).exists(field).find({ useMasterKey: true })
-      ),
-    ]);
+    for (const field of internalFields) {
+      await expectAsync(
+        new Parse.Query(Parse.User).exists(field).find()
+      ).toBeRejectedWith(
+        new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${field}`)
+      );
+      await new Parse.Query(Parse.User).exists(field).find({ useMasterKey: true });
+    }
   });
 
   it('query protected field', async () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
Closes #9273

## Approach
The `rest query query internal field` test was marked as flaky due to an `Unhandled promise rejection` error during CI runs. This was caused by using `Promise.all` combined with `.map` to fire 16 database queries simultaneously, which occasionally overwhelmed the test database connection pool.

**Fix:** Replaced the parallel `Promise.all` execution with a sequential `for...of` loop. This ensures each query is safely `awaited` before moving to the next, entirely eliminating the race conditions and connection exhaustion that were causing the unhandled rejections.

## Tasks
*(No tasks apply as this is a fix to an existing test case).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored internal user field validation tests to use sequential execution instead of parallel processing, improving test clarity and maintainability while preserving existing validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->