### PR TITLE
fix: Resolve flaky test ParseLiveQuery handle invalid websocket payload length

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -956,7 +956,7 @@ describe('ParseLiveQuery', function () {
     await expectAsync(query.subscribe()).toBeRejectedWith(new Error('Invalid session token'));
   });
 
-  it_id('4ccc9508-ae6a-46ec-932a-9f5e49ab3b9e')(it)('handle invalid websocket payload length', async done => {
+  it_id('4ccc9508-ae6a-46ec-932a-9f5e49ab3b9e')(it)('handle invalid websocket payload length', async () => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['TestObject'],
@@ -982,15 +982,17 @@ describe('ParseLiveQuery', function () {
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     client.socket._socket.write(Buffer.from([0x89, 0xfe]));
 
-    subscription.on('update', async object => {
-      expect(object.get('foo')).toBe('bar');
-      done();
+    const updatePromise = new Promise(resolve => {
+      subscription.on('update', updatedObject => {
+        expect(updatedObject.get('foo')).toBe('bar');
+        resolve();
+      });
     });
-    // Wait for Websocket timeout to reconnect
-    setTimeout(async () => {
-      object.set({ foo: 'bar' });
-      await object.save();
-    }, 1000);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    object.set({ foo: 'bar' });
+    await object.save();
+
+    await updatePromise;
   });
 
   it_id('39a9191f-26dd-4e05-a379-297a67928de8')(it)('should execute live query update on email validation', async done => {

--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -988,6 +988,7 @@ describe('ParseLiveQuery', function () {
         resolve();
       });
     });
+    // Wait for Websocket timeout to reconnect
     await new Promise(resolve => setTimeout(resolve, 1000));
     object.set({ foo: 'bar' });
     await object.save();

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -205,16 +205,14 @@ describe('rest query', () => {
       '_password_changed_at',
       '_password_history',
     ];
-    await Promise.all([
-      ...internalFields.map(field =>
-        expectAsync(new Parse.Query(Parse.User).exists(field).find()).toBeRejectedWith(
-          new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${field}`)
-        )
-      ),
-      ...internalFields.map(field =>
-        new Parse.Query(Parse.User).exists(field).find({ useMasterKey: true })
-      ),
-    ]);
+    for (const field of internalFields) {
+      await expectAsync(
+        new Parse.Query(Parse.User).exists(field).find()
+      ).toBeRejectedWith(
+        new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${field}`)
+      );
+      await new Parse.Query(Parse.User).exists(field).find({ useMasterKey: true });
+    }
   });
 
   it('query protected field', async () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
Closes #9272

## Approach
The `ParseLiveQuery handle invalid websocket payload length` test was identified as flaky due to a "Timeout" error in the CI environment. This was caused by mixing an `async` function with a `done` callback, which can lead to unresolved promises or hung tests if the event listener does not fire within the expected window.

**Fix:**
- Removed the `done` callback and converted the test to a purely `async/await` flow.
- Wrapped the `subscription.on('update')` event listener in a Promise (`updatePromise`) to ensure the test explicitly waits for the event to fire.
- Replaced the disconnected `setTimeout` with an awaited delay to ensure the server reconfiguration and simulated payload are processed sequentially.

## Tasks
*(No tasks apply as this is a fix to an existing test case).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test implementations to use modern async/await patterns and improved execution flow for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->