### PR TITLE
fix: Resolve flaky test ParseLiveQuery handle invalid websocket payload length

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -956,7 +956,7 @@ describe('ParseLiveQuery', function () {
     await expectAsync(query.subscribe()).toBeRejectedWith(new Error('Invalid session token'));
   });
 
-  it_id('4ccc9508-ae6a-46ec-932a-9f5e49ab3b9e')(it)('handle invalid websocket payload length', async done => {
+  it_id('4ccc9508-ae6a-46ec-932a-9f5e49ab3b9e')(it)('handle invalid websocket payload length', async () => {
     await reconfigureServer({
       liveQuery: {
         classNames: ['TestObject'],
@@ -982,15 +982,18 @@ describe('ParseLiveQuery', function () {
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     client.socket._socket.write(Buffer.from([0x89, 0xfe]));
 
-    subscription.on('update', async object => {
-      expect(object.get('foo')).toBe('bar');
-      done();
+    const updatePromise = new Promise(resolve => {
+      subscription.on('update', updatedObject => {
+        expect(updatedObject.get('foo')).toBe('bar');
+        resolve();
+      });
     });
     // Wait for Websocket timeout to reconnect
-    setTimeout(async () => {
-      object.set({ foo: 'bar' });
-      await object.save();
-    }, 1000);
+    await sleep(1000);
+    object.set({ foo: 'bar' });
+    await object.save();
+
+    await updatePromise;
   });
 
   it_id('39a9191f-26dd-4e05-a379-297a67928de8')(it)('should execute live query update on email validation', async done => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
Closes #9272

## Approach
The `ParseLiveQuery handle invalid websocket payload length` test was marked as flaky due to random timeout errors in the CI environment. This was caused by mixing an `async` function declaration with a `done` callback, which confuses the testing framework and can lead to hung tests if events are delayed.

**Fix:**
- Removed the `done` callback and converted the test to a standard `async/await` flow.
- Wrapped the websocket `subscription.on('update')` event listener in a Promise to ensure the test explicitly and safely awaits the event resolution.
- Replaced the disconnected `setTimeout` with an awaited Promise delay to ensure server reconfiguration and payload simulation occur sequentially.

## Tasks
*(No tasks apply as this is a fix to an existing test case).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Converted callback-style async tests to promise-based signaling.
  * Replaced ad-hoc timeout flow with an explicit short sleep before modifying and saving test data.
  * Replaced done() callbacks with promise resolution tied to the update event, improving reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->