### PR TITLE
fix: Maintenance key blocked from querying protected fields

### DIFF
--- a/spec/ProtectedFields.spec.js
+++ b/spec/ProtectedFields.spec.js
@@ -2393,12 +2393,12 @@ describe('ProtectedFields', function () {
         config,
         auth: maintenanceAuth,
         className: '_User',
-        restWhere: { emailVerified: false },
+        restWhere: { email: 'test@example.com' },
         runBeforeFind: false,
       });
-      // Should not throw OPERATION_FORBIDDEN
       const result = await query.execute();
-      expect(result.results).toBeDefined();
+      expect(result.results.length).toBe(1);
+      expect(result.results[0].objectId).toBe(user.id);
     });
   });
 });

--- a/spec/ProtectedFields.spec.js
+++ b/spec/ProtectedFields.spec.js
@@ -2368,4 +2368,37 @@ describe('ProtectedFields', function () {
       expect(response.data.secretField).toBeUndefined();
     });
   });
+
+  describe('maintenance auth', function () {
+    it('should allow maintenance auth to query using protected fields as WHERE keys', async function () {
+      await reconfigureServer({
+        protectedFields: { _User: { '*': ['email', 'emailVerified'] } },
+        protectedFieldsOwnerExempt: false,
+      });
+
+      const user = new Parse.User();
+      user.setUsername('testuser');
+      user.setPassword('password');
+      user.setEmail('test@example.com');
+      await user.signUp();
+
+      // Query using a protected field as a WHERE key with maintenance auth
+      const Auth = require('../lib/Auth');
+      const Config = require('../lib/Config');
+      const RestQuery = require('../lib/RestQuery');
+      const config = Config.get('test');
+      const maintenanceAuth = Auth.maintenance(config);
+      const query = await RestQuery({
+        method: RestQuery.Method.get,
+        config,
+        auth: maintenanceAuth,
+        className: '_User',
+        restWhere: { emailVerified: false },
+        runBeforeFind: false,
+      });
+      // Should not throw OPERATION_FORBIDDEN
+      const result = await query.execute();
+      expect(result.results).toBeDefined();
+    });
+  });
 });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -896,7 +896,7 @@ _UnsafeRestQuery.prototype.runCount = function () {
 };
 
 _UnsafeRestQuery.prototype.denyProtectedFields = async function () {
-  if (this.auth.isMaster) {
+  if (this.auth.isMaster || this.auth.isMaintenance) {
     return;
   }
   const schemaController = await this.config.database.loadSchema();


### PR DESCRIPTION
## Summary
- `denyProtectedFields` in `RestQuery.js` exempts `isMaster` but not `isMaintenance`, causing maintenance auth queries that use protected fields as WHERE keys to be rejected with `OPERATION_FORBIDDEN`
- This breaks internal operations like `verifyEmail()` in `UserController` when `protectedFieldsOwnerExempt: false` and `emailVerified` is in `protectedFields`, because `verifyEmail` uses maintenance auth with a `{ emailVerified: false }` query condition

## Test plan
- [x] Maintenance auth can query `_User` using protected fields as WHERE keys without `OPERATION_FORBIDDEN`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed maintenance authentication to properly handle protected fields in queries. Maintenance-authenticated requests can now query and filter using protected fields, consistent with master authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->