### PR TITLE
refactor: Unnecessary deprecation warning on `enableProductPurchaseLegacyApi: false`

### DIFF
--- a/spec/Deprecator.spec.js
+++ b/spec/Deprecator.spec.js
@@ -194,6 +194,17 @@ describe('Deprecator', () => {
     );
   });
 
+  it('does not log deprecation for enableProductPurchaseLegacyApi when set to false', async () => {
+    const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
+
+    await reconfigureServer({ enableProductPurchaseLegacyApi: false });
+    expect(logSpy).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        optionKey: 'enableProductPurchaseLegacyApi',
+      })
+    );
+  });
+
   it('does not log deprecation for requestComplexity limits when explicitly set', async () => {
     const logSpy = spyOn(Deprecator, '_logOption').and.callFake(() => {});
 

--- a/src/Deprecator/Deprecations.js
+++ b/src/Deprecator/Deprecations.js
@@ -8,6 +8,11 @@
  * or set to an empty string if the current key will be removed without replacement.
  * - `changeNewDefault` {String}: Set the new default value if the key's default value
  * will change in a future version.
+ * - `resolvedValue` {any}: The option value that suppresses the deprecation warning,
+ * indicating the user has already adopted the future behavior. Only applicable when
+ * `changeNewKey` is an empty string (option will be removed without replacement).
+ * For example, `false` for an option that will be removed, if setting it to `false`
+ * disables the deprecated feature.
  * - `solution`: The instruction to resolve this deprecation warning. Optional. This
  * instruction must not include the deprecation warning which is auto-generated.
  * It should only contain additional instruction regarding the deprecation if
@@ -79,11 +84,13 @@ module.exports = [
   {
     optionKey: 'enableProductPurchaseLegacyApi',
     changeNewKey: '',
+    resolvedValue: false,
     solution: "The product purchase API is an undocumented, unmaintained legacy feature that may not function as expected and will be removed in a future major version. We strongly advise against using it. Set 'enableProductPurchaseLegacyApi' to 'false' to disable it, or remove the option to accept the future removal.",
   },
   {
     optionKey: 'allowExpiredAuthDataToken',
     changeNewKey: '',
+    resolvedValue: false,
     solution: "Auth providers are always validated on login regardless of this setting. Set 'allowExpiredAuthDataToken' to 'false' or remove the option to accept the future removal.",
   },
   {

--- a/src/Deprecator/Deprecator.js
+++ b/src/Deprecator/Deprecator.js
@@ -27,8 +27,11 @@ class Deprecator {
         Deprecator._logOption({ optionKey, changeNewDefault, solution });
       }
 
-      // If key will be removed or renamed, only throw a warning if option is set
-      if (changeNewKey != null && Utils.getNestedProperty(options, optionKey) != null) {
+      // If key will be removed or renamed, only throw a warning if option is set;
+      // skip if option is set to the resolved value that suppresses the deprecation
+      const resolvedValue = deprecation.resolvedValue;
+      const optionValue = Utils.getNestedProperty(options, optionKey);
+      if (changeNewKey != null && optionValue != null && optionValue !== resolvedValue) {
         Deprecator._logOption({ optionKey, changeNewKey, solution });
       }
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Remove unnecessary deprecation warning for `enableProductPurchaseLegacyApi`

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined deprecation warning system to suppress warnings for `enableProductPurchaseLegacyApi` and `allowExpiredAuthDataToken` when set to `false`, eliminating unnecessary alerts for already-resolved configurations.

* **Tests**
  * Added test coverage to verify deprecation warnings are correctly suppressed for resolved option values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->