### PR TITLE
refactor: Bump lru-cache from 10.4.0 to 11.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.17.23",
-        "lru-cache": "10.4.0",
+        "lru-cache": "11.2.6",
         "mime": "4.0.7",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
@@ -272,15 +272,6 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
-    "node_modules/@apollo/server/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@apollo/usage-reporting-protobuf": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
@@ -342,15 +333,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@apollo/utils.logger": {
@@ -14003,6 +13985,13 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -15863,12 +15852,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.0.tgz",
-      "integrity": "sha512-bfJaPTuEiTYBu+ulDaeQ0F+uLmlfFkMgXj4cbwfuMSjgObGMzb55FMMbDvbRU0fAHZ4sLGkz2mKwcMg8Dvm8Ww==",
-      "license": "ISC",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       }
     },
     "node_modules/lru-memoizer": {
@@ -20426,6 +20415,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
@@ -26990,13 +26986,6 @@
         "negotiator": "^1.0.0",
         "uuid": "^11.1.0",
         "whatwg-mimetype": "^4.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "11.2.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-          "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="
-        }
       }
     },
     "@apollo/server-gateway-interface": {
@@ -27050,13 +27039,6 @@
       "requires": {
         "@apollo/utils.logger": "^3.0.0",
         "lru-cache": "^11.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "11.2.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-          "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="
-        }
       }
     },
     "@apollo/utils.logger": {
@@ -36428,6 +36410,14 @@
       "dev": true,
       "requires": {
         "lru-cache": "^10.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        }
       }
     },
     "html-entities": {
@@ -37786,9 +37776,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.0.tgz",
-      "integrity": "sha512-bfJaPTuEiTYBu+ulDaeQ0F+uLmlfFkMgXj4cbwfuMSjgObGMzb55FMMbDvbRU0fAHZ4sLGkz2mKwcMg8Dvm8Ww=="
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="
     },
     "lru-memoizer": {
       "version": "2.2.0",
@@ -40871,6 +40861,14 @@
       "requires": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "devOptional": true
+        }
       }
     },
     "path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jwks-rsa": "3.2.0",
     "ldapjs": "3.0.7",
     "lodash": "4.17.23",
-    "lru-cache": "10.4.0",
+    "lru-cache": "11.2.6",
     "mime": "4.0.7",
     "mongodb": "7.1.0",
     "mustache": "4.2.0",


### PR DESCRIPTION
### Changes

- **10.4.1–10.4.3**: Engine field adjustments only
- **11.0.0**: Raised Node.js requirement to `node: 20 || >=22`
- **11.0.1**: Removed `implements Map<K,V>` from TypeScript types
- **11.0.2**: Documentation fix
- **11.1.0**: Added `onInsert` callback option
- **11.2.0**: Added `perf` option for custom time source
- **11.2.1**: Moved esbuild to devDependency
- **11.2.2**: Fixed ignored-abort fetches not updating cache
- **11.2.3**: Fixed timer cleanup for `ttlAutopurge`; license changed from ISC to BlueOak-1.0.0
- **11.2.4**: Fixed autopurge timer cleanup on eviction and `clear()`
- **11.2.5**: Fixed background fetch promise preservation
- **11.2.6**: Default export now serves minified version

Closes #10057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `lru-cache` dependency to version 11.2.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->