### PR TITLE
test: Fix flaky test

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -359,9 +359,6 @@ describe('Parse.User testing', () => {
       uri: databaseURI,
     });
     await adapter.connect();
-    await adapter.database.dropDatabase();
-    delete adapter.connectionPromise;
-    Config.get(Parse.applicationId).schemaCache.clear();
 
     const user = new Parse.User();
     await user.signUp({


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Fix flaky test. The flakiness was caused by the test "should let legacy users without ACL login" calling `adapter.database.dropDatabase()`, which dropped all MongoDB indexes including the `_auth_data_anonymous_id` unique index. Because that test called `reconfigureServer()` with no args, `didChangeConfiguration` stayed false, so `afterEach` only called the adapter's no-op `performInitialization()` instead of the full `DatabaseController.performInitialization()` that recreates the auth data unique indexes. With `random: true` in Jasmine, whenever this test ran before the duplicate-authData test, the missing index allowed the duplicate insert to succeed.

Fix: Removed the unnecessary `dropDatabase()` call (and related cleanup lines). The test infrastructure already cleans up data between tests via afterEach, and `reconfigureServer()` sets up fresh schemas. The `insertOne` for the legacy user works fine without dropping the database since MongoDB doesn't enforce Parse-level schemas at the driver level.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup for user authentication testing by removing explicit cache clearing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->