### PR TITLE
refactor: Bump lru-cache from 11.2.6 to 11.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.17.23",
-        "lru-cache": "11.2.6",
+        "lru-cache": "11.2.7",
         "mime": "4.0.7",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
@@ -15852,9 +15852,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -22086,16 +22086,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/semantic-release/node_modules/marked": {
@@ -37776,9 +37766,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="
     },
     "lru-memoizer": {
       "version": "2.2.0",
@@ -42011,12 +42001,6 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
           "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "11.2.7",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-          "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
           "dev": true
         },
         "marked": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jwks-rsa": "3.2.0",
     "ldapjs": "3.0.7",
     "lodash": "4.17.23",
-    "lru-cache": "11.2.6",
+    "lru-cache": "11.2.7",
     "mime": "4.0.7",
     "mongodb": "7.1.0",
     "mustache": "4.2.0",


### PR DESCRIPTION
Closes #10301

### Changes

- **11.2.7**: Fixed autopurge timer not rescheduling when `updateAgeOnGet` resets TTL start, which could make entries immortal

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the lru-cache dependency to v11.2.7 to ensure the runtime pulls the newer package version, improving dependency consistency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->