### PR TITLE
refactor: Bump ws from 8.18.2 to 8.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "uuid": "11.1.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "5.0.0",
-        "ws": "8.18.2"
+        "ws": "8.20.0"
       },
       "bin": {
         "parse-server": "bin/parse-server"
@@ -26652,9 +26652,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -45095,9 +45095,9 @@
       }
     },
     "ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "requires": {}
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "uuid": "11.1.0",
     "winston": "3.19.0",
     "winston-daily-rotate-file": "5.0.0",
-    "ws": "8.18.2"
+    "ws": "8.20.0"
   },
   "devDependencies": {
     "@actions/core": "3.0.0",


### PR DESCRIPTION
## Changes

- **8.18.3**: Fixed spec violation where `Sec-WebSocket-Version` header was not added to HTTP response for invalid/unacceptable client version
- **8.19.0**: Added `closeTimeout` option; handled forthcoming breaking change in Node.js core
- **8.20.0**: Added exports for `PerMessageDeflate` class and utilities for `Sec-WebSocket-Extensions` and `Sec-WebSocket-Protocol` headers

## Breaking Changes

None

## Code Changes Required

None — the upgrade is a drop-in replacement.

Closes #10299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WebSocket library dependency to version 8.20.0 for improved system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->