### PR TITLE
refactor: Bump follow-redirects from 1.15.9 to 1.15.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "cors": "2.8.6",
         "express": "5.2.1",
         "express-rate-limit": "8.3.0",
-        "follow-redirects": "1.15.9",
+        "follow-redirects": "1.15.11",
         "graphql": "16.11.0",
         "graphql-list-fields": "2.0.4",
         "graphql-relay": "0.10.2",
@@ -12764,15 +12764,16 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -35562,9 +35563,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
     },
     "for-each": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cors": "2.8.6",
     "express": "5.2.1",
     "express-rate-limit": "8.3.0",
-    "follow-redirects": "1.15.9",
+    "follow-redirects": "1.15.11",
     "graphql": "16.11.0",
     "graphql-list-fields": "2.0.4",
     "graphql-relay": "0.10.2",


### PR DESCRIPTION
## Changes

- **1.15.10**: Internal dependency bump (minimist 1.2.5 → 1.2.8), tree-shaking optimization
- **1.15.11**: Reverted tree-shaking change from 1.15.10 (caused issues)

## Breaking Changes

None

## Code Changes Required

None — the upgrade is a drop-in replacement.

Closes #10298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->