### PR TITLE
fix: Postgres query on non-existent column throws internal server error

### DIFF
--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -229,6 +229,15 @@ describe('rest query', () => {
     expect(results.length).toBe(0);
   });
 
+  it('count internal field that has no database column', async () => {
+    const user = new Parse.User();
+    user.setUsername('user1');
+    user.setPassword('password');
+    await user.signUp();
+    const count = await new Parse.Query(Parse.User).exists('_tombstone').count({ useMasterKey: true });
+    expect(count).toBe(0);
+  });
+
   it('query protected field', async () => {
     const user = new Parse.User();
     user.setUsername('username1');

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -217,6 +217,18 @@ describe('rest query', () => {
     }
   });
 
+  it('query internal field that has no database column', async () => {
+    const user = new Parse.User();
+    user.setUsername('user1');
+    user.setPassword('password');
+    await user.signUp();
+    // _tombstone is registered as an internal field but has no column in the
+    // Postgres _User table. Querying it with master key should return empty
+    // results (consistent with MongoDB behavior), not throw an error.
+    const results = await new Parse.Query(Parse.User).exists('_tombstone').find({ useMasterKey: true });
+    expect(results.length).toBe(0);
+  });
+
   it('query protected field', async () => {
     const user = new Parse.User();
     user.setUsername('username1');

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -2191,7 +2191,10 @@ export class PostgresStorageAdapter implements StorageAdapter {
         }
       })
       .catch(error => {
-        if (error.code !== PostgresRelationDoesNotExistError) {
+        if (
+          error.code !== PostgresRelationDoesNotExistError &&
+          error.code !== PostgresMissingColumnError
+        ) {
           throw error;
         }
         return 0;

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1992,8 +1992,10 @@ export class PostgresStorageAdapter implements StorageAdapter {
     return this._client
       .any(qs, values)
       .catch(error => {
-        // Query on non existing table, don't crash
-        if (error.code !== PostgresRelationDoesNotExistError) {
+        if (
+          error.code !== PostgresRelationDoesNotExistError &&
+          error.code !== PostgresMissingColumnError
+        ) {
           throw error;
         }
         return [];


### PR DESCRIPTION
## Summary

Querying an internal field that has no corresponding column in the Postgres `_User` table (e.g. `_tombstone`) throws an internal server error instead of returning empty results like MongoDB.

This caused the flaky test `rest query query internal field` on Postgres. The flakiness depended on randomized test order: if the previous test triggered `reconfigureServer()`, the `_User` table was recreated (without a `_tombstone` column), and the query failed with `PostgresMissingColumnError` (42703). If the previous test used the lightweight `performInitialization()`, the `_User` table didn't exist, and the already-caught `PostgresRelationDoesNotExistError` (42P01) returned empty results.

The fix catches `PostgresMissingColumnError` in the Postgres adapter's `find` and `count` methods, aligning behavior with MongoDB and with the `distinct` method which already handles this case.

## Issue

Fixes flaky test: https://github.com/parse-community/parse-server/actions/runs/23509218104/job/68425397105?pr=10307

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query reliability to gracefully handle edge cases involving internal fields, returning appropriate empty results instead of throwing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->