### PR TITLE
ci: Remove feature to retry flaky tests

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -25,8 +25,6 @@ if (dns.setDefaultResultOrder) {
 jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.PARSE_SERVER_TEST_TIMEOUT || 10000;
 jasmine.getEnv().addReporter(new CurrentSpecReporter());
 jasmine.getEnv().addReporter(new SpecReporter());
-global.retryFlakyTests();
-
 global.on_db = (db, callback, elseCallback) => {
   if (process.env.PARSE_SERVER_TEST_DB == db) {
     return callback();

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -25,6 +25,7 @@ if (dns.setDefaultResultOrder) {
 jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.PARSE_SERVER_TEST_TIMEOUT || 10000;
 jasmine.getEnv().addReporter(new CurrentSpecReporter());
 jasmine.getEnv().addReporter(new SpecReporter());
+global.normalizeAsyncTests();
 global.on_db = (db, callback, elseCallback) => {
   if (process.env.PARSE_SERVER_TEST_DB == db) {
     return callback();

--- a/spec/support/CurrentSpecReporter.js
+++ b/spec/support/CurrentSpecReporter.js
@@ -4,21 +4,10 @@ const { performance } = require('perf_hooks');
 
 global.currentSpec = null;
 
-/**
- * Names of tests that fail randomly and are considered flaky. These tests will be retried
- * a number of times to reduce the chance of false negatives. The test name must be the same
- * as the one displayed in the CI log test output.
- */
-const flakyTests = [];
-
 /** The minimum execution time in seconds for a test to be considered slow. */
 const slowTestLimit = 2;
 
-/** The number of times to retry a flaky test. */
-const retries = 5;
-
 const timerMap = {};
-const retryMap = {};
 const duplicates = [];
 class CurrentSpecReporter {
   specStarted(spec) {
@@ -52,61 +41,6 @@ global.displayTestStats = function() {
     console.warn('Duplicate spec: ' + spec);
   });
   console.log('\n');
-  Object.keys(retryMap).forEach((spec) => {
-    console.warn(`Flaky test: ${spec} failed ${retryMap[spec]} times`);
-  });
-  console.log('\n');
 };
-
-global.retryFlakyTests = function() {
-  const originalSpecConstructor = jasmine.Spec;
-
-  jasmine.Spec = function(attrs) {
-    const spec = new originalSpecConstructor(attrs);
-    const originalTestFn = spec.queueableFn.fn;
-    const runOriginalTest = () => {
-      if (originalTestFn.length == 0) {
-        // handle async testing
-        return originalTestFn();
-      } else {
-        // handle done() callback
-        return new Promise((resolve) => {
-          originalTestFn(resolve);
-        });
-      }
-    };
-    spec.queueableFn.fn = async function() {
-      const isFlaky = flakyTests.includes(spec.result.fullName);
-      const runs = isFlaky ? retries : 1;
-      let exceptionCaught;
-      let returnValue;
-
-      for (let i = 0; i < runs; ++i) {
-        spec.result.failedExpectations = [];
-        returnValue = undefined;
-        exceptionCaught = undefined;
-        try {
-          returnValue = await runOriginalTest();
-        } catch (exception) {
-          exceptionCaught = exception;
-        }
-        const failed = !spec.markedPending &&
-            (exceptionCaught || spec.result.failedExpectations.length != 0);
-        if (!failed) {
-          break;
-        }
-        if (isFlaky) {
-          retryMap[spec.result.fullName] = (retryMap[spec.result.fullName] || 0) + 1;
-          await global.afterEachFn();
-        }
-      }
-      if (exceptionCaught) {
-        throw exceptionCaught;
-      }
-      return returnValue;
-    };
-    return spec;
-  };
-}
 
 module.exports = CurrentSpecReporter;

--- a/spec/support/CurrentSpecReporter.js
+++ b/spec/support/CurrentSpecReporter.js
@@ -44,25 +44,52 @@ global.displayTestStats = function() {
 };
 
 /**
- * Wraps test functions that use both `async` and a `done` callback, which Jasmine
+ * Wraps test functions that use both `async` and a `done` callback, which Jasmine 5
  * does not support. This converts `async (done) => { ... }` to a promise-based
  * function so Jasmine does not throw:
  * "An asynchronous before/it/after function was defined with the async keyword
  * but also took a done callback."
  */
 global.normalizeAsyncTests = function() {
-  const originalSpecConstructor = jasmine.Spec;
-  jasmine.Spec = function(attrs) {
-    const spec = new originalSpecConstructor(attrs);
-    const originalTestFn = spec.queueableFn.fn;
-    if (originalTestFn.length > 0) {
-      spec.queueableFn.fn = function() {
+  function wrapDoneCallback(fn) {
+    if (fn.length > 0) {
+      return function() {
         return new Promise((resolve) => {
-          originalTestFn(resolve);
+          fn.call(this, resolve);
         });
       };
     }
+    return fn;
+  }
+
+  // Wrap it() specs
+  const originalSpecConstructor = jasmine.Spec;
+  jasmine.Spec = function(attrs) {
+    const spec = new originalSpecConstructor(attrs);
+    spec.queueableFn.fn = wrapDoneCallback(spec.queueableFn.fn);
     return spec;
+  };
+
+  // Wrap beforeEach/afterEach/beforeAll/afterAll
+  const originalBeforeEach = jasmine.Suite.prototype.beforeEach;
+  jasmine.Suite.prototype.beforeEach = function(fn) {
+    fn.fn = wrapDoneCallback(fn.fn);
+    return originalBeforeEach.call(this, fn);
+  };
+  const originalAfterEach = jasmine.Suite.prototype.afterEach;
+  jasmine.Suite.prototype.afterEach = function(fn) {
+    fn.fn = wrapDoneCallback(fn.fn);
+    return originalAfterEach.call(this, fn);
+  };
+  const originalBeforeAll = jasmine.Suite.prototype.beforeAll;
+  jasmine.Suite.prototype.beforeAll = function(fn) {
+    fn.fn = wrapDoneCallback(fn.fn);
+    return originalBeforeAll.call(this, fn);
+  };
+  const originalAfterAll = jasmine.Suite.prototype.afterAll;
+  jasmine.Suite.prototype.afterAll = function(fn) {
+    fn.fn = wrapDoneCallback(fn.fn);
+    return originalAfterAll.call(this, fn);
   };
 };
 

--- a/spec/support/CurrentSpecReporter.js
+++ b/spec/support/CurrentSpecReporter.js
@@ -44,11 +44,19 @@ global.displayTestStats = function() {
 };
 
 /**
- * Wraps test functions that use both `async` and a `done` callback, which Jasmine 5
- * does not support. This converts `async (done) => { ... }` to a promise-based
- * function so Jasmine does not throw:
+ * Transitional compatibility shim for Jasmine 5.
+ *
+ * Jasmine 5 throws when a test or hook function uses both `async` and a `done` callback:
  * "An asynchronous before/it/after function was defined with the async keyword
  * but also took a done callback."
+ *
+ * Many existing tests use `async (done) => { ... done(); }`. This wrapper converts
+ * those to promise-based functions by intercepting the `done` callback and resolving
+ * a promise instead, so Jasmine sees a plain async function.
+ *
+ * To remove this shim, convert each file below so that tests and hooks use plain
+ * `async () => {}` without a `done` parameter, then remove the file from this list.
+ * Once the list is empty, delete this function and its call in `helper.js`.
  */
 global.normalizeAsyncTests = function() {
   function wrapDoneCallback(fn) {

--- a/spec/support/CurrentSpecReporter.js
+++ b/spec/support/CurrentSpecReporter.js
@@ -43,4 +43,27 @@ global.displayTestStats = function() {
   console.log('\n');
 };
 
+/**
+ * Wraps test functions that use both `async` and a `done` callback, which Jasmine
+ * does not support. This converts `async (done) => { ... }` to a promise-based
+ * function so Jasmine does not throw:
+ * "An asynchronous before/it/after function was defined with the async keyword
+ * but also took a done callback."
+ */
+global.normalizeAsyncTests = function() {
+  const originalSpecConstructor = jasmine.Spec;
+  jasmine.Spec = function(attrs) {
+    const spec = new originalSpecConstructor(attrs);
+    const originalTestFn = spec.queueableFn.fn;
+    if (originalTestFn.length > 0) {
+      spec.queueableFn.fn = function() {
+        return new Promise((resolve) => {
+          originalTestFn(resolve);
+        });
+      };
+    }
+    return spec;
+  };
+};
+
 module.exports = CurrentSpecReporter;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #9272
Closes #9273

## Approach

Remove the flaky test retry feature from the test harness.

Retrying flaky tests masks underlying bugs and delays fixing them. Flaky tests should fail immediately so they are fixed as soon as possible.

The retry feature also monkey-patched `jasmine.Spec` which had the side effect of silently converting all `async (done) => {}` test functions to promise-based. This masked a Jasmine 5 behavior change that throws an error when a test function uses both `async` and a `done` callback. The `normalizeAsyncTests` wrapper is added as a transitional compatibility shim for the ~390 tests that use this pattern, until they are migrated to plain `async`.

## Tasks

- [x] Add tests
- [ ] ~~Add changes to documentation (guides, repository pages, code comments)~~
- [ ] ~~Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)~~
- [ ] ~~Add new Parse Error codes to Parse JS SDK~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved testing infrastructure compatibility with enhanced async test handling capabilities for better framework support
* Removed legacy test retry mechanisms to streamline test execution and reduce complexity
* Updated test statistics reporting to focus on performance metrics and duplicate test detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->