### PR TITLE
refactor: Bump graphql from 16.11.0 to 16.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "express": "5.2.1",
         "express-rate-limit": "8.3.0",
         "follow-redirects": "1.15.11",
-        "graphql": "16.11.0",
+        "graphql": "16.13.2",
         "graphql-list-fields": "2.0.4",
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
@@ -13729,9 +13729,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -36234,9 +36234,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="
     },
     "graphql-list-fields": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express": "5.2.1",
     "express-rate-limit": "8.3.0",
     "follow-redirects": "1.15.11",
-    "graphql": "16.11.0",
+    "graphql": "16.13.2",
     "graphql-list-fields": "2.0.4",
     "graphql-relay": "0.10.2",
     "graphql-upload": "15.0.2",


### PR DESCRIPTION
Closes #10312

### Changes

- **16.12.0**: New features: executable descriptions, schema coordinates backport. Bug fix: catch unhandled exception in abstract resolution.
- **16.13.0**: New feature: sibling errors not added after propagation. Bug fixes: deprecation note on `assertValidExecutionArguments`, fix validation errors with variable descriptions.
- **16.13.1**: Docs and internal only (trusted publishing, release flow).
- **16.13.2**: Polish: use `Object.create(null)` over `{}` to avoid prototype issues. Docs.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GraphQL runtime library to include the latest bug fixes and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->