### PR TITLE
refactor: Bump redis from 5.10.0 to 5.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
         "rate-limit-redis": "4.3.1",
-        "redis": "5.10.0",
+        "redis": "5.11.0",
         "semver": "7.7.2",
         "tv4": "1.3.0",
         "uuid": "11.1.0",
@@ -4289,58 +4289,71 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@redis/bloom": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
-      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
+      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
+      "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
-      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
+      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
-      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
+      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
-      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
+      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@saithodev/semantic-release-backmerge": {
@@ -10309,6 +10322,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21347,15 +21361,16 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
-      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
+      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
+      "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "5.11.0",
+        "@redis/client": "5.11.0",
+        "@redis/json": "5.11.0",
+        "@redis/search": "5.11.0",
+        "@redis/time-series": "5.11.0"
       },
       "engines": {
         "node": ">= 18"
@@ -29759,35 +29774,35 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@redis/bloom": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
-      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
+      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
       "requires": {}
     },
     "@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "requires": {
         "cluster-key-slot": "1.1.2"
       }
     },
     "@redis/json": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
-      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
+      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
       "requires": {}
     },
     "@redis/search": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
-      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
+      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
       "requires": {}
     },
     "@redis/time-series": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
-      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
+      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
       "requires": {}
     },
     "@saithodev/semantic-release-backmerge": {
@@ -41507,15 +41522,15 @@
       }
     },
     "redis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
-      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
+      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
       "requires": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "5.11.0",
+        "@redis/client": "5.11.0",
+        "@redis/json": "5.11.0",
+        "@redis/search": "5.11.0",
+        "@redis/time-series": "5.11.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pluralize": "8.0.0",
     "punycode": "2.3.1",
     "rate-limit-redis": "4.3.1",
-    "redis": "5.10.0",
+    "redis": "5.11.0",
     "semver": "7.7.2",
     "tv4": "1.3.0",
     "uuid": "11.1.0",


### PR DESCRIPTION
Closes #10311

### Changes

- **5.11.0**: Redis 8.6 support (XADD idempotency, XCFGSET, HOTKEYS commands), smart client handoffs for Enterprise OSS, VRANGE command for vector sets, sentinel `nodeAddressMap`, `socket.servname` config option. Bug fixes: IPv6 URL support, consistent Promise returns in cluster, pool private member access fix, type mapping fix.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis dependency to version 5.11.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->