### PR TITLE
fix: Duplicate session destruction can cause unhandled promise rejection

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1466,13 +1466,7 @@ describe('Parse.User testing', () => {
     const user = await Parse.User.logInWith('facebook');
     const sessionToken = user.getSessionToken();
     const query = new Parse.Query('_Session');
-    // destroyDuplicatedSessions is fire-and-forget, poll until cleanup completes
-    let results;
-    for (let i = 0; i < 10; i++) {
-      results = await query.find({ useMasterKey: true });
-      if (results.length <= 1) { break; }
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
+    const results = await query.find({ useMasterKey: true });
     expect(results.length).toBe(1);
     expect(results[0].get('sessionToken')).toBe(sessionToken);
     expect(results[0].get('createdWith')).toEqual({

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1140,7 +1140,7 @@ RestWrite.prototype.destroyDuplicatedSessions = function () {
   if (!user.objectId) {
     return;
   }
-  this.config.database.destroy(
+  return this.config.database.destroy(
     '_Session',
     {
       user,
@@ -1149,7 +1149,11 @@ RestWrite.prototype.destroyDuplicatedSessions = function () {
     },
     {},
     this.validSchemaController
-  );
+  ).catch(e => {
+    if (e.code !== Parse.Error.OBJECT_NOT_FOUND) {
+      throw e;
+    }
+  });
 };
 
 // Handles any followup logic


### PR DESCRIPTION
## Issue

`destroyDuplicatedSessions` in `RestWrite.js` calls `database.destroy()` without returning the promise (fire-and-forget). This causes unhandled promise rejections when the database operation fails, which in modern Node.js terminates the process by default. It also causes flaky tests when `reconfigureServer()` tears down the database while the background destroy is still pending.

## Approach

- Return the `database.destroy()` promise from `destroyDuplicatedSessions` so it is properly awaited in the `RestWrite` execute chain
- Catch `OBJECT_NOT_FOUND` errors since having no duplicate sessions to delete is a normal condition
- Remove the polling workaround in `ParseUser.spec.js` that was compensating for the fire-and-forget pattern

## Tasks

- [x] Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicate sessions could be created for a user/installation pair during login operations, ensuring only a single session is created and properly handled in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->