### PR TITLE
ci: Increase npm network timeout for Docker arm64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ COPY package*.json ./
 # Copy src to have config files for install
 COPY . .
 
+# Increase npm network timeout and retries for slow platforms (e.g. arm64 via QEMU)
+ENV npm_config_fetch_retries=5
+ENV npm_config_fetch_retry_mintimeout=60000
+ENV npm_config_fetch_retry_maxtimeout=300000
+
 # Install without scripts
 RUN npm ci --omit=dev --ignore-scripts \
     # Copy production node_modules aside for later


### PR DESCRIPTION
## Summary
- Increases npm fetch retries and timeout values in the Dockerfile to prevent `ETIMEDOUT` errors during cross-platform Docker builds
- The arm64 build via QEMU emulation on amd64 runners is significantly slower, causing npm registry requests to time out with default settings
- Sets 5 retries (default 2), 60s min timeout (default 10s), and 300s max timeout (default 60s)

## Test plan
- [ ] Verify Docker CI check passes for both `linux/amd64` and `linux/arm64/v8` platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to enhance npm dependency installation reliability with improved retry settings during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->