### PR TITLE
refactor: Bump @apollo/server from 5.4.0 to 5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/server": "5.4.0",
+        "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",
         "@graphql-tools/merge": "9.0.24",
         "@graphql-tools/schema": "10.0.23",
@@ -224,9 +224,10 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.4.0.tgz",
-      "integrity": "sha512-E0/2C5Rqp7bWCjaDh4NzYuEPDZ+dltTf2c0FI6GCKJA6GBetVferX3h1//1rS4+NxD36wrJsGGJK+xyT/M3ysg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.0.tgz",
+      "integrity": "sha512-vWtodBOK/SZwBTJzItECOmLfL8E8pn/IdvP7pnxN5g2tny9iW4+9sxdajE798wV1H2+PYp/rRcl/soSHIBKMPw==",
+      "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^2.0.0",
@@ -26967,9 +26968,9 @@
       }
     },
     "@apollo/server": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.4.0.tgz",
-      "integrity": "sha512-E0/2C5Rqp7bWCjaDh4NzYuEPDZ+dltTf2c0FI6GCKJA6GBetVferX3h1//1rS4+NxD36wrJsGGJK+xyT/M3ysg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.0.tgz",
+      "integrity": "sha512-vWtodBOK/SZwBTJzItECOmLfL8E8pn/IdvP7pnxN5g2tny9iW4+9sxdajE798wV1H2+PYp/rRcl/soSHIBKMPw==",
       "requires": {
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@apollo/server": "5.4.0",
+    "@apollo/server": "5.5.0",
     "@as-integrations/express5": "1.1.2",
     "@graphql-tools/merge": "9.0.24",
     "@graphql-tools/schema": "10.0.23",


### PR DESCRIPTION
### Changes

- **5.5.0**: Security enhancement — stricter Content-Type validation for GraphQL GET requests. Rejects GET requests with non-`application/json` Content-Type headers (returns 415). Defense-in-depth against XS-Search CSRF. See [GHSA-9q82-xgwf-vj6h](https://github.com/apollographql/apollo-server/security/advisories/GHSA-9q82-xgwf-vj6h).

### Breaking Changes

None — Apollo reports no known GraphQL clients sending non-standard Content-Type headers with GET requests.

### Code Changes Required

None — the upgrade is a drop-in replacement.

Closes #10329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apollo Server dependency to version 5.5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->