### PR TITLE
refactor: Bump jasmine from 5.7.1 to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "form-data": "4.0.5",
         "globals": "17.3.0",
         "graphql-tag": "2.12.6",
-        "jasmine": "5.7.1",
+        "jasmine": "6.1.0",
         "jasmine-spec-reporter": "7.0.0",
         "jsdoc": "4.0.4",
         "jsdoc-babel": "0.5.0",
@@ -3234,6 +3234,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@jasminejs/reporters": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jasminejs/reporters/-/reporters-1.0.0.tgz",
+      "integrity": "sha512-rM3GG4vx2H1Gp5kYCTr9aKlOEJFd43pzpiMAiy5b1+FUc2ub4e6bS6yCi/WQNDzAa5MVp9++dwcoEtcIfoEnhA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -14759,23 +14766,24 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-5.7.1.tgz",
-      "integrity": "sha512-E/4fkRNy/9ALz6z3Z3/tYXFAohoznVy7In9FWutG2fqBSkILJHFzbgZtHJUw5UrL3jgUQ4sdGYOVZ5KpSXYjGw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
+      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob": "^10.2.2",
-        "jasmine-core": "~5.7.0"
+        "@jasminejs/reporters": "^1.0.0",
+        "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
+        "jasmine-core": "~6.1.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.7.1.tgz",
-      "integrity": "sha512-QnurrtpKsPoixxG2R3d1xP0St/2kcX5oTZyDyQJMY+Vzi/HUlu1kGm+2V8Tz+9lV991leB1l0xcsyz40s9xOOw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
+      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
       "dev": true,
       "license": "MIT"
     },
@@ -28992,6 +29000,12 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jasminejs/reporters": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jasminejs/reporters/-/reporters-1.0.0.tgz",
+      "integrity": "sha512-rM3GG4vx2H1Gp5kYCTr9aKlOEJFd43pzpiMAiy5b1+FUc2ub4e6bS6yCi/WQNDzAa5MVp9++dwcoEtcIfoEnhA==",
+      "dev": true
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -36963,13 +36977,14 @@
       }
     },
     "jasmine": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-5.7.1.tgz",
-      "integrity": "sha512-E/4fkRNy/9ALz6z3Z3/tYXFAohoznVy7In9FWutG2fqBSkILJHFzbgZtHJUw5UrL3jgUQ4sdGYOVZ5KpSXYjGw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
+      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
       "dev": true,
       "requires": {
-        "glob": "^10.2.2",
-        "jasmine-core": "~5.7.0"
+        "@jasminejs/reporters": "^1.0.0",
+        "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
+        "jasmine-core": "~6.1.0"
       },
       "dependencies": {
         "brace-expansion": {
@@ -37029,9 +37044,9 @@
       }
     },
     "jasmine-core": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.7.1.tgz",
-      "integrity": "sha512-QnurrtpKsPoixxG2R3d1xP0St/2kcX5oTZyDyQJMY+Vzi/HUlu1kGm+2V8Tz+9lV991leB1l0xcsyz40s9xOOw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
+      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
       "dev": true
     },
     "jasmine-spec-reporter": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "form-data": "4.0.5",
     "globals": "17.3.0",
     "graphql-tag": "2.12.6",
-    "jasmine": "5.7.1",
+    "jasmine": "6.1.0",
     "jasmine-spec-reporter": "7.0.0",
     "jsdoc": "4.0.4",
     "jsdoc-babel": "0.5.0",

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -166,7 +166,7 @@ describe('InstallationsRouter', () => {
       });
   });
 
-  it_only_db('postgres')('query installations with count = 1', async () => {
+  it_only_db('postgres')('query installations with count = 1 postgres', async () => {
     const config = Config.get('test');
     const androidDeviceRequest = {
       installationId: '12345678-abcd-abcd-abcd-123456789abc',

--- a/spec/ParsePolygon.spec.js
+++ b/spec/ParsePolygon.spec.js
@@ -423,7 +423,7 @@ describe('Parse.Polygon testing', () => {
   });
 });
 
-describe_only_db('mongo')('Parse.Polygon testing', () => {
+describe_only_db('mongo')('Parse.Polygon testing mongo', () => {
   const Config = require('../lib/Config');
   let config;
   beforeEach(async () => {

--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -474,7 +474,7 @@ describe('Parse.Query Aggregate testing', () => {
   });
 
   it_only_db('postgres')(
-    'can group by any date field (it does not work if you have dirty data)', // rows in your collection with non date data in the field that is supposed to be a date
+    'can group by any date field postgres (it does not work if you have dirty data)', // rows in your collection with non date data in the field that is supposed to be a date
     done => {
       const obj1 = new TestObject({ dateField2019: new Date(1990, 11, 1) });
       const obj2 = new TestObject({ dateField2019: new Date(1990, 5, 1) });

--- a/spec/ParseQuery.hint.spec.js
+++ b/spec/ParseQuery.hint.spec.js
@@ -39,7 +39,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(explain.queryPlanner.winningPlan.inputStage.indexName).toBe('_id_');
   });
 
-  it_only_mongodb_version('>=8')('query find with hint string', async () => {
+  it_only_mongodb_version('>=8')('query find with hint string mongodb 8', async () => {
     const object = new TestObject();
     await object.save();
 
@@ -65,7 +65,7 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     });
   });
 
-  it_only_mongodb_version('>=8')('query find with hint object', async () => {
+  it_only_mongodb_version('>=8')('query find with hint object mongodb 8', async () => {
     const object = new TestObject();
     await object.save();
 

--- a/spec/support/CurrentSpecReporter.js
+++ b/spec/support/CurrentSpecReporter.js
@@ -70,35 +70,28 @@ global.normalizeAsyncTests = function() {
     return fn;
   }
 
-  // Wrap it() specs
-  const originalSpecConstructor = jasmine.Spec;
-  jasmine.Spec = function(attrs) {
-    const spec = new originalSpecConstructor(attrs);
-    spec.queueableFn.fn = wrapDoneCallback(spec.queueableFn.fn);
-    return spec;
-  };
+  function wrapGlobal(name) {
+    const original = global[name];
+    global[name] = function(descriptionOrFn, fn, timeout) {
+      if (typeof descriptionOrFn === 'function') {
+        return original.call(this, wrapDoneCallback(descriptionOrFn));
+      }
+      if (typeof fn === 'function') {
+        return original.call(this, descriptionOrFn, wrapDoneCallback(fn), timeout);
+      }
+      return original.apply(this, arguments);
+    };
+    if (original.each) {
+      global[name].each = original.each;
+    }
+  }
 
-  // Wrap beforeEach/afterEach/beforeAll/afterAll
-  const originalBeforeEach = jasmine.Suite.prototype.beforeEach;
-  jasmine.Suite.prototype.beforeEach = function(fn) {
-    fn.fn = wrapDoneCallback(fn.fn);
-    return originalBeforeEach.call(this, fn);
-  };
-  const originalAfterEach = jasmine.Suite.prototype.afterEach;
-  jasmine.Suite.prototype.afterEach = function(fn) {
-    fn.fn = wrapDoneCallback(fn.fn);
-    return originalAfterEach.call(this, fn);
-  };
-  const originalBeforeAll = jasmine.Suite.prototype.beforeAll;
-  jasmine.Suite.prototype.beforeAll = function(fn) {
-    fn.fn = wrapDoneCallback(fn.fn);
-    return originalBeforeAll.call(this, fn);
-  };
-  const originalAfterAll = jasmine.Suite.prototype.afterAll;
-  jasmine.Suite.prototype.afterAll = function(fn) {
-    fn.fn = wrapDoneCallback(fn.fn);
-    return originalAfterAll.call(this, fn);
-  };
+  wrapGlobal('it');
+  wrapGlobal('fit');
+  wrapGlobal('beforeEach');
+  wrapGlobal('afterEach');
+  wrapGlobal('beforeAll');
+  wrapGlobal('afterAll');
 };
 
 module.exports = CurrentSpecReporter;

--- a/spec/support/CurrentSpecReporter.js
+++ b/spec/support/CurrentSpecReporter.js
@@ -73,13 +73,16 @@ global.normalizeAsyncTests = function() {
   function wrapGlobal(name) {
     const original = global[name];
     global[name] = function(descriptionOrFn, fn, timeout) {
+      const args = Array.from(arguments);
       if (typeof descriptionOrFn === 'function') {
-        return original.call(this, wrapDoneCallback(descriptionOrFn));
+        args[0] = wrapDoneCallback(descriptionOrFn);
+        return original.apply(this, args);
       }
       if (typeof fn === 'function') {
-        return original.call(this, descriptionOrFn, wrapDoneCallback(fn), timeout);
+        args[1] = wrapDoneCallback(fn);
+        return original.apply(this, args);
       }
-      return original.apply(this, arguments);
+      return original.apply(this, args);
     };
     if (original.each) {
       global[name].each = original.each;


### PR DESCRIPTION
Closes #10309

### Changes

**jasmine-npm:**
- **5.8.0**: Documentation only; bumps jasmine-core to 5.8.0
- **5.9.0**: Fixed startup hang with ES module loaders in parallel mode; Node < 18.20.5 no longer supported
- **5.10.0–5.13.0**: Bumps jasmine-core only
- **6.0.0**: Node 18 dropped; `ConsoleReporter` removed (moved to `@jasminejs/reporters`); only first config file loaded; glob 12/13 compatibility
- **6.1.0**: Bumps jasmine-core to 6.1.0

**jasmine-core:**
- **5.8.0**: `saveArgumentsByValue` function customization; function names in pretty printer
- **5.9.0**: Mock clock timer ID conflict fix; `filename` properties deprecated (later reversed)
- **5.10.0**: `detectLateRejectionHandling` config (opt-in); `getSpecProperty` added
- **5.11.0**: `detectLateRejectionHandling` in `beforeAll`/`afterAll`; global error handling fix
- **5.12.0–5.12.1**: Reverted exact spec filtering; custom matchers fix
- **5.13.0**: `jasmine.allOf` asymmetric equality tester; `extraItStackFrames`/`extraDescribeStackFrames` config
- **6.0.0**: Major breaking changes (see below); `HtmlReporterV2`; `jasmine.pp()` exposed
- **6.0.1**: Bug fix for deprecation warning in ES modules
- **6.1.0**: `AggregateError` underlying error reporting; Safari 16/17 dropped

### Breaking Changes

- **6.0.0**: Node 18 dropped (requires Node 20+)
- **6.0.0**: `ConsoleReporter` removed from jasmine package
- **6.0.0**: Only the first config file is loaded when multiple exist
- **6.0.0 (core)**: `forbidDuplicateNames` defaults to `true`
- **6.0.0 (core)**: Mock clock timing functions cannot be spied on
- **6.0.0 (core)**: Mock clock no longer supports eval form of `setTimeout`/`setInterval`
- **6.0.0 (core)**: Spy `.call(null, ...)` — `this` is now `null`, not `globalThis`
- **6.0.0 (core)**: `expected`/`actual` removed from expectation results
- **6.0.0 (core)**: Spec filter argument changed to spec metadata instance
- **6.0.0 (core)**: `boot()` creates new core instance by default
- **6.0.0 (core)**: Private APIs removed from `jasmine` namespace

### Code Changes Required

None anticipated — the upgrade is a drop-in replacement for the manifest and lock file. Breaking changes may surface as test failures during CI, which will be addressed if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chore**
  * Upgraded the testing framework dev dependency to a newer release.

* **Tests**
  * Clarified multiple test descriptions to indicate their target databases.
  * Standardized internal test runner wrapping to more reliably handle async test callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->