### PR TITLE
refactor: Bump path-to-regexp from 8.3.0 to 8.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
         "parse": "8.5.0",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.0",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -20459,9 +20459,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -40912,9 +40912,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mustache": "4.2.0",
     "otpauth": "9.4.0",
     "parse": "8.5.0",
-    "path-to-regexp": "8.3.0",
+    "path-to-regexp": "8.4.0",
     "pg-monitor": "3.1.0",
     "pg-promise": "12.6.0",
     "pluralize": "8.0.0",


### PR DESCRIPTION
Closes #10339

### Changes

- **8.4.0**: Security fixes for CVE-2026-4926 and CVE-2026-4923; restricts wildcard backtracking; dedupes regex prefixes for shorter regexes; rejects large optional route combinations (> 256)

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated project dependencies to improve application stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->