### PR TITLE
feat: Add support for `partialFilterExpression` in MongoDB storage adapter

### DIFF
--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -502,6 +502,30 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     expect(schemaAfterDeletion.fields.test).toBeUndefined();
   });
 
+  it('should create index with partialFilterExpression', async () => {
+    const database = Config.get(Parse.applicationId).database;
+    const adapter = database.adapter;
+
+    const user = new Parse.User();
+    user.set('username', 'testuser');
+    user.set('password', 'testpass');
+    await user.signUp();
+
+    const schema = await new Parse.Schema('_User').get();
+    const partialFilterExpression = { _email_verify_token: { $exists: true } };
+
+    await adapter.ensureIndex('_User', schema, ['username'], 'partial_username_index', false, {
+      partialFilterExpression,
+      sparse: false,
+    });
+
+    const indexes = await adapter.getIndexes('_User');
+    const createdIndex = indexes.find(idx => idx.name === 'partial_username_index');
+    expect(createdIndex).toBeDefined();
+    expect(createdIndex.partialFilterExpression).toEqual({ _email_verify_token: { $exists: true } });
+    expect(createdIndex.sparse).toBeFalsy();
+  });
+
   if (process.env.MONGODB_TOPOLOGY === 'replicaset') {
     describe('transactions', () => {
       const headers = {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -800,12 +800,17 @@ export class MongoStorageAdapter implements StorageAdapter {
     const caseInsensitiveOptions: Object = caseInsensitive
       ? { collation: MongoCollection.caseInsensitiveCollation() }
       : {};
+    const partialFilterOptions: Object =
+      options.partialFilterExpression !== undefined
+        ? { partialFilterExpression: options.partialFilterExpression }
+        : {};
     const indexOptions: Object = {
       ...defaultOptions,
       ...caseInsensitiveOptions,
       ...indexNameOptions,
       ...ttlOptions,
       ...sparseOptions,
+      ...partialFilterOptions,
     };
 
     return this._adaptiveCollection(className)


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Add support for `partialFilterExpression` in MongoDB storage adapter.

## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK <!-- no hard-coded error codes in Parse Server -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating partial MongoDB indexes with conditional filter expressions, enabling more efficient indexing strategies.

* **Tests**
  * Added test coverage to validate partial index creation and verification of index properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->