### PR TITLE
fix: Session field immutability bypass via falsy-value guard (GHSA-f6j3-w9v3-cq22)

### DIFF
--- a/spec/ParseSession.spec.js
+++ b/spec/ParseSession.spec.js
@@ -394,6 +394,158 @@ describe('Parse.Session', () => {
     expect(verifyRes.data.expiresAt.iso).toBe(farFuture);
   });
 
+  it('should reject null expiresAt when updating a session via PUT', async () => {
+    const user = await Parse.User.signUp('sessionupdatenull1', 'password');
+    const sessionToken = user.getSessionToken();
+
+    const sessionRes = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/sessions/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+    const sessionId = sessionRes.data.objectId;
+    const originalExpiresAt = sessionRes.data.expiresAt;
+
+    const updateRes = await request({
+      method: 'PUT',
+      url: `http://localhost:8378/1/sessions/${sessionId}`,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        expiresAt: null,
+      },
+    }).catch(e => e);
+
+    expect(updateRes.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+
+    const verifyRes = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/sessions/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+    expect(verifyRes.data.expiresAt).toEqual(originalExpiresAt);
+  });
+
+  it('should reject null createdWith when updating a session via PUT', async () => {
+    const user = await Parse.User.signUp('sessionupdatenull2', 'password');
+    const sessionToken = user.getSessionToken();
+
+    const sessionRes = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/sessions/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+    const sessionId = sessionRes.data.objectId;
+    const originalCreatedWith = sessionRes.data.createdWith;
+
+    const updateRes = await request({
+      method: 'PUT',
+      url: `http://localhost:8378/1/sessions/${sessionId}`,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        createdWith: null,
+      },
+    }).catch(e => e);
+
+    expect(updateRes.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+
+    const verifyRes = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/sessions/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+    expect(verifyRes.data.createdWith).toEqual(originalCreatedWith);
+  });
+
+  it('should reject null installationId when updating a session via PUT', async () => {
+    const user = await Parse.User.signUp('sessionupdatenull3', 'password');
+    const sessionToken = user.getSessionToken();
+
+    const sessionRes = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/sessions/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+    const sessionId = sessionRes.data.objectId;
+
+    const updateRes = await request({
+      method: 'PUT',
+      url: `http://localhost:8378/1/sessions/${sessionId}`,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        installationId: null,
+      },
+    }).catch(e => e);
+
+    expect(updateRes.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
+  it('should reject null sessionToken when updating a session via PUT', async () => {
+    const user = await Parse.User.signUp('sessionupdatenull4', 'password');
+    const sessionToken = user.getSessionToken();
+
+    const sessionRes = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/sessions/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+      },
+    });
+    const sessionId = sessionRes.data.objectId;
+
+    const updateRes = await request({
+      method: 'PUT',
+      url: `http://localhost:8378/1/sessions/${sessionId}`,
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': sessionToken,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        sessionToken: null,
+      },
+    }).catch(e => e);
+
+    expect(updateRes.data.code).toBe(Parse.Error.INVALID_KEY_NAME);
+  });
+
   describe('PUT /sessions/me', () => {
     it('should return error with invalid session token', async () => {
       const response = await request({

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1235,13 +1235,13 @@ RestWrite.prototype.handleSession = function () {
   if (this.query) {
     if (this.data.user && !this.auth.isMaster && this.data.user.objectId != this.auth.user.id) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: user');
-    } else if (this.data.installationId) {
+    } else if ('installationId' in this.data) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: installationId');
-    } else if (this.data.sessionToken) {
+    } else if ('sessionToken' in this.data) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: sessionToken');
-    } else if (this.data.expiresAt && !this.auth.isMaster && !this.auth.isMaintenance) {
+    } else if ('expiresAt' in this.data && !this.auth.isMaster && !this.auth.isMaintenance) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: expiresAt');
-    } else if (this.data.createdWith && !this.auth.isMaster && !this.auth.isMaintenance) {
+    } else if ('createdWith' in this.data && !this.auth.isMaster && !this.auth.isMaintenance) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: createdWith');
     }
     if (!this.auth.isMaster) {


### PR DESCRIPTION
## Issue
Session field immutability bypass via falsy-value guard ([GHSA-f6j3-w9v3-cq22](https://github.com/parse-community/parse-server/security/advisories/GHSA-f6j3-w9v3-cq22))