### PR TITLE
refactor: Bump express-rate-limit from 8.3.0 to 8.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "commander": "14.0.3",
         "cors": "2.8.6",
         "express": "5.2.1",
-        "express-rate-limit": "8.3.0",
+        "express-rate-limit": "8.3.1",
         "follow-redirects": "1.15.11",
         "graphql": "16.13.2",
         "graphql-list-fields": "2.0.4",
@@ -12198,9 +12198,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -35213,9 +35213,9 @@
       }
     },
     "express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "requires": {
         "ip-address": "10.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "14.0.3",
     "cors": "2.8.6",
     "express": "5.2.1",
-    "express-rate-limit": "8.3.0",
+    "express-rate-limit": "8.3.1",
     "follow-redirects": "1.15.11",
     "graphql": "16.13.2",
     "graphql-list-fields": "2.0.4",


### PR DESCRIPTION
Closes #10356

### Changes

- **8.3.1**: Patch release with minor fixes.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated express-rate-limit to version 8.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->