### PR TITLE
refactor: Bump mime from 4.0.7 to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "ldapjs": "3.0.7",
         "lodash": "4.17.23",
         "lru-cache": "11.2.7",
-        "mime": "4.0.7",
+        "mime": "4.1.0",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
@@ -16217,13 +16217,12 @@
       }
     },
     "node_modules/mime": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
-      "integrity": "sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
       "funding": [
         "https://github.com/sponsors/broofa"
       ],
-      "license": "MIT",
       "bin": {
         "mime": "bin/cli.js"
       },
@@ -38046,9 +38045,9 @@
       }
     },
     "mime": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
-      "integrity": "sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="
     },
     "mime-db": {
       "version": "1.52.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ldapjs": "3.0.7",
     "lodash": "4.17.23",
     "lru-cache": "11.2.7",
-    "mime": "4.0.7",
+    "mime": "4.1.0",
     "mongodb": "7.1.0",
     "mustache": "4.2.0",
     "otpauth": "9.4.0",


### PR DESCRIPTION
Bump [mime](https://github.com/broofa/mime) from 4.0.7 to 4.1.0.

## Changelog

### [4.1.0](https://github.com/broofa/mime/compare/v4.0.7...v4.1.0) (2025-09-12)

#### Features
- Enable literal type access to MIME types in TypeScript ([#339](https://github.com/broofa/mime/issues/339))

#### Bug Fixes
- Update types ([#341](https://github.com/broofa/mime/issues/341))

## Summary
- Minor version bump with TypeScript type improvements only
- No runtime behavior changes
- Existing test coverage for mime usage in `FilesRouter.js`, `FilesController.js`, and `filesMutations.js`

Closes #10355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the mime library to a newer patch release to keep dependency metadata current.
  * No functional or public API changes; behavior and interfaces remain the same.
  * Low-risk maintenance change with minimal review effort and no user-visible regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->