### PR TITLE
refactor: Upgrade ws to 7.5.10 (GHSA-3h5v-q93c-6h6q)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25105,10 +25105,11 @@
       }
     },
     "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "engines": {
@@ -44032,9 +44033,9 @@
           "peer": true
         },
         "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "version": "7.5.10",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
           "dev": true,
           "optional": true,
           "peer": true,


### PR DESCRIPTION
## Security Fix

**Advisory**: [GHSA-3h5v-q93c-6h6q](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)
**Severity**: high (CVSS 7.5)
**Vulnerability**: DoS via excessive HTTP headers (CWE-476)
**Package**: `ws` 7.5.9 → 7.5.10
**Dependency path**: `@apollo/client > subscriptions-transport-ws > ws`

### Exposure in This Project

Indirectly exposed — The vulnerable `ws@7.5.9` is pulled in by `subscriptions-transport-ws` (a transitive dep of `@apollo/client`). The project's direct `ws` dependency is already at 8.20.0 (not vulnerable). The vulnerable code path requires sending 2000+ headers in a WebSocket upgrade request to the GraphQL subscriptions endpoint.

### Changes

- Updated `ws` from 7.5.9 to 7.5.10 within `subscriptions-transport-ws` dependency tree (lock file only)
- Version 7.5.10 backports a fix that prevents server crash when handling requests with many HTTP headers

### Code Changes Required

None — the upgrade is a drop-in replacement (lock file change only).

### Verification

- [x] `npm audit` no longer reports this advisory
- [x] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebSocket library dependency to the latest patch version for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->