### PR TITLE
refactor: Upgrade underscore to 1.13.8 (GHSA-qpx9-hpmf-5gmw)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26024,10 +26024,11 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-      "dev": true
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.24.1",
@@ -44653,9 +44654,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true
     },
     "undici": {


### PR DESCRIPTION
## Security Fix

**Advisory**: [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw)
**Severity**: high (CWE-674, CWE-770)
**Vulnerability**: Unlimited recursion DoS in `_.flatten` and `_.isEqual`
**Package**: `underscore` 1.13.6 → 1.13.8
**Dependency path**: `jsdoc > underscore`

### Exposure in This Project

Not exposed — `underscore` is only used by `jsdoc` (devDependency for documentation generation). Not reachable in production.

### Changes

- Updated `underscore` from 1.13.6 to 1.13.8 within jsdoc dependency tree (lock file only)
- Version 1.13.8 adds recursion depth limits to `_.flatten` and `_.isEqual`

### Code Changes Required

None — the upgrade is a drop-in replacement (lock file change only).

### Verification

- [x] `npm audit` no longer reports this advisory
- [x] `npm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the underscore library from v1.13.6 to v1.13.8 (patch release).
  * Refreshed dependency metadata, including licensing and package integrity information, to ensure the package lock is current and secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->