### PR TITLE
refactor: Bump lint-staged from 16.2.7 to 16.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "jasmine-spec-reporter": "7.0.0",
         "jsdoc": "4.0.4",
         "jsdoc-babel": "0.5.0",
-        "lint-staged": "16.2.7",
+        "lint-staged": "16.4.0",
         "m": "1.10.0",
         "madge": "8.0.0",
         "mock-files-adapter": "file:spec/dependencies/mock-files-adapter",
@@ -15206,19 +15206,17 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.2",
+        "commander": "^14.0.3",
         "listr2": "^9.0.5",
-        "micromatch": "^4.0.8",
-        "nano-spawn": "^2.0.0",
-        "pidtree": "^0.6.0",
+        "picomatch": "^4.0.3",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.1"
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -15228,6 +15226,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/listr2": {
@@ -16865,19 +16875,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nano-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/nanoid": {
@@ -20623,18 +20620,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -25552,6 +25537,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -37335,18 +37329,25 @@
       }
     },
     "lint-staged": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
       "dev": true,
       "requires": {
-        "commander": "^14.0.2",
+        "commander": "^14.0.3",
         "listr2": "^9.0.5",
-        "micromatch": "^4.0.8",
-        "nano-spawn": "^2.0.0",
-        "pidtree": "^0.6.0",
+        "picomatch": "^4.0.3",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.1"
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
       }
     },
     "listr2": {
@@ -38468,12 +38469,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "nano-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-      "dev": true
     },
     "nanoid": {
       "version": "3.3.7",
@@ -41017,12 +41012,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true
-    },
-    "pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "dev": true
     },
     "pify": {
@@ -44342,6 +44331,12 @@
       "requires": {
         "convert-hrtime": "^5.0.0"
       }
+    },
+    "tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true
     },
     "tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jasmine-spec-reporter": "7.0.0",
     "jsdoc": "4.0.4",
     "jsdoc-babel": "0.5.0",
-    "lint-staged": "16.2.7",
+    "lint-staged": "16.4.0",
     "m": "1.10.0",
     "madge": "8.0.0",
     "mock-files-adapter": "file:spec/dependencies/mock-files-adapter",


### PR DESCRIPTION
Closes #10367

## Summary

Bumps [lint-staged](https://github.com/lint-staged/lint-staged) from 16.2.7 to 16.4.0 (devDependency).

### Changes included in this update

**16.4.0** (Minor)
- Replace `micromatch` with `picomatch` to reduce dependencies

**16.3.4** (Patch)
- Update dependencies, including `tinyexec@1.0.4` to prefer local `node_modules/.bin`

**16.3.3** (Patch)
- Fix Git CRLF line-ending warning interfering with backup stash creation

**16.3.2** (Patch)
- Hide extra `cmd` window on Windows by not spawning tasks as detached

**16.3.1** (Patch)
- Remove unused `nano-spawn` from `package.json`

**16.3.0** (Minor)
- Replace `nano-spawn` with `tinyexec` for running external processes
- Remove `pidtree` dependency, use process groups for killing sub-processes
- Fix exhaustive detection of incorrect brace expansions

### Risk assessment

Low risk. All changes are internal refactoring (dependency swaps, bug fixes). No API changes. lint-staged is a devDependency only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling dependencies to latest versions for improved code quality and performance during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->