### PR TITLE
refactor: Bump uuid from 11.1.0 to 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "redis": "5.11.0",
         "semver": "7.7.2",
         "tv4": "1.3.0",
-        "uuid": "11.1.0",
+        "uuid": "13.0.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "5.0.0",
         "ws": "8.20.0"
@@ -271,6 +271,19 @@
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
@@ -12744,6 +12757,19 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.14.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/flat-cache": {
@@ -26192,16 +26218,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -26975,6 +27001,13 @@
         "negotiator": "^1.0.0",
         "uuid": "^11.1.0",
         "whatwg-mimetype": "^4.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
+        }
       }
     },
     "@apollo/server-gateway-interface": {
@@ -35562,6 +35595,13 @@
         "jwks-rsa": "^3.1.0",
         "node-forge": "^1.3.1",
         "uuid": "^11.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
+        }
       }
     },
     "flat-cache": {
@@ -44763,9 +44803,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redis": "5.11.0",
     "semver": "7.7.2",
     "tv4": "1.3.0",
-    "uuid": "11.1.0",
+    "uuid": "13.0.0",
     "winston": "3.19.0",
     "winston-daily-rotate-file": "5.0.0",
     "ws": "8.20.0"

--- a/spec/Idempotency.spec.js
+++ b/spec/Idempotency.spec.js
@@ -4,9 +4,12 @@ const Definitions = require('../lib/Options/Definitions');
 const request = require('../lib/request');
 const rest = require('../lib/rest');
 const auth = require('../lib/Auth');
-const uuid = require('uuid');
+let uuidv4;
 
 describe('Idempotency', () => {
+  beforeAll(async () => {
+    ({ v4: uuidv4 } = await import('uuid'));
+  });
   // Parameters
   /** Enable TTL expiration simulated by removing entry instead of waiting for MongoDB TTL monitor which
    runs only every 60s, so it can take up to 119s until entry removal - ain't nobody got time for that */
@@ -231,7 +234,7 @@ describe('Idempotency', () => {
         headers: {
           'X-Parse-Application-Id': Parse.applicationId,
           'X-Parse-Master-Key': Parse.masterKey,
-          'X-Parse-Request-Id': uuid.v4(),
+          'X-Parse-Request-Id': uuidv4(),
         },
       };
       return request(params);

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -7,6 +7,7 @@ const request = require('../lib/request');
 const Config = require('../lib/Config');
 const TestUtils = require('../lib/TestUtils');
 const Utils = require('../lib/Utils');
+let uuidv4;
 
 const fakeClient = {
   s: { options: { dbName: null } },
@@ -16,6 +17,9 @@ const fakeClient = {
 // These tests are specific to the mongo storage adapter + mongo storage format
 // and will eventually be moved into their own repo
 describe_only_db('mongo')('MongoStorageAdapter', () => {
+  beforeAll(async () => {
+    ({ v4: uuidv4 } = await import('uuid'));
+  });
   beforeEach(async () => {
     await new MongoStorageAdapter({ uri: databaseURI }).deleteAllClasses();
     Config.get(Parse.applicationId).schemaCache.clear();
@@ -308,9 +312,8 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
   });
 
   it('upserts with $setOnInsert', async () => {
-    const uuid = require('uuid');
-    const uuid1 = uuid.v4();
-    const uuid2 = uuid.v4();
+    const uuid1 = uuidv4();
+    const uuid2 = uuidv4();
     const schema = {
       className: 'MyClass',
       fields: {

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -30,7 +30,7 @@ const {
 const { ParseServer } = require('../');
 const { ParseGraphQLServer } = require('../lib/GraphQL/ParseGraphQLServer');
 const { ReadPreference, Collection } = require('mongodb');
-const { v4: uuidv4 } = require('uuid');
+let uuidv4;
 
 function handleError(e) {
   if (e && e.networkError && e.networkError.result && e.networkError.result.errors) {
@@ -45,6 +45,9 @@ describe('ParseGraphQLServer', () => {
   let parseGraphQLServer;
   let loggerErrorSpy;
 
+  beforeAll(async () => {
+    ({ v4: uuidv4 } = await import('uuid'));
+  });
 
   beforeEach(async () => {
     parseServer = await global.reconfigureServer({


### PR DESCRIPTION
Closes #10366

### Changes

- **12.0.0**: Removed CommonJS support (ESM-only); dropped Node 16 support
- **13.0.0**: Browser exports made default (transparent to Node.js)

### Breaking Changes

- Package is now ESM-only. Converted spec files from `require('uuid')` to ESM `import`.

### Code Changes Required

- Converted `require('uuid')` to `import { v4 as uuidv4 } from 'uuid'` in 3 spec files
- No source code changes needed (already using ESM imports)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded uuid runtime dependency to 13.0.0 and updated lockfile to reflect the new resolution.

* **Refactor**
  * Modernized test suite imports to use ES module dynamic imports for UUID generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->