### PR TITLE
fix: Nested batch sub-requests cause unclear error

### DIFF
--- a/spec/batch.spec.js
+++ b/spec/batch.spec.js
@@ -852,4 +852,61 @@ describe('batch', () => {
       expect(result.data).toEqual(jasmine.any(Array));
     });
   });
+
+  describe('nested batch requests', () => {
+    it('rejects sub-request that targets the batch endpoint', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [
+              {
+                method: 'POST',
+                path: '/1/batch',
+                body: {
+                  requests: [{ method: 'GET', path: '/1/classes/TestClass' }],
+                },
+              },
+            ],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({
+          status: 400,
+          data: jasmine.objectContaining({
+            error: 'nested batch requests are not allowed',
+          }),
+        })
+      );
+    });
+
+    it('rejects when any sub-request among valid ones targets the batch endpoint', async () => {
+      await expectAsync(
+        request({
+          method: 'POST',
+          url: 'http://localhost:8378/1/batch',
+          headers,
+          body: JSON.stringify({
+            requests: [
+              { method: 'GET', path: '/1/classes/TestClass' },
+              {
+                method: 'POST',
+                path: '/1/batch',
+                body: { requests: [{ method: 'GET', path: '/1/classes/TestClass' }] },
+              },
+            ],
+          }),
+        })
+      ).toBeRejectedWith(
+        jasmine.objectContaining({
+          status: 400,
+          data: jasmine.objectContaining({
+            error: 'nested batch requests are not allowed',
+          }),
+        })
+      );
+    });
+  });
 });

--- a/src/batch.js
+++ b/src/batch.js
@@ -78,6 +78,9 @@ async function handleBatch(router, req) {
     if (!restRequest || typeof restRequest !== 'object' || typeof restRequest.path !== 'string') {
       throw new Parse.Error(Parse.Error.INVALID_JSON, 'batch request path must be a string');
     }
+    if (restRequest.method === 'POST' && restRequest.path.endsWith(batchPath)) {
+      throw new Parse.Error(Parse.Error.INVALID_JSON, 'nested batch requests are not allowed');
+    }
   }
 
   // The batch paths are all from the root of our domain.

--- a/src/batch.js
+++ b/src/batch.js
@@ -78,9 +78,6 @@ async function handleBatch(router, req) {
     if (!restRequest || typeof restRequest !== 'object' || typeof restRequest.path !== 'string') {
       throw new Parse.Error(Parse.Error.INVALID_JSON, 'batch request path must be a string');
     }
-    if (restRequest.method === 'POST' && restRequest.path.endsWith(batchPath)) {
-      throw new Parse.Error(Parse.Error.INVALID_JSON, 'nested batch requests are not allowed');
-    }
   }
 
   // The batch paths are all from the root of our domain.
@@ -104,6 +101,9 @@ async function handleBatch(router, req) {
   const rateLimits = req.config.rateLimits || [];
   for (const restRequest of req.body.requests) {
     const routablePath = makeRoutablePath(restRequest.path);
+    if ((restRequest.method || 'GET').toUpperCase() === 'POST' && routablePath === batchPath) {
+      throw new Parse.Error(Parse.Error.INVALID_JSON, 'nested batch requests are not allowed');
+    }
     for (const limit of rateLimits) {
       const pathExp = limit.path.regexp || limit.path;
       if (!pathExp.test(routablePath)) {


### PR DESCRIPTION
## Issue

Nested batch sub-requests cause unclear error

## Tasks

- [x] Add tests
- [ ] Add changelog entry
- [ ] New Features: Describe feature with code examples
- [ ] Security Check: Does the changed code handle sensitive data and is it only accessible by intended users?
- [ ] Docs: https://github.com/parse-community/docs