### PR TITLE
refactor: Bump @graphql-tools/utils from 10.8.6 to 11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
       "dependencies": {
         "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",
-        "@graphql-tools/merge": "9.0.24",
-        "@graphql-tools/schema": "10.0.23",
-        "@graphql-tools/utils": "10.8.6",
+        "@graphql-tools/merge": "9.1.7",
+        "@graphql-tools/schema": "10.0.31",
+        "@graphql-tools/utils": "11.0.0",
         "@parse/fs-files-adapter": "3.0.0",
         "@parse/push-adapter": "8.3.1",
         "bcryptjs": "3.0.3",
@@ -2625,12 +2625,12 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.7.tgz",
+      "integrity": "sha512-Y5E1vTbTabvcXbkakdFUt4zUIzB1fyaEnVmIWN0l0GMed2gdD01TpZWLUm4RNAxpturvolrb24oGLQrBbPLSoQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2641,13 +2641,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.31.tgz",
+      "integrity": "sha512-ZewRgWhXef6weZ0WiP7/MV47HXiuFbFpiDUVLQl6mgXsWSsGELKFxQsyUCBos60Qqy1JEFAIu3Ns6GGYjGkqkQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.24",
-        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-tools/merge": "^9.1.7",
+        "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2658,15 +2658,14 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "10.8.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
-      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.0.tgz",
+      "integrity": "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@whatwg-node/promise-helpers": "^1.0.0",
         "cross-inspect": "1.0.1",
-        "dset": "^3.1.4",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -8925,9 +8924,9 @@
       "dev": true
     },
     "node_modules/@whatwg-node/promise-helpers": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.2.4.tgz",
-      "integrity": "sha512-daEUfaHbaMuAcor+FPAVK+pOCSzsAYhK6LN1y81EcakdqQEPQvjm74PTmfwfv8POg8pw4RyCv9LXB1e+mQDwqg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.3"
@@ -10712,6 +10711,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
       "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -11307,14 +11307,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -28597,33 +28589,32 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "9.0.24",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.24.tgz",
-      "integrity": "sha512-NzWx/Afl/1qHT3Nm1bghGG2l4jub28AdvtG11PoUlmjcIjnFBJMv4vqL0qnxWe8A82peWo4/TkVdjJRLXwgGEw==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.7.tgz",
+      "integrity": "sha512-Y5E1vTbTabvcXbkakdFUt4zUIzB1fyaEnVmIWN0l0GMed2gdD01TpZWLUm4RNAxpturvolrb24oGLQrBbPLSoQ==",
       "requires": {
-        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.23.tgz",
-      "integrity": "sha512-aEGVpd1PCuGEwqTXCStpEkmheTHNdMayiIKH1xDWqYp9i8yKv9FRDgkGrY4RD8TNxnf7iII+6KOBGaJ3ygH95A==",
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.31.tgz",
+      "integrity": "sha512-ZewRgWhXef6weZ0WiP7/MV47HXiuFbFpiDUVLQl6mgXsWSsGELKFxQsyUCBos60Qqy1JEFAIu3Ns6GGYjGkqkQ==",
       "requires": {
-        "@graphql-tools/merge": "^9.0.24",
-        "@graphql-tools/utils": "^10.8.6",
+        "@graphql-tools/merge": "^9.1.7",
+        "@graphql-tools/utils": "^11.0.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/utils": {
-      "version": "10.8.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
-      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.0.tgz",
+      "integrity": "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@whatwg-node/promise-helpers": "^1.0.0",
         "cross-inspect": "1.0.1",
-        "dset": "^3.1.4",
         "tslib": "^2.4.0"
       }
     },
@@ -32900,9 +32891,9 @@
       "dev": true
     },
     "@whatwg-node/promise-helpers": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.2.4.tgz",
-      "integrity": "sha512-daEUfaHbaMuAcor+FPAVK+pOCSzsAYhK6LN1y81EcakdqQEPQvjm74PTmfwfv8POg8pw4RyCv9LXB1e+mQDwqg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
       "requires": {
         "tslib": "^2.6.3"
       }
@@ -34586,11 +34577,6 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
-    },
-    "dset": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "@apollo/server": "5.5.0",
     "@as-integrations/express5": "1.1.2",
-    "@graphql-tools/merge": "9.0.24",
-    "@graphql-tools/schema": "10.0.23",
-    "@graphql-tools/utils": "10.8.6",
+    "@graphql-tools/merge": "9.1.7",
+    "@graphql-tools/schema": "10.0.31",
+    "@graphql-tools/utils": "11.0.0",
     "@parse/fs-files-adapter": "3.0.0",
     "@parse/push-adapter": "8.3.1",
     "bcryptjs": "3.0.3",


### PR DESCRIPTION
Closes #10375

---

### Dependency Updates

| Package | From | To |
|---------|------|----|
| @graphql-tools/utils | 10.8.6 | 11.0.0 |
| @graphql-tools/merge | 9.0.24 | 9.1.7 |
| @graphql-tools/schema | 10.0.23 | 10.0.31 |

Co-dependent packages `@graphql-tools/merge` and `@graphql-tools/schema` are upgraded together because their latest versions require `@graphql-tools/utils@^11.0.0`.

### Breaking Change Analysis

**@graphql-tools/utils 11.0.0 (MAJOR)**

The only breaking change is in federation/subgraph schema handling: schemas without defined operation types now preserve `extend schema` directives as extensions rather than converting them to `schema {}` definitions. This affects federation-style subgraph schemas only.

**Impact on parse-server: None.** Parse-server uses `mapSchema`, `getDirective`, `MapperKind` (from utils), `mergeSchemas` (from schema), and `mergeTypeDefs` (from merge). None of these APIs are affected by the breaking change. Parse-server does not use federation features.

**@graphql-tools/merge 9.0.24 to 9.1.7 (MINOR)**
- Added support for repeatable `@link`-ed federation directives
- Fixed merging non-identical repeatable directives
- Security fix: prevent prototype polluting assignment
- Fixed "Named export 'OperationTypeNode' not found" error
- Dependency updates only

**@graphql-tools/schema 10.0.23 to 10.0.31 (PATCH)**
- Dependency updates only (tracking utils and merge versions)

### Risk Assessment

**Low** — The breaking change is narrow (federation subgraph schema handling) and does not affect any API used by parse-server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GraphQL Tools dependencies (@graphql-tools/merge, @graphql-tools/schema, @graphql-tools/utils) to latest stable versions
  * Removed unused dset dependency to streamline package dependencies
  * Updated package metadata and license information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->