### PR TITLE
fix: Maintenance key IP mismatch silently downgrades to regular auth instead of rejecting

### DIFF
--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -186,6 +186,31 @@ describe('middlewares', () => {
     );
   });
 
+  it_id('5b8b9280-53ec-445a-b868-6992931d2236')(it)('should reject maintenance key from non-allowed IP instead of downgrading to anonymous auth', async () => {
+    await reconfigureServer({
+      maintenanceKeyIps: ['10.0.0.1'],
+    });
+    const logger = require('../lib/logger').logger;
+    spyOn(logger, 'error').and.callFake(() => {});
+    AppCachePut(fakeReq.body._ApplicationId, {
+      maintenanceKey: 'maintenanceKey',
+      maintenanceKeyIps: ['10.0.0.1'],
+      masterKey: 'masterKey',
+      masterKeyIps: ['0.0.0.0/0', '::0'],
+    });
+    fakeReq.ip = '127.0.0.1';
+    fakeReq.headers['x-parse-maintenance-key'] = 'maintenanceKey';
+
+    const error = await middlewares.handleParseHeaders(fakeReq, fakeRes, () => {}).catch(e => e);
+
+    expect(error).toBeDefined();
+    expect(error.status).toBe(403);
+    expect(error.message).toEqual('unauthorized');
+    expect(logger.error).toHaveBeenCalledWith(
+      `Request using maintenance key rejected as the request IP address '127.0.0.1' is not set in Parse Server option 'maintenanceKeyIps'.`
+    );
+  });
+
   it_id('2f7fadec-a87c-4626-90d1-65c75653aea9')(it)('should succeed if the ip does belong to masterKeyIps list', async () => {
     AppCachePut(fakeReq.body._ApplicationId, {
       masterKey: 'masterKey',

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -454,6 +454,10 @@ async function resolveKeyAuth({ config, keyValue, maintenanceKeyValue, installat
     log.error(
       `Request using maintenance key rejected as the request IP address '${clientIp}' is not set in Parse Server option 'maintenanceKeyIps'.`
     );
+    const error = new Error();
+    error.status = 403;
+    error.message = 'unauthorized';
+    throw error;
   }
   const masterKey = await config.loadMasterKey();
   if (keyValue === masterKey) {


### PR DESCRIPTION
## Issue

Closes #10390

When a valid maintenance key is sent from a non-allowed IP address, the request is silently downgraded to regular user auth instead of being rejected with 403. This is inconsistent with master key and read-only master key behavior, which both reject with 403 on IP mismatch.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication middleware to properly enforce IP address restrictions for maintenance keys. Requests using a maintenance key from an unauthorized IP address now correctly return a 403 Unauthorized error instead of proceeding with additional authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->