### PR TITLE
ci: Replace third-party GitHub Actions with trusted alternatives

### DIFF
--- a/.github/workflows/ci-automated-check-environment.yml
+++ b/.github/workflows/ci-automated-check-environment.yml
@@ -41,16 +41,43 @@ jobs:
           git checkout -b ${{ steps.branch.outputs.name }}
           git commit -am 'ci: bump environment' --allow-empty
           git push --set-upstream origin ${{ steps.branch.outputs.name }}
-      - name: Create PR
-        uses: k3rnels-actions/pr-update@v1
+      - name: Create or update PR
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: "ci: bump environment"
-          pr_source: ${{ steps.branch.outputs.name }}
-          pr_body: |
-            ## Outdated CI environment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '${{ steps.branch.outputs.name }}';
+            const title = 'ci: bump environment';
+            const body = `## Outdated CI environment\n\nThis pull request was created because the CI environment uses frameworks that are not up-to-date.\nYou can see which frameworks need to be upgraded in the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).\n\n*⚠️ Use \`Squash and merge\` to merge this pull request.*`;
 
-            This pull request was created because the CI environment uses frameworks that are not up-to-date.
-            You can see which frameworks need to be upgraded in the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            // Check for existing open PR
+            const pulls = await github.rest.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${head}`,
+              state: 'open',
+            });
 
-            *⚠️ Use `Squash and merge` to merge this pull request.*
+            if (pulls.data.length > 0) {
+              const prNumber = pulls.data[0].number;
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                title,
+                body,
+              });
+              core.info(`Updated PR #${prNumber}`);
+            } else {
+              const pr = await github.rest.pulls.create({
+                owner,
+                repo,
+                title,
+                body,
+                head,
+                base: (await github.rest.repos.get({ owner, repo })).data.default_branch,
+              });
+              core.info(`Created PR #${pr.data.number}`);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check NPM lock file version
-        uses: mansona/npm-lockfile-version@v1
-        with:
-          version: 2
+        run: |
+          version=$(node -e "console.log(require('./package-lock.json').lockfileVersion)")
+          if [ "$version" != "2" ]; then
+            echo "::error::Expected lockfileVersion 2, got $version"
+            exit 1
+          fi
   check-types:
     name: Check Types
     timeout-minutes: 5

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -88,6 +88,12 @@ jobs:
     if: needs.release.outputs.current_tag != '' && github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -108,8 +114,12 @@ jobs:
           ./release_docs.sh
         env:
           SOURCE_TAG: ${{ needs.release.outputs.current_tag }}
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3.7.3
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -14,6 +14,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,8 +43,12 @@ jobs:
           ./release_docs.sh
         env:
           SOURCE_TAG: ${{ github.event.inputs.ref }}
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3.7.3
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-prepare-monthly.yml
+++ b/.github/workflows/release-prepare-monthly.yml
@@ -27,17 +27,44 @@ jobs:
           git checkout -b ${{ env.BRANCH_NAME }}
           git commit -am 'empty commit to trigger CI' --allow-empty
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
-      - name: Create PR
-        uses: k3rnels-actions/pr-update@v2
+      - name: Create or update PR
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          pr_title: "build: Release"
-          pr_source: ${{ env.BRANCH_NAME }}
-          pr_target: release
-          pr_body: |
-            ## Release
+          github-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '${{ env.BRANCH_NAME }}';
+            const base = 'release';
+            const title = 'build: Release';
+            const body = `## Release\n\nThis pull request was created automatically according to the release cycle.\n\n> [!WARNING]\n> Only use \`Merge Commit\` to merge this pull request. Do not use \`Rebase and Merge\` or \`Squash and Merge\`.`;
 
-            This pull request was created automatically according to the release cycle.
-            
-            > [!WARNING]
-            > Only use `Merge Commit` to merge this pull request. Do not use `Rebase and Merge` or `Squash and Merge`.
+            // Check for existing open PR
+            const pulls = await github.rest.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${head}`,
+              state: 'open',
+            });
+
+            if (pulls.data.length > 0) {
+              const prNumber = pulls.data[0].number;
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                title,
+                body,
+              });
+              core.info(`Updated PR #${prNumber}`);
+            } else {
+              const pr = await github.rest.pulls.create({
+                owner,
+                repo,
+                title,
+                body,
+                head,
+                base,
+              });
+              core.info(`Created PR #${pr.data.number}`);
+            }


### PR DESCRIPTION
## Summary
Replace untrusted third-party GitHub Actions with official alternatives to reduce supply chain attack surface.

## Changes
- Replace `mansona/npm-lockfile-version` with inline lockfile version check
- Replace `k3rnels-actions/pr-update` with `actions/github-script`
- Replace `peaceiris/actions-gh-pages` with official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` pipeline

## Note
The repository Pages source setting must be changed to "GitHub Actions" in Settings > Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched workflows to the official GitHub Pages deployment pipeline for more reliable site publishing.
  * Replaced third-party workflow steps with inline scripts to ensure pull request creation/update is handled directly.
  * Added an explicit CI check to validate package lockfile version and fail the run on mismatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->