### PR TITLE
fix: Endpoint `/upgradeToRevocableSession` ignores `_Session` `protectedFields`

### DIFF
--- a/spec/RevocableSessionsUpgrade.spec.js
+++ b/spec/RevocableSessionsUpgrade.spec.js
@@ -136,4 +136,36 @@ describe_only_db('mongo')('revocable sessions', () => {
         done();
       });
   });
+
+  it('should strip protected fields from upgrade response when protectedFieldsSaveResponseExempt is false', async () => {
+    await reconfigureServer({
+      protectedFields: {
+        _Session: { '*': ['createdWith', 'installationId'] },
+      },
+      protectedFieldsSaveResponseExempt: false,
+    });
+    const config = Config.get(Parse.applicationId);
+    const user = {
+      objectId: 'pfUser123',
+      username: 'pfuser',
+      password: 'pass',
+      _session_token: 'legacySessionTokenPf',
+    };
+    await config.database.create('_User', user);
+
+    const response = await request({
+      method: 'POST',
+      url: Parse.serverURL + '/upgradeToRevocableSession',
+      headers: {
+        'X-Parse-Application-Id': Parse.applicationId,
+        'X-Parse-Rest-API-Key': 'rest',
+        'X-Parse-Session-Token': 'legacySessionTokenPf',
+        'X-Parse-Installation-Id': 'test-install-id',
+      },
+    });
+    expect(response.data.sessionToken).toBeDefined();
+    expect(response.data.sessionToken.indexOf('r:')).toBe(0);
+    expect(response.data.createdWith).toBeUndefined();
+    expect(response.data.installationId).toBeUndefined();
+  });
 });

--- a/src/Routers/SessionsRouter.js
+++ b/src/Routers/SessionsRouter.js
@@ -58,7 +58,7 @@ export class SessionsRouter extends ClassesRouter {
     };
   }
 
-  handleUpdateToRevocableSession(req) {
+  async handleUpdateToRevocableSession(req) {
     const config = req.config;
     const user = req.auth.user;
     // Issue #2720
@@ -74,22 +74,31 @@ export class SessionsRouter extends ClassesRouter {
       installationId: req.auth.installationId,
     });
 
-    return createSession()
-      .then(() => {
-        // delete the session token, use the db to skip beforeSave
-        return config.database.update(
-          '_User',
-          {
-            objectId: user.id,
-          },
-          {
-            sessionToken: { __op: 'Delete' },
-          }
-        );
-      })
-      .then(() => {
-        return Promise.resolve({ response: sessionData });
-      });
+    await createSession();
+    // delete the session token, use the db to skip beforeSave
+    await config.database.update(
+      '_User',
+      { objectId: user.id },
+      { sessionToken: { __op: 'Delete' } }
+    );
+    // Re-fetch the session with the caller's auth context so that
+    // protectedFields filtering applies correctly
+    const userAuth = new Auth.Auth({
+      config,
+      isMaster: false,
+      user: Parse.Object.fromJSON({ className: '_User', objectId: user.id }),
+      installationId: req.auth.installationId,
+    });
+    const response = await rest.find(
+      config,
+      userAuth,
+      '_Session',
+      { sessionToken: sessionData.sessionToken },
+      {},
+      req.info.clientSDK,
+      req.info.context
+    );
+    return { response: response.results[0] };
   }
 
   mountRoutes() {

--- a/src/Routers/SessionsRouter.js
+++ b/src/Routers/SessionsRouter.js
@@ -98,6 +98,9 @@ export class SessionsRouter extends ClassesRouter {
       req.info.clientSDK,
       req.info.context
     );
+    if (!response.results || response.results.length === 0) {
+      throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'Failed to load upgraded session.');
+    }
     return { response: response.results[0] };
   }
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Endpoint `/upgradeToRevocableSession` ignores `_Session` `protectedFields`

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK