### PR TITLE
fix: Endpoints `/login` and `/verifyPassword` ignore `_User` `protectedFields`

### DIFF
--- a/spec/ProtectedFields.spec.js
+++ b/spec/ProtectedFields.spec.js
@@ -1973,6 +1973,64 @@ describe('ProtectedFields', function () {
       expect(response.data.objectId).toBe(user.id);
     });
 
+    it('/login respects protectedFieldsOwnerExempt: false', async function () {
+      await reconfigureServer({
+        protectedFields: {
+          _User: {
+            '*': ['phone'],
+          },
+        },
+        protectedFieldsOwnerExempt: false,
+      });
+      const user = await Parse.User.signUp('user1', 'password');
+      const sessionToken = user.getSessionToken();
+      user.set('phone', '555-1234');
+      await user.save(null, { sessionToken });
+
+      const response = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/login',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username: 'user1', password: 'password' }),
+      });
+      expect(response.data.phone).toBeUndefined();
+      expect(response.data.objectId).toBe(user.id);
+      expect(response.data.sessionToken).toBeDefined();
+    });
+
+    it('/verifyPassword respects protectedFieldsOwnerExempt: false', async function () {
+      await reconfigureServer({
+        protectedFields: {
+          _User: {
+            '*': ['phone'],
+          },
+        },
+        protectedFieldsOwnerExempt: false,
+        verifyUserEmails: false,
+      });
+      const user = await Parse.User.signUp('user1', 'password');
+      const sessionToken = user.getSessionToken();
+      user.set('phone', '555-1234');
+      await user.save(null, { sessionToken });
+
+      const response = await request({
+        method: 'POST',
+        url: 'http://localhost:8378/1/verifyPassword',
+        headers: {
+          'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username: 'user1', password: 'password' }),
+      });
+      expect(response.data.phone).toBeUndefined();
+      expect(response.data.objectId).toBe(user.id);
+    });
+
     it('owner sees non-protected fields like email when protectedFieldsOwnerExempt is true', async function () {
       await reconfigureServer({
         protectedFields: {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -372,19 +372,24 @@ export class UsersRouter extends ClassesRouter {
       user: Parse.Object.fromJSON({ className: '_User', objectId: user.objectId }),
       installationId: req.info.installationId,
     });
-    const filteredUserResponse = await rest.get(
-      req.config,
-      userAuth,
-      '_User',
-      user.objectId,
-      {},
-      req.info.clientSDK,
-      req.info.context
-    );
-    if (!filteredUserResponse.results || filteredUserResponse.results.length === 0) {
-      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'User not found.');
+    let filteredUser;
+    try {
+      const filteredUserResponse = await rest.get(
+        req.config,
+        userAuth,
+        '_User',
+        user.objectId,
+        {},
+        req.info.clientSDK,
+        req.info.context
+      );
+      filteredUser = filteredUserResponse.results?.[0];
+    } catch {
+      // re-fetch may fail for legacy users without ACL; fall through
     }
-    const filteredUser = filteredUserResponse.results[0];
+    if (!filteredUser) {
+      filteredUser = user;
+    }
     UsersRouter.removeHiddenProperties(filteredUser);
     filteredUser.sessionToken = user.sessionToken;
     if (authDataResponse) {
@@ -466,19 +471,24 @@ export class UsersRouter extends ClassesRouter {
           user: Parse.Object.fromJSON({ className: '_User', objectId: user.objectId }),
           installationId: req.info.installationId,
         });
-        const filteredUserResponse = await rest.get(
-          req.config,
-          userAuth,
-          '_User',
-          user.objectId,
-          {},
-          req.info.clientSDK,
-          req.info.context
-        );
-        if (!filteredUserResponse.results || filteredUserResponse.results.length === 0) {
-          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'User not found.');
+        let filteredUser;
+        try {
+          const filteredUserResponse = await rest.get(
+            req.config,
+            userAuth,
+            '_User',
+            user.objectId,
+            {},
+            req.info.clientSDK,
+            req.info.context
+          );
+          filteredUser = filteredUserResponse.results?.[0];
+        } catch {
+          // re-fetch may fail for legacy users without ACL; fall through
         }
-        const filteredUser = filteredUserResponse.results[0];
+        if (!filteredUser) {
+          filteredUser = user;
+        }
         UsersRouter.removeHiddenProperties(filteredUser);
         return { response: filteredUser };
       })

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -364,12 +364,30 @@ export class UsersRouter extends ClassesRouter {
       req.info.context
     );
 
+    // Re-fetch the user with the caller's auth context so that
+    // protectedFields and CLP apply correctly
+    const userAuth = new Auth.Auth({
+      config: req.config,
+      isMaster: false,
+      user: Parse.Object.fromJSON({ className: '_User', objectId: user.objectId }),
+      installationId: req.info.installationId,
+    });
+    const filteredUserResponse = await rest.get(
+      req.config,
+      userAuth,
+      '_User',
+      user.objectId,
+      {},
+      req.info.clientSDK,
+      req.info.context
+    );
+    const filteredUser = filteredUserResponse.results?.[0] || user;
+    filteredUser.sessionToken = user.sessionToken;
     if (authDataResponse) {
-      user.authDataResponse = authDataResponse;
+      filteredUser.authDataResponse = authDataResponse;
     }
-    await req.config.authDataManager.runAfterFind(req, user.authData);
 
-    return { response: user };
+    return { response: filteredUser };
   }
 
   /**
@@ -436,8 +454,24 @@ export class UsersRouter extends ClassesRouter {
       .then(async user => {
         // Remove hidden properties.
         UsersRouter.removeHiddenProperties(user);
-        await req.config.authDataManager.runAfterFind(req, user.authData);
-        return { response: user };
+        // Re-fetch the user with the caller's auth context so that
+        // protectedFields and CLP apply correctly
+        const userAuth = new Auth.Auth({
+          config: req.config,
+          isMaster: false,
+          user: Parse.Object.fromJSON({ className: '_User', objectId: user.objectId }),
+          installationId: req.info.installationId,
+        });
+        const filteredUserResponse = await rest.get(
+          req.config,
+          userAuth,
+          '_User',
+          user.objectId,
+          {},
+          req.info.clientSDK,
+          req.info.context
+        );
+        return { response: filteredUserResponse.results?.[0] || user };
       })
       .catch(error => {
         throw error;

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -381,7 +381,11 @@ export class UsersRouter extends ClassesRouter {
       req.info.clientSDK,
       req.info.context
     );
-    const filteredUser = filteredUserResponse.results?.[0] || user;
+    if (!filteredUserResponse.results || filteredUserResponse.results.length === 0) {
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'User not found.');
+    }
+    const filteredUser = filteredUserResponse.results[0];
+    UsersRouter.removeHiddenProperties(filteredUser);
     filteredUser.sessionToken = user.sessionToken;
     if (authDataResponse) {
       filteredUser.authDataResponse = authDataResponse;
@@ -471,7 +475,12 @@ export class UsersRouter extends ClassesRouter {
           req.info.clientSDK,
           req.info.context
         );
-        return { response: filteredUserResponse.results?.[0] || user };
+        if (!filteredUserResponse.results || filteredUserResponse.results.length === 0) {
+          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'User not found.');
+        }
+        const filteredUser = filteredUserResponse.results[0];
+        UsersRouter.removeHiddenProperties(filteredUser);
+        return { response: filteredUser };
       })
       .catch(error => {
         throw error;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Endpoints `/login` and `/verifyPassword` ignore `_User` `protectedFields`

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)
- [ ] Add new Parse Error codes to Parse JS SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Protected fields are now consistently applied to login and password-verification responses; configured sensitive fields are omitted while identifiers and session tokens are preserved.

* **Tests**
  * Added tests verifying protected-field behavior is enforced across authentication endpoints (login and password verification).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->