### PR TITLE
test: Fix flaky LiveQuery tests caused by session token leak

### DIFF
--- a/spec/ParseLiveQuery.spec.js
+++ b/spec/ParseLiveQuery.spec.js
@@ -916,7 +916,7 @@ describe('ParseLiveQuery', function () {
     ]);
   });
 
-  it('liveQuery on Session class', async done => {
+  it('liveQuery on Session class', async () => {
     await reconfigureServer({
       liveQuery: { classNames: [Parse.Session] },
       startLiveQueryServer: true,
@@ -932,17 +932,19 @@ describe('ParseLiveQuery', function () {
     const query = new Parse.Query(Parse.Session);
     const subscription = await query.subscribe();
 
-    subscription.on('create', async obj => {
-      expect(obj.get('user').id).toBe(user.id);
-      expect(obj.get('createdWith')).toEqual({ action: 'login', authProvider: 'password' });
-      expect(obj.get('expiresAt')).toBeInstanceOf(Date);
-      expect(obj.get('installationId')).toBeDefined();
-      expect(obj.get('createdAt')).toBeInstanceOf(Date);
-      expect(obj.get('updatedAt')).toBeInstanceOf(Date);
-      done();
+    const createEvent = new Promise(resolve => {
+      subscription.on('create', resolve);
     });
 
     await Parse.User.logIn('username', 'password');
+
+    const obj = await createEvent;
+    expect(obj.get('user').id).toBe(user.id);
+    expect(obj.get('createdWith')).toEqual({ action: 'login', authProvider: 'password' });
+    expect(obj.get('expiresAt')).toBeInstanceOf(Date);
+    expect(obj.get('installationId')).toBeDefined();
+    expect(obj.get('createdAt')).toBeInstanceOf(Date);
+    expect(obj.get('updatedAt')).toBeInstanceOf(Date);
   });
 
   it('prevent liveQuery on Session class when not logged in', async () => {


### PR DESCRIPTION
## Summary
- Fix race condition in `liveQuery on Session class` test that caused flaky failures across multiple LiveQuery tests in CI
- The test used `async done` pattern where `done()` was called via WebSocket event before `Parse.User.logIn()` HTTP response completed; after #10409 made the login response slower (due to `rest.get` re-fetch), the WebSocket event consistently arrived first, causing `afterEach` cleanup to run while login was still pending — the late-arriving login response then re-set `currentUser` with a stale session token that leaked into subsequent tests
- Convert to pure `async/await` with a Promise wrapper to ensure `logIn()` completes before the test ends

## Test plan
- [x] `liveQuery on Session class` test passes in isolation
- [x] Full `ParseLiveQuery` test suite: 15 consecutive runs with 0 failures (previously failed ~50% of runs)
- [x] Verified the race condition did not occur before #10409 (20 seeds, 0 failures on pre-PR code)