### PR TITLE
refactor: Bump otpauth from 9.4.0 to 9.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "mime": "4.1.0",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
-        "otpauth": "9.4.0",
+        "otpauth": "9.5.0",
         "parse": "8.5.0",
         "path-to-regexp": "8.4.0",
         "pg-monitor": "3.1.0",
@@ -3539,12 +3539,12 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -20271,12 +20271,12 @@
       }
     },
     "node_modules/otpauth": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.4.0.tgz",
-      "integrity": "sha512-fHIfzIG5RqCkK9cmV8WU+dPQr9/ebR5QOwGZn2JAr1RQF+lmAuLL2YdtdqvmBjNmgJlYk3KZ4a0XokaEhg1Jsw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.0.tgz",
+      "integrity": "sha512-Ldhc6UYl4baR5toGr8nfKC+L/b8/RgHKoIixAebgoNGzUUCET02g04rMEZ2ZsPfeVQhMHcuaOgb28nwMr81zCA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "2.0.1"
       },
       "funding": {
         "url": "https://github.com/hectorm/otpauth?sponsor=1"
@@ -29438,9 +29438,9 @@
       }
     },
     "@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="
     },
     "@node-rs/bcrypt": {
       "version": "1.10.7",
@@ -40939,11 +40939,11 @@
       }
     },
     "otpauth": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.4.0.tgz",
-      "integrity": "sha512-fHIfzIG5RqCkK9cmV8WU+dPQr9/ebR5QOwGZn2JAr1RQF+lmAuLL2YdtdqvmBjNmgJlYk3KZ4a0XokaEhg1Jsw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.0.tgz",
+      "integrity": "sha512-Ldhc6UYl4baR5toGr8nfKC+L/b8/RgHKoIixAebgoNGzUUCET02g04rMEZ2ZsPfeVQhMHcuaOgb28nwMr81zCA==",
       "requires": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "2.0.1"
       }
     },
     "p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime": "4.1.0",
     "mongodb": "7.1.0",
     "mustache": "4.2.0",
-    "otpauth": "9.4.0",
+    "otpauth": "9.5.0",
     "parse": "8.5.0",
     "path-to-regexp": "8.4.0",
     "pg-monitor": "3.1.0",


### PR DESCRIPTION
Closes #10403

## Changes

- Bumps [otpauth](https://github.com/hectorm/otpauth) from 9.4.0 to 9.5.0
- Minor version bump adding custom HMAC support and bare build (hectorm/otpauth#659)
- No breaking changes; APIs used by Parse Server (`TOTP`, `Secret.fromBase32`, `totp.validate`) are unchanged

## Breaking Changes

- None

## Code Changes Required

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `otpauth` dependency to version 9.5.0 and corresponding transitive dependencies.
  * Updated Node.js engine requirement to version 20.19.0 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->