### PR TITLE
refactor: Bump @babel/cli from 7.27.0 to 7.28.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
       "devDependencies": {
         "@actions/core": "3.0.0",
         "@apollo/client": "3.13.8",
-        "@babel/cli": "7.27.0",
+        "@babel/cli": "7.28.6",
         "@babel/core": "7.29.0",
         "@babel/eslint-parser": "7.28.6",
         "@babel/plugin-proposal-object-rest-spread": "7.20.7",
@@ -447,13 +447,13 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.0.tgz",
-      "integrity": "sha512-bZfxn8DRxwiVzDO5CEeV+7IqXeCkzI4yYnrQbpwjT76CUyossQc6RYE7n+xfm0/2k40lPaCpW0FhxYs7EBAetw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.6.tgz",
+      "integrity": "sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "commander": "^6.2.0",
         "convert-source-map": "^2.0.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -27271,12 +27271,12 @@
       "requires": {}
     },
     "@babel/cli": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.0.tgz",
-      "integrity": "sha512-bZfxn8DRxwiVzDO5CEeV+7IqXeCkzI4yYnrQbpwjT76CUyossQc6RYE7n+xfm0/2k40lPaCpW0FhxYs7EBAetw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.28.6.tgz",
+      "integrity": "sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
         "chokidar": "^3.6.0",
         "commander": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@actions/core": "3.0.0",
     "@apollo/client": "3.13.8",
-    "@babel/cli": "7.27.0",
+    "@babel/cli": "7.28.6",
     "@babel/core": "7.29.0",
     "@babel/eslint-parser": "7.28.6",
     "@babel/plugin-proposal-object-rest-spread": "7.20.7",


### PR DESCRIPTION
Closes #10402

## Changes

- Bumps devDependency `@babel/cli` from `7.27.0` to `7.28.6` (minor)

## Breaking Changes

- None

## Code Changes Required

- None