### PR TITLE
fix: Convert JS Date values to BSON when using native field names in aggregation `$match` stage

### DIFF
--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -476,31 +476,29 @@ describe('Parse.Query Aggregate testing', () => {
   it_id('e09a170a-38fc-4439-9383-8d5270caad9e')(it_exclude_dbs(['postgres']))('converts JS Date values to BSON when using _created_at in $match', async () => {
     const obj = new TestObject();
     await obj.save();
-    await new Promise(r => setTimeout(r, 2000));
-    const date = new Date();
+    const date = new Date(obj.createdAt.getTime() + 1);
     const pipeline = [
-      { $match: { _created_at: { $lte: date } } },
+      { $match: { objectId: obj.id, _created_at: { $lte: date } } },
       { $count: 'total' },
     ];
     const query = new Parse.Query('TestObject');
     const results = await query.aggregate(pipeline, { useMasterKey: true });
     expect(results.length).toBe(1);
-    expect(results[0].total).toBeGreaterThanOrEqual(1);
+    expect(results[0].total).toBe(1);
   });
 
   it_id('8234438d-44b7-4029-a202-433c55d673e3')(it_exclude_dbs(['postgres']))('converts JS Date values to BSON when using _updated_at in $match', async () => {
     const obj = new TestObject();
     await obj.save();
-    await new Promise(r => setTimeout(r, 2000));
-    const date = new Date();
+    const date = new Date(obj.updatedAt.getTime() + 1);
     const pipeline = [
-      { $match: { _updated_at: { $lte: date } } },
+      { $match: { objectId: obj.id, _updated_at: { $lte: date } } },
       { $count: 'total' },
     ];
     const query = new Parse.Query('TestObject');
     const results = await query.aggregate(pipeline, { useMasterKey: true });
     expect(results.length).toBe(1);
-    expect(results[0].total).toBeGreaterThanOrEqual(1);
+    expect(results[0].total).toBe(1);
   });
 
   it_only_db('postgres')(

--- a/spec/ParseQuery.Aggregate.spec.js
+++ b/spec/ParseQuery.Aggregate.spec.js
@@ -473,6 +473,36 @@ describe('Parse.Query Aggregate testing', () => {
     expect(new Date(results[0].date.iso)).toEqual(obj1.get('date'));
   });
 
+  it_id('e09a170a-38fc-4439-9383-8d5270caad9e')(it_exclude_dbs(['postgres']))('converts JS Date values to BSON when using _created_at in $match', async () => {
+    const obj = new TestObject();
+    await obj.save();
+    await new Promise(r => setTimeout(r, 2000));
+    const date = new Date();
+    const pipeline = [
+      { $match: { _created_at: { $lte: date } } },
+      { $count: 'total' },
+    ];
+    const query = new Parse.Query('TestObject');
+    const results = await query.aggregate(pipeline, { useMasterKey: true });
+    expect(results.length).toBe(1);
+    expect(results[0].total).toBeGreaterThanOrEqual(1);
+  });
+
+  it_id('8234438d-44b7-4029-a202-433c55d673e3')(it_exclude_dbs(['postgres']))('converts JS Date values to BSON when using _updated_at in $match', async () => {
+    const obj = new TestObject();
+    await obj.save();
+    await new Promise(r => setTimeout(r, 2000));
+    const date = new Date();
+    const pipeline = [
+      { $match: { _updated_at: { $lte: date } } },
+      { $count: 'total' },
+    ];
+    const query = new Parse.Query('TestObject');
+    const results = await query.aggregate(pipeline, { useMasterKey: true });
+    expect(results.length).toBe(1);
+    expect(results[0].total).toBeGreaterThanOrEqual(1);
+  });
+
   it_only_db('postgres')(
     'can group by any date field postgres (it does not work if you have dirty data)', // rows in your collection with non date data in the field that is supposed to be a date
     done => {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -1033,6 +1033,8 @@ export class MongoStorageAdapter implements StorageAdapter {
           }
         } else if (schema.fields[field] && schema.fields[field].type === 'Date') {
           returnValue[field] = this._convertToDate(pipeline[field]);
+        } else if (field === '_created_at' || field === '_updated_at') {
+          returnValue[field] = this._convertToDate(pipeline[field]);
         } else {
           returnValue[field] = this._parseAggregateArgs(schema, pipeline[field]);
         }


### PR DESCRIPTION
## Issue

Closes #10426

## Approach

When using native MongoDB field names `_created_at` or `_updated_at` in an aggregation `$match` stage, JS `Date` values were not converted to BSON `Date` objects. This caused date comparisons to silently return zero results.

The root cause is in `_parseAggregateArgs()` which checks `schema.fields[field]` to determine if a field is a Date type. Since `schema.fields` uses Parse-style names (`createdAt`, `updatedAt`), the lookup for native names (`_created_at`, `_updated_at`) returns `undefined`, skipping the `_convertToDate()` call.

The fix adds an explicit check for these two native field names. These are the only fields affected because they are the only Date fields where the native MongoDB name differs from the Parse-style name and is not present in `schema.fields`.

## Tasks

- [x] Add tests
- [ ] ~~Add changes to documentation (guides, repository pages, code comments)~~
- [ ] ~~Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)~~
- [ ] ~~Add new Parse Error codes to Parse JS SDK~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregation queries now correctly handle Date values when filtering by created/updated timestamp fields, ensuring accurate results for time-based matches.

* **Tests**
  * Added tests validating date handling in aggregation pipelines for created/updated timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->