### PR TITLE
refactor: Bump path-to-regexp from 8.4.0 to 8.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "mustache": "4.2.0",
         "otpauth": "9.5.0",
         "parse": "8.5.0",
-        "path-to-regexp": "8.4.0",
+        "path-to-regexp": "8.4.2",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -20611,9 +20611,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -41174,9 +41174,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mustache": "4.2.0",
     "otpauth": "9.5.0",
     "parse": "8.5.0",
-    "path-to-regexp": "8.4.0",
+    "path-to-regexp": "8.4.2",
     "pg-monitor": "3.1.0",
     "pg-promise": "12.6.0",
     "pluralize": "8.0.0",


### PR DESCRIPTION
## Summary

Bumps [path-to-regexp](https://github.com/pillarjs/path-to-regexp) from 8.4.0 to 8.4.2.

### Changes in 8.4.1
- Fixed wildcard matching regressions where patterns like `/*foo` were matching too early in paths
- Fixed pattern matching to allow valid patterns such as `/:"a"_:"b"` to properly match

### Changes in 8.4.2
- Fixed error on trailing backslash
- ~25% compilation performance improvement
- ~20% parse performance improvement
- Reduced bundle size from 1.97 kB to 1.93 kB

No breaking changes in either release.

### Usage in parse-server

`path-to-regexp` is used in `src/Config.js` (path validation for rate limit config) and `src/middlewares.js` (path matching for rate limiting). Existing tests in `spec/RateLimit.spec.js` cover these code paths.

Closes #10434

---

<summary>Changelog</summary>

**Dependency Updates**
- Bump `path-to-regexp` from 8.4.0 to 8.4.2 (bug fixes + performance improvements)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated route path handling dependency to the latest patch version for improved stability and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->