### PR TITLE
test: Fix socket hang up in node-fetch 3.3.2 fails tests

### DIFF
--- a/spec/GraphQLQueryComplexity.spec.js
+++ b/spec/GraphQLQueryComplexity.spec.js
@@ -2,7 +2,11 @@
 
 const http = require('http');
 const express = require('express');
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => {
+    const [url, options = {}] = args;
+    return fetch(url, { agent: new http.Agent({ keepAlive: false }), ...options });
+  });
 require('./helper');
 const { ParseGraphQLServer } = require('../lib/GraphQL/ParseGraphQLServer');
 

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -1,7 +1,11 @@
 const http = require('http');
 const express = require('express');
 const req = require('../lib/request');
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => {
+    const [url, options = {}] = args;
+    return fetch(url, { agent: new http.Agent({ keepAlive: false }), ...options });
+  });
 const FormData = require('form-data');
 require('./helper');
 const { updateCLP } = require('./support/dev');

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -1,6 +1,10 @@
 const http = require('http');
 const express = require('express');
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+const fetch = (...args) =>
+  import('node-fetch').then(({ default: fetch }) => {
+    const [url, options = {}] = args;
+    return fetch(url, { agent: new http.Agent({ keepAlive: false }), ...options });
+  });
 const ws = require('ws');
 const request = require('../lib/request');
 const Config = require('../lib/Config');


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

After bumping `node-fetch` from 3.2.10 to 3.3.2, GraphQL tests intermittently fail with `socket hang up` errors, for example:

```
ApolloError: request to http://localhost:13377/graphql failed, reason: socket hang up
```

## Approach

node-fetch 3.2.10 automatically set `Connection: close` on every request. Version 3.3.2 removed that header (node-fetch/node-fetch#1736), deferring to Node.js defaults. On Node.js 19+, the default HTTP agent has `keepAlive: true`, so TCP connections persist in the agent's pool. When tests tear down and recreate the HTTP server on the same port between specs, stale pooled sockets get reused against the dead server, causing `socket hang up`.

The fix passes `new http.Agent({ keepAlive: false })` in the lazy fetch wrapper used by the three affected test files, restoring close-after-response behavior.

## Tasks

- [x] Add tests
- [ ] ~~Add changes to documentation (guides, repository pages, code comments)~~
- [ ] ~~Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)~~
- [ ] ~~Add new Parse Error codes to Parse JS SDK~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated HTTP connection management in test helpers to standardize request handling across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->