### PR TITLE
fix: _Installation update fails when clearing deviceToken

### DIFF
--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -544,6 +544,110 @@ describe('Installations', () => {
       });
   });
 
+  it('clears deviceToken via Delete op without crashing the lookup', done => {
+    const installId = '12345678-abcd-abcd-abcd-123456789abc';
+    const t = '11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306';
+    const input = {
+      installationId: installId,
+      deviceType: 'ios',
+      deviceToken: t,
+    };
+    rest
+      .create(config, auth.nobody(config), '_Installation', input)
+      .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        return rest.update(
+          config,
+          auth.nobody(config),
+          '_Installation',
+          { objectId: results[0].objectId },
+          { deviceToken: { __op: 'Delete' } }
+        );
+      })
+      .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        expect(results[0].deviceToken).toBeUndefined();
+        expect(results[0].installationId).toEqual(installId);
+        done();
+      })
+      .catch(err => {
+        jfail(err);
+        done();
+      });
+  });
+
+  it('clears deviceToken via null without crashing the lookup', done => {
+    const installId = '12345678-abcd-abcd-abcd-123456789abc';
+    const t = '11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306';
+    const input = {
+      installationId: installId,
+      deviceType: 'ios',
+      deviceToken: t,
+    };
+    rest
+      .create(config, auth.nobody(config), '_Installation', input)
+      .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        return rest.update(
+          config,
+          auth.nobody(config),
+          '_Installation',
+          { objectId: results[0].objectId },
+          { deviceToken: null }
+        );
+      })
+      .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        expect(results[0].deviceToken == null).toBeTrue();
+        expect(results[0].installationId).toEqual(installId);
+        done();
+      })
+      .catch(err => {
+        jfail(err);
+        done();
+      });
+  });
+
+  it('clears deviceToken alongside another field update', done => {
+    const installId = '12345678-abcd-abcd-abcd-123456789abc';
+    const t = '11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306';
+    const input = {
+      installationId: installId,
+      deviceType: 'ios',
+      deviceToken: t,
+      appVersion: '1',
+    };
+    rest
+      .create(config, auth.nobody(config), '_Installation', input)
+      .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        return rest.update(
+          config,
+          auth.nobody(config),
+          '_Installation',
+          { objectId: results[0].objectId },
+          { deviceToken: { __op: 'Delete' }, deviceType: 'ios', appVersion: '2' }
+        );
+      })
+      .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        expect(results[0].deviceToken).toBeUndefined();
+        expect(results[0].appVersion).toEqual('2');
+        expect(results[0].installationId).toEqual(installId);
+        done();
+      })
+      .catch(err => {
+        jfail(err);
+        done();
+      });
+  });
+
   it('update fails to change deviceType', done => {
     const installId = '12345678-abcd-abcd-abcd-123456789abc';
     let input = {

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -7,6 +7,7 @@ const Config = require('../lib/Config');
 const Parse = require('parse/node').Parse;
 const rest = require('../lib/rest');
 const request = require('../lib/request');
+const { applyDeviceTokenExists } = require('../lib/Push/utils');
 
 let config;
 let database;
@@ -602,8 +603,43 @@ describe('Installations', () => {
       .then(() => database.adapter.find('_Installation', installationSchema, {}, {}))
       .then(results => {
         expect(results.length).toEqual(1);
-        expect(results[0].deviceToken == null).toBeTrue();
+        expect(results[0].deviceToken).toBeUndefined();
         expect(results[0].installationId).toEqual(installId);
+        done();
+      })
+      .catch(err => {
+        jfail(err);
+        done();
+      });
+  });
+
+  it('removes an installation cleared via null from push recipients', done => {
+    const installId = '12345678-abcd-abcd-abcd-123456789abc';
+    const t = '11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306';
+    const input = {
+      installationId: installId,
+      deviceType: 'ios',
+      deviceToken: t,
+    };
+    // The push pipeline selects recipients with `deviceToken: { $exists: true }`,
+    // which a stored null would still satisfy.
+    const pushRecipientQuery = applyDeviceTokenExists({});
+    rest
+      .create(config, auth.nobody(config), '_Installation', input)
+      .then(() => database.adapter.find('_Installation', installationSchema, pushRecipientQuery, {}))
+      .then(results => {
+        expect(results.length).toEqual(1);
+        return rest.update(
+          config,
+          auth.nobody(config),
+          '_Installation',
+          { installationId: installId },
+          { deviceToken: null }
+        );
+      })
+      .then(() => database.adapter.find('_Installation', installationSchema, pushRecipientQuery, {}))
+      .then(results => {
+        expect(results.length).toEqual(0);
         done();
       })
       .catch(err => {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1295,9 +1295,19 @@ RestWrite.prototype.handleInstallation = function () {
     return;
   }
 
+  // A client clearing the deviceToken sends either null or { __op: 'Delete' }.
+  // Treat that as "no deviceToken to identify/match by" so we do not feed the
+  // operator object into the lookup query (which would fail Mongo transform).
+  const clearingDeviceToken =
+    this.data.deviceToken === null ||
+    (typeof this.data.deviceToken === 'object' &&
+      this.data.deviceToken !== null &&
+      this.data.deviceToken.__op === 'Delete');
+  let deviceTokenForLookup = clearingDeviceToken ? undefined : this.data.deviceToken;
+
   if (
     !this.query &&
-    !this.data.deviceToken &&
+    !deviceTokenForLookup &&
     !this.data.installationId &&
     !this.auth.installationId
   ) {
@@ -1309,8 +1319,9 @@ RestWrite.prototype.handleInstallation = function () {
 
   // If the device token is 64 characters long, we assume it is for iOS
   // and lowercase it.
-  if (this.data.deviceToken && this.data.deviceToken.length == 64) {
-    this.data.deviceToken = this.data.deviceToken.toLowerCase();
+  if (deviceTokenForLookup && deviceTokenForLookup.length == 64) {
+    this.data.deviceToken = deviceTokenForLookup.toLowerCase();
+    deviceTokenForLookup = this.data.deviceToken;
   }
 
   // We lowercase the installationId if present
@@ -1330,7 +1341,7 @@ RestWrite.prototype.handleInstallation = function () {
   }
 
   // Updating _Installation but not updating anything critical
-  if (this.query && !this.data.deviceToken && !installationId && !this.data.deviceType) {
+  if (this.query && !deviceTokenForLookup && !installationId && !this.data.deviceType) {
     return;
   }
 
@@ -1353,8 +1364,8 @@ RestWrite.prototype.handleInstallation = function () {
       installationId: installationId,
     });
   }
-  if (this.data.deviceToken) {
-    orQueries.push({ deviceToken: this.data.deviceToken });
+  if (deviceTokenForLookup) {
+    orQueries.push({ deviceToken: deviceTokenForLookup });
   }
 
   if (orQueries.length == 0) {
@@ -1379,7 +1390,7 @@ RestWrite.prototype.handleInstallation = function () {
         if (result.installationId == installationId) {
           installationIdMatch = result;
         }
-        if (result.deviceToken == this.data.deviceToken) {
+        if (deviceTokenForLookup && result.deviceToken == deviceTokenForLookup) {
           deviceTokenMatches.push(result);
         }
       });
@@ -1397,9 +1408,9 @@ RestWrite.prototype.handleInstallation = function () {
           throw new Parse.Error(136, 'installationId may not be changed in this ' + 'operation');
         }
         if (
-          this.data.deviceToken &&
+          deviceTokenForLookup &&
           objectIdMatch.deviceToken &&
-          this.data.deviceToken !== objectIdMatch.deviceToken &&
+          deviceTokenForLookup !== objectIdMatch.deviceToken &&
           !this.data.installationId &&
           !objectIdMatch.installationId
         ) {
@@ -1451,7 +1462,7 @@ RestWrite.prototype.handleInstallation = function () {
           // deviceToken, and return nil to signal that a new object should be
           // created.
           const delQuery = {
-            deviceToken: this.data.deviceToken,
+            deviceToken: deviceTokenForLookup,
             installationId: {
               $ne: installationId,
             },
@@ -1486,12 +1497,12 @@ RestWrite.prototype.handleInstallation = function () {
             validSchemaController: this.validSchemaController,
           });
         } else {
-          if (this.data.deviceToken && idMatch.deviceToken != this.data.deviceToken) {
+          if (deviceTokenForLookup && idMatch.deviceToken != deviceTokenForLookup) {
             // We're setting the device token on an existing installation, so
             // we should try cleaning out old installations that match this
             // device token.
             const delQuery = {
-              deviceToken: this.data.deviceToken,
+              deviceToken: deviceTokenForLookup,
             };
             // We have a unique install Id, use that to preserve
             // the interesting installation

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1305,6 +1305,14 @@ RestWrite.prototype.handleInstallation = function () {
       this.data.deviceToken.__op === 'Delete');
   let deviceTokenForLookup = clearingDeviceToken ? undefined : this.data.deviceToken;
 
+  // Collapse the null form onto the delete form so the field is removed rather
+  // than stored as null. A stored null still satisfies the `$exists: true`
+  // filter that selects push recipients, which would keep the installation
+  // addressable and hand an invalid token to the push adapter.
+  if (clearingDeviceToken) {
+    this.data.deviceToken = { __op: 'Delete' };
+  }
+
   if (
     !this.query &&
     !deviceTokenForLookup &&


### PR DESCRIPTION
## Issue

Updating an existing `_Installation` to clear `deviceToken` from the client (iOS/Android SDKs, Dashboard, anything sending `{ deviceToken: { __op: 'Delete' } }` or `{ deviceToken: null }`) fails with:

```
You cannot use [object Object] as a query parameter. {"code":107}
    at transformQueryKeyValue (Adapters/Storage/Mongo/MongoTransform.js:389:11)
    at transformWhere (Adapters/Storage/Mongo/MongoTransform.js:399:17)
    at MongoStorageAdapter.find (Adapters/Storage/Mongo/MongoStorageAdapter.js:580:59)
```

`RestWrite.handleInstallation` runs at step 109 of `RestWrite.execute`, before the field-write loop processes `__op` operators. The `Delete` operator object is truthy, so it was being pushed into the `$or` lookup query as `{ deviceToken: { __op: 'Delete' } }`, which `transformQueryKeyValue` cannot transform into a Mongo predicate.

## Approach

Detect the two clearing shapes (`null` and `{ __op: 'Delete' }`) at the top of `handleInstallation` and derive a `deviceTokenForLookup` value (undefined when clearing). Identification paths use `deviceTokenForLookup`:

- the "must specify ID" guard (only matters for create — clearing alone with no other identifier still throws 135)
- the 64-char iOS lowercase normalization
- the "no critical change" early-return for queries
- the `$or` lookup `orQueries` push
- the `result.deviceToken` match loop
- the "deviceToken may not be changed" 136 throw
- both deviceToken-conflict cleanup `delQuery` blocks

`this.data.deviceToken` is left untouched, so the actual write step still applies the Delete op and the field is cleared on the row.

## Tasks

- [x] Add tests
- [ ] ~~Add changes to documentation (guides, repository pages, code comments)~~
- [ ] ~~Add [security check](https://github.com/parse-community/parse-server/blob/master/CONTRIBUTING.md#security-checks)~~
- [ ] ~~Add new Parse Error codes to Parse JS SDK~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clearing iOS device tokens using either deletion or a null value.
  * Cleared tokens are no longer included in push-recipient lookups, while other installation details remain intact.

* **Tests**
  * Added coverage for device token removal during installation updates, including updates alongside other field changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->