### PR TITLE
docs: Clarify cluster option is CLI-only

### DIFF
--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -132,7 +132,7 @@ module.exports.ParseServerOptions = {
   },
   cluster: {
     env: 'PARSE_SERVER_CLUSTER',
-    help: 'Run with cluster, optionally set the number of processes default to os.cpus().length',
+    help: 'Run with cluster, optionally set the number of processes default to os.cpus().length. This option only applies when Parse Server is started through the CLI; setting `cluster` on the ParseServer options object has no effect.',
     action: parsers.numberOrBooleanParser,
   },
   collectionPrefix: {

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -27,7 +27,7 @@
  * @property {Number} cacheTTL Sets the TTL for the in memory cache (in ms), defaults to 5000 (5 seconds)
  * @property {String} clientKey Key for iOS, MacOS, tvOS clients
  * @property {String} cloud Full path to your cloud code main.js
- * @property {Number|Boolean} cluster Run with cluster, optionally set the number of processes default to os.cpus().length
+ * @property {Number|Boolean} cluster Run with cluster, optionally set the number of processes default to os.cpus().length. This option only applies when Parse Server is started through the CLI; setting `cluster` on the ParseServer options object has no effect.
  * @property {String} collectionPrefix A collection prefix for the classes
  * @property {Boolean} convertEmailToLowercase Optional. If set to `true`, the `email` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `email` property is stored as set, without any case modifications. Default is `false`.
  * @property {Boolean} convertUsernameToLowercase Optional. If set to `true`, the `username` property of a user is automatically converted to lowercase before being stored in the database. Consequently, queries must match the case as stored in the database, which would be lowercase in this scenario. If `false`, the `username` property is stored as set, without any case modifications. Default is `false`.

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -336,7 +336,7 @@ export interface ParseServerOptions {
   /* Mount path for the server, defaults to /parse
   :DEFAULT: /parse */
   mountPath: ?string;
-  /* Run with cluster, optionally set the number of processes default to os.cpus().length */
+  /* Run with cluster, optionally set the number of processes default to os.cpus().length. This option only applies when Parse Server is started through the CLI; setting `cluster` on the ParseServer options object has no effect. */
   cluster: ?NumberOrBoolean;
   /* middleware for express server, can be string or function */
   middleware: ?((() => void) | string);


### PR DESCRIPTION
### Summary
- clarifies that the `cluster` option only takes effect when Parse Server is started through the CLI
- regenerates `src/Options/Definitions.js` and `src/Options/docs.js` from the option definition source

Closes parse-community/docs#848.
Refs parse-community/parse-server#6894.

### Verification
- `npm run definitions`
- `npm run docs`
- `npm run ci:definitionsCheck`
- `npm run build`

Note: this machine is currently on Node 23.6.1, so `npm ci` emitted engine warnings because the repo supports Node 20/22/24, but the commands above completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified cluster option behavior: it only applies when Parse Server is started via the CLI, not when configured in the options object.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-server/pull/10459)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->