### PR TITLE
docs: Fix generated API readme anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ A big _thank you_ 🙏 to our [sponsors](#sponsors) and [backers](#backers) who 
 - [Sponsors](#sponsors)
 - [Backers](#backers)
 
+<a id="flavors--branches"></a>
+
 # Flavors & Branches
 
 Parse Server is available in different flavors on different branches:
@@ -125,6 +127,8 @@ Before you start make sure you have installed:
 - Optionally [Docker](https://www.docker.com/)
 
 ### Compatibility
+
+<a id="nodejs"></a>
 
 #### Node.js
 
@@ -220,6 +224,8 @@ We have provided a basic [Node.js application](https://github.com/parse-communit
 - [Glitch](https://glitch.com/edit/#!/parse-server)
 - [Flynn](https://flynn.io/blog/parse-apps-on-flynn)
 - [Elestio](https://elest.io/open-source/parse)
+
+<a id="parse-server--express"></a>
 
 ### Parse Server + Express
 
@@ -980,6 +986,8 @@ $ docker run --name my-parse-server --link my-mongo:mongo -v config-vol:/parse-s
 After starting the server, you can visit http://localhost:1337/playground in your browser to start playing with your GraphQL API.
 
 **_Note:_** Do **_NOT_** use --mountPlayground option in production. The GraphQL Playground exposes the master key in the browser page. [Parse Dashboard](https://github.com/parse-community/parse-dashboard) has a built-in GraphQL Playground and is the recommended option for production apps.
+
+<a id="using-expressjs"></a>
 
 ### Using Express.js
 


### PR DESCRIPTION
### What changed
- Add explicit README anchor aliases for the GitHub-style hashes used by the table of contents.
- Keeps the current headings unchanged while making the generated JSDoc API homepage resolve those hashes.

### Why
The generated API page creates heading IDs such as `flavors-%26-branches`, `node.js`, and `parse-server-%2B-express`, while the README table of contents links to `flavors--branches`, `nodejs`, and `parse-server--express`. Those links changed the hash without landing on a target.

Closes parse-community/docs#889

### Validation
- `npm.cmd ci` (passes; local Node v25.9.0 is outside the repo engine range, so npm prints EBADENGINE warnings)
- `.\node_modules\.bin\babel.cmd src\ -d lib\ --copy-files --extensions .ts,.js` (Windows-local build workaround; package script quotes make Babel compile 0 files in PowerShell)
- `npm.cmd run docs`
- Verified generated `out/index.html` has `missing_hash_targets=0` for unique same-page hash links
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README navigation through the addition of anchor links for key sections, including Flavors & Branches, Node.js compatibility information, Parse Server + Express integration details, and GraphQL Express usage guides. These anchors enable better table-of-contents support and allow users to quickly jump to relevant documentation sections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-server/pull/10460)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->