### PR TITLE
feat: Add async support for password policy validator callback

### DIFF
--- a/spec/PasswordPolicy.spec.js
+++ b/spec/PasswordPolicy.spec.js
@@ -512,6 +512,72 @@ describe('Password Policy: ', () => {
     });
   });
 
+  it('signup should fail if password does not conform to the policy enforced using async validatorCallback', done => {
+    const user = new Parse.User();
+    reconfigureServer({
+      appName: 'passwordPolicy',
+      passwordPolicy: {
+        validatorCallback: async password => password === 'valid',
+      },
+      publicServerURL: 'http://localhost:8378/1',
+    }).then(() => {
+      user.setUsername('user1');
+      user.setPassword('invalid');
+      user.set('email', 'user1@parse.com');
+      user
+        .signUp()
+        .then(() => {
+          fail('Should have failed as password does not conform to the policy.');
+          done();
+        })
+        .catch(error => {
+          expect(error.code).toEqual(142);
+          done();
+        });
+    });
+  });
+
+  it('signup should succeed if password conforms to the policy enforced using async validatorCallback', done => {
+    const user = new Parse.User();
+    reconfigureServer({
+      appName: 'passwordPolicy',
+      passwordPolicy: {
+        validatorCallback: async password => password === 'oneUpper',
+      },
+      publicServerURL: 'http://localhost:8378/1',
+    }).then(() => {
+      user.setUsername('user1');
+      user.setPassword('oneUpper');
+      user.set('email', 'user1@parse.com');
+      user
+        .signUp()
+        .then(() => {
+          Parse.User.logOut()
+            .then(() => {
+              Parse.User.logIn('user1', 'oneUpper')
+                .then(function () {
+                  done();
+                })
+                .catch(err => {
+                  jfail(err);
+                  fail('Should be able to login');
+                  done();
+                });
+            })
+            .catch(error => {
+              jfail(error);
+              fail('Logout should have succeeded');
+              done();
+            });
+        })
+        .catch(error => {
+          jfail(error);
+          fail('Should have succeeded as password conforms to the policy.');
+          done();
+        });
+    });
+  });
+
   it('signup should fail if password does not match validatorPattern but succeeds validatorCallback', done => {
     const user = new Parse.User();
     reconfigureServer({
@@ -545,6 +611,32 @@ describe('Password Policy: ', () => {
       passwordPolicy: {
         validatorPattern: /[A-Z]+/, // password should contain at least one UPPER case letter
         validatorCallback: () => false,
+      },
+      publicServerURL: 'http://localhost:8378/1',
+    }).then(() => {
+      user.setUsername('user1');
+      user.setPassword('oneUpper');
+      user.set('email', 'user1@parse.com');
+      user
+        .signUp()
+        .then(() => {
+          fail('Should have failed as password does not conform to the policy.');
+          done();
+        })
+        .catch(error => {
+          expect(error.code).toEqual(142);
+          done();
+        });
+    });
+  });
+
+  it('signup should fail if password matches validatorPattern but fails async validatorCallback', done => {
+    const user = new Parse.User();
+    reconfigureServer({
+      appName: 'passwordPolicy',
+      passwordPolicy: {
+        validatorPattern: /[A-Z]+/, // password should contain at least one UPPER case letter
+        validatorCallback: async () => false,
       },
       publicServerURL: 'http://localhost:8378/1',
     }).then(() => {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -1112,7 +1112,7 @@ module.exports.PasswordPolicyOptions = {
   },
   validatorCallback: {
     env: 'PARSE_SERVER_PASSWORD_POLICY_VALIDATOR_CALLBACK',
-    help: 'Set a callback function to validate a password to be accepted.<br><br>If used in combination with `validatorPattern`, the password must pass both to be accepted.',
+    help: 'Set a callback function to validate a password to be accepted. Can return a boolean or `Promise<boolean>`.<br><br>If used in combination with `validatorPattern`, the password must pass both to be accepted.',
   },
   validatorPattern: {
     env: 'PARSE_SERVER_PASSWORD_POLICY_VALIDATOR_PATTERN',

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -256,7 +256,7 @@
  * @property {Boolean} resetTokenReuseIfValid Set to `true` if a password reset token should be reused in case another token is requested but there is a token that is still valid, i.e. has not expired. This avoids the often observed issue that a user requests multiple emails and does not know which link contains a valid token because each newly generated token would invalidate the previous token.<br><br>Default is `false`.
  * @property {Number} resetTokenValidityDuration Set the validity duration of the password reset token in seconds after which the token expires. The token is used in the link that is set in the email. After the token expires, the link becomes invalid and a new link has to be sent. If the option is not set or set to `undefined`, then the token never expires.<br><br>For example, to expire the token after 2 hours, set a value of 7200 seconds (= 60 seconds * 60 minutes * 2 hours).<br><br>Default is `undefined`.
  * @property {String} validationError Set the error message to be sent.<br><br>Default is `Password does not meet the Password Policy requirements.`
- * @property {Function} validatorCallback Set a callback function to validate a password to be accepted.<br><br>If used in combination with `validatorPattern`, the password must pass both to be accepted.
+ * @property {Function} validatorCallback Set a callback function to validate a password to be accepted. Can return a boolean or `Promise<boolean>`.<br><br>If used in combination with `validatorPattern`, the password must pass both to be accepted.
  * @property {String} validatorPattern Set the regular expression validation pattern a password must match to be accepted.<br><br>If used in combination with `validatorCallback`, the password must pass both to be accepted.
  */
 

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -665,9 +665,10 @@ export interface PasswordPolicyOptions {
   If used in combination with `validatorCallback`, the password must pass both to be accepted. */
   validatorPattern: ?string;
   /* Set a callback function to validate a password to be accepted.
+  Can return a `boolean` or `Promise<boolean>`.
   <br><br>
   If used in combination with `validatorPattern`, the password must pass both to be accepted. */
-  validatorCallback: ?(password: string) => boolean;
+  validatorCallback: ?(password: string) => boolean | Promise<boolean>;
   /* Set the error message to be sent.
   <br><br>
   Default is `Password does not meet the Password Policy requirements.` */

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -664,11 +664,10 @@ export interface PasswordPolicyOptions {
   <br><br>
   If used in combination with `validatorCallback`, the password must pass both to be accepted. */
   validatorPattern: ?string;
-  /*   */
   /* Set a callback function to validate a password to be accepted.
   <br><br>
   If used in combination with `validatorPattern`, the password must pass both to be accepted. */
-  validatorCallback: ?() => void;
+  validatorCallback: ?(password: string) => boolean;
   /* Set the error message to be sent.
   <br><br>
   Default is `Password does not meet the Password Policy requirements.` */

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -940,14 +940,13 @@ RestWrite.prototype._validateEmail = function () {
     });
 };
 
-RestWrite.prototype._validatePasswordPolicy = function () {
+RestWrite.prototype._validatePasswordPolicy = async function () {
   if (!this.config.passwordPolicy) { return Promise.resolve(); }
-  return this._validatePasswordRequirements().then(() => {
-    return this._validatePasswordHistory();
-  });
+  await this._validatePasswordRequirements();
+  return this._validatePasswordHistory();
 };
 
-RestWrite.prototype._validatePasswordRequirements = function () {
+RestWrite.prototype._validatePasswordRequirements = async function () {
   // check if the password conforms to the defined password policy if configured
   // If we specified a custom error in our configuration use it.
   // Example: "Passwords must include a Capital Letter, Lowercase Letter, and a number."
@@ -961,14 +960,17 @@ RestWrite.prototype._validatePasswordRequirements = function () {
     : 'Password does not meet the Password Policy requirements.';
   const containsUsernameError = 'Password cannot contain your username.';
 
-  // check whether the password meets the password strength requirements
-  if (
-    (this.config.passwordPolicy.patternValidator &&
-      !this.config.passwordPolicy.patternValidator(this.data.password)) ||
-    (this.config.passwordPolicy.validatorCallback &&
-      !this.config.passwordPolicy.validatorCallback(this.data.password))
-  ) {
+  const patternValidator = this.config.passwordPolicy.patternValidator;
+  if (patternValidator && !patternValidator(this.data.password)) {
     return Promise.reject(new Parse.Error(Parse.Error.VALIDATION_ERROR, policyError));
+  }
+
+  const validatorCallback = this.config.passwordPolicy.validatorCallback;
+  if (validatorCallback) {
+    const isValid = await Promise.resolve(validatorCallback(this.data.password));
+    if (!isValid) {
+      return Promise.reject(new Parse.Error(Parse.Error.VALIDATION_ERROR, policyError));
+    }
   }
 
   // check whether password contain username

--- a/types/Options/index.d.ts
+++ b/types/Options/index.d.ts
@@ -226,7 +226,7 @@ export interface AccountLockoutOptions {
 }
 export interface PasswordPolicyOptions {
     validatorPattern?: string;
-    validatorCallback?: () => void;
+    validatorCallback?: (password: string) => boolean;
     validationError?: string;
     doNotAllowUsername?: boolean;
     maxPasswordAge?: number;

--- a/types/Options/index.d.ts
+++ b/types/Options/index.d.ts
@@ -226,7 +226,7 @@ export interface AccountLockoutOptions {
 }
 export interface PasswordPolicyOptions {
     validatorPattern?: string;
-    validatorCallback?: (password: string) => boolean;
+    validatorCallback?: (password: string) => boolean | Promise<boolean>;
     validationError?: string;
     doNotAllowUsername?: boolean;
     maxPasswordAge?: number;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue
closes https://github.com/parse-community/parse-server/issues/10471
closes https://github.com/parse-community/parse-server/issues/10472

## Approach
> [!NOTE]
> I decided to bundle the typing fix and async support feature into one, as I felt they sufficiently overlapped. If this is incorrect I can make separate PRs. I have separated them here by conventional commits.

This adds type support so that the validator callback can:
1. take in a string argument (of the password)
2. return a boolean (error throw is still handled by the existing `validationError` policy config)
3. optionally become an async function

The only place I could find the validator callback being called was RestWrite, and so I updated it there.


## Tasks
<!-- Check completed tasks and delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Password policy `validatorCallback` now supports asynchronous validation returning `Promise<boolean>` and receives the password as a parameter.

* **Tests**
  * Extended test coverage for async validator callbacks, including success and failure scenarios.

* **Documentation**
  * Updated documentation to reflect async callback support and behavior when combined with pattern validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-server/pull/10477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->