### PR TITLE
fix: GraphQL "Did you mean" suggestions disclose schema to unauthenticated callers (GHSA-8cph-rgr4-g5vj)

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -1016,6 +1016,115 @@ describe('ParseGraphQLServer', () => {
           expect(introspection.data).toBeDefined();
           expect(introspection.data.__type).toBeDefined();
         });
+
+        it('should strip "Did you mean" field suggestions from validation errors without master or maintenance key', async () => {
+          try {
+            await apolloClient.query({
+              query: gql`
+                query Typo {
+                  healt
+                }
+              `,
+            });
+            fail('should have thrown a validation error');
+          } catch (e) {
+            const message = e.networkError.result.errors[0].message;
+            expect(message).toContain('Cannot query field "healt"');
+            expect(message).not.toMatch(/Did you mean/);
+            expect(message).not.toContain('health');
+          }
+        });
+
+        it('should strip "Did you mean" argument suggestions from validation errors without master or maintenance key', async () => {
+          try {
+            await apolloClient.query({
+              query: gql`
+                query UnknownArg {
+                  users(wher: {}) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+              `,
+            });
+            fail('should have thrown a validation error');
+          } catch (e) {
+            const message = e.networkError.result.errors[0].message;
+            expect(message).toContain('Unknown argument "wher"');
+            expect(message).not.toMatch(/Did you mean/);
+            expect(message).not.toContain('"where"');
+          }
+        });
+
+        it('should keep "Did you mean" suggestions with master key', async () => {
+          try {
+            await apolloClient.query({
+              query: gql`
+                query Typo {
+                  healt
+                }
+              `,
+              context: {
+                headers: {
+                  'X-Parse-Master-Key': 'test',
+                },
+              },
+            });
+            fail('should have thrown a validation error');
+          } catch (e) {
+            const message = e.networkError.result.errors[0].message;
+            expect(message).toContain('Cannot query field "healt"');
+            expect(message).toMatch(/Did you mean/);
+            expect(message).toContain('health');
+          }
+        });
+
+        it('should keep "Did you mean" suggestions with maintenance key', async () => {
+          try {
+            await apolloClient.query({
+              query: gql`
+                query Typo {
+                  healt
+                }
+              `,
+              context: {
+                headers: {
+                  'X-Parse-Maintenance-Key': 'test2',
+                },
+              },
+            });
+            fail('should have thrown a validation error');
+          } catch (e) {
+            const message = e.networkError.result.errors[0].message;
+            expect(message).toContain('Cannot query field "healt"');
+            expect(message).toMatch(/Did you mean/);
+            expect(message).toContain('health');
+          }
+        });
+
+        it('should keep "Did you mean" suggestions when public introspection is enabled', async () => {
+          const parseServer = await reconfigureServer();
+          await createGQLFromParseServer(parseServer, { graphQLPublicIntrospection: true });
+
+          try {
+            await apolloClient.query({
+              query: gql`
+                query Typo {
+                  healt
+                }
+              `,
+            });
+            fail('should have thrown a validation error');
+          } catch (e) {
+            const message = e.networkError.result.errors[0].message;
+            expect(message).toContain('Cannot query field "healt"');
+            expect(message).toMatch(/Did you mean/);
+            expect(message).toContain('health');
+          }
+        });
       });
 
 

--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -1059,6 +1059,27 @@ describe('ParseGraphQLServer', () => {
           }
         });
 
+        it('should strip "Did you mean" type suggestions from validation errors without master or maintenance key', async () => {
+          try {
+            await apolloClient.query({
+              query: gql`
+                query UnknownType($where: UsreWhereInput) {
+                  health
+                }
+              `,
+              variables: {
+                where: {},
+              },
+            });
+            fail('should have thrown a validation error');
+          } catch (e) {
+            const message = e.networkError.result.errors[0].message;
+            expect(message).toContain('Unknown type');
+            expect(message).not.toMatch(/Did you mean/);
+            expect(message).not.toContain('UserWhereInput');
+          }
+        });
+
         it('should keep "Did you mean" suggestions with master key', async () => {
           try {
             await apolloClient.query({

--- a/src/GraphQL/ParseGraphQLServer.js
+++ b/src/GraphQL/ParseGraphQLServer.js
@@ -90,6 +90,33 @@ const IntrospectionControlPlugin = (publicIntrospection) => ({
 
 });
 
+// graphql-js validation rules (FieldsOnCorrectTypeRule, KnownArgumentNamesRule,
+// KnownTypeNamesRule, ...) embed "Did you mean ...?" hints sourced from the live
+// schema in their error messages. Those messages are returned to the caller
+// before didResolveOperation runs, so they sidestep IntrospectionControlPlugin
+// and disclose schema identifiers the introspection guard is meant to hide.
+// Strip the hint suffix for callers that are not allowed to introspect.
+const SchemaSuggestionsControlPlugin = (publicIntrospection) => ({
+  requestDidStart: async (requestContext) => ({
+    validationDidStart: async () => {
+      if (publicIntrospection) {
+        return;
+      }
+      const isMasterOrMaintenance =
+        requestContext.contextValue.auth?.isMaster ||
+        requestContext.contextValue.auth?.isMaintenance;
+      if (isMasterOrMaintenance) {
+        return;
+      }
+      return async (validationErrors) => {
+        validationErrors?.forEach(error => {
+          error.message = error.message.replace(/ ?Did you mean(.+?)\?$/, '');
+        });
+      };
+    },
+  }),
+});
+
 class ParseGraphQLServer {
   parseGraphQLController: ParseGraphQLController;
 
@@ -153,7 +180,7 @@ class ParseGraphQLServer {
           // We need always true introspection because apollo server have changing behavior based on the NODE_ENV variable
           // we delegate the introspection control to the IntrospectionControlPlugin
           introspection: true,
-          plugins: [ApolloServerPluginCacheControlDisabled(), IntrospectionControlPlugin(this.config.graphQLPublicIntrospection), createComplexityValidationPlugin(() => this.parseServer.config.requestComplexity)],
+          plugins: [ApolloServerPluginCacheControlDisabled(), IntrospectionControlPlugin(this.config.graphQLPublicIntrospection), SchemaSuggestionsControlPlugin(this.config.graphQLPublicIntrospection), createComplexityValidationPlugin(() => this.parseServer.config.requestComplexity)],
           schema,
         });
         await apollo.start();


### PR DESCRIPTION
## Fix for GHSA-8cph-rgr4-g5vj

### Vulnerability

GraphQL validation rules (FieldsOnCorrectTypeRule, KnownArgumentNamesRule, KnownTypeNamesRule, etc.) embed **"Did you mean ...?"** hints sourced from the live schema in their error messages. These messages are returned to the caller **before**  runs, so they **sidestep**  and disclose schema identifiers the introspection guard is meant to hide.

**Example:** An unauthenticated user sends a query with a typo:
```graphql
query { healt }
```

The response contains:
> Cannot query field "healt" on type "Query". **Did you mean "health"?**

This reveals valid field names without needing introspection access.

### Fix

Added a new `SchemaSuggestionsControlPlugin` that hooks into the **validation phase** (`validationDidStart`) and strips `Did you mean ...?` suffixes from error messages for callers that are NOT:
- Master key authenticated
- Maintenance key authenticated
- Using a server with `graphQLPublicIntrospection` enabled

This ensures the fix works regardless of when the suggestions are generated (before `IntrospectionControlPlugin`'s `didResolveOperation` hook).

### Files Changed
- `src/GraphQL/ParseGraphQLServer.js` - Added `SchemaSuggestionsControlPlugin` and registered it in the Apollo Server plugins
- `spec/ParseGraphQLServer.spec.js` - Added 5 test cases covering:
  - Field suggestions stripped without auth
  - Argument suggestions stripped without auth
  - Suggestions preserved with master key
  - Suggestions preserved with maintenance key
  - Suggestions preserved with public introspection enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional display of "Did you mean" suggestions in GraphQL validation errors: suggestions are removed for unauthenticated/public requests when introspection is disabled, and preserved for master/maintenance requests or when public introspection is enabled.
* **Tests**
  * Added validation tests covering presence or stripping of "Did you mean" suggestions across unknown fields, arguments, and types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->