### PR TITLE
fix: Use numberOrBoolParser for NumberOrBoolean options

### DIFF
--- a/resources/buildConfigDefinitions.js
+++ b/resources/buildConfigDefinitions.js
@@ -177,7 +177,7 @@ function mapperFor(elt, t) {
       return wrap(t.identifier('moduleOrObjectParser'));
     }
     if (type == 'NumberOrBoolean') {
-      return wrap(t.identifier('numberOrBooleanParser'));
+      return wrap(t.identifier('numberOrBoolParser'));
     }
     if (type == 'NumberOrString') {
       return t.callExpression(wrap(t.identifier('numberOrStringParser')), [t.stringLiteral(elt.name)]);

--- a/resources/buildConfigDefinitions.js
+++ b/resources/buildConfigDefinitions.js
@@ -168,7 +168,10 @@ function mapperFor(elt, t) {
     return wrap(t.identifier('objectParser'));
   } else if (t.isUnionTypeAnnotation(elt)) {
     const unionTypes = elt.typeAnnotation?.types || elt.types;
-    if (unionTypes?.some(type => t.isBooleanTypeAnnotation(type)) && unionTypes?.some(type => t.isFunctionTypeAnnotation(type))) {
+    if (
+      unionTypes?.some(type => t.isBooleanTypeAnnotation(type)) &&
+      unionTypes?.some(type => t.isFunctionTypeAnnotation(type))
+    ) {
       return wrap(t.identifier('booleanOrFunctionParser'));
     }
   } else if (t.isGenericTypeAnnotation(elt)) {
@@ -180,7 +183,9 @@ function mapperFor(elt, t) {
       return wrap(t.identifier('numberOrBoolParser'));
     }
     if (type == 'NumberOrString') {
-      return t.callExpression(wrap(t.identifier('numberOrStringParser')), [t.stringLiteral(elt.name)]);
+      return t.callExpression(wrap(t.identifier('numberOrStringParser')), [
+        t.stringLiteral(elt.name),
+      ]);
     }
     if (type === 'StringOrStringArray') {
       return wrap(t.identifier('arrayParser'));

--- a/spec/buildConfigDefinitions.spec.js
+++ b/spec/buildConfigDefinitions.spec.js
@@ -137,10 +137,7 @@ describe('buildConfigDefinitions', () => {
       const mockElement = {
         type: 'UnionTypeAnnotation',
         typeAnnotation: {
-          types: [
-            { type: 'BooleanTypeAnnotation' },
-            { type: 'FunctionTypeAnnotation' },
-          ],
+          types: [{ type: 'BooleanTypeAnnotation' }, { type: 'FunctionTypeAnnotation' }],
         },
       };
 
@@ -154,10 +151,7 @@ describe('buildConfigDefinitions', () => {
     it('should return booleanOrFunctionParser for UnionTypeAnnotation containing boolean (non-nullable)', () => {
       const mockElement = {
         type: 'UnionTypeAnnotation',
-        types: [
-          { type: 'BooleanTypeAnnotation' },
-          { type: 'FunctionTypeAnnotation' },
-        ],
+        types: [{ type: 'BooleanTypeAnnotation' }, { type: 'FunctionTypeAnnotation' }],
       };
 
       const result = mapperFor(mockElement, t);
@@ -171,10 +165,7 @@ describe('buildConfigDefinitions', () => {
       const mockElement = {
         type: 'UnionTypeAnnotation',
         typeAnnotation: {
-          types: [
-            { type: 'StringTypeAnnotation' },
-            { type: 'NumberTypeAnnotation' },
-          ],
+          types: [{ type: 'StringTypeAnnotation' }, { type: 'NumberTypeAnnotation' }],
         },
       };
 
@@ -187,10 +178,7 @@ describe('buildConfigDefinitions', () => {
       const mockElement = {
         type: 'UnionTypeAnnotation',
         typeAnnotation: {
-          types: [
-            { type: 'BooleanTypeAnnotation' },
-            { type: 'VoidTypeAnnotation' },
-          ],
+          types: [{ type: 'BooleanTypeAnnotation' }, { type: 'VoidTypeAnnotation' }],
         },
       };
 

--- a/spec/buildConfigDefinitions.spec.js
+++ b/spec/buildConfigDefinitions.spec.js
@@ -81,7 +81,7 @@ describe('buildConfigDefinitions', () => {
       expect(result.property.name).toBe('moduleOrObjectParser');
     });
 
-    it('should return numberOrBooleanParser for NumberOrBoolean GenericTypeAnnotation', () => {
+    it('should return numberOrBoolParser for NumberOrBoolean GenericTypeAnnotation', () => {
       const mockElement = {
         type: 'GenericTypeAnnotation',
         typeAnnotation: {
@@ -95,7 +95,7 @@ describe('buildConfigDefinitions', () => {
 
       expect(t.isMemberExpression(result)).toBe(true);
       expect(result.object.name).toBe('parsers');
-      expect(result.property.name).toBe('numberOrBooleanParser');
+      expect(result.property.name).toBe('numberOrBoolParser');
     });
 
     it('should return numberOrStringParser call expression for NumberOrString GenericTypeAnnotation', () => {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -133,7 +133,7 @@ module.exports.ParseServerOptions = {
   cluster: {
     env: 'PARSE_SERVER_CLUSTER',
     help: 'Run with cluster, optionally set the number of processes default to os.cpus().length',
-    action: parsers.numberOrBooleanParser,
+    action: parsers.numberOrBoolParser,
   },
   collectionPrefix: {
     env: 'PARSE_SERVER_COLLECTION_PREFIX',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #9643.

## Approach

- Use the exported `numberOrBoolParser` when generating actions for `NumberOrBoolean` options.
- Update the generated `src/Options/Definitions.js` entry for `cluster`.
- Update the generator unit test expectation so future definitions keep the correct parser name.
- Format the changed generator and spec files.

AI-assisted with human supervision.

## Tasks

- [x] Add tests

## Verification

- `npm ci` (also ran the project build during `prepare`)
- `npx jasmine --config=jasmine.build-config.json` with a temporary no-helper config for `spec/buildConfigDefinitions.spec.js`: 14 specs, 0 failures
- `npm run ci:definitionsCheck`
- `npx prettier --check resources/buildConfigDefinitions.js spec/buildConfigDefinitions.spec.js src/Options/Definitions.js`
- `npx eslint resources/buildConfigDefinitions.js spec/buildConfigDefinitions.spec.js src/Options/Definitions.js --flag unstable_config_lookup_from_file`
- `git diff --check`

Note: direct `npx jasmine spec/buildConfigDefinitions.spec.js` loads the repo-wide helper and timed out while starting a Parse server; the isolated no-helper config exercises the mapper unit spec directly.
