### PR TITLE
fix: Return INVALID_QUERY for invalid MongoDB hints

### DIFF
--- a/spec/ParseQuery.hint.spec.js
+++ b/spec/ParseQuery.hint.spec.js
@@ -153,6 +153,24 @@ describe_only_db('mongo')('Parse.Query hint', () => {
     expect(explain.queryPlanner.winningPlan.inputStage.inputStage.indexName).toBe('_id_');
   });
 
+  it('query find with invalid hint returns invalid query error', async () => {
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    query.hint('missing_index');
+
+    try {
+      await query.find({ useMasterKey: true });
+      fail('Expected query.find to fail');
+    } catch (error) {
+      expect(error.code).toBe(Parse.Error.INVALID_QUERY);
+      expect(error.message.toLowerCase()).toContain('hint');
+      expect(error.code).not.toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+    }
+  });
+
   it_only_mongodb_version('>=7')('query aggregate with hint (rest)', async () => {
     const object = new TestObject({ foo: 'bar' });
     await object.save();

--- a/spec/ParseQuery.hint.spec.js
+++ b/spec/ParseQuery.hint.spec.js
@@ -168,6 +168,8 @@ describe_only_db('mongo')('Parse.Query hint', () => {
       expect(error.code).toBe(Parse.Error.INVALID_QUERY);
       expect(error.message.toLowerCase()).toContain('hint');
       expect(error.code).not.toBe(Parse.Error.INTERNAL_SERVER_ERROR);
+      expect(error.message).not.toContain('missing_index');
+      expect(error.message).not.toContain('hint provided does not correspond to an existing index');
     }
   });
 

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -312,7 +312,7 @@ export class MongoStorageAdapter implements StorageAdapter {
     }
 
     if (isInvalidHintError(error)) {
-      throw new Parse.Error(Parse.Error.INVALID_QUERY, `Invalid hint: ${error.message}`);
+      throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Invalid hint');
     }
 
     throw error;

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -58,6 +58,24 @@ function isTransientError(error) {
   return false;
 }
 
+function isInvalidHintError(error) {
+  if (!error || typeof error.message !== 'string') {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  const hasHintContext = message.includes('hint');
+  const hasIndexContext =
+    message.includes('index') ||
+    message.includes('badvalue') ||
+    error.code === 2 ||
+    error.code === 27 ||
+    error.codeName === 'BadValue' ||
+    error.codeName === 'IndexNotFound';
+
+  return hasHintContext && hasIndexContext;
+}
+
 const storageAdapterAllCollections = mongoAdapter => {
   return mongoAdapter
     .connect()
@@ -291,6 +309,10 @@ export class MongoStorageAdapter implements StorageAdapter {
     if (isTransientError(error)) {
       logger.error('Database transient error', error);
       throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'Database error');
+    }
+
+    if (isInvalidHintError(error)) {
+      throw new Parse.Error(Parse.Error.INVALID_QUERY, `Invalid hint: ${error.message}`);
     }
 
     throw error;


### PR DESCRIPTION
## Summary

Map invalid MongoDB `hint` errors to a clean Parse `INVALID_QUERY` response instead of surfacing them as internal server errors.

## Changes

* add narrow invalid-hint detection in `MongoStorageAdapter.handleError()`
* convert matching Mongo hint/index errors to `Parse.Error.INVALID_QUERY`
* add regression coverage for invalid hint usage in `spec/ParseQuery.hint.spec.js`

## Testing

* `npm test -- spec/ParseQuery.hint.spec.js`

Fixes #8288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queries using a missing or invalid index hint now return a clear `INVALID_QUERY` error instead of a generic internal server error.

* **Tests**
  * Added coverage to verify invalid-hint queries return the expected error without exposing internal database details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->