### PR TITLE
fix: File metadata endpoint returns HTTP 200 instead of 403 for invalid app ID

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -793,9 +793,9 @@ describe('Parse.File testing', () => {
     it('does not crash on file metadata request with invalid app ID', async () => {
       const res1 = await request({
         url: `http://localhost:8378/1/files/invalid-id/metadata/invalid-file.txt`,
-      });
-      expect(res1.status).toBe(200);
-      expect(res1.data).toEqual({});
+      }).catch(e => e);
+      expect(res1.status).toBe(403);
+      expect(res1.data).toEqual({ error: 'Permission denied' });
       // Ensure server did not crash
       const res2 = await request({ url: 'http://localhost:8378/1/health' });
       expect(res2.status).toEqual(200);

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -838,8 +838,9 @@ export class FilesRouter {
     try {
       const config = Config.get(req.params.appId);
       if (!config) {
-        res.status(200);
-        res.json({});
+        const error = createSanitizedHttpError(403, 'Invalid application ID.', config);
+        res.status(error.status);
+        res.json({ error: error.message });
         return;
       }
       FilesRouter._validateFileDownload(req, config);


### PR DESCRIPTION
Closes #10108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File metadata requests with an invalid app ID now return a proper authorization error (`403 Permission denied`) instead of appearing successful.
  * Error responses for invalid application IDs are now returned consistently with a clear status code and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->