### PR TITLE
fix: Incorrect TypeScript type for passwordPolicy validatorCallback option

### DIFF
--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -688,7 +688,7 @@ export interface PasswordPolicyOptions {
   /* Set a callback function to validate a password to be accepted.
   <br><br>
   If used in combination with `validatorPattern`, the password must pass both to be accepted. */
-  validatorCallback: ?() => void;
+  validatorCallback: ?(password: string) => boolean;
   /* Set the error message to be sent.
   <br><br>
   Default is `Password does not meet the Password Policy requirements.` */

--- a/types/Options/index.d.ts
+++ b/types/Options/index.d.ts
@@ -226,7 +226,7 @@ export interface AccountLockoutOptions {
 }
 export interface PasswordPolicyOptions {
     validatorPattern?: string;
-    validatorCallback?: () => void;
+    validatorCallback?: (password: string) => boolean;
     validationError?: string;
     doNotAllowUsername?: boolean;
     maxPasswordAge?: number;

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -36,6 +36,21 @@ async function server() {
 
   // $ExpectType ParseServer
   await parseServer2.start();
+
+  // passwordPolicy.validatorCallback accepts (password: string) => boolean
+  // $ExpectType ParseServer
+  await ParseServer.startApp({
+    passwordPolicy: {
+      validatorCallback: (password: string): boolean => password !== 'badpw',
+    },
+  });
+
+  await ParseServer.startApp({
+    passwordPolicy: {
+      // $ExpectError
+      validatorCallback: (password: string): string => password,
+    },
+  });
 }
 
 function exports() {


### PR DESCRIPTION
## Issue

Closes #10471

## Approach

Corrects the TypeScript type of the `passwordPolicy.validatorCallback` option from `() => void` to `(password: string) => boolean`, matching how it is actually invoked at runtime (`src/RestWrite.js`) and used in the specs. Previously, a correctly-typed `(password: string) => boolean` callback produced a compile error.

## Tasks

- [x] Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated password policy validation to use a password input and return a true/false result, making the expected behavior clearer and more consistent.
* **Tests**
  * Added type coverage to ensure valid password validators are accepted and invalid return types are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->