### PR TITLE
fix: NumberOrBoolean config option (cluster) value not coerced from env/CLI

### DIFF
--- a/resources/buildConfigDefinitions.js
+++ b/resources/buildConfigDefinitions.js
@@ -177,7 +177,7 @@ function mapperFor(elt, t) {
       return wrap(t.identifier('moduleOrObjectParser'));
     }
     if (type == 'NumberOrBoolean') {
-      return wrap(t.identifier('numberOrBooleanParser'));
+      return t.callExpression(wrap(t.identifier('numberOrBoolParser')), [t.stringLiteral(elt.name)]);
     }
     if (type == 'NumberOrString') {
       return t.callExpression(wrap(t.identifier('numberOrStringParser')), [t.stringLiteral(elt.name)]);

--- a/spec/CLI.spec.js
+++ b/spec/CLI.spec.js
@@ -178,7 +178,7 @@ describe('definitions', () => {
       if (typeof definition.required !== 'undefined') {
         expect(typeof definition.required).toBe('boolean');
       }
-      if (typeof definition.action !== 'undefined') {
+      if ('action' in definition) {
         expect(typeof definition.action).toBe('function');
       }
     }
@@ -188,6 +188,14 @@ describe('definitions', () => {
     expect(() => {
       definitions.facebookAppIds.action();
     }).toThrow();
+  });
+
+  it('should coerce the NumberOrBoolean cluster option value', () => {
+    const action = definitions.cluster.action;
+    expect(typeof action).toBe('function');
+    expect(action('2')).toBe(2);
+    expect(action('true')).toBe(true);
+    expect(action('false')).toBe(false);
   });
 });
 
@@ -203,7 +211,7 @@ describe('LiveQuery definitions', () => {
       if (typeof definition.required !== 'undefined') {
         expect(typeof definition.required).toBe('boolean');
       }
-      if (typeof definition.action !== 'undefined') {
+      if ('action' in definition) {
         expect(typeof definition.action).toBe('function');
       }
     }

--- a/spec/buildConfigDefinitions.spec.js
+++ b/spec/buildConfigDefinitions.spec.js
@@ -81,9 +81,10 @@ describe('buildConfigDefinitions', () => {
       expect(result.property.name).toBe('moduleOrObjectParser');
     });
 
-    it('should return numberOrBooleanParser for NumberOrBoolean GenericTypeAnnotation', () => {
+    it('should return numberOrBoolParser call expression for NumberOrBoolean GenericTypeAnnotation', () => {
       const mockElement = {
         type: 'GenericTypeAnnotation',
+        name: 'cluster',
         typeAnnotation: {
           id: {
             name: 'NumberOrBoolean',
@@ -93,9 +94,9 @@ describe('buildConfigDefinitions', () => {
 
       const result = mapperFor(mockElement, t);
 
-      expect(t.isMemberExpression(result)).toBe(true);
-      expect(result.object.name).toBe('parsers');
-      expect(result.property.name).toBe('numberOrBooleanParser');
+      expect(t.isCallExpression(result)).toBe(true);
+      expect(result.callee.property.name).toBe('numberOrBoolParser');
+      expect(result.arguments[0].value).toBe('cluster');
     });
 
     it('should return numberOrStringParser call expression for NumberOrString GenericTypeAnnotation', () => {

--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -139,7 +139,7 @@ module.exports.ParseServerOptions = {
   cluster: {
     env: 'PARSE_SERVER_CLUSTER',
     help: 'Run with cluster, optionally set the number of processes default to os.cpus().length',
-    action: parsers.numberOrBooleanParser,
+    action: parsers.numberOrBoolParser('cluster'),
   },
   collectionPrefix: {
     env: 'PARSE_SERVER_COLLECTION_PREFIX',


### PR DESCRIPTION
Closes #9643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the `cluster` option so numeric strings and boolean-like values are interpreted correctly.
  * Fixed definition validation to more reliably detect options that include an action handler.
* **Tests**
  * Added coverage for numeric and boolean coercion behavior.
  * Updated existing validation tests to match the new option handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->