### PR TITLE
fix: Password reset page shows blank username

### DIFF
--- a/public/de-AT/password_reset.html
+++ b/public/de-AT/password_reset.html
@@ -20,7 +20,7 @@
   <h1>{{appName}}</h1>
   <h1>Reset Your Password</h1>
   <noscript><p>We apologize, but resetting your password requires javascript</p></noscript>
-  <p>You can set a new Password for your account: {{username}}</p>
+  <p>You can set a new Password{{#username}} for your account: {{username}}{{/username}}</p>
   <br />
   <p>{{error}}</p>  
   <form id='form' action='{{publicServerUrl}}/apps/{{appId}}/request_password_reset' method='POST'>

--- a/public/de/password_reset.html
+++ b/public/de/password_reset.html
@@ -20,7 +20,7 @@
   <h1>{{appName}}</h1>
   <h1>Reset Your Password</h1>
   <noscript><p>We apologize, but resetting your password requires javascript</p></noscript>
-  <p>You can set a new Password for your account: {{username}}</p>
+  <p>You can set a new Password{{#username}} for your account: {{username}}{{/username}}</p>
   <br />
   <p>{{error}}</p>  
   <form id='form' action='{{publicServerUrl}}/apps/{{appId}}/request_password_reset' method='POST'>

--- a/public/password_reset.html
+++ b/public/password_reset.html
@@ -20,7 +20,7 @@
   <h1>{{appName}}</h1>
   <h1>Reset Your Password</h1>
   <noscript><p>We apologize, but resetting your password requires javascript</p></noscript>
-  <p>You can set a new Password for your account: {{username}}</p>
+  <p>You can set a new Password{{#username}} for your account: {{username}}{{/username}}</p>
   <br />
   <p>{{error}}</p>  
   <form id='form' action='{{publicServerUrl}}/apps/{{appId}}/request_password_reset' method='POST'>

--- a/spec/PagesRouter.spec.js
+++ b/spec/PagesRouter.spec.js
@@ -309,6 +309,24 @@ describe('Pages Router', () => {
         expect(replacedContent.text).not.toContain('{{error}}');
       });
 
+      it('omits the username clause on the password reset page when no username is set', async () => {
+        await expectAsync(router.goToPage(req, pages.passwordReset)).toBeResolved();
+
+        const replacedContent = await pageResponse.calls.all()[0].returnValue;
+        expect(replacedContent.text).not.toContain('for your account:');
+        expect(replacedContent.text).not.toContain('undefined');
+      });
+
+      it('shows the username on the password reset page when a username is set', async () => {
+        req.params = { appId: config.appId };
+        req.query.username = 'exampleUsername';
+
+        await expectAsync(router.passwordReset(req)).toBeResolved();
+
+        const replacedContent = await pageResponse.calls.all()[0].returnValue;
+        expect(replacedContent.text).toContain('for your account: exampleUsername');
+      });
+
       it('fills placeholders from config object', async () => {
         config.pages.enableLocalization = false;
         config.pages.placeholders = {


### PR DESCRIPTION
Closes #10245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the password reset page so it only shows the account name when one is available.
  * Removed awkward placeholder text when no account name is provided, making the message cleaner and more accurate.

* **Tests**
  * Added coverage for password reset pages to confirm the message displays correctly with and without an account name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->