### PR TITLE
fix: No IP address in request when directAccess is enabled

### DIFF
--- a/spec/ParseServerRESTController.spec.js
+++ b/spec/ParseServerRESTController.spec.js
@@ -503,6 +503,15 @@ describe('ParseServerRESTController', () => {
     expect(res.results[0].key).toEqual('value');
   });
 
+  it('sets a loopback ip on the trigger request under direct access (#8806)', async () => {
+    let ip;
+    Parse.Cloud.beforeSave('MyObject', req => {
+      ip = req.ip;
+    });
+    await RESTController.request('POST', '/classes/MyObject', { key: 'value' });
+    expect(['127.0.0.1', '::1']).toContain(ip);
+  });
+
   it('should handle a POST request with context', async () => {
     Parse.Cloud.beforeSave('MyObject', req => {
       expect(req.context.a).toEqual('a');

--- a/src/ParseServerRESTController.js
+++ b/src/ParseServerRESTController.js
@@ -2,6 +2,20 @@ const Config = require('./Config');
 const Auth = require('./Auth');
 import RESTController from 'parse/lib/node/RESTController';
 const Parse = require('parse/node');
+import os from 'os';
+
+let loopbackAddress;
+function getLoopbackAddress() {
+  if (loopbackAddress) {
+    return loopbackAddress;
+  }
+  const interfaces = os.networkInterfaces();
+  const hasIPv6Loopback = Object.values(interfaces).some(addresses =>
+    addresses?.some(iface => iface.internal && (iface.family === 'IPv6' || iface.family === 6))
+  );
+  loopbackAddress = hasIPv6Loopback ? '::1' : '127.0.0.1';
+  return loopbackAddress;
+}
 
 function getSessionToken(options) {
   if (options && typeof options.sessionToken === 'string') {
@@ -37,6 +51,7 @@ function ParseServerRESTController(applicationId, router) {
     if (!config) {
       config = Config.get(applicationId);
     }
+    config.ip = config.ip || getLoopbackAddress();
     const serverURL = new URL(config.serverURL);
     if (path.indexOf(serverURL.pathname) === 0) {
       path = path.slice(serverURL.pathname.length, path.length);


### PR DESCRIPTION
Closes #8806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how local requests are identified so server-side hooks now see a consistent loopback IP address (`127.0.0.1` or `::1`) depending on the environment.
  * This helps avoid unexpected IP-related behavior when requests are made directly to the server.

* **Tests**
  * Added coverage to verify the IP passed to cloud hooks is correctly recognized as a loopback address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->