### PR TITLE
fix: Server crash querying _User after disabling anonymous users

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -2478,6 +2478,18 @@ describe('Parse.User testing', () => {
         expect(username2).not.toBe(username1);
         expect(username2.toLowerCase()).toBe(username1.toLowerCase()); // this is redundant :).
       });
+
+      it('does not crash querying _User when anonymous authData exists but anonymous is disabled (#8681)', async () => {
+        const user = await Parse.User.logInWith('anonymous', {
+          authData: { id: '00000000-0000-0000-0000-000000000abc' },
+        });
+        // App later turns anonymous users off while the user still carries anonymous authData
+        await reconfigureServer({ enableAnonymousUsers: false });
+        // afterFind runs over each provider on _User reads; 'anonymous' must be skipped, not crash
+        const results = await new Parse.Query(Parse.User).find({ useMasterKey: true });
+        expect(results.length).toBe(1);
+        expect(results[0].id).toBe(user.id);
+      });
     });
   });
 

--- a/src/Adapters/Auth/index.js
+++ b/src/Adapters/Auth/index.js
@@ -213,7 +213,10 @@ module.exports = function (authOptions = {}, enableAnonymousUsers = true) {
   // To handle the test cases on configuration
   const getValidatorForProvider = function (provider) {
     if (provider === 'anonymous' && !_enableAnonymousUsers) {
-      return { validator: undefined };
+      // Return undefined (not a partial object) so every consumer's `if (!authAdapter)` guard
+      // fires, rather than passing a shape with no `adapter` key that crashes runAfterFind /
+      // handleChallenge when they read `adapter.afterFind` / destructure `adapter` (#8681).
+      return;
     }
     const authAdapter = loadAuthAdapter(provider, authOptions);
     if (!authAdapter) { return; }


### PR DESCRIPTION
Closes #8681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when anonymous user support is turned off after an anonymous account already exists.
  * Queries against user records now return results reliably instead of failing in this edge case.
  * Added coverage for this anonymous-user reconfiguration scenario to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->