### PR TITLE
fix: Server crash on unhandled rejection when an email adapter fails to send

### DIFF
--- a/spec/UserController.spec.js
+++ b/spec/UserController.spec.js
@@ -81,4 +81,57 @@ describe('UserController', () => {
       });
     });
   });
+
+  describe('email adapter send rejection (#8496)', () => {
+    it('logs and does not crash when the verification email adapter rejects', async () => {
+      const logged = resolvingPromise();
+      const adapter = {
+        sendVerificationEmail: () => Promise.reject(new Error('boom')),
+        sendPasswordResetEmail: () => Promise.resolve(),
+        sendMail: () => Promise.resolve(),
+      };
+      await reconfigureServer({
+        verifyUserEmails: true,
+        emailAdapter: adapter,
+        appName: 'test',
+        publicServerURL: 'http://localhost:8378/1',
+      });
+      spyOn(require('../lib/logger').logger, 'error').and.callFake(msg => logged.resolve(msg));
+
+      const user = new Parse.User();
+      user.setUsername('u8496a');
+      user.setPassword('pass');
+      user.setEmail('u8496a@example.com');
+      await user.signUp();
+
+      const msg = await logged;
+      expect(msg).toContain('Failed to send verification email');
+    });
+
+    it('logs and does not crash when the password reset email adapter rejects', async () => {
+      const logged = resolvingPromise();
+      const adapter = {
+        sendVerificationEmail: () => Promise.resolve(),
+        sendPasswordResetEmail: () => Promise.reject(new Error('boom')),
+        sendMail: () => Promise.resolve(),
+      };
+      await reconfigureServer({
+        appName: 'test',
+        emailAdapter: adapter,
+        publicServerURL: 'http://localhost:8378/1',
+      });
+
+      const user = new Parse.User();
+      user.setUsername('u8496b');
+      user.setPassword('pass');
+      user.setEmail('u8496b@example.com');
+      await user.signUp();
+
+      spyOn(require('../lib/logger').logger, 'error').and.callFake(msg => logged.resolve(msg));
+      await Parse.User.requestPasswordReset('u8496b@example.com');
+
+      const msg = await logged;
+      expect(msg).toContain('Failed to send password reset email');
+    });
+  });
 });

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -6,6 +6,7 @@ import rest from '../rest';
 import Parse from 'parse/node';
 import AccountLockout from '../AccountLockout';
 import Config from '../Config';
+import logger from '../logger';
 
 var RestQuery = require('../RestQuery');
 var Auth = require('../Auth');
@@ -177,11 +178,16 @@ export class UserController extends AdaptableController {
       link: link,
       user: inflate('_User', fetchedUser),
     };
-    if (this.adapter.sendVerificationEmail) {
-      this.adapter.sendVerificationEmail(options);
-    } else {
-      this.adapter.sendMail(this.defaultVerificationEmail(options));
-    }
+    // Dispatch detached so the request does not block on email delivery, but attach a
+    // catch so a rejected send (e.g. bad SMTP config, throwing apiCallback) is logged
+    // instead of crashing the process with an unhandled rejection (#8496).
+    Promise.resolve()
+      .then(() =>
+        this.adapter.sendVerificationEmail
+          ? this.adapter.sendVerificationEmail(options)
+          : this.adapter.sendMail(this.defaultVerificationEmail(options))
+      )
+      .catch(e => logger.error(`Failed to send verification email: ${e?.message || e}`, { error: e }));
   }
 
   /**
@@ -289,11 +295,15 @@ export class UserController extends AdaptableController {
       user: inflate('_User', user),
     };
 
-    if (this.adapter.sendPasswordResetEmail) {
-      this.adapter.sendPasswordResetEmail(options);
-    } else {
-      this.adapter.sendMail(this.defaultResetPasswordEmail(options));
-    }
+    // Dispatch detached (see sendVerificationEmail) so a rejected send is logged rather
+    // than crashing the process with an unhandled rejection (#8496).
+    Promise.resolve()
+      .then(() =>
+        this.adapter.sendPasswordResetEmail
+          ? this.adapter.sendPasswordResetEmail(options)
+          : this.adapter.sendMail(this.defaultResetPasswordEmail(options))
+      )
+      .catch(e => logger.error(`Failed to send password reset email: ${e?.message || e}`, { error: e }));
 
     return Promise.resolve(user);
   }


### PR DESCRIPTION
Closes #8496

Also noting: the method-level fire-and-forget callers (`RestWrite.js`, `UsersRouter.js`, and `resendVerificationEmail`) could still surface a rejection from a pre-send step like `getUserIfNeeded`. That's a separate pre-existing pattern so i've kept this PR scoped to the email-send crash the issue actually reports - happy to do a follow-up for the broader pattern if we want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of verification and password-reset email delivery.
  * Email delivery failures are now logged clearly without crashing the application.
  * Prevented unhandled errors when email services reject requests or encounter configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->