### PR TITLE
fix: A null Date field is returned as epoch (1970) instead of null

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -429,6 +429,20 @@ describe('parseObjectToMongoObjectForCreate', () => {
     done();
   });
 
+  it('untransforms a null expiresAt to null, not epoch (#7576)', () => {
+    const output = transform.mongoObjectToParseObject('Document', { expiresAt: null }, {
+      fields: { expiresAt: { type: 'Date' } },
+    });
+    expect(output.expiresAt).toBeNull();
+  });
+
+  it('untransforms a null lastUsed to null, not epoch (#7576)', () => {
+    const output = transform.mongoObjectToParseObject('Document', { lastUsed: null }, {
+      fields: { lastUsed: { type: 'Date' } },
+    });
+    expect(output.lastUsed).toBeNull();
+  });
+
   it('object with undefined nested values', () => {
     const input = {
       _id: 'vQHyinCW1l',

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -1179,11 +1179,14 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
             break;
           case 'expiresAt':
           case '_expiresAt':
-            restObject['expiresAt'] = Parse._encode(new Date(mongoObject[key]));
+            // A cleared date is stored as null; keep it null instead of coercing to epoch (#7576)
+            restObject['expiresAt'] =
+              mongoObject[key] === null ? null : Parse._encode(new Date(mongoObject[key]));
             break;
           case 'lastUsed':
           case '_last_used':
-            restObject['lastUsed'] = Parse._encode(new Date(mongoObject[key])).iso;
+            restObject['lastUsed'] =
+              mongoObject[key] === null ? null : Parse._encode(new Date(mongoObject[key])).iso;
             break;
           case 'timesUsed':
           case 'times_used':


### PR DESCRIPTION
Closes #7576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mongo-to-Parse conversion so cleared `expiresAt` and `lastUsed` values stay `null` instead of being turned into a date value.
  * Ensured existing date values continue to be converted correctly.
* **Tests**
  * Added coverage for `null` handling on `expiresAt` and `lastUsed` to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->