### PR TITLE
fix: Cloud function specific rate limit is ignored when cloud code is loaded at startup

### DIFF
--- a/spec/RateLimit.spec.js
+++ b/spec/RateLimit.spec.js
@@ -86,6 +86,26 @@ describe('rate limit', () => {
     );
   });
 
+  it('can limit cloud function with per-function rateLimit defined in cloud code loaded at startup (#8684)', async () => {
+    await reconfigureServer({
+      cloud: Parse => {
+        Parse.Cloud.define('test8684', () => 'Abc', {
+          rateLimit: {
+            requestTimeWindow: 10000,
+            requestCount: 1,
+            errorResponseMessage: 'Too many requests',
+            includeInternalRequests: true,
+          },
+        });
+      },
+    });
+    const response1 = await Parse.Cloud.run('test8684');
+    expect(response1).toBe('Abc');
+    await expectAsync(Parse.Cloud.run('test8684')).toBeRejectedWith(
+      new Parse.Error(Parse.Error.CONNECTION_FAILED, 'Too many requests')
+    );
+  });
+
   it('can skip with masterKey', async () => {
     Parse.Cloud.define('test', () => 'Abc');
     await reconfigureServer({

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -664,7 +664,7 @@ export function promiseEnforceMasterKeyAccess(request) {
 
 export const addRateLimit = (route, config, cloud) => {
   if (typeof config === 'string') {
-    config = Config.get(config);
+    config = AppCache.get(config);
   }
   for (const key in route) {
     if (!RateLimitOptions[key]) {


### PR DESCRIPTION
Closes #8684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rate limits configured for individual Cloud Functions to be correctly applied when defined in server-side cloud code.
  * Improved loading of rate-limit configuration to ensure the intended settings are used.
  * Requests exceeding a configured function-specific limit now return the expected connection failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->