### PR TITLE
fix: GraphQL classes query passes a boolean instead of options to getAllClasses

### DIFF
--- a/spec/ParseGraphQLServer.spec.js
+++ b/spec/ParseGraphQLServer.spec.js
@@ -3402,6 +3402,27 @@ describe('ParseGraphQLServer', () => {
       });
 
       describe('Class Schema Mutations', () => {
+        it('classes query passes an options object (not a boolean) to getAllClasses (#7677)', async () => {
+          const { SchemaController } = require('../lib/Controllers/SchemaController');
+          const spy = spyOn(SchemaController.prototype, 'getAllClasses').and.callThrough();
+          await apolloClient.query({
+            query: gql`
+              query {
+                classes {
+                  name
+                }
+              }
+            `,
+            context: {
+              headers: {
+                'X-Parse-Master-Key': 'test',
+              },
+            },
+          });
+          expect(spy).toHaveBeenCalled();
+          expect(spy).not.toHaveBeenCalledWith(true);
+        });
+
         it('should create a new class', async () => {
           try {
             const result = await apolloClient.mutate({

--- a/src/GraphQL/loaders/schemaQueries.js
+++ b/src/GraphQL/loaders/schemaQueries.js
@@ -60,7 +60,7 @@ const load = parseGraphQLSchema => {
           enforceMasterKeyAccess(auth, config);
 
           const schema = await config.database.loadSchema({ clearCache: true });
-          return (await schema.getAllClasses(true)).map(parseClass => ({
+          return (await schema.getAllClasses({ clearCache: true })).map(parseClass => ({
             name: parseClass.className,
             schemaFields: transformToGraphQL(parseClass.fields),
           }));


### PR DESCRIPTION
Closes #7677

The GraphQL `classes` query resolver called `getAllClasses(true)` - a bare boolean - but the method expects a `{ clearCache }` options object, so `true.clearCache` is `undefined` (falsy) and the cache clear silently no-ops. The sibling REST path in `SchemasRouter.getAllSchemas` already does it right with `{ clearCache: true }`, so this just matches it.

Heads up on the test: the line right above already calls `loadSchema({ clearCache: true })`, which refreshes the schema cache, so the query response is actually identical either way in the normal single-request path (the two only diverge under a concurrent in-flight schema load). A black-box assertion can't tell fixed from unfixed here, so the regression test asserts the resolver passes the correct argument type (`not.toHaveBeenCalledWith(true)`) - that's the reliable guard for a wrong-type bug. Verified it fails without the fix and passes with it, on both Mongo and Postgres.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the GraphQL `classes` query’s cache-refresh handling.
  * Preserved master-key access controls and existing error handling while returning class names and schema fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->