### PR TITLE
docs: Clarify that maxUploadSize limits the request body size, not the file size

### DIFF
--- a/src/Options/Definitions.js
+++ b/src/Options/Definitions.js
@@ -416,7 +416,7 @@ module.exports.ParseServerOptions = {
   },
   maxUploadSize: {
     env: 'PARSE_SERVER_MAX_UPLOAD_SIZE',
-    help: 'Max file size for uploads, defaults to 20mb',
+    help: 'The maximum size of the HTTP request body for file uploads, for example `20mb`. This limits the request body size, not the file size: the encoded upload is larger than the file itself, so set this higher than your largest intended file to allow for encoding overhead. Files sent as base64 (for example via the JavaScript SDK) inflate the payload by roughly 33%, and multipart uploads add boundary and header overhead. Defaults to `20mb`.',
     default: '20mb',
   },
   middleware: {

--- a/src/Options/docs.js
+++ b/src/Options/docs.js
@@ -78,7 +78,7 @@
  * @property {Number} masterKeyTtl (Optional) The duration in seconds for which the current `masterKey` is being used before it is requested again if `masterKey` is set to a function. If `masterKey` is not set to a function, this option has no effect. Default is `0`, which means the master key is requested by invoking the  `masterKey` function every time the master key is used internally by Parse Server.
  * @property {Number} maxLimit Max value for limit option on queries, defaults to unlimited
  * @property {Number|String} maxLogFiles Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null)
- * @property {String} maxUploadSize Max file size for uploads, defaults to 20mb
+ * @property {String} maxUploadSize The maximum size of the HTTP request body for file uploads, for example `20mb`. This limits the request body size, not the file size: the encoded upload is larger than the file itself, so set this higher than your largest intended file to allow for encoding overhead. Files sent as base64 (for example via the JavaScript SDK) inflate the payload by roughly 33%, and multipart uploads add boundary and header overhead. Defaults to `20mb`.
  * @property {Union} middleware middleware for express server, can be string or function
  * @property {Boolean} mountGraphQL Mounts the GraphQL endpoint
  * @property {String} mountPath Mount path for the server, defaults to /parse

--- a/src/Options/index.js
+++ b/src/Options/index.js
@@ -208,7 +208,7 @@ export interface ParseServerOptions {
   :ENV: PARSE_SERVER_ENABLE_INSECURE_AUTH_ADAPTERS
   :DEFAULT: false */
   enableInsecureAuthAdapters: ?boolean;
-  /* Max file size for uploads, defaults to 20mb
+  /* The maximum size of the HTTP request body for file uploads, for example `20mb`. This limits the request body size, not the file size: the encoded upload is larger than the file itself, so set this higher than your largest intended file to allow for encoding overhead. Files sent as base64 (for example via the JavaScript SDK) inflate the payload by roughly 33%, and multipart uploads add boundary and header overhead. Defaults to `20mb`.
   :DEFAULT: 20mb */
   maxUploadSize: ?string;
   /* Set to `true` to require users to verify their email address to complete the sign-up process. Supports a function with a return value of `true` or `false` for conditional verification. The function receives a request object that includes `createdWith` to indicate whether the invocation is for `signup` or `login` and the used auth provider.


### PR DESCRIPTION
Closes #8224

`maxUploadSize` limits the HTTP request body size, not the file size - but the docs just said "Max file size for uploads", which is misleading. The request body is larger than the file itself, so a file well under the limit can still be rejected with "request entity too large" (the reporter's 9.2mb file produced a 12.25mb request body, ~33% over).

This updates the option docs to explain that the limit applies to the request body and should be set higher than the largest intended file to allow for encoding overhead (base64 inflates by ~33%, multipart adds framing). Docs-only - regenerated `Definitions.js` and `docs.js` from `index.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `maxUploadSize` limits the total HTTP request body size, not the raw file size.
  * Added guidance on additional payload overhead from base64 and multipart uploads.
  * Confirmed the default limit remains `20mb`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->