### PR TITLE
fix: Bump ws from 8.20.0 to 8.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "tv4": "1.3.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "5.0.0",
-        "ws": "8.20.0"
+        "ws": "8.21.0"
       },
       "bin": {
         "parse-server": "bin/parse-server"
@@ -20403,6 +20403,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -26714,9 +26735,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -40858,6 +40879,14 @@
         "idb-keyval": "6.2.2",
         "react-native-crypto-js": "1.0.0",
         "ws": "8.20.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+          "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+          "requires": {}
+        }
       }
     },
     "parse-json": {
@@ -45171,9 +45200,9 @@
       }
     },
     "ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "requires": {}
     },
     "xml-naming": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tv4": "1.3.0",
     "winston": "3.19.0",
     "winston-daily-rotate-file": "5.0.0",
-    "ws": "8.20.0"
+    "ws": "8.21.0"
   },
   "devDependencies": {
     "@actions/core": "3.0.0",


### PR DESCRIPTION
Closes #10509

Replaces the Dependabot PR with a `fix:` release-triggering security update. `ws` is a direct production dependency.

### Changes

- Bumps `ws` from 8.20.0 to 8.21.0.
- Resolves ws advisory GHSA-96hv-2xvq-fx4p (HIGH) — memory-exhaustion DoS.
- Resolves ws advisory GHSA-58qx-3vcg-4xpx (MEDIUM) — uninitialized memory disclosure.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement (manifest + lock file only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WebSocket library to a newer version.
  * Refreshed dependency metadata to keep installations consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->