### PR TITLE
test: Add _Installation non-master access control regression tests

### DIFF
--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -1298,6 +1298,82 @@ describe('Installations', () => {
   // TODO: Do we need to support _tombstone disabling of installations?
   // TODO: Test deletion, badge increments
 
+  describe('access control for non-master clients', () => {
+    const anonymousHeaders = {
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+    };
+
+    it('blocks the find operation for an unauthenticated client', async () => {
+      await rest.create(config, auth.nobody(config), '_Installation', {
+        installationId: '12345678-abcd-abcd-abcd-123456789abc',
+        deviceType: 'android',
+      });
+      let error;
+      try {
+        await request({
+          method: 'GET',
+          headers: anonymousHeaders,
+          url: 'http://localhost:8378/1/installations',
+        });
+        fail('find should have been rejected');
+      } catch (e) {
+        error = e;
+      }
+      expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
+      expect(error.data.error).toBe('Permission denied');
+    });
+
+    it('blocks the delete operation for an unauthenticated client', async () => {
+      const created = await rest.create(config, auth.nobody(config), '_Installation', {
+        installationId: '12345678-abcd-abcd-abcd-123456789abc',
+        deviceType: 'android',
+      });
+      let error;
+      try {
+        await request({
+          method: 'DELETE',
+          headers: anonymousHeaders,
+          url: 'http://localhost:8378/1/installations/' + created.response.objectId,
+        });
+        fail('delete should have been rejected');
+      } catch (e) {
+        error = e;
+      }
+      expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
+      expect(error.data.error).toBe('Permission denied');
+      // The row is still present: the anonymous delete did not take effect.
+      const remaining = await new Parse.Query(Parse.Installation).count({ useMasterKey: true });
+      expect(remaining).toBe(1);
+    });
+
+    it('blocks the find operation for an authenticated non-master user', async () => {
+      // Even a logged-in user cannot enumerate installations, so another
+      // device's objectId cannot be discovered through an authenticated session.
+      const user = await Parse.User.signUp('installation-acl-user', 'pass-12345678');
+      await rest.create(config, auth.nobody(config), '_Installation', {
+        installationId: '12345678-abcd-abcd-abcd-123456789abc',
+        deviceType: 'android',
+      });
+      let error;
+      try {
+        await request({
+          method: 'GET',
+          headers: {
+            ...anonymousHeaders,
+            'X-Parse-Session-Token': user.getSessionToken(),
+          },
+          url: 'http://localhost:8378/1/installations',
+        });
+        fail('find should have been rejected');
+      } catch (e) {
+        error = e;
+      }
+      expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
+      expect(error.data.error).toBe('Permission denied');
+    });
+  });
+
   describe('deviceToken deduplication on new install (no installationId match)', () => {
     const { randomUUID } = require('crypto');
     const installationSchema = {

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -1345,8 +1345,8 @@ describe('Installations', () => {
       expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
       expect(error.data.error).toBe('Permission denied');
       // The row is still present: the anonymous delete did not take effect.
-      const remaining = await new Parse.Query(Parse.Installation).count({ useMasterKey: true });
-      expect(remaining).toBe(1);
+      const remaining = await database.adapter.find('_Installation', installationSchema, {}, {});
+      expect(remaining.length).toBe(1);
     });
 
     it('blocks the find operation for an authenticated non-master user', async () => {
@@ -1400,8 +1400,8 @@ describe('Installations', () => {
       expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
       expect(error.data.error).toBe('Permission denied');
       // The row is still present: the authenticated non-master delete did not take effect.
-      const remaining = await new Parse.Query(Parse.Installation).count({ useMasterKey: true });
-      expect(remaining).toBe(1);
+      const remaining = await database.adapter.find('_Installation', installationSchema, {}, {});
+      expect(remaining.length).toBe(1);
     });
   });
 

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -1317,6 +1317,7 @@ describe('Installations', () => {
           url: 'http://localhost:8378/1/installations',
         });
         fail('find should have been rejected');
+        return;
       } catch (e) {
         error = e;
       }
@@ -1337,6 +1338,7 @@ describe('Installations', () => {
           url: 'http://localhost:8378/1/installations/' + created.response.objectId,
         });
         fail('delete should have been rejected');
+        return;
       } catch (e) {
         error = e;
       }
@@ -1366,11 +1368,40 @@ describe('Installations', () => {
           url: 'http://localhost:8378/1/installations',
         });
         fail('find should have been rejected');
+        return;
       } catch (e) {
         error = e;
       }
       expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
       expect(error.data.error).toBe('Permission denied');
+    });
+
+    it('blocks the delete operation for an authenticated non-master user', async () => {
+      const user = await Parse.User.signUp('installation-acl-user', 'pass-12345678');
+      const created = await rest.create(config, auth.nobody(config), '_Installation', {
+        installationId: '12345678-abcd-abcd-abcd-123456789abc',
+        deviceType: 'android',
+      });
+      let error;
+      try {
+        await request({
+          method: 'DELETE',
+          headers: {
+            ...anonymousHeaders,
+            'X-Parse-Session-Token': user.getSessionToken(),
+          },
+          url: 'http://localhost:8378/1/installations/' + created.response.objectId,
+        });
+        fail('delete should have been rejected');
+        return;
+      } catch (e) {
+        error = e;
+      }
+      expect(error.data.code).toBe(Parse.Error.OPERATION_FORBIDDEN);
+      expect(error.data.error).toBe('Permission denied');
+      // The row is still present: the authenticated non-master delete did not take effect.
+      const remaining = await new Parse.Query(Parse.Installation).count({ useMasterKey: true });
+      expect(remaining).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Issue

The `_Installation` access-control contract for non-master clients was only partially covered by tests. `enforceRoleSecurity` (`src/SharedRest.js`) blocks the `find` and `delete` operations on `_Installation` for non-master/non-maintenance callers, while intentionally allowing `create`, `update`, and `get` to fall through (push registration happens before a user logs in). There was no explicit regression coverage for the `delete` block, nor for the fact that `find` is blocked for authenticated non-master users, not just anonymous ones.

## Approach

Add a `describe('access control for non-master clients')` block in `spec/ParseInstallation.spec.js` that locks in the contract:

- `find` is rejected for an unauthenticated client and for an authenticated non-master user, so installations cannot be enumerated and a row's identifier cannot be discovered.
- `delete` is rejected for an unauthenticated client and for an authenticated non-master user, and the row is verified to survive via an exact adapter `find` (which avoids Postgres estimated-count behavior).

The by-design `get`/`update` of one's own installation remains covered by the existing `#1718` and `#2090` tests referenced in the block.

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add security check
- [ ] Add new Parse Error codes to Parse JS SDK
