### PR TITLE
refactor: Bump cross-env from 7.0.3 to 10.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "all-node-versions": "13.0.1",
         "apollo-upload-client": "18.0.1",
         "clean-jsdoc-theme": "4.3.0",
-        "cross-env": "7.0.3",
+        "cross-env": "10.1.0",
         "deep-diff": "1.0.2",
         "eslint": "9.27.0",
         "eslint-plugin-expect-type": "0.6.2",
@@ -2260,6 +2260,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -10766,22 +10773,21 @@
       }
     },
     "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       },
       "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": ">=20"
       }
     },
     "node_modules/cross-inspect": {
@@ -28389,6 +28395,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -34214,12 +34226,13 @@
       }
     },
     "cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       }
     },
     "cross-inspect": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "all-node-versions": "13.0.1",
     "apollo-upload-client": "18.0.1",
     "clean-jsdoc-theme": "4.3.0",
-    "cross-env": "7.0.3",
+    "cross-env": "10.1.0",
     "deep-diff": "1.0.2",
     "eslint": "9.27.0",
     "eslint-plugin-expect-type": "0.6.2",


### PR DESCRIPTION
Closes #10435

Replaces the Dependabot PR with a manually verified upgrade of the `cross-env` devDependency, pinned to an exact version.

### Changes

`cross-env` is a direct **devDependency** only (used in `npm test`, coverage, and benchmark scripts). This is a 3-major jump (`7.x` → `10.x`); the intermediate majors were reviewed:

- **8.0.0**: Dropped support for old Node.js versions; raised the Node engine floor.
- **9.0.0**: Continued Node engine floor increase; internal packaging changes (ships compiled output from `dist/`).
- **10.0.0**: Node engine floor set to `>=20`. Added `@epic-web/invariant` as a runtime dependency and bumped the `cross-spawn` requirement to `^7.0.6`.
- **10.1.0**: Latest patch/minor on the `10.x` line.

The CLI surface (`cross-env` / `cross-env-shell`) is unchanged, so the existing npm scripts work without modification.

### Breaking Changes

None affecting this repo. The only breaking change across `v8`/`v9`/`v10` is the Node.js engine floor, now `>=20`. This repository already requires `>=20.19.0` via `engines.node`, so the requirement is satisfied.

### Code Changes Required

None. The upgrade is a drop-in replacement; no source or script changes are needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling package `cross-env` to version 10.1.0.
  * Updated the lockfile to reflect the refreshed package metadata and dependencies.
  * The updated tooling now requires Node.js 20 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->