### PR TITLE
fix: Creating a session can delete another user's session

### DIFF
--- a/spec/ParseSession.spec.js
+++ b/spec/ParseSession.spec.js
@@ -257,6 +257,71 @@ describe('Parse.Session', () => {
     expect(newSession.createdWith.authProvider).toBeUndefined();
   });
 
+  it('does not delete another user\'s session when creating a session via POST /classes/_Session', async () => {
+    const victim = await Parse.User.signUp('dedupvictim', 'password');
+    const attacker = await Parse.User.signUp('dedupattacker', 'password');
+    const victimId = victim.id;
+    const installationId = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+
+    // Victim logs in on a known installation, creating a session with that installationId.
+    const victimLogin = await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/login',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Installation-Id': installationId,
+        'Content-Type': 'application/json',
+      },
+      body: { username: 'dedupvictim', password: 'password' },
+    });
+    const victimSessionToken = victimLogin.data.sessionToken;
+
+    // Another user creates a session while naming the victim as `user` and supplying
+    // the victim's installationId. The session dedup must not delete the victim's session.
+    await request({
+      method: 'POST',
+      url: 'http://localhost:8378/1/classes/_Session',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': attacker.getSessionToken(),
+        'Content-Type': 'application/json',
+      },
+      body: {
+        user: { __type: 'Pointer', className: '_User', objectId: victimId },
+        installationId,
+        sessionToken: 'r:someothertoken',
+      },
+    });
+
+    // The victim's session on that installation must still exist...
+    const sessions = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/classes/_Session',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Master-Key': 'test',
+      },
+    });
+    const victimSession = sessions.data.results.find(
+      s => s.installationId === installationId && s.user && s.user.objectId === victimId
+    );
+    expect(victimSession).toBeDefined();
+
+    // ...and the victim's session token must still authenticate.
+    const meResponse = await request({
+      method: 'GET',
+      url: 'http://localhost:8378/1/users/me',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest',
+        'X-Parse-Session-Token': victimSessionToken,
+      },
+    });
+    expect(meResponse.data.objectId).toBe(victimId);
+  });
+
   it('should reject expiresAt when updating a session via PUT', async () => {
     const user = await Parse.User.signUp('sessionupdateuser1', 'password');
     const sessionToken = user.getSessionToken();

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1151,6 +1151,14 @@ RestWrite.prototype.deleteEmailResetTokenIfNeeded = function () {
 };
 
 RestWrite.prototype.destroyDuplicatedSessions = function () {
+  // Skip if the response is already set, matching the other write-pipeline steps
+  // (runDatabaseOperation, runAfterSaveTrigger). A non-master POST /classes/_Session
+  // create has handleSession() set this.response before this runs, so this guard
+  // prevents the dedup delete from acting on the client-supplied `user`/`installationId`
+  // rather than on the server-generated session data.
+  if (this.response) {
+    return;
+  }
   // Only for _Session, and at creation time
   if (this.className != '_Session' || this.query) {
     return;


### PR DESCRIPTION
## Issue

`RestWrite.destroyDuplicatedSessions()` runs the `_Session` deduplication delete without the `if (this.response) return;` guard that the other write-pipeline steps (`runDatabaseOperation`, `runAfterSaveTrigger`) use. On a non-master `POST /classes/_Session` create, `handleSession()` has already created the caller's own session and set `this.response`, but the dedup then issues a master-privileged delete keyed on the client-supplied `user` and `installationId` from the request body instead of the server-generated session data. As a result, creating a session can delete another user's `_Session` record for the supplied `installationId`.

## Tasks

- [x] Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling to prevent valid user sessions from being deleted during duplicate-session cleanup.
  * Preserved existing session authentication when a new session is created with a matching installation identifier.
  * Added safeguards against unintended session changes after an earlier response has been generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->