### PR TITLE
refactor: Bump @semantic-release/release-notes-generator from 14.1.0 to 14.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "12.0.6",
         "@semantic-release/npm": "13.0.0",
-        "@semantic-release/release-notes-generator": "14.1.0",
+        "@semantic-release/release-notes-generator": "14.1.1",
         "all-node-versions": "13.0.1",
         "apollo-upload-client": "18.0.1",
         "clean-jsdoc-theme": "4.3.0",
@@ -7764,19 +7764,18 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.0.tgz",
-      "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+      "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^7.0.0",
         "import-from-esm": "^2.0.0",
-        "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
       },
@@ -7785,18 +7784,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-      "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/import-from-esm": {
@@ -32176,9 +32163,9 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.0.tgz",
-      "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+      "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^8.0.0",
@@ -32186,19 +32173,11 @@
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^7.0.0",
         "import-from-esm": "^2.0.0",
-        "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-          "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
-          "dev": true
-        },
         "import-from-esm": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "12.0.6",
     "@semantic-release/npm": "13.0.0",
-    "@semantic-release/release-notes-generator": "14.1.0",
+    "@semantic-release/release-notes-generator": "14.1.1",
     "all-node-versions": "13.0.1",
     "apollo-upload-client": "18.0.1",
     "clean-jsdoc-theme": "4.3.0",


### PR DESCRIPTION
Closes #10585

Replacement PR for the Dependabot bump of `@semantic-release/release-notes-generator` (direct devDependency) from `14.1.0` to `14.1.1`.

### Changes
- Bumps `@semantic-release/release-notes-generator` from `14.1.0` to `14.1.1` (patch).
- Upstream changelog: `fix(deps): update dependency get-stream to v9` ([v14.1.0...v14.1.1](https://github.com/semantic-release/release-notes-generator/compare/v14.1.0...v14.1.1)). The published `14.1.1` no longer declares `get-stream`/`into-stream` as direct dependencies, so the lockfile drops the previously-nested `get-stream@7.0.1`; the change is fully scoped to this package.

### Breaking Changes
- None. Patch release; dev-only release-tooling dependency (used by `semantic-release`), no impact on project runtime code.

### Code Changes Required
- None. Only `package.json` and `package-lock.json` changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release notes generation tooling to version 14.1.1.
  * Refreshed locked dependency metadata to ensure consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->