### PR TITLE
refactor: Bump @actions/core from 3.0.0 to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "parse-server": "bin/parse-server"
       },
       "devDependencies": {
-        "@actions/core": "3.0.0",
+        "@actions/core": "3.0.1",
         "@apollo/client": "3.13.8",
         "@babel/cli": "7.28.6",
         "@babel/core": "7.29.7",
@@ -114,10 +114,11 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@actions/exec": "^3.0.0",
         "@actions/http-client": "^4.0.0"
@@ -27291,9 +27292,9 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
       "dev": true,
       "requires": {
         "@actions/exec": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ws": "8.21.0"
   },
   "devDependencies": {
-    "@actions/core": "3.0.0",
+    "@actions/core": "3.0.1",
     "@apollo/client": "3.13.8",
     "@babel/cli": "7.28.6",
     "@babel/core": "7.29.7",


### PR DESCRIPTION
Closes #10590

## Summary
Bumps the direct devDependency `@actions/core` from 3.0.0 to 3.0.1 (patch release).

## Changes
- `package.json`: `@actions/core` `3.0.0` -> `3.0.1` (pinned, exact)
- `package-lock.json`: regenerated for the `@actions/core` subtree only; `lockfileVersion` preserved at 2

## Notes
Replacement for the Dependabot PR #10590. Patch-level update, no API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions core package to version 3.0.1.
  * Refreshed the associated package metadata and integrity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->