### PR TITLE
ci: Skip CI checks for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [release, alpha, beta, next-major, 'release-[0-9]+.x.x']
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
     paths-ignore:
@@ -15,6 +16,7 @@ permissions:
 jobs:
   check-code-analysis:
     name: Code Analysis
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -36,6 +38,7 @@ jobs:
         uses: github/codeql-action/analyze@v2
   check-ci:
     name: Node Engine Check
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +55,7 @@ jobs:
         run: npm run ci:checkNodeEngine
   check-lint:
     name: Lint
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +76,7 @@ jobs:
       - run: npm run lint
   check-definitions:
     name: Check Definitions
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +98,7 @@ jobs:
         run: npm run ci:definitionsCheck
   check-circular:
     name: Circular Dependencies
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -113,6 +119,7 @@ jobs:
       - run: npm run madge:circular
   check-docs:
     name: Docs
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -136,6 +143,7 @@ jobs:
         run: npm run docs
   check-docker:
     name: Docker Build
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -153,6 +161,7 @@ jobs:
           platforms: linux/amd64, linux/arm64/v8
   check-lock-file-version:
     name: NPM Lock File Version
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -166,6 +175,7 @@ jobs:
           fi
   check-types:
     name: Check Types
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -206,6 +216,7 @@ jobs:
             NODE_VERSION: 22.12.0
       fail-fast: false
     name: ${{ matrix.name }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 20
     runs-on: ubuntu-latest
     services:
@@ -260,6 +271,7 @@ jobs:
             NODE_VERSION: 24.11.0
       fail-fast: false
     name: ${{ matrix.name }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 20
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Draft pull requests currently trigger the full CI workflow, spending Actions minutes on work that isn't ready for review. This follows the approach discussed in https://github.com/orgs/community/discussions/120231.

## Approach

- Add `if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}` to every job. Draft PRs skip all jobs; pushes to the protected branches and non-draft PRs run as before. The `github.event_name != 'pull_request'` clause guards `push` runs, since the `draft` field doesn't exist for push events.
- Add `ready_for_review` to the `pull_request` trigger `types`. Without it, marking a draft as ready fires an event type the workflow doesn't listen for by default, so CI wouldn't run until the next push. The default types (`opened`, `synchronize`, `reopened`) are re-listed because specifying `types` replaces the default set rather than extending it.

Behavior:

| Event | Result |
| --- | --- |
| Push to `release` / `alpha` / `beta` / ... | Runs |
| Open or update a **draft** PR | All jobs skipped |
| Open or update a **ready** (non-draft) PR | Runs |
| Mark a draft PR **ready for review** | Runs |

Note: GitHub does not bill for skipped jobs, so draft PRs incur no Actions charges.

## Tasks

<!-- CI configuration change only; the standard tasks below do not apply. -->
