### PR TITLE
fix: Saving a role clears the entire cache instead of only the cached roles

### DIFF
--- a/spec/CacheController.spec.js
+++ b/spec/CacheController.spec.js
@@ -58,6 +58,39 @@ describe('CacheController', function () {
     expect(FakeCacheAdapter.clear.calls.count()).toEqual(3);
   });
 
+  it('should scope clear to the app', () => {
+    const cache = new CacheController(FakeCacheAdapter, FakeAppID);
+
+    cache.clear();
+    expect(FakeCacheAdapter.clear.calls.first().args[0]).toEqual(FakeAppID);
+  });
+
+  ['role', 'user', 'graphQL'].forEach(cacheName => {
+    it('should scope clear of the ' + cacheName + ' cache to its prefix', () => {
+      const cache = new CacheController(FakeCacheAdapter, FakeAppID);
+
+      cache[cacheName].clear();
+      expect(FakeCacheAdapter.clear.calls.first().args[0]).toEqual(
+        [FakeAppID, cacheName].join(':')
+      );
+    });
+  });
+
+  it('should not evict cached users when a _Role is saved', async () => {
+    const cacheController = Parse.Server.cacheController;
+    await cacheController.user.put('r:someSessionToken', { objectId: 'someUser' });
+    await cacheController.role.put('someUser', ['role:Admin']);
+
+    await new Parse.Role('Admin', new Parse.ACL()).save(null, { useMasterKey: true });
+    // The role cache is cleared without being awaited by RestWrite.
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    expect(await cacheController.role.get('someUser')).toEqual(null);
+    expect(await cacheController.user.get('r:someSessionToken')).toEqual({
+      objectId: 'someUser',
+    });
+  });
+
   it('should handle cache rejections', done => {
     FakeCacheAdapter.get = () => Promise.reject();
 

--- a/spec/InMemoryCacheAdapter.spec.js
+++ b/spec/InMemoryCacheAdapter.spec.js
@@ -36,6 +36,20 @@ describe('InMemoryCacheAdapter', function () {
       .then(done);
   });
 
+  it('should only clear the given prefix', async () => {
+    const cache = new InMemoryCacheAdapter({ ttl: NaN });
+
+    await cache.put('myAppId:role:someUser', VALUE);
+    await cache.put('myAppId:user:someToken', VALUE);
+    await cache.put('otherAppId:role:someUser', VALUE);
+
+    await cache.clear('myAppId:role');
+
+    expect(await cache.get('myAppId:role:someUser')).toEqual(null);
+    expect(await cache.get('myAppId:user:someToken')).toEqual(VALUE);
+    expect(await cache.get('otherAppId:role:someUser')).toEqual(VALUE);
+  });
+
   it('should expire after ttl', done => {
     const cache = new InMemoryCacheAdapter({
       ttl: 10,

--- a/spec/RedisCacheAdapter.spec.js
+++ b/spec/RedisCacheAdapter.spec.js
@@ -37,6 +37,42 @@ describe_only(() => {
     await cacheNaN.clear();
   });
 
+  it('should only clear the given prefix', async () => {
+    const scoped = new RedisCacheAdapter(null, 5000);
+    await scoped.connect();
+
+    await scoped.put('myAppId:role:someUser', VALUE);
+    await scoped.put('myAppId:user:someToken', VALUE);
+    await scoped.put('otherAppId:role:someUser', VALUE);
+    // A key owned by an unrelated consumer of the same Redis database.
+    await scoped.put('queue:default', VALUE);
+
+    await scoped.clear('myAppId:role');
+
+    expect(await scoped.get('myAppId:role:someUser')).toEqual(null);
+    expect(await scoped.get('myAppId:user:someToken')).toEqual(VALUE);
+    expect(await scoped.get('otherAppId:role:someUser')).toEqual(VALUE);
+    expect(await scoped.get('queue:default')).toEqual(VALUE);
+
+    await scoped.clear();
+    expect(await scoped.get('queue:default')).toEqual(null);
+  });
+
+  it('should not treat glob characters in the prefix as wildcards', async () => {
+    const scoped = new RedisCacheAdapter(null, 5000);
+    await scoped.connect();
+
+    await scoped.put('a*:someKey', VALUE);
+    await scoped.put('ab:someKey', VALUE);
+
+    await scoped.clear('a*');
+
+    expect(await scoped.get('a*:someKey')).toEqual(null);
+    expect(await scoped.get('ab:someKey')).toEqual(VALUE);
+
+    await scoped.clear();
+  });
+
   it('should expire after ttl', done => {
     cache
       .put(KEY, VALUE)

--- a/src/Adapters/Cache/CacheAdapter.js
+++ b/src/Adapters/Cache/CacheAdapter.js
@@ -27,6 +27,11 @@ export class CacheAdapter {
 
   /**
    * Empty a cache
+   * @param {String} prefix Optional key prefix limiting the scope of the
+   * operation to keys of the form `<prefix>:*`. When omitted, the whole cache
+   * is emptied. Implementing scoped clearing is optional: an adapter that
+   * ignores this parameter empties the whole cache, which remains correct as
+   * long as the adapter is the sole owner of its storage.
    */
-  clear() {}
+  clear(prefix) {}
 }

--- a/src/Adapters/Cache/InMemoryCacheAdapter.js
+++ b/src/Adapters/Cache/InMemoryCacheAdapter.js
@@ -23,8 +23,8 @@ export class InMemoryCacheAdapter {
     return Promise.resolve();
   }
 
-  clear() {
-    this.cache.clear();
+  clear(prefix) {
+    this.cache.clear(prefix);
     return Promise.resolve();
   }
 }

--- a/src/Adapters/Cache/LRUCache.js
+++ b/src/Adapters/Cache/LRUCache.js
@@ -21,8 +21,18 @@ export class LRUCache {
     this.cache.delete(key);
   }
 
-  clear() {
-    this.cache.clear();
+  clear(prefix) {
+    if (prefix == null) {
+      this.cache.clear();
+      return;
+    }
+    const scope = `${prefix}:`;
+    // Materialize the keys first, deleting while iterating the LRU is unsafe.
+    for (const key of [...this.cache.keys()]) {
+      if (typeof key === 'string' && key.startsWith(scope)) {
+        this.cache.delete(key);
+      }
+    }
   }
 }
 

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -4,6 +4,15 @@ import { KeyPromiseQueue } from '../../KeyPromiseQueue';
 
 const DEFAULT_REDIS_TTL = 30 * 1000; // 30 seconds in milliseconds
 const FLUSH_DB_KEY = '__flush_db__';
+// Number of keys SCAN is asked to examine per iteration when clearing a scope.
+const SCAN_COUNT = 100;
+// Characters that carry meaning in a Redis glob pattern and therefore have to
+// be escaped before a caller-supplied prefix is used as a SCAN MATCH pattern.
+const GLOB_SPECIAL_CHARS = /[?*[\]^\\]/g;
+
+function escapeGlob(value) {
+  return String(value).replace(GLOB_SPECIAL_CHARS, char => `\\${char}`);
+}
 
 function debug(...args: any) {
   const message = ['RedisCacheAdapter: ' + arguments[0]].concat(args.slice(1, args.length));
@@ -80,10 +89,27 @@ export class RedisCacheAdapter {
     return this.client.del(key);
   }
 
-  async clear() {
-    debug('clear');
+  /**
+   * Empty the cache. When a `prefix` is given, only keys of the form
+   * `<prefix>:*` are removed, using SCAN and UNLINK so that keys belonging to
+   * other Parse apps or to other consumers of the same Redis database survive.
+   * Without a `prefix` the whole database is flushed.
+   */
+  async clear(prefix) {
+    debug('clear', { prefix });
     await this.queue.enqueue(FLUSH_DB_KEY);
-    return this.client.sendCommand(['FLUSHDB']);
+    if (prefix == null) {
+      return this.client.sendCommand(['FLUSHDB']);
+    }
+    const match = `${escapeGlob(prefix)}:*`;
+    let cursor = '0';
+    do {
+      const reply = await this.client.scan(cursor, { MATCH: match, COUNT: SCAN_COUNT });
+      cursor = String(reply.cursor);
+      if (reply.keys.length) {
+        await this.client.unlink(reply.keys);
+      }
+    } while (cursor !== '0');
   }
 
   // Used for testing

--- a/src/Controllers/CacheController.js
+++ b/src/Controllers/CacheController.js
@@ -35,8 +35,11 @@ export class SubCache {
   }
 
   /**
-   * Empty this sub-cache, leaving keys owned by other sub-caches, other Parse
-   * apps, and other consumers of the same cache backend untouched.
+   * Empty this sub-cache by asking the adapter to clear only this sub-cache's
+   * key scope. Adapters that implement scoped clearing, which includes the
+   * built-in Redis and in-memory adapters, leave keys owned by other
+   * sub-caches, other Parse apps, and other consumers of the same backend
+   * untouched. An adapter that ignores the prefix empties the whole cache.
    */
   clear() {
     return this.cache.clear(this.prefix);
@@ -68,8 +71,10 @@ export class CacheController extends AdaptableController {
   }
 
   /**
-   * Empty this app's cache. Keys belonging to other Parse apps sharing the
-   * same cache backend are left untouched.
+   * Empty this app's cache by asking the adapter to clear only this app's key
+   * scope. Adapters that implement scoped clearing leave keys belonging to
+   * other Parse apps sharing the same backend untouched. An adapter that
+   * ignores the prefix empties the whole cache.
    *
    * @param {String} prefix Optional sub-cache prefix to narrow the scope
    * further, for example `role`.

--- a/src/Controllers/CacheController.js
+++ b/src/Controllers/CacheController.js
@@ -34,8 +34,12 @@ export class SubCache {
     return this.cache.del(cacheKey);
   }
 
+  /**
+   * Empty this sub-cache, leaving keys owned by other sub-caches, other Parse
+   * apps, and other consumers of the same cache backend untouched.
+   */
   clear() {
-    return this.cache.clear();
+    return this.cache.clear(this.prefix);
   }
 }
 
@@ -63,8 +67,16 @@ export class CacheController extends AdaptableController {
     return this.adapter.del(cacheKey);
   }
 
-  clear() {
-    return this.adapter.clear();
+  /**
+   * Empty this app's cache. Keys belonging to other Parse apps sharing the
+   * same cache backend are left untouched.
+   *
+   * @param {String} prefix Optional sub-cache prefix to narrow the scope
+   * further, for example `role`.
+   */
+  clear(prefix) {
+    const scope = prefix == null ? this.appId : joinKeys(this.appId, prefix);
+    return this.adapter.clear(scope);
   }
 
   expectedAdapterType() {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10617.

`SubCache#clear()` dropped the key prefix that every other method on the class applies, so `cacheController.role.clear()`, fired on every `_Role` write, reached the adapter as an unscoped clear. On `RedisCacheAdapter` that is a raw `FLUSHDB`, which empties the whole Redis database.

The consequences, in order of how many deployments they touch:

1. Every `_Role` write evicts all cached entries for every app on that server, including the `<appId>:user:<sessionToken>` entries backing session authentication. Apps that create a role per organization, workspace or team at signup destroy their own cache continuously.
2. Where the cache shares a Redis database with anything else, a job queue, rate limiter state or application data, a single `_Role` write deletes that data too.
3. Where an app's CLP permits non-master-key `_Role` writes, any client can trigger `FLUSHDB` at will.

## Approach

Scoped clearing is added as an **optional** part of the `CacheAdapter` contract, so third-party adapters keep working unchanged.

- `CacheAdapter#clear(prefix)` documents the new optional parameter. An adapter that ignores it empties the whole cache, which is exactly today's behavior.
- `SubCache#clear()` passes its prefix, so `role.clear()` resolves to `<appId>:role`.
- `CacheController#clear(prefix)` joins the app id, so it resolves to `<appId>` or `<appId>:<prefix>`.
- `RedisCacheAdapter#clear(prefix)` iterates `SCAN` with `MATCH <prefix>:*` and removes matches with `UNLINK`, glob-escaping the prefix so an app id containing `*`, `?`, `[` or `]` cannot widen the pattern. It keeps the existing `KeyPromiseQueue` barrier. Called with no prefix it still issues `FLUSHDB`.
- `InMemoryCacheAdapter` and `LRUCache` filter their own keys by prefix.

One scope limit worth stating: the in-memory adapter is per-process by construction, so on a multi-node deployment a clear still only evicts the node that handled the write. This PR narrows what a clear destroys, not how far it reaches, and Redis, being shared, is invalidated for the whole cluster.

Worth flagging for review: `CacheController#clear()` with no arguments now scopes to the app id rather than emptying the adapter outright. Nothing in the codebase relied on the wider behavior, and `TestUtils` calls `cacheAdapter.clear()` on the adapter directly, so test teardown still performs a full flush.

`SCAN` is only reached on role writes and purges, which are rare, and it uses `UNLINK` so the deletion itself does not block the server.

This continues the direction of #3523, which narrowed the adapter from `FLUSHALL` to `FLUSHDB`. Narrowing once more, to the key prefix, drops the remaining assumption that Parse Server exclusively owns the Redis database.

## Tests

- `spec/CacheController.spec.js` asserts each sub-cache clears under its own `<appId>:<prefix>` scope, and adds an end-to-end regression test that a `_Role` save leaves a cached user entry intact. That test fails on `alpha` with `Expected null to equal Object({ objectId: 'someUser' })` and passes here. It runs against the in-memory adapter by default and against Redis under `PARSE_SERVER_TEST_CACHE=redis`.
- `spec/RedisCacheAdapter.spec.js` asserts a scoped clear removes only its own prefix while leaving another app's keys and an unrelated `queue:default` key in place, that an unscoped clear still empties everything, and that glob characters in a prefix are treated literally.
- `spec/InMemoryCacheAdapter.spec.js` covers the same scoping for the default adapter.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped cache clearing by application and sub-cache prefix.
  * Clearing a sub-cache now preserves unrelated cached data.
  * Cache clearing supports both targeted removal and full-cache clearing.

* **Bug Fixes**
  * Improved handling of special characters in Redis cache keys.
  * Prevented unrelated entries from being removed during targeted cache operations.

* **Tests**
  * Added coverage for scoped clearing across in-memory, Redis, and controller-level caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
