### PR TITLE
fix: Deleting a role does not invalidate the cached role closures

### DIFF
--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -677,30 +677,42 @@ describe('Parse Role testing', () => {
   });
 
   it('clears the role cache when a role is deleted', async () => {
-    const cacheController = Parse.Server.cacheController;
+    const config = Config.get(Parse.applicationId);
     const role = new Parse.Role('Doomed', new Parse.ACL());
     await role.save(null, { useMasterKey: true });
 
     // Saving the role already clears the cache, so seed the entry afterwards.
-    await cacheController.role.put('someUser', ['role:Doomed']);
-    expect(await cacheController.role.get('someUser')).toEqual(['role:Doomed']);
+    await config.cacheController.role.put('someUser', ['role:Doomed']);
+    expect(await config.cacheController.role.get('someUser')).toEqual(['role:Doomed']);
+
+    const clearSpy = spyOn(config.cacheController.role, 'clear').and.callThrough();
+    const liveQuerySpy = spyOn(config.liveQueryController, 'clearCachedRoles').and.callThrough();
 
     await role.destroy({ useMasterKey: true });
-    // The clear is issued without being awaited, matching RestWrite.
-    await new Promise(resolve => setTimeout(resolve, 200));
 
-    expect(await cacheController.role.get('someUser')).toEqual(null);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(liveQuerySpy).toHaveBeenCalledTimes(1);
+    // The clear is issued without being awaited, matching RestWrite, so wait on
+    // the promise the call returned rather than on a fixed delay.
+    await clearSpy.calls.mostRecent().returnValue;
+
+    expect(await config.cacheController.role.get('someUser')).toEqual(null);
   });
 
   it('leaves the role cache alone when a non-role object is deleted', async () => {
-    const cacheController = Parse.Server.cacheController;
+    const config = Config.get(Parse.applicationId);
     const object = new Parse.Object('TestObject');
     await object.save(null, { useMasterKey: true });
 
-    await cacheController.role.put('someUser', ['role:Admin']);
-    await object.destroy({ useMasterKey: true });
-    await new Promise(resolve => setTimeout(resolve, 200));
+    await config.cacheController.role.put('someUser', ['role:Admin']);
 
-    expect(await cacheController.role.get('someUser')).toEqual(['role:Admin']);
+    const clearSpy = spyOn(config.cacheController.role, 'clear').and.callThrough();
+    const liveQuerySpy = spyOn(config.liveQueryController, 'clearCachedRoles').and.callThrough();
+
+    await object.destroy({ useMasterKey: true });
+
+    expect(clearSpy).not.toHaveBeenCalled();
+    expect(liveQuerySpy).not.toHaveBeenCalled();
+    expect(await config.cacheController.role.get('someUser')).toEqual(['role:Admin']);
   });
 });

--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -675,4 +675,32 @@ describe('Parse Role testing', () => {
     const fetchedRole = await query.get(savedRole.id, { useMasterKey: true });
     expect(fetchedRole.get('name')).toBe('ModifiedName');
   });
+
+  it('clears the role cache when a role is deleted', async () => {
+    const cacheController = Parse.Server.cacheController;
+    const role = new Parse.Role('Doomed', new Parse.ACL());
+    await role.save(null, { useMasterKey: true });
+
+    // Saving the role already clears the cache, so seed the entry afterwards.
+    await cacheController.role.put('someUser', ['role:Doomed']);
+    expect(await cacheController.role.get('someUser')).toEqual(['role:Doomed']);
+
+    await role.destroy({ useMasterKey: true });
+    // The clear is issued without being awaited, matching RestWrite.
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    expect(await cacheController.role.get('someUser')).toEqual(null);
+  });
+
+  it('leaves the role cache alone when a non-role object is deleted', async () => {
+    const cacheController = Parse.Server.cacheController;
+    const object = new Parse.Object('TestObject');
+    await object.save(null, { useMasterKey: true });
+
+    await cacheController.role.put('someUser', ['role:Admin']);
+    await object.destroy({ useMasterKey: true });
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    expect(await cacheController.role.get('someUser')).toEqual(['role:Admin']);
+  });
 });

--- a/src/rest.js
+++ b/src/rest.js
@@ -15,6 +15,7 @@ var triggers = require('./triggers');
 const Auth = require('./Auth');
 const { enforceRoleSecurity } = require('./SharedRest');
 const { createSanitizedError } = require('./Error');
+const logger = require('./logger').logger;
 
 function checkTriggers(className, config, types) {
   return types.some(triggerType => {
@@ -248,7 +249,12 @@ function del(config, auth, className, objectId, context) {
       // of its children, and the whole role cache is cleared rather than one
       // user's entry.
       if (className === '_Role') {
-        config.cacheController.role.clear();
+        // Issued without being awaited so a cache outage cannot fail a delete
+        // that already committed, but the rejection is caught so it does not
+        // surface as an unhandled rejection.
+        config.cacheController.role
+          .clear()
+          .catch(e => logger.error('Could not clear role cache after role deletion', { error: e }));
         if (config.liveQueryController) {
           config.liveQueryController.clearCachedRoles(auth.user);
         }

--- a/src/rest.js
+++ b/src/rest.js
@@ -255,9 +255,7 @@ function del(config, auth, className, objectId, context) {
         config.cacheController.role
           .clear()
           .catch(e => logger.error('Could not clear role cache after role deletion', { error: e }));
-        if (config.liveQueryController) {
-          config.liveQueryController.clearCachedRoles(auth.user);
-        }
+        config.liveQueryController.clearCachedRoles(auth.user);
       }
       // Notify LiveQuery server if possible
       const perms = schemaController.getClassLevelPermissions(className);

--- a/src/rest.js
+++ b/src/rest.js
@@ -241,6 +241,18 @@ function del(config, auth, className, objectId, context) {
       );
     })
     .then(() => {
+      // A deleted role is revoked from everyone who held it, so the cached role
+      // closures have to be dropped the same way they are on a role write (see
+      // RestWrite#runDatabaseOperation). The cached value is a flattened
+      // transitive closure, so deleting a parent role also affects the members
+      // of its children, and the whole role cache is cleared rather than one
+      // user's entry.
+      if (className === '_Role') {
+        config.cacheController.role.clear();
+        if (config.liveQueryController) {
+          config.liveQueryController.clearCachedRoles(auth.user);
+        }
+      }
       // Notify LiveQuery server if possible
       const perms = schemaController.getClassLevelPermissions(className);
       config.liveQueryController.onAfterDelete(className, inflatedObject, null, perms);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10619.

Deleting a `_Role` did not invalidate the role cache, so every user who held that role kept it in their cached closure until the entry expired. ACLs granting access to `role:<name>` continued to be honored for a role that no longer existed.

`cacheController.role.clear()` was called from only two places, `RestWrite.js:1566` (create and update) and `PurgeRouter.js:22`. Deletes do not go through `RestWrite`; they go through `rest.js` `del()`, which had no role cache handling at all.

The asymmetry is what makes it a bug rather than a tradeoff: removing a user from a role is a `_Role` update and clears the cache correctly, while deleting the whole role revokes the same access from every member and cleared nothing.

## Approach

Clear the role cache in `rest.js` `del()` when `className === '_Role'`, mirroring `RestWrite#runDatabaseOperation`, including the accompanying `liveQueryController.clearCachedRoles` call that the delete path was also missing.

Two details worth reviewer attention:

- **Placed after the delete commits**, in the `.then()` following `database.destroy`, rather than before the write as `RestWrite` does. Clearing before the write leaves a window in which a concurrent read repopulates the closure from pre-delete state, which would outlive the invalidation.
- **Deliberately outside** the `hasTriggers || hasLiveQuery || className == '_Session'` branch, so it runs for a `_Role` with no triggers registered. That branch is why the existing `cacheAdapter.user.del` at `rest.js:199` does not run for most classes.
- **Not awaited**, matching the existing call site at `RestWrite.js:1566`. Awaiting would make a Redis blip fail the delete, since `RedisCacheAdapter#clear` has no internal error handling, and that seemed the worse trade. Happy to change it if maintainers prefer.

The whole role cache is cleared rather than one user's entry, for the same reason `RestWrite` does it: the cached value is a flattened transitive closure, so deleting a parent role affects the members of every child role, and the delete does not identify which users are affected.

This is independent of #10618 and applies with or without it. With that change merged, `role.clear()` becomes a scoped `SCAN` over `<appId>:role:*` instead of a `FLUSHDB`, which makes adding this call inexpensive.

## Tests

`spec/ParseRole.spec.js` gains two specs:

- A deleted role clears the cached closure. This fails on `alpha` with `Expected [ 'role:Doomed' ] to equal null` and passes here.
- Deleting a non-role object leaves the role cache untouched, so the new branch does not over-clear.

The full `spec/ParseRole.spec.js` (20 specs) and `spec/Auth.spec.js` (11 specs), the latter being the main consumer of the role cache, both pass against MongoDB 8.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a role now immediately clears its cached data.
  * Cached role information for the acting user is invalidated during role deletion.
  * LiveQuery results now reflect removed roles more reliably after deletion.
  * Deleting non-role objects no longer affects role cache entries.
  * Role deletion continues successfully even if cache cleanup encounters an error, ensuring the deletion is completed without interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->