### PR TITLE
refactor: Bump yaml from 2.8.3 to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "semantic-release": "25.0.3",
         "typescript": "5.9.3",
         "typescript-eslint": "8.59.1",
-        "yaml": "2.8.3"
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=20.19.0 <21.0.0 || >=22.13.0 <23.0.0 || >=24.11.0 <25.0.0"
@@ -27120,9 +27120,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -45757,9 +45757,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "semantic-release": "25.0.3",
     "typescript": "5.9.3",
     "typescript-eslint": "8.59.1",
-    "yaml": "2.8.3"
+    "yaml": "2.9.0"
   },
   "scripts": {
     "ci:check": "node ./ci/ciCheck.js",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10597

This PR replaces the original Dependabot pull request #10597. Dependabot branches live in the upstream repository and cannot be modified directly, so the update is re-created here from a fork to allow the branch to be rebased and re-run against CI.

## Approach

Bumps the `yaml` development dependency from `2.8.3` to `2.9.0`.

`yaml` is a `devDependency` only. It is used by the CI tooling in `ci/CiVersionCheck.js`, which reads the GitHub Actions workflow YAML files and parses them (`yaml.parse`) to verify that the Node.js, MongoDB and PostgreSQL versions declared in the CI matrix stay in sync with the versions supported by Parse Server. It is not part of the published package runtime and has no effect on Parse Server's public API.

Upstream changes included in this bump (`2.8.4` and `2.9.0`):

- `2.9.0` — fix: avoid calling `Array.prototype.push.apply()` with a large source array.
- `2.9.0` — fix(lexer): avoid recursive calls that may exhaust the call stack.
- `2.9.0` — documentation change only: the claim that `parseDocument()` and `parseAllDocuments()` "never throw" has been removed; upstream will from now on treat call-stack-exhaustion errors triggered by malicious input as ordinary bugs rather than security vulnerabilities. This is a policy and docs change upstream, not an API change.
- `2.8.4` — fix: disable alias resolution with `maxAliasCount: 0`; handle invalid unicode escapes; apply `minFractionDigits` only to decimal strings.

No breaking changes are documented for this range, and none of the fixed behaviours are relied upon by the CI version check.

Scope of the diff: only `package.json` and `package-lock.json` are touched. The lockfile churn is confined to the `yaml` subtree (the version, `resolved` URL and `integrity` hash of the `yaml` entries); no other dependency, transitive tree or lockfile section is modified.

## Tasks

<!-- Tasks that do not apply to a version-only dependency upgrade have been deleted, as instructed by the template. -->

- [x] Reviewed the upstream changelog for breaking changes between `2.8.3` and `2.9.0`; none apply to this bump.

No new tests and no documentation changes are required: this is a version-only bump of a development dependency and contains no changes to Parse Server source code, behaviour or public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the YAML development dependency to version 2.9.0.
  * Refreshed the locked dependency metadata to keep installations consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
