### PR TITLE
fix: Query on /installations and /audiences fails with "Invalid key name: 0" when sent as POST with _method=GET

### DIFF
--- a/spec/AudienceRouter.spec.js
+++ b/spec/AudienceRouter.spec.js
@@ -96,6 +96,30 @@ describe('AudiencesRouter', () => {
       });
   });
 
+  it('uses find condition from a where string in request.body', async () => {
+    const config = Config.get('test');
+    await rest.create(config, auth.master(config), '_Audience', {
+      name: 'Android Users',
+      query: '{ "test": "android" }',
+    });
+    await rest.create(config, auth.master(config), '_Audience', {
+      name: 'Iphone Users',
+      query: '{ "test": "ios" }',
+    });
+
+    const router = new AudiencesRouter();
+    const res = await router.handleFind({
+      config: config,
+      auth: auth.master(config),
+      body: { where: JSON.stringify({ query: '{ "test": "android" }' }) },
+      query: {},
+      info: {},
+    });
+
+    expect(res.response.results.length).toEqual(1);
+    expect(res.response.results[0].name).toEqual('Android Users');
+  });
+
   it('query installations with limit = 0', done => {
     const config = Config.get('test');
     const androidAudienceRequest = {

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -273,15 +273,22 @@ describe('InstallationsRouter', () => {
   it('rejects an invalid where string in request.body', async () => {
     const config = Config.get('test');
     const router = new InstallationsRouter();
-    expect(() =>
-      router.handleFind({
+    let error;
+    try {
+      await router.handleFind({
         config: config,
         auth: auth.master(config),
         body: { where: 'not json' },
         query: {},
         info: {},
-      })
-    ).toThrowError(Parse.Error, 'where parameter is not valid JSON');
+      });
+      fail('find should have been rejected');
+      return;
+    } catch (e) {
+      error = e;
+    }
+    expect(error.code).toEqual(Parse.Error.INVALID_JSON);
+    expect(error.message).toEqual('where parameter is not valid JSON');
   });
 
   it('finds installations when the client sends the find as POST with _method=GET', async () => {

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -1,6 +1,7 @@
 const auth = require('../lib/Auth');
 const Config = require('../lib/Config');
 const rest = require('../lib/rest');
+const httpRequest = require('../lib/request');
 const InstallationsRouter = require('../lib/Routers/InstallationsRouter').InstallationsRouter;
 
 describe('InstallationsRouter', () => {
@@ -243,5 +244,73 @@ describe('InstallationsRouter', () => {
         fail(JSON.stringify(err));
         done();
       });
+  });
+
+  it('uses find condition from a where string in request.body', async () => {
+    const config = Config.get('test');
+    await rest.create(config, auth.nobody(config), '_Installation', {
+      installationId: '12345678-abcd-abcd-abcd-123456789abc',
+      deviceType: 'android',
+    });
+    await rest.create(config, auth.nobody(config), '_Installation', {
+      installationId: '12345678-abcd-abcd-abcd-123456789abd',
+      deviceType: 'ios',
+    });
+
+    const router = new InstallationsRouter();
+    const res = await router.handleFind({
+      config: config,
+      auth: auth.master(config),
+      body: { where: JSON.stringify({ deviceType: 'android' }) },
+      query: {},
+      info: {},
+    });
+
+    expect(res.response.results.length).toEqual(1);
+    expect(res.response.results[0].deviceType).toEqual('android');
+  });
+
+  it('rejects an invalid where string in request.body', async () => {
+    const config = Config.get('test');
+    const router = new InstallationsRouter();
+    expect(() =>
+      router.handleFind({
+        config: config,
+        auth: auth.master(config),
+        body: { where: 'not json' },
+        query: {},
+        info: {},
+      })
+    ).toThrowError(Parse.Error, 'where parameter is not valid JSON');
+  });
+
+  it('finds installations when the client sends the find as POST with _method=GET', async () => {
+    const config = Config.get('test');
+    await rest.create(config, auth.nobody(config), '_Installation', {
+      installationId: '12345678-abcd-abcd-abcd-123456789abc',
+      deviceType: 'android',
+    });
+    await rest.create(config, auth.nobody(config), '_Installation', {
+      installationId: '12345678-abcd-abcd-abcd-123456789abd',
+      deviceType: 'ios',
+    });
+
+    // A client that exceeds the maximum URL length sends the find as a POST
+    // with a urlencoded body, so `where` arrives as a string.
+    const response = await httpRequest({
+      method: 'POST',
+      url: 'http://localhost:8378/1/installations',
+      headers: {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-Master-Key': 'test',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `_method=GET&where=${encodeURIComponent(
+        JSON.stringify({ installationId: { $in: ['12345678-abcd-abcd-abcd-123456789abc'] } })
+      )}`,
+    });
+
+    expect(response.data.results.length).toEqual(1);
+    expect(response.data.results[0].deviceType).toEqual('android');
   });
 });

--- a/src/Routers/AudiencesRouter.js
+++ b/src/Routers/AudiencesRouter.js
@@ -10,6 +10,7 @@ export class AudiencesRouter extends ClassesRouter {
   handleFind(req) {
     const body = Object.assign(req.body || {}, ClassesRouter.JSONFromQuery(req.query));
     const options = ClassesRouter.optionsFromBody(body, req.config.defaultLimit);
+    ClassesRouter.decodeWhere(body);
 
     return rest
       .find(

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -29,13 +29,7 @@ export class ClassesRouter extends PromiseRouter {
     if (body.redirectClassNameForKey) {
       options.redirectClassNameForKey = String(body.redirectClassNameForKey);
     }
-    if (typeof body.where === 'string') {
-      try {
-        body.where = JSON.parse(body.where);
-      } catch {
-        throw new Parse.Error(Parse.Error.INVALID_JSON, 'where parameter is not valid JSON');
-      }
-    }
+    ClassesRouter.decodeWhere(body);
     return rest
       .find(
         req.config,
@@ -155,6 +149,28 @@ export class ClassesRouter extends PromiseRouter {
       }
     }
     return json;
+  }
+
+  /**
+   * Decodes a `where` that arrives as a JSON string instead of an object.
+   *
+   * A client that exceeds the maximum URL length sends a find as
+   * `POST` + `_method=GET` with a urlencoded body, so `where` reaches the
+   * router as a string rather than being decoded by `JSONFromQuery`. Every
+   * router that serves a find has to decode it, otherwise the string is passed
+   * to the query layer and iterated character by character.
+   *
+   * Mutates `body` in place and returns the decoded `where`.
+   */
+  static decodeWhere(body) {
+    if (typeof body.where === 'string') {
+      try {
+        body.where = JSON.parse(body.where);
+      } catch {
+        throw new Parse.Error(Parse.Error.INVALID_JSON, 'where parameter is not valid JSON');
+      }
+    }
+    return body.where;
   }
 
   static optionsFromBody(body, defaultLimit) {

--- a/src/Routers/InstallationsRouter.js
+++ b/src/Routers/InstallationsRouter.js
@@ -12,6 +12,7 @@ export class InstallationsRouter extends ClassesRouter {
   handleFind(req) {
     const body = Object.assign(req.body || {}, ClassesRouter.JSONFromQuery(req.query));
     const options = ClassesRouter.optionsFromBody(body, req.config.defaultLimit);
+    ClassesRouter.decodeWhere(body);
     return rest
       .find(
         req.config,


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes: #10626

`InstallationsRouter.handleFind` and `AudiencesRouter.handleFind` override `ClassesRouter.handleFind` but omit its string-`where` decoding, so a find sent as `POST` + `_method=GET` (what SDKs fall back to once the URL exceeds the maximum length) fails on `/installations` and `/audiences` with `Invalid key name: 0`, while the identical query succeeds on `/classes/_Installation`.

The undecoded `where` string reaches `DatabaseController.validateQuery`, which runs `Object.keys()` over it and walks the string character by character, so the first index fails the key-name check.

## Approach

Extract the decoding into `ClassesRouter.decodeWhere(body)` and call it from all three routers that serve a find. Behavior for the classes route is unchanged: the helper still mutates `body.where` in place and still throws `Parse.Error.INVALID_JSON` on malformed JSON.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
