### PR TITLE
fix: LiveQuery role cache is not invalidated for all users affected by a role write or delete

### DIFF
--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -1904,6 +1904,88 @@ describe('ParseLiveQueryServer', function () {
     expect(parseLiveQueryServer.authCache.get('invalid')).not.toBe(undefined);
   });
 
+  describe('role cache invalidation', () => {
+    const clearCacheChannel = () => `${Parse.applicationId}clearCache`;
+
+    // The subscriber is mocked, so the handler registered for the clearCache
+    // channel is recovered from the spy rather than by publishing for real.
+    const clearCacheHandler = server => {
+      const call = server.subscriber.subscribe.calls
+        .all()
+        .find(({ args }) => args[0] === clearCacheChannel());
+      return call.args[1];
+    };
+
+    it('publishes a full clear when a role changes without an acting user', () => {
+      const controller = new LiveQueryController({ classNames: ['Yolo'] });
+      const publish = controller.liveQueryPublisher.parsePublisher.publish;
+
+      controller.clearCachedRoles(undefined);
+
+      expect(publish).toHaveBeenCalledTimes(1);
+      const [channel, payload] = publish.calls.mostRecent().args;
+      expect(channel).toBe(clearCacheChannel());
+      expect(JSON.parse(payload)).toEqual({ clearAll: true });
+    });
+
+    it('keeps publishing the user id for older LiveQuery servers', () => {
+      const controller = new LiveQueryController({ classNames: ['Yolo'] });
+      const publish = controller.liveQueryPublisher.parsePublisher.publish;
+
+      controller.clearCachedRoles({ id: testUserId });
+
+      const payload = JSON.parse(publish.calls.mostRecent().args[1]);
+      expect(payload).toEqual({ userId: testUserId, clearAll: true });
+    });
+
+    it('clears every cached auth on a full clear message', async () => {
+      const parseLiveQueryServer = new ParseLiveQueryServer({});
+      const clearAll = spyOn(parseLiveQueryServer, '_clearAllCachedRoles').and.resolveTo();
+      const clearOne = spyOn(parseLiveQueryServer, '_clearCachedRoles').and.resolveTo();
+
+      clearCacheHandler(parseLiveQueryServer)(JSON.stringify({ clearAll: true }));
+
+      expect(clearAll).toHaveBeenCalledTimes(1);
+      expect(clearOne).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the targeted clear when the message has no clearAll', async () => {
+      const parseLiveQueryServer = new ParseLiveQueryServer({});
+      const clearAll = spyOn(parseLiveQueryServer, '_clearAllCachedRoles').and.resolveTo();
+      const clearOne = spyOn(parseLiveQueryServer, '_clearCachedRoles').and.resolveTo();
+
+      clearCacheHandler(parseLiveQueryServer)(JSON.stringify({ userId: testUserId }));
+
+      expect(clearOne).toHaveBeenCalledWith(testUserId);
+      expect(clearAll).not.toHaveBeenCalled();
+    });
+
+    it('drops the auth cache and the role cache on a full clear', async () => {
+      const parseLiveQueryServer = new ParseLiveQueryServer({});
+      const roleClear = jasmine.createSpy('clear').and.resolveTo();
+      parseLiveQueryServer.cacheController = { role: { clear: roleClear } };
+      parseLiveQueryServer.authCache.set('someToken', Promise.resolve({}));
+      expect(parseLiveQueryServer.authCache.size).toBe(1);
+
+      await parseLiveQueryServer._clearAllCachedRoles();
+
+      expect(parseLiveQueryServer.authCache.size).toBe(0);
+      expect(roleClear).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives a role cache that rejects on a full clear', async () => {
+      const parseLiveQueryServer = new ParseLiveQueryServer({});
+      parseLiveQueryServer.cacheController = {
+        role: { clear: () => Promise.reject(new Error('cache down')) },
+      };
+      parseLiveQueryServer.authCache.set('someToken', Promise.resolve({}));
+
+      await expectAsync(parseLiveQueryServer._clearAllCachedRoles()).toBeResolved();
+
+      expect(parseLiveQueryServer.authCache.size).toBe(0);
+    });
+  });
+
   afterEach(function () {
     jasmine.restoreLibrary('../lib/LiveQuery/ParseWebSocketServer', 'ParseWebSocketServer');
     jasmine.restoreLibrary('../lib/LiveQuery/Client', 'Client');
@@ -2115,4 +2197,5 @@ describe('LiveQueryController', () => {
       original: undefined,
     });
   });
+
 });

--- a/src/Controllers/LiveQueryController.js
+++ b/src/Controllers/LiveQueryController.js
@@ -61,9 +61,8 @@ export class LiveQueryController {
   }
 
   clearCachedRoles(user: any) {
-    if (!user) {
-      return;
-    }
+    // Published even without a user. A master key role write or delete carries
+    // no acting user, and it revokes access just the same.
     return this.liveQueryPublisher.onClearCachedRoles(user);
   }
 

--- a/src/LiveQuery/ParseCloudCodePublisher.js
+++ b/src/LiveQuery/ParseCloudCodePublisher.js
@@ -28,10 +28,16 @@ class ParseCloudCodePublisher {
     this._onCloudCodeMessage(Parse.applicationId + 'afterDelete', request);
   }
 
-  onClearCachedRoles(user: Parse.Object) {
+  onClearCachedRoles(user: ?Parse.Object) {
+    // A role write or delete changes the effective role closure of every member
+    // of that role and of any role inheriting from it, not just the acting
+    // user, and a master key request has no acting user at all. `clearAll` asks
+    // subscribers to drop every cached auth. `userId` is still sent when it is
+    // known so that a LiveQuery server running an older version, which only
+    // understands the targeted form, keeps behaving as it does today.
     this.parsePublisher.publish(
       Parse.applicationId + 'clearCache',
-      JSON.stringify({ userId: user.id })
+      JSON.stringify({ userId: user?.id, clearAll: true })
     );
   }
 

--- a/src/LiveQuery/ParseLiveQueryServer.ts
+++ b/src/LiveQuery/ParseLiveQueryServer.ts
@@ -132,7 +132,13 @@ class ParseLiveQueryServer {
         return;
       }
       if (channel === Parse.applicationId + 'clearCache') {
-        this._clearCachedRoles(message.userId);
+        if (message.clearAll) {
+          this._clearAllCachedRoles();
+        } else {
+          // Sent by a Parse Server running an older version, which only
+          // invalidates the acting user.
+          this._clearCachedRoles(message.userId);
+        }
         return;
       }
       this._inflateParseObject(message);
@@ -656,6 +662,20 @@ class ParseLiveQueryServer {
           this.authCache.delete(sessionToken);
         })
       );
+    } catch (e) {
+      logger.verbose(`Could not clear role cache. ${e}`);
+    }
+  }
+
+  async _clearAllCachedRoles() {
+    try {
+      // Every cached auth holds a flattened role closure, and a role write can
+      // change the closure of any user, so the whole cache goes. Entries are
+      // repopulated lazily by getAuthForSessionToken.
+      this.authCache.clear();
+      // A standalone LiveQuery server has its own cache controller, which the
+      // Parse Server that published this message did not clear.
+      await this.cacheController?.role?.clear();
     } catch (e) {
       logger.verbose(`Could not clear role cache. ${e}`);
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10628.

`LiveQueryController.clearCachedRoles(user)` invalidated the LiveQuery server's cached auth for one user, the actor on the request, and only when there was one. Two cases were never invalidated:

- **No user on the request.** The method returned early when `user` was falsy, so a master key role write or delete published nothing at all. Managing roles with the master key, from admin tooling or cloud code, is the common case.
- **Users other than the actor.** The publisher sent a single `{ userId }` and `ParseLiveQueryServer#_clearCachedRoles` resolved `_Session` rows for that one user. A role write changes the effective closure of every member of the role and of any role inheriting from it. Adding a member is the clearest example: the actor is the admin doing the write, the affected user is the member being added, and only the actor was invalidated.

Until its `authCache` entry expired on `cacheTimeout`, a subscriber kept receiving events decided from a stale role closure.

## Approach

`clearCache` messages now carry `clearAll: true`, and a LiveQuery server receiving one drops its whole `authCache` rather than one user's sessions. Entries are repopulated lazily by `getAuthForSessionToken`, so the cost is a re-resolution per active session after a role write, and role writes are rare relative to events.

Three details worth reviewer attention:

- **`userId` is still published when it is known.** A LiveQuery server on an older version ignores `clearAll` and reads `userId`, so it keeps doing exactly what it does today rather than silently doing nothing. Mixed-version deployments degrade to current behavior instead of breaking.
- **`_clearCachedRoles(userId)` is kept** for the reverse direction, an older Parse Server publishing `{ userId }` to a LiveQuery server on this version.
- **A standalone LiveQuery server clears its own role cache.** It runs in its own process with its own cache controller, which the publishing Parse Server's `cacheController.role.clear()` never touched. Failures there are caught and logged rather than propagated, matching `_clearCachedRoles`.

The whole cache is cleared rather than a computed set of affected sessions because the affected set cannot be reconstructed for a delete: by the time the message is published, the `_Role` row and its `_Join` rows are gone. Snapshotting members before the destroy would put the cost on every delete and still miss transitive members.

## Tests

`spec/ParseLiveQueryServer.spec.js` gains a `role cache invalidation` block:

- A role change with no acting user publishes `clearAll`, which is the master key case that previously published nothing.
- A role change with an acting user still publishes `userId` alongside `clearAll`, pinning the back compat contract.
- A `clearAll` message routes to the full clear, and a message without it routes to the targeted clear.
- A full clear empties `authCache` and clears the role cache.
- A full clear resolves rather than rejecting when the role cache is unavailable.

`spec/ParseLiveQueryServer.spec.js`, `spec/ParseLiveQuery.spec.js`, `spec/ParseRole.spec.js`, `spec/Auth.spec.js` and `spec/rest.spec.js` all pass against MongoDB 8.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LiveQuery authorization cache invalidation when roles change.
  * Changes made without an acting user now correctly invalidate cached authorization data.
  * Added safeguards to keep cache cleanup resilient when clearing operations fail.
  * Existing targeted role-cache invalidation behavior remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->