### PR TITLE
fix: Per-entry cache TTL is ignored by the in-memory cache adapter

### DIFF
--- a/spec/InMemoryCacheAdapter.spec.js
+++ b/spec/InMemoryCacheAdapter.spec.js
@@ -50,4 +50,33 @@ describe('InMemoryCacheAdapter', function () {
       .then(value => expect(value).toEqual(null))
       .then(done);
   });
+
+  it('should keep an entry whose ttl outlives the cache ttl', async () => {
+    const cache = new InMemoryCacheAdapter({ ttl: 10 });
+
+    await cache.put(KEY, VALUE, 5000);
+    await wait(50);
+
+    expect(await cache.get(KEY)).toEqual(VALUE);
+  });
+
+  it('should expire an entry whose ttl is shorter than the cache ttl', async () => {
+    const cache = new InMemoryCacheAdapter({ ttl: 5000 });
+
+    await cache.put(KEY, VALUE, 10);
+    expect(await cache.get(KEY)).toEqual(VALUE);
+    await wait(50);
+
+    expect(await cache.get(KEY)).toEqual(null);
+  });
+
+  it('should fall back to the cache ttl when the entry ttl is not a positive number', async () => {
+    const cache = new InMemoryCacheAdapter({ ttl: 10 });
+
+    await cache.put(KEY, VALUE, 'not a ttl');
+    expect(await cache.get(KEY)).toEqual(VALUE);
+    await wait(50);
+
+    expect(await cache.get(KEY)).toEqual(null);
+  });
 });

--- a/spec/InMemoryCacheAdapter.spec.js
+++ b/spec/InMemoryCacheAdapter.spec.js
@@ -70,6 +70,15 @@ describe('InMemoryCacheAdapter', function () {
     expect(await cache.get(KEY)).toEqual(null);
   });
 
+  it('should not expire an entry with an infinite ttl', async () => {
+    const cache = new InMemoryCacheAdapter({ ttl: 10 });
+
+    await cache.put(KEY, VALUE, Infinity);
+    await wait(50);
+
+    expect(await cache.get(KEY)).toEqual(VALUE);
+  });
+
   it('should fall back to the cache ttl when the entry ttl is not a positive number', async () => {
     const cache = new InMemoryCacheAdapter({ ttl: 10 });
 

--- a/src/Adapters/Cache/LRUCache.js
+++ b/src/Adapters/Cache/LRUCache.js
@@ -1,8 +1,11 @@
 import { LRUCache as LRU } from 'lru-cache';
 import defaults from '../../defaults';
 
+const isValidTTL = ttl => typeof ttl === 'number' && ttl > 0;
+
 export class LRUCache {
   constructor({ ttl = defaults.cacheTTL, maxSize = defaults.cacheMaxSize }) {
+    this.ttl = ttl;
     this.cache = new LRU({
       max: maxSize,
       ttl,
@@ -14,7 +17,11 @@ export class LRUCache {
   }
 
   put(key, value, ttl = this.ttl) {
-    this.cache.set(key, value, ttl);
+    // `lru-cache` takes the per-entry TTL as a property of an options object.
+    // Passed positionally it is silently discarded, leaving the entry on the
+    // cache-wide TTL. A TTL that is not a positive number is forwarded as
+    // `undefined`, which is how the library expresses "use the cache-wide TTL".
+    this.cache.set(key, value, { ttl: isValidTTL(ttl) ? ttl : undefined });
   }
 
   del(key) {

--- a/src/Adapters/Cache/LRUCache.js
+++ b/src/Adapters/Cache/LRUCache.js
@@ -1,7 +1,10 @@
 import { LRUCache as LRU } from 'lru-cache';
 import defaults from '../../defaults';
 
-const isValidTTL = ttl => typeof ttl === 'number' && ttl > 0;
+const isValidTTL = ttl => typeof ttl === 'number' && Number.isFinite(ttl) && ttl > 0;
+
+// `lru-cache` expresses "never expires" as a TTL of zero.
+const NO_EXPIRY = 0;
 
 export class LRUCache {
   constructor({ ttl = defaults.cacheTTL, maxSize = defaults.cacheMaxSize }) {
@@ -19,9 +22,21 @@ export class LRUCache {
   put(key, value, ttl = this.ttl) {
     // `lru-cache` takes the per-entry TTL as a property of an options object.
     // Passed positionally it is silently discarded, leaving the entry on the
-    // cache-wide TTL. A TTL that is not a positive number is forwarded as
+    // cache-wide TTL.
+    //
+    // A TTL of `Infinity` means "never expires", matching `RedisCacheAdapter`,
+    // and is translated to the zero that `lru-cache` uses for that. `Infinity`
+    // is not forwarded as-is because it is not a valid `lru-cache` TTL: under
+    // `ttlAutopurge` it overflows the entry's timer and evicts it almost
+    // immediately. Any other TTL that is not a positive number is forwarded as
     // `undefined`, which is how the library expresses "use the cache-wide TTL".
-    this.cache.set(key, value, { ttl: isValidTTL(ttl) ? ttl : undefined });
+    let entryTTL;
+    if (ttl === Infinity) {
+      entryTTL = NO_EXPIRY;
+    } else if (isValidTTL(ttl)) {
+      entryTTL = ttl;
+    }
+    this.cache.set(key, value, { ttl: entryTTL });
   }
 
   del(key) {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10630.

`LRUCache#put` passed the per-entry TTL to `lru-cache` positionally, but the library takes it as a property of an options object. `set()` destructures its third argument, so a number contributed no properties and the entry silently fell back to the cache-wide `cacheTTL`. On the default in-memory adapter a per-entry TTL could not be set at all.

The one caller that asks for one is `ParseGraphQLController`, which caches the GraphQL config for 60 seconds and instead got `cacheTTL`, 5000ms by default, so the config was re-read from the database roughly 12 times more often than intended. `RedisCacheAdapter#put` honors the TTL via `PX`, so the same call behaved differently depending on the configured adapter.

## Approach

- `LRUCache#put` passes `{ ttl }` rather than a positional number.
- The constructor assigns `this.ttl`, which the `ttl = this.ttl` default in `put` already referenced but which was never set, so that default was always `undefined`.
- A TTL that is not a positive number is forwarded as `undefined`, which is how `lru-cache` expresses "use the cache-wide TTL". This preserves today's behavior for every input that is not a valid TTL, including the `ttl: NaN` construction used in the existing specs. Without that guard, `lru-cache` reads `0`, `NaN` and `Infinity` as "never expire" and a negative TTL as "already expired", which would be a behavior change beyond the fix.

Deliberately left alone: `RedisCacheAdapter` treats `put(key, value, 0)` as a no-op that stores nothing, while the in-memory adapter stores the value under the cache-wide TTL. That divergence predates this PR and is not part of the reported bug, so aligning the two is left for a separate change.

`SubCache` also accepts a `ttl` in its constructor, stores it, and never uses it, since `put()` forwards only the caller's argument and `CacheController` constructs all three sub-caches without one. That dead parameter is likewise out of scope here.

## Tests

`spec/InMemoryCacheAdapter.spec.js` gains three cases, the first two of which fail on `alpha`:

- an entry whose TTL outlives the cache TTL survives past the cache TTL, failing on `alpha` with `Expected null to equal 'world'`
- an entry whose TTL is shorter than the cache TTL expires early, failing on `alpha` with `Expected 'world' to equal null`
- an invalid TTL falls back to the cache TTL, pinning the behavior the guard preserves

## Tasks

- [x] Add tests
- [x] Add changes to documentation (code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache expiration handling for individual entries.
  * Valid per-entry expiration times now override the default cache duration.
  * Entries can remain available indefinitely when configured without expiration.
  * Invalid or non-positive expiration values safely use the cache-wide default.
  * Added coverage for entries expiring earlier or later than the default duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->