### PR TITLE
fix: Server crash from unhandled promise rejection when Redis is unavailable during a cache write

### DIFF
--- a/spec/RedisCacheAdapter.spec.js
+++ b/spec/RedisCacheAdapter.spec.js
@@ -182,3 +182,68 @@ describe_only(() => {
     expect(client.isOpen).toBeTrue();
   });
 });
+
+// These run without a Redis server: the client is replaced with one that always
+// rejects, which is what a Redis outage looks like to the adapter.
+describe('RedisCacheAdapter error handling', () => {
+  const KEY = 'hello';
+  const VALUE = 'world';
+  const failure = new Error('Redis is unavailable');
+
+  let cache;
+  let loggerErrorSpy;
+
+  beforeEach(() => {
+    cache = new RedisCacheAdapter(null, 100);
+    cache.client = {
+      get: () => Promise.reject(failure),
+      set: () => Promise.reject(failure),
+      del: () => Promise.reject(failure),
+      sendCommand: () => Promise.reject(failure),
+    };
+    const logger = require('../lib/logger').default;
+    loggerErrorSpy = spyOn(logger, 'error').and.callFake(() => {});
+  });
+
+  it('resolves and logs when get fails', async () => {
+    await expectAsync(cache.get(KEY)).toBeResolved();
+    expect(loggerErrorSpy.calls.mostRecent().args[0]).toBe('RedisCacheAdapter error on get');
+  });
+
+  it('resolves and logs when put fails', async () => {
+    await expectAsync(cache.put(KEY, VALUE)).toBeResolved();
+    expect(loggerErrorSpy.calls.mostRecent().args[0]).toBe('RedisCacheAdapter error on put');
+  });
+
+  it('resolves and logs when put with an infinite ttl fails', async () => {
+    await expectAsync(cache.put(KEY, VALUE, Infinity)).toBeResolved();
+    expect(loggerErrorSpy.calls.mostRecent().args[0]).toBe('RedisCacheAdapter error on put');
+  });
+
+  it('resolves and logs when del fails', async () => {
+    await expectAsync(cache.del(KEY)).toBeResolved();
+    expect(loggerErrorSpy.calls.mostRecent().args[0]).toBe('RedisCacheAdapter error on del');
+  });
+
+  it('resolves and logs when clear fails', async () => {
+    await expectAsync(cache.clear()).toBeResolved();
+    expect(loggerErrorSpy.calls.mostRecent().args[0]).toBe('RedisCacheAdapter error on clear');
+  });
+
+  it('does not reject when a caller does not await the write', async () => {
+    // The call sites in Auth and RestWrite are deliberately not awaited, so a
+    // rejection here would surface as an unhandled rejection.
+    const rejections = [];
+    const onUnhandled = reason => rejections.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    cache.put(KEY, VALUE);
+    cache.del(KEY);
+    cache.clear();
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    process.removeListener('unhandledRejection', onUnhandled);
+    expect(rejections).toEqual([]);
+  });
+});

--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -58,32 +58,44 @@ export class RedisCacheAdapter {
   async put(key, value, ttl = this.ttl) {
     value = JSON.stringify(value);
     debug('put', { key, value, ttl });
-    await this.queue.enqueue(key);
-    if (ttl === 0) {
-      // ttl of zero is a logical no-op, but redis cannot set expire time of zero
-      return;
-    }
+    try {
+      await this.queue.enqueue(key);
+      if (ttl === 0) {
+        // ttl of zero is a logical no-op, but redis cannot set expire time of zero
+        return;
+      }
 
-    if (ttl === Infinity) {
-      return this.client.set(key, value);
-    }
+      if (ttl === Infinity) {
+        return await this.client.set(key, value);
+      }
 
-    if (!isValidTTL(ttl)) {
-      ttl = this.ttl;
+      if (!isValidTTL(ttl)) {
+        ttl = this.ttl;
+      }
+      return await this.client.set(key, value, { PX: ttl });
+    } catch (err) {
+      logger.error('RedisCacheAdapter error on put', { error: err });
     }
-    return this.client.set(key, value, { PX: ttl });
   }
 
   async del(key) {
     debug('del', { key });
-    await this.queue.enqueue(key);
-    return this.client.del(key);
+    try {
+      await this.queue.enqueue(key);
+      return await this.client.del(key);
+    } catch (err) {
+      logger.error('RedisCacheAdapter error on del', { error: err });
+    }
   }
 
   async clear() {
     debug('clear');
-    await this.queue.enqueue(FLUSH_DB_KEY);
-    return this.client.sendCommand(['FLUSHDB']);
+    try {
+      await this.queue.enqueue(FLUSH_DB_KEY);
+      return await this.client.sendCommand(['FLUSHDB']);
+    } catch (err) {
+      logger.error('RedisCacheAdapter error on clear', { error: err });
+    }
   }
 
   // Used for testing


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10634.

`RedisCacheAdapter#get` catches adapter errors, logs them and resolves. `put`, `del` and `clear` do not, so they reject when Redis is unavailable. Parse Server calls all three without awaiting them in six places, so a transient Redis failure becomes an unhandled promise rejection, which depending on the Node version and process configuration either logs a warning or terminates the process.

| Location | Call | Runs on |
|---|---|---|
| `src/Auth.js:140` | `cacheController.user.del(sessionToken)` | every expired-session auth |
| `src/Auth.js:203` | `cacheController.user.put(sessionToken, …)` | every session-token auth |
| `src/Auth.js:342` | `cacheController.role.put(user.id, …)` | every role-closure computation |
| `src/Auth.js:350` | `cacheController.role.del(user.id)` | `clearRoleCache` |
| `src/Auth.js:351` | `cacheController.user.del(sessionToken)` | `clearRoleCache` |
| `src/RestWrite.js:1566` | `cacheController.role.clear()` | every `_Role` write |

Not awaiting is correct in each case, since a cache write must not delay or fail the request that triggered it. The defect is that the adapter rejects at all, when its own `get` establishes the opposite contract.

## Approach

`put`, `del` and `clear` get the handling `get` already has: the operation is wrapped, the error is logged with the operation name, and the promise resolves. No call site changes, so every current and future caller is covered.

Details worth noting for review:

- The awaited calls inside each `try` use `return await` rather than returning the promise, otherwise the rejection escapes the `try` block.
- Error messages follow the existing `RedisCacheAdapter error on get` wording, so a log line now names the failing operation instead of surfacing as a bare unhandled rejection.
- Behavior on success is unchanged, including the `ttl === 0` no-op and the `ttl === Infinity` path in `put`.

Two overlaps with open work, both trivial to resolve:

- #10620 adds a `.catch()` at a single new call site in `src/rest.js` in response to the same review comment. Once this lands, that `.catch()` is redundant. It is harmless either way, so no change is proposed there.
- #10618 rewrites `clear()` to take a prefix. Whichever of the two lands second needs a small rebase inside that one method.

## Tests

`spec/RedisCacheAdapter.spec.js` gains a describe block that runs **without** a Redis server, since a client that always rejects is what an outage looks like to the adapter. The existing Redis specs remain gated behind `PARSE_SERVER_TEST_CACHE=redis`.

- `get`, `put`, `put` with an infinite TTL, `del` and `clear` each resolve and log an error naming the operation
- an unawaited `put`, `del` and `clear` produce no unhandled rejection, asserted with a `process.on('unhandledRejection')` listener, which is the reported symptom

On `alpha` the five write-path cases fail with `Expected a promise to be resolved but it was rejected with Error: Redis is unavailable`, and the last reports three unhandled rejections. The `get` case passes on `alpha` and is included as a control for the behavior being matched.

## Tasks

- [x] Add tests
- [x] Add changes to documentation (code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache operations now handle Redis outages gracefully without interrupting application flows.
  * Cache writes, deletions, and clearing operations log operation-specific errors instead of propagating failures.
  * Non-expiring cache writes now complete reliably, including when Redis is unavailable.
  * Prevented unhandled promise rejections from background cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->