### PR TITLE
fix: Validate CIDR masks in IP configuration

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -460,10 +460,51 @@ describe('server', () => {
     });
   });
 
+  it('fails if you provide an invalid CIDR mask in masterKeyIps', async () => {
+    const invalidIps = [
+      '127.0.0.1/999',
+      '10.0.0.0/8.9',
+      '127.0.0.0/32.0',
+      '127.0.0.0/3.2e1',
+      '127.0.0.0/0x20',
+      '127.0.0.0/0b100000',
+      '127.0.0.0/ 32',
+      '127.0.0.0/32 ',
+      '127.0.0.1/-1',
+      '127.0.0.1/',
+      '127.0.0.1/32/ignored',
+      '2001:db8::/129',
+    ];
+
+    for (const ip of invalidIps) {
+      expect(() => Config.validateIps('masterKeyIps', [ip]))
+        .withContext(ip)
+        .toThrow(
+          `The Parse Server option "masterKeyIps" contains an invalid CIDR notation "${ip}".`
+        );
+    }
+
+    const startupIp = '127.0.0.1/33';
+    await expectAsync(reconfigureServer({ masterKeyIps: [startupIp] })).toBeRejectedWith(
+      `The Parse Server option \"masterKeyIps\" contains an invalid CIDR notation \"${startupIp}\".`
+    );
+  });
+
   it('should succeed if you provide valid ip in masterKeyIps', done => {
     reconfigureServer({
       masterKeyIps: ['1.2.3.4', '2001:0db8:0000:0042:0000:8a2e:0370:7334'],
     }).then(done);
+  });
+
+  it('should succeed if you provide valid CIDR boundaries in masterKeyIps', () => {
+    expect(() =>
+      Config.validateIps('masterKeyIps', [
+        '0.0.0.0/0',
+        '255.255.255.255/32',
+        '::/0',
+        '2001:db8::/128',
+      ])
+    ).not.toThrow();
   });
 
   it('should set default masterKeyIps for IPv4 and IPv6 localhost', () => {

--- a/src/Config.js
+++ b/src/Config.js
@@ -625,12 +625,19 @@ export class Config {
   }
 
   static validateIps(field, masterKeyIps) {
-    for (let ip of masterKeyIps) {
-      if (ip.includes('/')) {
-        ip = ip.split('/')[0];
+    for (const ip of masterKeyIps) {
+      const parts = ip.split('/');
+      const address = parts[0];
+      const ipVersion = net.isIP(address);
+      if (!ipVersion) {
+        throw `The Parse Server option "${field}" contains an invalid IP address "${address}".`;
       }
-      if (!net.isIP(ip)) {
-        throw `The Parse Server option "${field}" contains an invalid IP address "${ip}".`;
+      if (parts.length > 1) {
+        const mask = parts[1];
+        const maxMask = ipVersion === 4 ? 32 : 128;
+        if (parts.length !== 2 || !/^\d+$/.test(mask) || Number(mask) > maxMask) {
+          throw `The Parse Server option "${field}" contains an invalid CIDR notation "${ip}".`;
+        }
       }
     }
   }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-server/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-server/blob/alpha/LICENSE).

## Issue

Closes #10640.

## Approach

- Validate a CIDR mask instead of discarding it before IP validation.
- Require decimal digits only and enforce the IPv4 (0–32) and IPv6 (0–128) boundaries.
- Reject empty masks, extra separators, whitespace, fractions, exponent/hex/binary forms, negative masks, and out-of-range masks.
- Add focused regression coverage for malformed masks, valid boundaries, and rejection through the server configuration path.

## Tasks

- [x] Add tests

## Validation

- Focused CIDR specs: 2 passed
- Full ESLint suite: passed
- Babel build: 197 files compiled successfully
