### PR TITLE
fix: Unauthenticated deletion of installation records via operator injection in device token deduplication (GHSA-cc6h-c8m4-hgrx)

### DIFF
--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -7138,6 +7138,79 @@ describe('Vulnerabilities', () => {
       );
     });
 
+    it('reports the received type when a deviceToken is an array', async () => {
+      await seedVictimInstallations(1);
+      await registerAttackerInstallation();
+
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: ['victimtoken0'],
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect(response.data.error).toBe(
+        'schema mismatch for _Installation.deviceToken; expected String but got Array'
+      );
+      expect((await allInstallations()).length).toBe(2);
+    });
+
+    it('skips the cleanup when appIdentifier is unset and the matched installation has none', async () => {
+      const victim = await postInstallation({
+        installationId: 'victim-uuid-0000-0000-00000000010',
+        deviceType: 'ios',
+        deviceToken: 'unscoped-token',
+        appIdentifier: 'com.example.victimapp',
+      });
+      expect(victim.status).toBe(201);
+      // The caller's own installation carries no application scope to fall back to.
+      const attacker = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceType: 'android',
+        deviceToken: 'attacker-token',
+      });
+      expect(attacker.status).toBe(201);
+
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: 'unscoped-token',
+        appIdentifier: { __op: 'Delete' },
+      });
+
+      expect(response.status).toBe(200);
+      expect(await allInstallations()).toEqual(
+        ['victim-uuid-0000-0000-00000000010', attackerInstallationId].sort()
+      );
+    });
+
+    it('skips the cleanup when appIdentifier is unset and no installation matches', async () => {
+      const first = await postInstallation({
+        installationId: 'victim-uuid-0000-0000-00000000011',
+        deviceType: 'ios',
+        deviceToken: 'collide-token',
+        appIdentifier: 'com.example.appone',
+      });
+      expect(first.status).toBe(201);
+      const second = await postInstallation({
+        installationId: 'victim-uuid-0000-0000-00000000012',
+        deviceType: 'ios',
+        deviceToken: 'collide-token-2',
+        appIdentifier: 'com.example.apptwo',
+      });
+      expect(second.status).toBe(201);
+
+      // An unregistered installationId reaches the branch that runs when nothing matches.
+      const response = await postInstallation({
+        installationId: 'unregistered-uuid-0000-0000-0001',
+        deviceType: 'android',
+        deviceToken: 'collide-token',
+        appIdentifier: { __op: 'Delete' },
+      });
+
+      expect(response.status).toBe(201);
+      expect(await allInstallations()).toContain('victim-uuid-0000-0000-00000000011');
+    });
+
     it('guards every _Installation field that the schema declares as String and the deduplication queries use', () => {
       // The guard in `handleInstallation` hardcodes `String` because the schema's own type
       // check runs too late in the write pipeline to be reused. This pins the two together:

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -6921,4 +6921,199 @@ describe('Vulnerabilities', () => {
       await sleep(0);
     });
   });
+
+  describe('(GHSA-cc6h-c8m4-hgrx) NoSQL injection via _Installation deviceToken deduplication', () => {
+    const serverURL = 'http://localhost:8378/1';
+    const publicHeaders = {
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+      'Content-Type': 'application/json',
+    };
+    const attackerInstallationId = 'attacker-uuid-0000-0000-000000000000';
+
+    const postInstallation = body =>
+      request({
+        method: 'POST',
+        headers: publicHeaders,
+        url: `${serverURL}/installations`,
+        body: JSON.stringify(body),
+      }).catch(e => e);
+
+    const putInstallation = (objectId, body) =>
+      request({
+        method: 'PUT',
+        headers: publicHeaders,
+        url: `${serverURL}/installations/${objectId}`,
+        body: JSON.stringify(body),
+      }).catch(e => e);
+
+    const allInstallations = async () => {
+      const query = new Parse.Query(Parse.Installation);
+      query.limit(1000);
+      const results = await query.find({ useMasterKey: true });
+      return results.map(r => r.get('installationId')).sort();
+    };
+
+    // Registers `count` unrelated installations, each with its own installationId and
+    // deviceToken, exactly as a device SDK would.
+    const seedVictimInstallations = async count => {
+      for (let i = 0; i < count; i++) {
+        const response = await postInstallation({
+          installationId: `victim-uuid-0000-0000-00000000000${i}`,
+          deviceType: 'ios',
+          deviceToken: `victimtoken${i}`,
+        });
+        expect(response.status).toBe(201);
+      }
+    };
+
+    // Doubles as a positive control: proves the unauthenticated client really reaches the
+    // application, so a later "nothing was deleted" result cannot be a broken harness.
+    const registerAttackerInstallation = async () => {
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceType: 'android',
+      });
+      expect(response.status).toBe(201);
+    };
+
+    it('does not delete other installations when deviceToken is an operator object', async () => {
+      await seedVictimInstallations(4);
+      await registerAttackerInstallation();
+      expect((await allInstallations()).length).toBe(5);
+
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: { $ne: null },
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect((await allInstallations()).length).toBe(5);
+    });
+
+    it('does not delete other installations when deviceToken is an operator object and no installation matches the installationId', async () => {
+      await seedVictimInstallations(4);
+      expect((await allInstallations()).length).toBe(4);
+
+      // No prior registration, so the request reaches the deduplication branch that runs
+      // when no row matches the installationId.
+      const response = await postInstallation({
+        installationId: 'unregistered-uuid-0000-0000-0000',
+        deviceType: 'android',
+        deviceToken: { $ne: null },
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect((await allInstallations()).length).toBe(4);
+    });
+
+    it('does not delete targeted installations when deviceToken is a regex operator', async () => {
+      await seedVictimInstallations(4);
+      await registerAttackerInstallation();
+
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: { $regex: '^victimtoken' },
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect((await allInstallations()).length).toBe(5);
+    });
+
+    it('does not clear device tokens when deviceToken is an operator object and the duplicate action is update', async () => {
+      await reconfigureServer({ installation: { duplicateDeviceTokenAction: 'update' } });
+      await seedVictimInstallations(4);
+      await registerAttackerInstallation();
+
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: { $ne: null },
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      const query = new Parse.Query(Parse.Installation);
+      query.exists('deviceToken');
+      expect(await query.count({ useMasterKey: true })).toBe(4);
+    });
+
+    it('does not delete other installations when deviceToken is an operator object on update', async () => {
+      await seedVictimInstallations(4);
+      const created = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceType: 'android',
+      });
+      expect(created.status).toBe(201);
+
+      const response = await putInstallation(created.data.objectId, {
+        deviceToken: { $ne: null },
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect((await allInstallations()).length).toBe(5);
+    });
+
+    it('does not delete other installations when appIdentifier is an operator object', async () => {
+      await seedVictimInstallations(4);
+      await registerAttackerInstallation();
+
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: 'victimtoken0',
+        appIdentifier: { $ne: null },
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect((await allInstallations()).length).toBe(5);
+    });
+
+    it('rejects a non-string installationId with a client error', async () => {
+      await seedVictimInstallations(1);
+
+      const response = await postInstallation({
+        installationId: { $ne: null },
+        deviceType: 'android',
+        deviceToken: 'sometoken',
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.code).toBe(Parse.Error.INCORRECT_TYPE);
+      expect((await allInstallations()).length).toBe(1);
+    });
+
+    it('guards every _Installation field that the schema declares as String and the deduplication queries use', () => {
+      // The guard in `handleInstallation` hardcodes `String` because the schema's own type
+      // check runs too late in the write pipeline to be reused. This pins the two together:
+      // if a field is renamed or redeclared, this fails rather than leaving a stale guard.
+      const { defaultColumns } = require('../lib/Controllers/SchemaController');
+      for (const fieldName of ['deviceToken', 'installationId', 'appIdentifier']) {
+        expect(defaultColumns._Installation[fieldName]).toEqual({ type: 'String' });
+      }
+    });
+
+    it('still deduplicates installations that share a string deviceToken', async () => {
+      const first = await postInstallation({
+        installationId: 'device-uuid-0000-0000-000000000001',
+        deviceType: 'ios',
+        deviceToken: 'sharedtoken',
+      });
+      expect(first.status).toBe(201);
+
+      // The same physical device re-registers under a new installationId: the stale row
+      // holding the device token must still be cleaned up.
+      const second = await postInstallation({
+        installationId: 'device-uuid-0000-0000-000000000002',
+        deviceType: 'ios',
+        deviceToken: 'sharedtoken',
+      });
+      expect(second.status).toBe(201);
+
+      expect(await allInstallations()).toEqual(['device-uuid-0000-0000-000000000002']);
+    });
+  });
 });

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -7086,6 +7086,28 @@ describe('Vulnerabilities', () => {
       expect((await allInstallations()).length).toBe(1);
     });
 
+    it('still allows appIdentifier to be unset with a Delete operation', async () => {
+      const created = await postInstallation({
+        installationId: 'device-uuid-0000-0000-000000000009',
+        deviceType: 'ios',
+        deviceToken: 'unsettoken',
+        appIdentifier: 'com.example.app',
+      });
+      expect(created.status).toBe(201);
+
+      // `appIdentifier` only narrows the deduplication query, so unsetting it is a valid
+      // operation that must survive the type validation above.
+      const response = await putInstallation(created.data.objectId, {
+        appIdentifier: { __op: 'Delete' },
+      });
+
+      expect(response.status).toBe(200);
+      const query = new Parse.Query(Parse.Installation);
+      query.equalTo('objectId', created.data.objectId);
+      const [installation] = await query.find({ useMasterKey: true });
+      expect(installation.get('appIdentifier')).toBeUndefined();
+    });
+
     it('guards every _Installation field that the schema declares as String and the deduplication queries use', () => {
       // The guard in `handleInstallation` hardcodes `String` because the schema's own type
       // check runs too late in the write pipeline to be reused. This pins the two together:

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -7208,7 +7208,13 @@ describe('Vulnerabilities', () => {
       });
 
       expect(response.status).toBe(201);
-      expect(await allInstallations()).toContain('victim-uuid-0000-0000-00000000011');
+      expect(await allInstallations()).toEqual(
+        [
+          'victim-uuid-0000-0000-00000000011',
+          'victim-uuid-0000-0000-00000000012',
+          'unregistered-uuid-0000-0000-0001',
+        ].sort()
+      );
     });
 
     it('guards every _Installation field that the schema declares as String and the deduplication queries use', () => {

--- a/spec/vulnerabilities.spec.js
+++ b/spec/vulnerabilities.spec.js
@@ -7108,6 +7108,36 @@ describe('Vulnerabilities', () => {
       expect(installation.get('appIdentifier')).toBeUndefined();
     });
 
+    it('does not clean up installations of other applications when appIdentifier is unset', async () => {
+      const victim = await postInstallation({
+        installationId: 'victim-uuid-0000-0000-00000000009',
+        deviceType: 'ios',
+        deviceToken: 'contested-token',
+        appIdentifier: 'com.example.victimapp',
+      });
+      expect(victim.status).toBe(201);
+      const attacker = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceType: 'android',
+        deviceToken: 'attacker-token',
+        appIdentifier: 'com.example.attackerapp',
+      });
+      expect(attacker.status).toBe(201);
+
+      // Claiming the other application's device token while unsetting `appIdentifier` must
+      // not drop the constraint that scopes the cleanup to the caller's own application.
+      const response = await postInstallation({
+        installationId: attackerInstallationId,
+        deviceToken: 'contested-token',
+        appIdentifier: { __op: 'Delete' },
+      });
+      expect(response.status).toBe(200);
+
+      expect(await allInstallations()).toEqual(
+        ['victim-uuid-0000-0000-00000000009', attackerInstallationId].sort()
+      );
+    });
+
     it('guards every _Installation field that the schema declares as String and the deduplication queries use', () => {
       // The guard in `handleInstallation` hardcodes `String` because the schema's own type
       // check runs too late in the write pipeline to be reused. This pins the two together:

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1489,7 +1489,7 @@ RestWrite.prototype.handleInstallation = function () {
               $ne: installationId,
             },
           };
-          if (typeof this.data.appIdentifier === 'string') {
+          if (this.data.appIdentifier) {
             delQuery['appIdentifier'] = this.data.appIdentifier;
           }
           const installationOpts = this.config.installation || {};
@@ -1545,8 +1545,15 @@ RestWrite.prototype.handleInstallation = function () {
               // What to do here? can't really clean up everything...
               return idMatch.objectId;
             }
-            if (typeof this.data.appIdentifier === 'string') {
-              delQuery['appIdentifier'] = this.data.appIdentifier;
+            if (this.data.appIdentifier) {
+              // A `Delete` operation clears `appIdentifier` only after the deduplication
+              // runs, so scope the cleanup to the value the matched installation still
+              // holds; dropping the constraint would let the cleanup reach installations
+              // belonging to other applications.
+              delQuery['appIdentifier'] =
+                typeof this.data.appIdentifier === 'string'
+                  ? this.data.appIdentifier
+                  : idMatch.appIdentifier || this.data.appIdentifier;
             }
             const installationOpts = this.config.installation || {};
             return InstallationDedup.removeConflictingDeviceToken({

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1313,15 +1313,19 @@ RestWrite.prototype.handleInstallation = function () {
   // deduplication queries below.
   for (const fieldName of ['deviceToken', 'installationId', 'appIdentifier']) {
     const value = this.data[fieldName];
-    if (value !== undefined && value !== null && typeof value !== 'string') {
-      const actualType = Array.isArray(value)
-        ? 'Array'
-        : `${typeof value}`.replace(/^./, character => character.toUpperCase());
-      throw new Parse.Error(
-        Parse.Error.INCORRECT_TYPE,
-        `schema mismatch for _Installation.${fieldName}; expected String but got ${actualType}`
-      );
+    if (value === undefined || value === null || typeof value === 'string') {
+      continue;
     }
+    if (fieldName === 'appIdentifier' && value.__op === 'Delete') {
+      continue;
+    }
+    const actualType = Array.isArray(value)
+      ? 'Array'
+      : `${typeof value}`.replace(/^./, character => character.toUpperCase());
+    throw new Parse.Error(
+      Parse.Error.INCORRECT_TYPE,
+      `schema mismatch for _Installation.${fieldName}; expected String but got ${actualType}`
+    );
   }
 
   if (
@@ -1485,7 +1489,7 @@ RestWrite.prototype.handleInstallation = function () {
               $ne: installationId,
             },
           };
-          if (this.data.appIdentifier) {
+          if (typeof this.data.appIdentifier === 'string') {
             delQuery['appIdentifier'] = this.data.appIdentifier;
           }
           const installationOpts = this.config.installation || {};
@@ -1541,7 +1545,7 @@ RestWrite.prototype.handleInstallation = function () {
               // What to do here? can't really clean up everything...
               return idMatch.objectId;
             }
-            if (this.data.appIdentifier) {
+            if (typeof this.data.appIdentifier === 'string') {
               delQuery['appIdentifier'] = this.data.appIdentifier;
             }
             const installationOpts = this.config.installation || {};

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1490,6 +1490,12 @@ RestWrite.prototype.handleInstallation = function () {
             },
           };
           if (this.data.appIdentifier) {
+            // A `Delete` operation is applied only after the deduplication runs, and no
+            // installation matched here to take a scope from. Skip the cleanup rather than
+            // run it unscoped across every application, or query on the operation itself.
+            if (typeof this.data.appIdentifier !== 'string') {
+              return;
+            }
             delQuery['appIdentifier'] = this.data.appIdentifier;
           }
           const installationOpts = this.config.installation || {};
@@ -1546,14 +1552,19 @@ RestWrite.prototype.handleInstallation = function () {
               return idMatch.objectId;
             }
             if (this.data.appIdentifier) {
-              // A `Delete` operation clears `appIdentifier` only after the deduplication
-              // runs, so scope the cleanup to the value the matched installation still
-              // holds; dropping the constraint would let the cleanup reach installations
-              // belonging to other applications.
-              delQuery['appIdentifier'] =
+              // A `Delete` operation is applied only after the deduplication runs, so scope
+              // the cleanup to the value the matched installation still holds. Dropping the
+              // constraint would let the cleanup reach installations of other applications,
+              // and the operation itself cannot match a String, so skip the cleanup when no
+              // scope is available.
+              const appIdentifier =
                 typeof this.data.appIdentifier === 'string'
                   ? this.data.appIdentifier
-                  : idMatch.appIdentifier || this.data.appIdentifier;
+                  : idMatch.appIdentifier;
+              if (typeof appIdentifier !== 'string') {
+                return idMatch.objectId;
+              }
+              delQuery['appIdentifier'] = appIdentifier;
             }
             const installationOpts = this.config.installation || {};
             return InstallationDedup.removeConflictingDeviceToken({

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -1301,6 +1301,29 @@ RestWrite.prototype.handleInstallation = function () {
     return;
   }
 
+  // The deduplication below embeds these client-supplied values directly into database
+  // queries that delete or update rows with master privileges, and it runs before
+  // `validateSchema`, so their types must be enforced here: a non-string value would
+  // otherwise reach the database as a query constraint (such as an operator object
+  // `{"$ne": null}`) matching rows the client never identified, instead of as a literal
+  // value to match against. The schema declares all three as `String`, but that check
+  // cannot be reused here; it runs later in the write pipeline and moving it earlier
+  // would mutate the schema before the permission check. The field list is a property of
+  // this function rather than of the schema: it is the set of values spliced into the
+  // deduplication queries below.
+  for (const fieldName of ['deviceToken', 'installationId', 'appIdentifier']) {
+    const value = this.data[fieldName];
+    if (value !== undefined && value !== null && typeof value !== 'string') {
+      const actualType = Array.isArray(value)
+        ? 'Array'
+        : `${typeof value}`.replace(/^./, character => character.toUpperCase());
+      throw new Parse.Error(
+        Parse.Error.INCORRECT_TYPE,
+        `schema mismatch for _Installation.${fieldName}; expected String but got ${actualType}`
+      );
+    }
+  }
+
   if (
     !this.query &&
     !this.data.deviceToken &&


### PR DESCRIPTION
## Issue

Unauthenticated deletion of installation records via operator injection in device token deduplication ([GHSA-cc6h-c8m4-hgrx](https://github.com/parse-community/parse-server/security/advisories/GHSA-cc6h-c8m4-hgrx))

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
- [ ] Add [security check](https://github.com/parse-community/parse-server/blob/alpha/src/Security/CheckGroups/CheckGroupServerConfig.js)
- [ ] Add new Parse Error codes to Parse JS SDK